### PR TITLE
[INTERNAL] refactor <LinkTo> tests

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -25,30 +25,42 @@ moduleFor(
       );
     }
 
-    ['@test populates href with fully supplied query param values']() {
+    async ['@test it populates href with fully supplied query param values']() {
       this.addTemplate(
         'index',
         `<LinkTo @route='index' @query={{hash foo='456' bar='NAW'}}>Index</LinkTo>`
       );
 
-      return this.visit('/').then(() => {
-        this.assertComponentElement(this.firstChild, {
-          tagName: 'a',
-          attrs: { href: '/?bar=NAW&foo=456' },
-          content: 'Index',
-        });
+      await this.visit('/');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/?bar=NAW&foo=456' },
+        content: 'Index',
       });
     }
 
-    ['@test populates href with partially supplied query param values, but omits if value is default value']() {
+    async ['@test it populates href with fully supplied query param values, but without @route param']() {
+      this.addTemplate('index', `<LinkTo @query={{hash foo='2' bar='NAW'}}>QueryParams</LinkTo>`);
+
+      await this.visit('/');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/?bar=NAW&foo=2' },
+        content: 'QueryParams',
+      });
+    }
+
+    async ['@test it populates href with partially supplied query param values, but omits if value is default value']() {
       this.addTemplate('index', `<LinkTo @route='index' @query={{hash foo='123'}}>Index</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        this.assertComponentElement(this.firstChild, {
-          tagName: 'a',
-          attrs: { href: '/', class: classMatcher('ember-view active') },
-          content: 'Index',
-        });
+      await this.visit('/');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/', class: classMatcher('ember-view active') },
+        content: 'Index',
       });
     }
   }
@@ -57,30 +69,34 @@ moduleFor(
 moduleFor(
   '<LinkTo /> component with query params (routing)',
   class extends ApplicationTestCase {
-    constructor() {
-      super();
+    constructor(...args) {
+      super(...args);
+
       let indexProperties = {
         foo: '123',
         bar: 'abc',
       };
+
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['foo', 'bar', 'abool'],
-          foo: indexProperties.foo,
-          bar: indexProperties.bar,
-          boundThing: 'OMG',
-          abool: true,
-        })
+        class extends Controller {
+          queryParams = ['foo', 'bar', 'abool'];
+          foo = indexProperties.foo;
+          bar = indexProperties.bar;
+          boundThing = 'OMG';
+          abool = true;
+        }
       );
+
       this.add(
         'controller:about',
-        Controller.extend({
-          queryParams: ['baz', 'bat'],
-          baz: 'alex',
-          bat: 'borf',
-        })
+        class extends Controller {
+          queryParams = ['baz', 'bat'];
+          baz = 'alex';
+          bat = 'borf';
+        }
       );
+
       this.indexProperties = indexProperties;
     }
 
@@ -105,22 +121,25 @@ moduleFor(
       );
     }
 
-    [`@test doesn't update controller QP properties on current route when invoked`](assert) {
+    async [`@test it doesn't update controller QP properties on current route when invoked`](
+      assert
+    ) {
       this.addTemplate('index', `<LinkTo id='the-link' @route='index'>Index</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          this.indexProperties,
-          'controller QP properties do not update'
-        );
-      });
+      await this.click('#the-link');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'controller QP properties do not update'
+      );
     }
 
-    [`@test doesn't update controller QP properties on current route when invoked (empty query-params obj)`](
+    async [`@test it doesn't update controller QP properties on current route when invoked (empty query-params obj)`](
       assert
     ) {
       this.addTemplate(
@@ -128,36 +147,38 @@ moduleFor(
         `<LinkTo id='the-link' @route='index' @query={{hash}}>Index</LinkTo>`
       );
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          this.indexProperties,
-          'controller QP properties do not update'
-        );
-      });
+      await this.click('#the-link');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'controller QP properties do not update'
+      );
     }
 
-    [`@test doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)`](
+    async [`@test it doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)`](
       assert
     ) {
       this.addTemplate('index', `<LinkTo id='the-link' @query={{hash}}>Index</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          this.indexProperties,
-          'controller QP properties do not update'
-        );
-      });
+      await this.click('#the-link');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'controller QP properties do not update'
+      );
     }
 
-    ['@test updates controller QP properties on current route when invoked'](assert) {
+    async ['@test it updates controller QP properties on current route when invoked'](assert) {
       this.addTemplate(
         'index',
         `
@@ -167,19 +188,20 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          { foo: '456', bar: 'abc' },
-          'controller QP properties updated'
-        );
-      });
+      await this.click('#the-link');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'abc' },
+        'controller QP properties updated'
+      );
     }
 
-    ['@test updates controller QP properties on current route when invoked (inferred route)'](
+    async ['@test it updates controller QP properties on current route when invoked (inferred route)'](
       assert
     ) {
       this.addTemplate(
@@ -191,19 +213,20 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          { foo: '456', bar: 'abc' },
-          'controller QP properties updated'
-        );
-      });
+      await this.click('#the-link');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'abc' },
+        'controller QP properties updated'
+      );
     }
 
-    ['@test updates controller QP properties on other route after transitioning to that route'](
+    async ['@test it updates controller QP properties on other route after transitioning to that route'](
       assert
     ) {
       this.router.map(function () {
@@ -219,23 +242,24 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        let theLink = this.$('#the-link');
-        assert.equal(theLink.attr('href'), '/about?baz=lol');
+      await this.visit('/');
 
-        runTask(() => this.click('#the-link'));
+      let theLink = this.$('#the-link');
 
-        let aboutController = this.getController('about');
+      assert.equal(theLink.attr('href'), '/about?baz=lol');
 
-        assert.deepEqual(
-          aboutController.getProperties('baz', 'bat'),
-          { baz: 'lol', bat: 'borf' },
-          'about controller QP properties updated'
-        );
-      });
+      runTask(() => this.click('#the-link'));
+
+      let aboutController = this.getController('about');
+
+      assert.deepEqual(
+        aboutController.getProperties('baz', 'bat'),
+        { baz: 'lol', bat: 'borf' },
+        'about controller QP properties updated'
+      );
     }
 
-    async ['@test generates proper href for `LinkTo` with no @route after transitioning to an error route GH#17963'](
+    async ['@test it generates proper href for `LinkTo` with no @route after transitioning to an error route [GH#17963]'](
       assert
     ) {
       this.router.map(function () {
@@ -244,18 +268,18 @@ moduleFor(
 
       this.add(
         'controller:application',
-        Controller.extend({
-          queryParams: ['baz'],
-        })
+        class extends Controller {
+          queryParams = ['baz'];
+        }
       );
 
       this.add(
         'route:bad',
-        Route.extend({
+        class extends Route {
           model() {
             throw new Error('bad!');
-          },
-        })
+          }
+        }
       );
 
       this.addTemplate('error', `Error: {{@model.message}}`);
@@ -304,7 +328,7 @@ moduleFor(
       );
     }
 
-    ['@test supplied QP properties can be bound'](assert) {
+    async ['@test supplied QP properties can be bound'](assert) {
       this.addTemplate(
         'index',
         `
@@ -314,19 +338,19 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        let indexController = this.getController('index');
-        let theLink = this.$('#the-link');
+      await this.visit('/');
 
-        assert.equal(theLink.attr('href'), '/?foo=OMG');
+      let indexController = this.getController('index');
+      let theLink = this.$('#the-link');
 
-        runTask(() => indexController.set('boundThing', 'ASL'));
+      assert.equal(theLink.attr('href'), '/?foo=OMG');
 
-        assert.equal(theLink.attr('href'), '/?foo=ASL');
-      });
+      runTask(() => indexController.set('boundThing', 'ASL'));
+
+      assert.equal(theLink.attr('href'), '/?foo=ASL');
     }
 
-    ['@test supplied QP properties can be bound (booleans)'](assert) {
+    async ['@test supplied QP properties can be bound (booleans)'](assert) {
       this.addTemplate(
         'index',
         `
@@ -336,25 +360,26 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        let indexController = this.getController('index');
-        let theLink = this.$('#the-link');
+      await this.visit('/');
 
-        assert.equal(theLink.attr('href'), '/?abool=OMG');
+      let indexController = this.getController('index');
+      let theLink = this.$('#the-link');
 
-        runTask(() => indexController.set('boundThing', false));
+      assert.equal(theLink.attr('href'), '/?abool=OMG');
 
-        assert.equal(theLink.attr('href'), '/?abool=false');
+      runTask(() => indexController.set('boundThing', false));
 
-        this.click('#the-link');
+      assert.equal(theLink.attr('href'), '/?abool=false');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar', 'abool'),
-          { foo: '123', bar: 'abc', abool: false },
-          'bound bool QP properties update'
-        );
-      });
+      await this.click('#the-link');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar', 'abool'),
+        { foo: '123', bar: 'abc', abool: false },
+        'bound bool QP properties update'
+      );
     }
+
     async ['@test href updates when unsupplied controller QP props change'](assert) {
       this.addTemplate(
         'index',
@@ -372,21 +397,20 @@ moduleFor(
 
       assert.equal(theLink.attr('href'), '/?foo=lol');
 
-      indexController.set('bar', 'BORF');
+      runTask(() => indexController.set('bar', 'BORF'));
       await runLoopSettled();
 
       assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
 
-      indexController.set('foo', 'YEAH');
+      runTask(() => indexController.set('foo', 'YEAH'));
       await runLoopSettled();
 
       assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
     }
 
-    ['@test The <LinkTo /> component with only query params always transitions to the current route with the query params applied'](
+    async ['@test [GH#12033] with only query params, it always transitions to the current route with the query params applied'](
       assert
     ) {
-      // Test harness for bug #12033
       this.addTemplate(
         'cars',
         `
@@ -409,35 +433,33 @@ moduleFor(
 
       this.add(
         'controller:cars',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+        }
       );
 
-      return this.visit('/cars/create').then(() => {
-        let router = this.appRouter;
-        let carsController = this.getController('cars');
+      await this.visit('/cars/create');
 
-        assert.equal(router.currentRouteName, 'cars.create');
+      let router = this.appRouter;
+      let carsController = this.getController('cars');
 
-        runTask(() => this.click('#close-link'));
+      assert.equal(router.currentRouteName, 'cars.create');
 
-        assert.equal(router.currentRouteName, 'cars.index');
-        assert.equal(router.get('url'), '/cars');
-        assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
+      runTask(() => this.click('#close-link'));
 
-        runTask(() => this.click('#page2-link'));
+      assert.equal(router.currentRouteName, 'cars.index');
+      assert.equal(router.get('url'), '/cars');
+      assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
 
-        assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
-        assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
-        assert.equal(carsController.get('page'), 2, 'The query params have been updated');
-      });
+      runTask(() => this.click('#page2-link'));
+
+      assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
+      assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
+      assert.equal(carsController.get('page'), 2, 'The query params have been updated');
     }
 
-    ['@test the <LinkTo /> component applies activeClass when query params are not changed'](
-      assert
-    ) {
+    async ['@test it applies activeClass when query params are not changed'](assert) {
       this.addTemplate(
         'index',
         `
@@ -482,68 +504,62 @@ moduleFor(
 
       this.add(
         'controller:search',
-        Controller.extend({
-          queryParams: ['search', 'archive'],
-          search: '',
-          archive: false,
-        })
+        class extends Controller {
+          queryParams = ['search', 'archive'];
+          search = '';
+          archive = false;
+        }
       );
 
       this.add(
         'controller:search.results',
-        Controller.extend({
-          queryParams: ['sort', 'showDetails'],
-          sort: 'title',
-          showDetails: true,
-        })
+        class extends Controller {
+          queryParams = ['sort', 'showDetails'];
+          sort = 'title';
+          showDetails = true;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#cat-link');
-          this.shouldNotBeActive(assert, '#dog-link');
+      await this.visit('/');
 
-          return this.visit('/?foo=cat');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#cat-link');
-          this.shouldNotBeActive(assert, '#dog-link');
+      this.shouldNotBeActive(assert, '#cat-link');
+      this.shouldNotBeActive(assert, '#dog-link');
 
-          return this.visit('/?foo=dog');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#dog-link');
-          this.shouldNotBeActive(assert, '#cat-link');
-          this.shouldBeActive(assert, '#change-nothing');
+      await this.visit('/?foo=cat');
 
-          return this.visit('/search?search=same');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#same-search');
-          this.shouldNotBeActive(assert, '#change-search');
-          this.shouldNotBeActive(assert, '#same-search-add-archive');
-          this.shouldNotBeActive(assert, '#only-add-archive');
-          this.shouldNotBeActive(assert, '#remove-one');
+      this.shouldBeActive(assert, '#cat-link');
+      this.shouldNotBeActive(assert, '#dog-link');
 
-          return this.visit('/search?search=same&archive=true');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#both-same');
-          this.shouldNotBeActive(assert, '#change-one');
+      await this.visit('/?foo=dog');
 
-          return this.visit('/search/results?search=same&sort=title&showDetails=true');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#same-sort-child-only');
-          this.shouldBeActive(assert, '#same-search-parent-only');
-          this.shouldNotBeActive(assert, '#change-search-parent-only');
-          this.shouldBeActive(assert, '#same-search-same-sort-child-and-parent');
-          this.shouldNotBeActive(assert, '#same-search-different-sort-child-and-parent');
-          this.shouldNotBeActive(assert, '#change-search-same-sort-child-and-parent');
-        });
+      this.shouldBeActive(assert, '#dog-link');
+      this.shouldNotBeActive(assert, '#cat-link');
+      this.shouldBeActive(assert, '#change-nothing');
+
+      await this.visit('/search?search=same');
+
+      this.shouldBeActive(assert, '#same-search');
+      this.shouldNotBeActive(assert, '#change-search');
+      this.shouldNotBeActive(assert, '#same-search-add-archive');
+      this.shouldNotBeActive(assert, '#only-add-archive');
+      this.shouldNotBeActive(assert, '#remove-one');
+
+      await this.visit('/search?search=same&archive=true');
+
+      this.shouldBeActive(assert, '#both-same');
+      this.shouldNotBeActive(assert, '#change-one');
+
+      await this.visit('/search/results?search=same&sort=title&showDetails=true');
+
+      this.shouldBeActive(assert, '#same-sort-child-only');
+      this.shouldBeActive(assert, '#same-search-parent-only');
+      this.shouldNotBeActive(assert, '#change-search-parent-only');
+      this.shouldBeActive(assert, '#same-search-same-sort-child-and-parent');
+      this.shouldNotBeActive(assert, '#same-search-different-sort-child-and-parent');
+      this.shouldNotBeActive(assert, '#change-search-same-sort-child-and-parent');
     }
 
-    ['@test the <LinkTo /> component applies active class when query-param is a number'](assert) {
+    async ['@test it applies active class when query-param is a number'](assert) {
       this.addTemplate(
         'index',
         `
@@ -555,24 +571,23 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-          pageNumber: 5,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+          pageNumber = 5;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#page-link');
-          return this.visit('/?page=5');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#page-link');
-        });
+      await this.visit('/');
+
+      this.shouldNotBeActive(assert, '#page-link');
+
+      await this.visit('/?page=5');
+
+      this.shouldBeActive(assert, '#page-link');
     }
 
-    ['@test the <LinkTo /> component applies active class when query-param is an array'](assert) {
+    async ['@test it applies active class when query-param is an array'](assert) {
       this.addTemplate(
         'index',
         `
@@ -584,42 +599,39 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['pages'],
-          pages: [],
-          pagesArray: [1, 2],
-          biggerArray: [1, 2, 3],
-          emptyArray: [],
-        })
+        class extends Controller {
+          queryParams = ['pages'];
+          pages = [];
+          pagesArray = [1, 2];
+          biggerArray = [1, 2, 3];
+          emptyArray = [];
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#array-link');
+      await this.visit('/');
 
-          return this.visit('/?pages=%5B1%2C2%5D');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#array-link');
-          this.shouldNotBeActive(assert, '#bigger-link');
-          this.shouldNotBeActive(assert, '#empty-link');
+      this.shouldNotBeActive(assert, '#array-link');
 
-          return this.visit('/?pages=%5B2%2C1%5D');
-        })
-        .then(() => {
-          this.shouldNotBeActive(assert, '#array-link');
-          this.shouldNotBeActive(assert, '#bigger-link');
-          this.shouldNotBeActive(assert, '#empty-link');
+      await this.visit('/?pages=%5B1%2C2%5D');
 
-          return this.visit('/?pages=%5B1%2C2%2C3%5D');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#bigger-link');
-          this.shouldNotBeActive(assert, '#array-link');
-          this.shouldNotBeActive(assert, '#empty-link');
-        });
+      this.shouldBeActive(assert, '#array-link');
+      this.shouldNotBeActive(assert, '#bigger-link');
+      this.shouldNotBeActive(assert, '#empty-link');
+
+      await this.visit('/?pages=%5B2%2C1%5D');
+
+      this.shouldNotBeActive(assert, '#array-link');
+      this.shouldNotBeActive(assert, '#bigger-link');
+      this.shouldNotBeActive(assert, '#empty-link');
+
+      await this.visit('/?pages=%5B1%2C2%2C3%5D');
+
+      this.shouldBeActive(assert, '#bigger-link');
+      this.shouldNotBeActive(assert, '#array-link');
+      this.shouldNotBeActive(assert, '#empty-link');
     }
-    ['@test the <LinkTo /> component applies active class to the parent route'](assert) {
+
+    async ['@test it applies active class to the parent route'](assert) {
       this.router.map(function () {
         this.route('parent', function () {
           this.route('child');
@@ -638,26 +650,25 @@ moduleFor(
 
       this.add(
         'controller:parent.child',
-        Controller.extend({
-          queryParams: ['foo'],
-          foo: 'bar',
-        })
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = 'bar';
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#parent-link');
-          this.shouldNotBeActive(assert, '#parent-child-link');
-          this.shouldNotBeActive(assert, '#parent-link-qp');
-          return this.visit('/parent/child?foo=dog');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#parent-link');
-          this.shouldNotBeActive(assert, '#parent-link-qp');
-        });
+      await this.visit('/');
+
+      this.shouldNotBeActive(assert, '#parent-link');
+      this.shouldNotBeActive(assert, '#parent-child-link');
+      this.shouldNotBeActive(assert, '#parent-link-qp');
+
+      await this.visit('/parent/child?foo=dog');
+
+      this.shouldBeActive(assert, '#parent-link');
+      this.shouldNotBeActive(assert, '#parent-link-qp');
     }
 
-    async ['@test The <LinkTo /> component disregards query-params in activeness computation when current-when is specified'](
+    async ['@test it disregards query-params in activeness computation when current-when is specified'](
       assert
     ) {
       let appLink;
@@ -688,10 +699,10 @@ moduleFor(
 
       this.add(
         'controller:parent',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+        }
       );
 
       await this.visit('/');
@@ -715,22 +726,19 @@ moduleFor(
 
       assert.equal(parentController.get('page'), 2);
 
-      parentController.set('page', 3);
+      runTask(() => parentController.set('page', 3));
       await runLoopSettled();
 
       assert.equal(router.get('location.path'), '/parent?page=3');
       this.shouldBeActive(assert, '#app-link');
       this.shouldBeActive(assert, '#parent-link');
 
-      this.click('#app-link');
-      await runLoopSettled();
+      await this.click('#app-link');
 
       assert.equal(router.get('location.path'), '/parent');
     }
 
-    ['@test the <LinkTo /> component default query params while in active transition regression test'](
-      assert
-    ) {
+    async ['@test it defaults query params while in active transition regression test'](assert) {
       this.router.map(function () {
         this.route('foos');
         this.route('bars');
@@ -750,66 +758,109 @@ moduleFor(
 
       this.add(
         'controller:foos',
-        Controller.extend({
-          queryParams: ['status'],
-          baz: false,
-        })
+        class extends Controller {
+          queryParams = ['status'];
+          baz = false;
+        }
       );
 
       this.add(
         'route:foos',
-        Route.extend({
+        class extends Route {
           model() {
             return foos.promise;
-          },
-        })
+          }
+        }
       );
 
       this.add(
         'controller:bars',
-        Controller.extend({
-          queryParams: ['status'],
-          quux: false,
-        })
+        class extends Controller {
+          queryParams = ['status'];
+          quux = false;
+        }
       );
 
       this.add(
         'route:bars',
-        Route.extend({
+        class extends Route {
           model() {
             return bars.promise;
-          },
-        })
+          }
+        }
       );
 
-      return this.visit('/').then(() => {
-        let router = this.appRouter;
-        let foosLink = this.$('#foos-link');
-        let barsLink = this.$('#bars-link');
-        let bazLink = this.$('#baz-foos-link');
+      await this.visit('/');
 
-        assert.equal(foosLink.attr('href'), '/foos');
-        assert.equal(bazLink.attr('href'), '/foos?baz=true');
-        assert.equal(barsLink.attr('href'), '/bars?quux=true');
-        assert.equal(router.get('location.path'), '/');
-        this.shouldNotBeActive(assert, '#foos-link');
-        this.shouldNotBeActive(assert, '#baz-foos-link');
-        this.shouldNotBeActive(assert, '#bars-link');
+      let router = this.appRouter;
+      let foosLink = this.$('#foos-link');
+      let barsLink = this.$('#bars-link');
+      let bazLink = this.$('#baz-foos-link');
 
-        runTask(() => barsLink.click());
-        this.shouldNotBeActive(assert, '#bars-link');
+      assert.equal(foosLink.attr('href'), '/foos');
+      assert.equal(bazLink.attr('href'), '/foos?baz=true');
+      assert.equal(barsLink.attr('href'), '/bars?quux=true');
+      assert.equal(router.get('location.path'), '/');
+      this.shouldNotBeActive(assert, '#foos-link');
+      this.shouldNotBeActive(assert, '#baz-foos-link');
+      this.shouldNotBeActive(assert, '#bars-link');
 
-        runTask(() => foosLink.click());
-        this.shouldNotBeActive(assert, '#foos-link');
+      runTask(() => barsLink.click());
+      this.shouldNotBeActive(assert, '#bars-link');
 
-        runTask(() => foos.resolve());
+      runTask(() => foosLink.click());
+      this.shouldNotBeActive(assert, '#foos-link');
 
-        assert.equal(router.get('location.path'), '/foos');
-        this.shouldBeActive(assert, '#foos-link');
-      });
+      runTask(() => foos.resolve());
+
+      assert.equal(router.get('location.path'), '/foos');
+      this.shouldBeActive(assert, '#foos-link');
     }
 
-    ['@test the <LinkTo /> component with dynamic segment and loading route should preserve query parameters'](
+    async ['@test it does not throw an error if called without a @route argument, but with a @query argument'](
+      assert
+    ) {
+      this.addTemplate(
+        'index',
+        `
+        <LinkTo @query={{hash page=this.pageNumber}} id="page-link">
+          Index
+        </LinkTo>
+        `
+      );
+
+      this.add(
+        'route:index',
+        class extends Route {
+          model() {
+            return [
+              { id: 'yehuda', name: 'Yehuda Katz' },
+              { id: 'tom', name: 'Tom Dale' },
+              { id: 'erik', name: 'Erik Brynroflsson' },
+            ];
+          }
+        }
+      );
+
+      this.add(
+        'controller:index',
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+          pageNumber = 5;
+        }
+      );
+
+      await this.visit('/');
+
+      this.shouldNotBeActive(assert, '#page-link');
+
+      await this.visit('/?page=5');
+
+      this.shouldBeActive(assert, '#page-link');
+    }
+
+    async ['@test with dynamic segment and loading route, it should preserve query parameters'](
       assert
     ) {
       this.router.map(function () {
@@ -826,27 +877,27 @@ moduleFor(
 
       this.add(
         'controller:foo.bar',
-        Controller.extend({
-          queryParams: ['qux'],
-          qux: null,
-        })
+        class extends Controller {
+          queryParams = ['qux'];
+          qux = null;
+        }
       );
 
       this.add(
         'route:foo.bar.baz',
-        Route.extend({
+        class extends Route {
           model() {
             return new RSVP.Promise((resolve) => {
               setTimeout(resolve, 1);
             });
-          },
-        })
+          }
+        }
       );
 
-      return this.visit('/foo/bar/baz?qux=abc').then(() => {
-        let bazLink = this.$('#baz-link');
-        assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
-      });
+      await this.visit('/foo/bar/baz?qux=abc');
+
+      let bazLink = this.$('#baz-link');
+      assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -26,37 +26,37 @@ moduleFor(
       );
     }
 
-    ['@test populates href with fully supplied query param values']() {
+    async ['@test populates href with fully supplied query param values']() {
       this.addTemplate(
         'index',
         `{{#link-to route='index' query=(hash foo='456' bar='NAW')}}Index{{/link-to}}`
       );
 
-      return this.visit('/').then(() => {
-        this.assertComponentElement(this.firstChild, {
-          tagName: 'a',
-          attrs: { href: '/?bar=NAW&foo=456' },
-          content: 'Index',
-        });
+      await this.visit('/');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/?bar=NAW&foo=456' },
+        content: 'Index',
       });
     }
 
-    ['@test populates href with fully supplied query param values, but without @route param']() {
+    async ['@test it populates href with fully supplied query param values, but without @route param']() {
       this.addTemplate(
         'index',
         `{{#link-to query=(hash foo='2' bar='NAW')}}QueryParams{{/link-to}}`
       );
 
-      return this.visit('/').then(() => {
-        this.assertComponentElement(this.firstChild, {
-          tagName: 'a',
-          attrs: { href: '/?bar=NAW&foo=2' },
-          content: 'QueryParams',
-        });
+      await this.visit('/');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/?bar=NAW&foo=2' },
+        content: 'QueryParams',
       });
     }
 
-    ['@test populates href with partially supplied query param values, but omits if value is default value']() {
+    async ['@test populates href with partially supplied query param values, but omits if value is default value']() {
       this.addTemplate(
         'index',
         `{{#link-to route='index' query=(hash foo='123')}}Index{{/link-to}}`
@@ -88,6 +88,7 @@ moduleFor(
         () => this.visit('/'),
         /The `query-params` helper is deprecated/
       );
+
       this.assertComponentElement(this.firstChild, {
         tagName: 'a',
         attrs: { href: '/?alon=BUKAI&foo=456', class: classMatcher('ember-view') },
@@ -100,30 +101,34 @@ moduleFor(
 moduleFor(
   '{{link-to}} component with query params (routing)',
   class extends ApplicationTestCase {
-    constructor() {
-      super(...arguments);
+    constructor(...args) {
+      super(...args);
+
       let indexProperties = {
         foo: '123',
         bar: 'abc',
       };
+
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['foo', 'bar', 'abool'],
-          foo: indexProperties.foo,
-          bar: indexProperties.bar,
-          boundThing: 'OMG',
-          abool: true,
-        })
+        class extends Controller {
+          queryParams = ['foo', 'bar', 'abool'];
+          foo = indexProperties.foo;
+          bar = indexProperties.bar;
+          boundThing = 'OMG';
+          abool = true;
+        }
       );
+
       this.add(
         'controller:about',
-        Controller.extend({
-          queryParams: ['baz', 'bat'],
-          baz: 'alex',
-          bat: 'borf',
-        })
+        class extends Controller {
+          queryParams = ['baz', 'bat'];
+          baz = 'alex';
+          bat = 'borf';
+        }
       );
+
       this.indexProperties = indexProperties;
     }
 
@@ -148,105 +153,122 @@ moduleFor(
       );
     }
 
-    [`@test doesn't update controller QP properties on current route when invoked`](assert) {
-      this.addTemplate('index', `{{#link-to route='index' id='the-link'}}Index{{/link-to}}`);
-
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
-
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          this.indexProperties,
-          'controller QP properties do not update'
-        );
-      });
-    }
-
-    [`@test doesn't update controller QP properties on current route when invoked (empty query-params obj)`](
+    async [`@test it doesn't update controller QP properties on current route when invoked`](
       assert
     ) {
       this.addTemplate(
         'index',
-        `{{#link-to route='index' query=(hash) id='the-link'}}Index{{/link-to}}`
+        `<div id='the-link'>{{#link-to route='index'}}Index{{/link-to}}</div>`
       );
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          this.indexProperties,
-          'controller QP properties do not update'
-        );
-      });
-    }
+      await this.click('#the-link > a');
 
-    [`@test doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)`](
-      assert
-    ) {
-      this.addTemplate('index', `{{#link-to query=(hash) id='the-link'}}Index{{/link-to}}`);
+      let indexController = this.getController('index');
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
-
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          this.indexProperties,
-          'controller QP properties do not update'
-        );
-      });
-    }
-
-    ['@test updates controller QP properties on current route when invoked'](assert) {
-      this.addTemplate(
-        'index',
-        `
-        {{#link-to route='index' query=(hash foo='456') id="the-link"}}
-          Index
-        {{/link-to}}
-        `
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'controller QP properties do not update'
       );
-
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
-
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          { foo: '456', bar: 'abc' },
-          'controller QP properties updated'
-        );
-      });
     }
 
-    ['@test updates controller QP properties on current route when invoked (inferred route)'](
+    async [`@test doesn't update controller QP properties on current route when invoked (empty query-params obj)`](
       assert
     ) {
       this.addTemplate(
         'index',
+        `<div id='the-link'>{{#link-to route='index' query=(hash)}}Index{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      await this.click('#the-link > a');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'controller QP properties do not update'
+      );
+    }
+
+    async [`@test it doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)`](
+      assert
+    ) {
+      this.addTemplate(
+        'index',
+        `<div id='the-link'>{{#link-to query=(hash)}}Index{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      await this.click('#the-link > a');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'controller QP properties do not update'
+      );
+    }
+
+    async ['@test it updates controller QP properties on current route when invoked'](assert) {
+      this.addTemplate(
+        'index',
         `
-        {{#link-to query=(hash foo='456') id="the-link"}}
-          Index
-        {{/link-to}}
+        <div id="the-link">
+          {{#link-to route='index' query=(hash foo='456')}}
+            Index
+          {{/link-to}}
+        </div>
         `
       );
 
-      return this.visit('/').then(() => {
-        this.click('#the-link');
-        let indexController = this.getController('index');
+      await this.visit('/');
 
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar'),
-          { foo: '456', bar: 'abc' },
-          'controller QP properties updated'
-        );
-      });
+      await this.click('#the-link > a');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'abc' },
+        'controller QP properties updated'
+      );
     }
 
-    ['@test updates controller QP properties on other route after transitioning to that route'](
+    async ['@test it updates controller QP properties on current route when invoked (inferred route)'](
+      assert
+    ) {
+      this.addTemplate(
+        'index',
+        `
+        <div id="the-link">
+          {{#link-to query=(hash foo='456')}}
+            Index
+          {{/link-to}}
+        </div>
+        `
+      );
+
+      await this.visit('/');
+
+      await this.click('#the-link > a');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'abc' },
+        'controller QP properties updated'
+      );
+    }
+
+    async ['@test it updates controller QP properties on other route after transitioning to that route'](
       assert
     ) {
       this.router.map(function () {
@@ -256,116 +278,124 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to route='about' query=(hash baz='lol') id='the-link'}}
-          About
-        {{/link-to}}
+        <div id='the-link'>
+          {{#link-to route='about' query=(hash baz='lol')}}
+            About
+          {{/link-to}}
+        </div>
         `
       );
 
-      return this.visit('/').then(() => {
-        let theLink = this.$('#the-link');
-        assert.equal(theLink.attr('href'), '/about?baz=lol');
+      await this.visit('/');
 
-        runTask(() => this.click('#the-link'));
+      let theLink = this.$('#the-link > a');
 
-        let aboutController = this.getController('about');
+      assert.equal(theLink.attr('href'), '/about?baz=lol');
 
-        assert.deepEqual(
-          aboutController.getProperties('baz', 'bat'),
-          { baz: 'lol', bat: 'borf' },
-          'about controller QP properties updated'
-        );
-      });
-    }
+      runTask(() => this.click('#the-link > a'));
 
-    ['@test supplied QP properties can be bound'](assert) {
-      this.addTemplate(
-        'index',
-        `{{#link-to query=(hash foo=this.boundThing) id='the-link'}}Index{{/link-to}}`
+      let aboutController = this.getController('about');
+
+      assert.deepEqual(
+        aboutController.getProperties('baz', 'bat'),
+        { baz: 'lol', bat: 'borf' },
+        'about controller QP properties updated'
       );
-
-      return this.visit('/').then(() => {
-        let indexController = this.getController('index');
-        let theLink = this.$('#the-link');
-
-        assert.equal(theLink.attr('href'), '/?foo=OMG');
-
-        runTask(() => indexController.set('boundThing', 'ASL'));
-
-        assert.equal(theLink.attr('href'), '/?foo=ASL');
-      });
     }
 
-    ['@test supplied QP properties can be bound (booleans)'](assert) {
+    async ['@test supplied QP properties can be bound'](assert) {
       this.addTemplate(
         'index',
-        `
-        {{#link-to query=(hash abool=this.boundThing) id='the-link'}}
-          Index
-        {{/link-to}}
-        `
-      );
-
-      return this.visit('/').then(() => {
-        let indexController = this.getController('index');
-        let theLink = this.$('#the-link');
-
-        assert.equal(theLink.attr('href'), '/?abool=OMG');
-
-        runTask(() => indexController.set('boundThing', false));
-
-        assert.equal(theLink.attr('href'), '/?abool=false');
-
-        this.click('#the-link');
-
-        assert.deepEqual(
-          indexController.getProperties('foo', 'bar', 'abool'),
-          { foo: '123', bar: 'abc', abool: false },
-          'bound bool QP properties update'
-        );
-      });
-    }
-
-    async ['@test href updates when unsupplied controller QP props change'](assert) {
-      this.addTemplate(
-        'index',
-        `{{#link-to query=(hash foo='lol') id='the-link'}}Index{{/link-to}}`
+        `<div id='the-link'>{{#link-to query=(hash foo=this.boundThing)}}Index{{/link-to}}</div>`
       );
 
       await this.visit('/');
 
       let indexController = this.getController('index');
-      let theLink = this.$('#the-link');
+      let theLink = this.$('#the-link > a');
+
+      assert.equal(theLink.attr('href'), '/?foo=OMG');
+
+      runTask(() => indexController.set('boundThing', 'ASL'));
+
+      assert.equal(theLink.attr('href'), '/?foo=ASL');
+    }
+
+    async ['@test supplied QP properties can be bound (booleans)'](assert) {
+      this.addTemplate(
+        'index',
+        `
+        <div id='the-link'>
+          {{#link-to query=(hash abool=this.boundThing)}}
+            Index
+          {{/link-to}}
+        </div>
+        `
+      );
+
+      await this.visit('/');
+
+      let indexController = this.getController('index');
+      let theLink = this.$('#the-link > a');
+
+      assert.equal(theLink.attr('href'), '/?abool=OMG');
+
+      runTask(() => indexController.set('boundThing', false));
+
+      assert.equal(theLink.attr('href'), '/?abool=false');
+
+      await this.click('#the-link > a');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar', 'abool'),
+        { foo: '123', bar: 'abc', abool: false },
+        'bound bool QP properties update'
+      );
+    }
+
+    async ['@test href updates when unsupplied controller QP props change'](assert) {
+      this.addTemplate(
+        'index',
+        `
+        <div id='the-link'>
+          {{#link-to query=(hash foo='lol')}}Index{{/link-to}}
+        </div>
+        `
+      );
+
+      await this.visit('/');
+
+      let indexController = this.getController('index');
+      let theLink = this.$('#the-link > a');
 
       assert.equal(theLink.attr('href'), '/?foo=lol');
 
-      indexController.set('bar', 'BORF');
+      runTask(() => indexController.set('bar', 'BORF'));
       await runLoopSettled();
 
       assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
 
-      indexController.set('foo', 'YEAH');
+      runTask(() => indexController.set('foo', 'YEAH'));
       await runLoopSettled();
 
       assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
     }
 
-    ['@test The {{link-to}} with only query params always transitions to the current route with the query params applied'](
+    async ['@test [GH#12033] with only query params, it always transitions to the current route with the query params applied'](
       assert
     ) {
-      // Test harness for bug #12033
       this.addTemplate(
         'cars',
         `
-        {{#link-to route='cars.create' id='create-link'}}Create new car{{/link-to}}
-        {{#link-to query=(hash page='2') id='page2-link'}}Page 2{{/link-to}}
+        <div id='create-link'>{{#link-to route='cars.create'}}Create new car{{/link-to}}</div>
+        <div id='page2-link'>{{#link-to query=(hash page='2')}}Page 2{{/link-to}}</div>
         {{outlet}}
         `
       );
 
       this.addTemplate(
         'cars.create',
-        `{{#link-to route='cars' id='close-link'}}Close create form{{/link-to}}`
+        `<div id='close-link'>{{#link-to route='cars'}}Close create form{{/link-to}}</div>`
       );
 
       this.router.map(function () {
@@ -376,52 +406,52 @@ moduleFor(
 
       this.add(
         'controller:cars',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+        }
       );
 
-      return this.visit('/cars/create').then(() => {
-        let router = this.appRouter;
-        let carsController = this.getController('cars');
+      await this.visit('/cars/create');
 
-        assert.equal(router.currentRouteName, 'cars.create');
+      let router = this.appRouter;
+      let carsController = this.getController('cars');
 
-        runTask(() => this.click('#close-link'));
+      assert.equal(router.currentRouteName, 'cars.create');
 
-        assert.equal(router.currentRouteName, 'cars.index');
-        assert.equal(router.get('url'), '/cars');
-        assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
+      runTask(() => this.click('#close-link > a'));
 
-        runTask(() => this.click('#page2-link'));
+      assert.equal(router.currentRouteName, 'cars.index');
+      assert.equal(router.get('url'), '/cars');
+      assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
 
-        assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
-        assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
-        assert.equal(carsController.get('page'), 2, 'The query params have been updated');
-      });
+      runTask(() => this.click('#page2-link > a'));
+
+      assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
+      assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
+      assert.equal(carsController.get('page'), 2, 'The query params have been updated');
     }
 
-    ['@test the {{link-to}} applies activeClass when query params are not changed'](assert) {
+    async ['@test it applies activeClass when query params are not changed'](assert) {
       this.addTemplate(
         'index',
         `
-        {{#link-to query=(hash foo='cat') id='cat-link'}}Index{{/link-to}}
-        {{#link-to query=(hash foo='dog') id='dog-link'}}Index{{/link-to}}
-        {{#link-to route='index' id='change-nothing'}}Index{{/link-to}}
+        <div id='cat-link'>{{#link-to query=(hash foo='cat')}}Index{{/link-to}}</div>
+        <div id='dog-link'>{{#link-to query=(hash foo='dog')}}Index{{/link-to}}</div>
+        <div id='change-nothing'>{{#link-to route='index'}}Index{{/link-to}}</div>
         `
       );
 
       this.addTemplate(
         'search',
         `
-        {{#link-to query=(hash search='same') id='same-search'}}Index{{/link-to}}
-        {{#link-to query=(hash search='change') id='change-search'}}Index{{/link-to}}
-        {{#link-to query=(hash search='same' archive=true) id='same-search-add-archive'}}Index{{/link-to}}
-        {{#link-to query=(hash archive=true) id='only-add-archive'}}Index{{/link-to}}
-        {{#link-to query=(hash search='same' archive=true) id='both-same'}}Index{{/link-to}}
-        {{#link-to query=(hash search='different' archive=true) id='change-one'}}Index{{/link-to}}
-        {{#link-to query=(hash search='different' archive=false) id='remove-one'}}Index{{/link-to}}
+        <div id='same-search'>{{#link-to query=(hash search='same')}}Index{{/link-to}}</div>
+        <div id='change-search'>{{#link-to query=(hash search='change')}}Index{{/link-to}}</div>
+        <div id='same-search-add-archive'>{{#link-to query=(hash search='same' archive=true)}}Index{{/link-to}}</div>
+        <div id='only-add-archive'>{{#link-to query=(hash archive=true)}}Index{{/link-to}}</div>
+        <div id='both-same'>{{#link-to query=(hash search='same' archive=true)}}Index{{/link-to}}</div>
+        <div id='change-one'>{{#link-to query=(hash search='different' archive=true)}}Index{{/link-to}}</div>
+        <div id='remove-one'>{{#link-to query=(hash search='different' archive=false)}}Index{{/link-to}}</div>
         {{outlet}}
         `
       );
@@ -429,13 +459,13 @@ moduleFor(
       this.addTemplate(
         'search.results',
         `
-        {{#link-to query=(hash sort='title') id='same-sort-child-only'}}Index{{/link-to}}
-        {{#link-to query=(hash search='same') id='same-search-parent-only'}}Index{{/link-to}}
-        {{#link-to query=(hash search='change') id='change-search-parent-only'}}Index{{/link-to}}
-        {{#link-to query=(hash search='same' sort='title') id='same-search-same-sort-child-and-parent'}}Index{{/link-to}}
-        {{#link-to query=(hash search='same' sort='author') id='same-search-different-sort-child-and-parent'}}Index{{/link-to}}
-        {{#link-to query=(hash search='change' sort='title') id='change-search-same-sort-child-and-parent'}}Index{{/link-to}}
-        {{#link-to query=(hash foo='dog') id='dog-link'}}Index{{/link-to}}
+        <div id='same-sort-child-only'>{{#link-to query=(hash sort='title')}}Index{{/link-to}}</div>
+        <div id='same-search-parent-only'>{{#link-to query=(hash search='same')}}Index{{/link-to}}</div>
+        <div id='change-search-parent-only'>{{#link-to query=(hash search='change')}}Index{{/link-to}}</div>
+        <div id='same-search-same-sort-child-and-parent'>{{#link-to query=(hash search='same' sort='title')}}Index{{/link-to}}</div>
+        <div id='same-search-different-sort-child-and-parent'>{{#link-to query=(hash search='same' sort='author')}}Index{{/link-to}}</div>
+        <div id='change-search-same-sort-child-and-parent'>{{#link-to query=(hash search='change' sort='title')}}Index{{/link-to}}</div>
+        <div id='dog-link'>{{#link-to query=(hash foo='dog')}}Index{{/link-to}}</div>
         `
       );
 
@@ -447,144 +477,136 @@ moduleFor(
 
       this.add(
         'controller:search',
-        Controller.extend({
-          queryParams: ['search', 'archive'],
-          search: '',
-          archive: false,
-        })
+        class extends Controller {
+          queryParams = ['search', 'archive'];
+          search = '';
+          archive = false;
+        }
       );
 
       this.add(
         'controller:search.results',
-        Controller.extend({
-          queryParams: ['sort', 'showDetails'],
-          sort: 'title',
-          showDetails: true,
-        })
+        class extends Controller {
+          queryParams = ['sort', 'showDetails'];
+          sort = 'title';
+          showDetails = true;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#cat-link');
-          this.shouldNotBeActive(assert, '#dog-link');
+      await this.visit('/');
 
-          return this.visit('/?foo=cat');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#cat-link');
-          this.shouldNotBeActive(assert, '#dog-link');
+      this.shouldNotBeActive(assert, '#cat-link > a');
+      this.shouldNotBeActive(assert, '#dog-link > a');
 
-          return this.visit('/?foo=dog');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#dog-link');
-          this.shouldNotBeActive(assert, '#cat-link');
-          this.shouldBeActive(assert, '#change-nothing');
+      await this.visit('/?foo=cat');
 
-          return this.visit('/search?search=same');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#same-search');
-          this.shouldNotBeActive(assert, '#change-search');
-          this.shouldNotBeActive(assert, '#same-search-add-archive');
-          this.shouldNotBeActive(assert, '#only-add-archive');
-          this.shouldNotBeActive(assert, '#remove-one');
+      this.shouldBeActive(assert, '#cat-link > a');
+      this.shouldNotBeActive(assert, '#dog-link > a');
 
-          return this.visit('/search?search=same&archive=true');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#both-same');
-          this.shouldNotBeActive(assert, '#change-one');
+      await this.visit('/?foo=dog');
 
-          return this.visit('/search/results?search=same&sort=title&showDetails=true');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#same-sort-child-only');
-          this.shouldBeActive(assert, '#same-search-parent-only');
-          this.shouldNotBeActive(assert, '#change-search-parent-only');
-          this.shouldBeActive(assert, '#same-search-same-sort-child-and-parent');
-          this.shouldNotBeActive(assert, '#same-search-different-sort-child-and-parent');
-          this.shouldNotBeActive(assert, '#change-search-same-sort-child-and-parent');
-        });
+      this.shouldBeActive(assert, '#dog-link > a');
+      this.shouldNotBeActive(assert, '#cat-link > a');
+      this.shouldBeActive(assert, '#change-nothing > a');
+
+      await this.visit('/search?search=same');
+
+      this.shouldBeActive(assert, '#same-search > a');
+      this.shouldNotBeActive(assert, '#change-search > a');
+      this.shouldNotBeActive(assert, '#same-search-add-archive > a');
+      this.shouldNotBeActive(assert, '#only-add-archive > a');
+      this.shouldNotBeActive(assert, '#remove-one > a');
+
+      await this.visit('/search?search=same&archive=true');
+
+      this.shouldBeActive(assert, '#both-same > a');
+      this.shouldNotBeActive(assert, '#change-one > a');
+
+      await this.visit('/search/results?search=same&sort=title&showDetails=true');
+
+      this.shouldBeActive(assert, '#same-sort-child-only > a');
+      this.shouldBeActive(assert, '#same-search-parent-only > a');
+      this.shouldNotBeActive(assert, '#change-search-parent-only > a');
+      this.shouldBeActive(assert, '#same-search-same-sort-child-and-parent > a');
+      this.shouldNotBeActive(assert, '#same-search-different-sort-child-and-parent > a');
+      this.shouldNotBeActive(assert, '#change-search-same-sort-child-and-parent > a');
     }
 
-    ['@test the {{link-to}} applies active class when query-param is a number'](assert) {
+    async ['@test it applies active class when query-param is a number'](assert) {
       this.addTemplate(
         'index',
         `
-        {{#link-to query=(hash page=this.pageNumber) id='page-link'}}
-          Index
-        {{/link-to}}
+        <div id='page-link'>
+          {{#link-to query=(hash page=this.pageNumber)}}
+            Index
+          {{/link-to}}
+        </div>
         `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-          pageNumber: 5,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+          pageNumber = 5;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#page-link');
-          return this.visit('/?page=5');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#page-link');
-        });
+      await this.visit('/');
+
+      this.shouldNotBeActive(assert, '#page-link > a');
+
+      await this.visit('/?page=5');
+
+      this.shouldBeActive(assert, '#page-link > a');
     }
 
-    ['@test the {{link-to}} applies active class when query-param is an array'](assert) {
+    async ['@test it applies active class when query-param is an array'](assert) {
       this.addTemplate(
         'index',
         `
-        {{#link-to query=(hash pages=this.pagesArray) id='array-link'}}Index{{/link-to}}
-        {{#link-to query=(hash pages=this.biggerArray) id='bigger-link'}}Index{{/link-to}}
-        {{#link-to query=(hash pages=this.emptyArray) id='empty-link'}}Index{{/link-to}}
+        <div id='array-link'>{{#link-to query=(hash pages=this.pagesArray)}}Index{{/link-to}}</div>
+        <div id='bigger-link'>{{#link-to query=(hash pages=this.biggerArray)}}Index{{/link-to}}</div>
+        <div id='empty-link'>{{#link-to query=(hash pages=this.emptyArray)}}Index{{/link-to}}</div>
         `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['pages'],
-          pages: [],
-          pagesArray: [1, 2],
-          biggerArray: [1, 2, 3],
-          emptyArray: [],
-        })
+        class extends Controller {
+          queryParams = ['pages'];
+          pages = [];
+          pagesArray = [1, 2];
+          biggerArray = [1, 2, 3];
+          emptyArray = [];
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#array-link');
+      await this.visit('/');
 
-          return this.visit('/?pages=%5B1%2C2%5D');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#array-link');
-          this.shouldNotBeActive(assert, '#bigger-link');
-          this.shouldNotBeActive(assert, '#empty-link');
+      this.shouldNotBeActive(assert, '#array-link > a');
 
-          return this.visit('/?pages=%5B2%2C1%5D');
-        })
-        .then(() => {
-          this.shouldNotBeActive(assert, '#array-link');
-          this.shouldNotBeActive(assert, '#bigger-link');
-          this.shouldNotBeActive(assert, '#empty-link');
+      await this.visit('/?pages=%5B1%2C2%5D');
 
-          return this.visit('/?pages=%5B1%2C2%2C3%5D');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#bigger-link');
-          this.shouldNotBeActive(assert, '#array-link');
-          this.shouldNotBeActive(assert, '#empty-link');
-        });
+      this.shouldBeActive(assert, '#array-link > a');
+      this.shouldNotBeActive(assert, '#bigger-link > a');
+      this.shouldNotBeActive(assert, '#empty-link > a');
+
+      await this.visit('/?pages=%5B2%2C1%5D');
+
+      this.shouldNotBeActive(assert, '#array-link > a');
+      this.shouldNotBeActive(assert, '#bigger-link > a');
+      this.shouldNotBeActive(assert, '#empty-link > a');
+
+      await this.visit('/?pages=%5B1%2C2%2C3%5D');
+
+      this.shouldBeActive(assert, '#bigger-link > a');
+      this.shouldNotBeActive(assert, '#array-link > a');
+      this.shouldNotBeActive(assert, '#empty-link > a');
     }
-    ['@test the {{link-to}} component applies active class to the parent route'](assert) {
+
+    async ['@test it applies active class to the parent route'](assert) {
       this.router.map(function () {
         this.route('parent', function () {
           this.route('child');
@@ -594,35 +616,34 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-        {{#link-to route='parent' id='parent-link'}}Parent{{/link-to}}
-        {{#link-to route='parent.child' id='parent-child-link'}}Child{{/link-to}}
-        {{#link-to route='parent' query=(hash foo=this.cat) id='parent-link-qp'}}Parent{{/link-to}}
+        <div id='parent-link'>{{#link-to route='parent'}}Parent{{/link-to}}</div>
+        <div id='parent-child-link'>{{#link-to route='parent.child'}}P}}Child{{/link-to}}</div>
+        <div id='parent-link-qp'>{{#link-to route='parent' query=(hash foo=this.cat)}}P}}Parent{{/link-to}}</div>
         {{outlet}}
         `
       );
 
       this.add(
         'controller:parent.child',
-        Controller.extend({
-          queryParams: ['foo'],
-          foo: 'bar',
-        })
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = 'bar';
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#parent-link');
-          this.shouldNotBeActive(assert, '#parent-child-link');
-          this.shouldNotBeActive(assert, '#parent-link-qp');
-          return this.visit('/parent/child?foo=dog');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#parent-link');
-          this.shouldNotBeActive(assert, '#parent-link-qp');
-        });
+      await this.visit('/');
+
+      this.shouldNotBeActive(assert, '#parent-link > a');
+      this.shouldNotBeActive(assert, '#parent-child-link > a');
+      this.shouldNotBeActive(assert, '#parent-link-qp > a');
+
+      await this.visit('/parent/child?foo=dog');
+
+      this.shouldBeActive(assert, '#parent-link > a');
+      this.shouldNotBeActive(assert, '#parent-link-qp > a');
     }
 
-    async ['@test The {{link-to}} component disregards query-params in activeness computation when current-when is specified'](
+    async ['@test it disregards query-params in activeness computation when current-when is specified'](
       assert
     ) {
       let appLink;
@@ -634,9 +655,11 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-        {{#link-to route='parent' query=(hash page=1) current-when='parent' id='app-link'}}
-          Parent
-        {{/link-to}}
+        <div id='app-link'>
+          {{#link-to route='parent' query=(hash page=1) current-when='parent'}}
+            Parent
+          {{/link-to}}
+        </div>
         {{outlet}}
         `
       );
@@ -644,56 +667,57 @@ moduleFor(
       this.addTemplate(
         'parent',
         `
-        {{#link-to route='parent' query=(hash page=1) current-when='parent' id='parent-link'}}
-          Parent
-        {{/link-to}}
+        <div id='parent-link'>
+          {{#link-to route='parent' query=(hash page=1) current-when='parent'}}
+            Parent
+          {{/link-to}}
+        </div>
         {{outlet}}
         `
       );
 
       this.add(
         'controller:parent',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+        }
       );
 
       await this.visit('/');
 
-      appLink = this.$('#app-link');
+      appLink = this.$('#app-link > a');
 
       assert.equal(appLink.attr('href'), '/parent');
-      this.shouldNotBeActive(assert, '#app-link');
+      this.shouldNotBeActive(assert, '#app-link > a');
 
       await this.visit('/parent?page=2');
 
-      appLink = this.$('#app-link');
+      appLink = this.$('#app-link > a');
       let router = this.appRouter;
 
       assert.equal(appLink.attr('href'), '/parent');
-      this.shouldBeActive(assert, '#app-link');
-      assert.equal(this.$('#parent-link').attr('href'), '/parent');
-      this.shouldBeActive(assert, '#parent-link');
+      this.shouldBeActive(assert, '#app-link > a');
+      assert.equal(this.$('#parent-link > a').attr('href'), '/parent');
+      this.shouldBeActive(assert, '#parent-link > a');
 
       let parentController = this.getController('parent');
 
       assert.equal(parentController.get('page'), 2);
 
-      parentController.set('page', 3);
+      runTask(() => parentController.set('page', 3));
       await runLoopSettled();
 
       assert.equal(router.get('location.path'), '/parent?page=3');
-      this.shouldBeActive(assert, '#app-link');
-      this.shouldBeActive(assert, '#parent-link');
+      this.shouldBeActive(assert, '#app-link > a');
+      this.shouldBeActive(assert, '#parent-link > a');
 
-      this.click('#app-link');
-      await runLoopSettled();
+      await this.click('#app-link > a');
 
       assert.equal(router.get('location.path'), '/parent');
     }
 
-    ['@test {{link-to}} default query params while in active transition regression test'](assert) {
+    async ['@test it defaults query params while in active transition regression test'](assert) {
       this.router.map(function () {
         this.route('foos');
         this.route('bars');
@@ -705,128 +729,129 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-        {{#link-to route='foos' id='foos-link'}}Foos{{/link-to}}
-        {{#link-to route='foos' query=(hash baz=true) id='baz-foos-link'}}Baz Foos{{/link-to}}
-        {{#link-to route='bars' query=(hash quux=true) id='bars-link'}}Quux Bars{{/link-to}}
+        <div id='foos-link'>{{#link-to route='foos'}}Foos{{/link-to}}</div>
+        <div id='baz-foos-link'>{{#link-to route='foos' query=(hash baz=true)}}Baz Foos{{/link-to}}</div>
+        <div id='bars-link'>{{#link-to route='bars' query=(hash quux=true)}}Quux Bars{{/link-to}}</div>
         `
       );
 
       this.add(
         'controller:foos',
-        Controller.extend({
-          queryParams: ['status'],
-          baz: false,
-        })
+        class extends Controller {
+          queryParams = ['status'];
+          baz = false;
+        }
       );
 
       this.add(
         'route:foos',
-        Route.extend({
+        class extends Route {
           model() {
             return foos.promise;
-          },
-        })
+          }
+        }
       );
 
       this.add(
         'controller:bars',
-        Controller.extend({
-          queryParams: ['status'],
-          quux: false,
-        })
+        class extends Controller {
+          queryParams = ['status'];
+          quux = false;
+        }
       );
 
       this.add(
         'route:bars',
-        Route.extend({
+        class extends Route {
           model() {
             return bars.promise;
-          },
-        })
+          }
+        }
       );
 
-      return this.visit('/').then(() => {
-        let router = this.appRouter;
-        let foosLink = this.$('#foos-link');
-        let barsLink = this.$('#bars-link');
-        let bazLink = this.$('#baz-foos-link');
+      await this.visit('/');
 
-        assert.equal(foosLink.attr('href'), '/foos');
-        assert.equal(bazLink.attr('href'), '/foos?baz=true');
-        assert.equal(barsLink.attr('href'), '/bars?quux=true');
-        assert.equal(router.get('location.path'), '/');
-        this.shouldNotBeActive(assert, '#foos-link');
-        this.shouldNotBeActive(assert, '#baz-foos-link');
-        this.shouldNotBeActive(assert, '#bars-link');
+      let router = this.appRouter;
+      let foosLink = this.$('#foos-link > a');
+      let barsLink = this.$('#bars-link > a');
+      let bazLink = this.$('#baz-foos-link > a');
 
-        runTask(() => barsLink.click());
-        this.shouldNotBeActive(assert, '#bars-link');
+      assert.equal(foosLink.attr('href'), '/foos');
+      assert.equal(bazLink.attr('href'), '/foos?baz=true');
+      assert.equal(barsLink.attr('href'), '/bars?quux=true');
+      assert.equal(router.get('location.path'), '/');
+      this.shouldNotBeActive(assert, '#foos-link > a');
+      this.shouldNotBeActive(assert, '#baz-foos-link > a');
+      this.shouldNotBeActive(assert, '#bars-link > a');
 
-        runTask(() => foosLink.click());
-        this.shouldNotBeActive(assert, '#foos-link');
+      runTask(() => barsLink.click());
+      this.shouldNotBeActive(assert, '#bars-link > a');
 
-        runTask(() => foos.resolve());
+      runTask(() => foosLink.click());
+      this.shouldNotBeActive(assert, '#foos-link > a');
 
-        assert.equal(router.get('location.path'), '/foos');
-        this.shouldBeActive(assert, '#foos-link');
-      });
+      runTask(() => foos.resolve());
+
+      assert.equal(router.get('location.path'), '/foos');
+      this.shouldBeActive(assert, '#foos-link > a');
     }
 
-    ['@test the {{link-to}} does not throw an error if called without a @route argument, but with a @query argument'](
+    async ['@test it does not throw an error if called without a @route argument, but with a @query argument'](
       assert
     ) {
       this.addTemplate(
         'index',
         `
-        {{#link-to query=(hash page=this.pageNumber) id='page-link'}}
-          Index
-        {{/link-to}}
+        <div id='page-link'>
+          {{#link-to query=(hash page=this.pageNumber)}}
+            Index
+          {{/link-to}}
+        </div>
         `
       );
 
       this.add(
         'route:index',
-        Route.extend({
+        class extends Route {
           model() {
             return [
               { id: 'yehuda', name: 'Yehuda Katz' },
               { id: 'tom', name: 'Tom Dale' },
               { id: 'erik', name: 'Erik Brynroflsson' },
             ];
-          },
-        })
+          }
+        }
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['page'],
-          page: 1,
-          pageNumber: 5,
-        })
+        class extends Controller {
+          queryParams = ['page'];
+          page = 1;
+          pageNumber = 5;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          this.shouldNotBeActive(assert, '#page-link');
-          return this.visit('/?page=5');
-        })
-        .then(() => {
-          this.shouldBeActive(assert, '#page-link');
-        });
+      await this.visit('/');
+
+      this.shouldNotBeActive(assert, '#page-link > a');
+
+      await this.visit('/?page=5');
+
+      this.shouldBeActive(assert, '#page-link > a');
     }
 
-    ['@test [DEPRECATED] [GH#17869] it does not cause shadowing assertion with `hash` local variable']() {
+    async ['@test [DEPRECATED] [GH#17869] it does not cause shadowing assertion with `hash` local variable']() {
       this.router.map(function () {
         this.route('post', { path: '/post/:id' });
       });
 
       this.add(
         'controller:post',
-        Controller.extend({
-          queryParams: ['showComments'],
-          showComments: true,
-        })
+        class extends Controller {
+          queryParams = ['showComments'];
+          showComments = true;
+        }
       );
 
       expectDeprecation(() => {
@@ -840,16 +865,16 @@ moduleFor(
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
 
-      return this.visit('/').then(() => {
-        this.assertComponentElement(this.element.firstElementChild, {
-          tagName: 'a',
-          attrs: { href: '/post/1?showComments=false', class: classMatcher('ember-view') },
-          content: 'View Post',
-        });
+      await this.visit('/');
+
+      this.assertComponentElement(this.element.firstElementChild, {
+        tagName: 'a',
+        attrs: { href: '/post/1?showComments=false', class: classMatcher('ember-view') },
+        content: 'View Post',
       });
     }
 
-    ['@test the {{link-to}} component with dynamic segment and loading route should preserve query parameters'](
+    async ['@test with dynamic segment and loading route, it should preserve query parameters'](
       assert
     ) {
       this.router.map(function () {
@@ -860,32 +885,35 @@ moduleFor(
         });
       });
 
-      this.addTemplate('foo.bar', `{{#link-to route='foo.bar.baz' id='baz-link'}}Baz{{/link-to}}`);
+      this.addTemplate(
+        'foo.bar',
+        `<div id='baz-link'>{{#link-to route='foo.bar.baz'}}Baz{{/link-to}}</div>`
+      );
       this.addTemplate('foo.bar.loading', 'Loading');
 
       this.add(
         'controller:foo.bar',
-        Controller.extend({
-          queryParams: ['qux'],
-          qux: null,
-        })
+        class extends Controller {
+          queryParams = ['qux'];
+          qux = null;
+        }
       );
 
       this.add(
         'route:foo.bar.baz',
-        Route.extend({
+        class extends Route {
           model() {
             return new RSVP.Promise((resolve) => {
               setTimeout(resolve, 1);
             });
-          },
-        })
+          }
+        }
       );
 
-      return this.visit('/foo/bar/baz?qux=abc').then(() => {
-        let bazLink = this.$('#baz-link');
-        assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
-      });
+      await this.visit('/foo/bar/baz?qux=abc');
+
+      let bazLink = this.$('#baz-link > a');
+      assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -13,8 +13,8 @@ import { LinkComponent } from '@ember/-internals/glimmer';
 moduleFor(
   '<LinkTo /> component (rendering tests)',
   class extends ApplicationTestCase {
-    async [`@test throws a useful error if you invoke it wrong`](assert) {
-      this.addTemplate('application', `<LinkTo id='the-link'>Index</LinkTo>`);
+    async [`@test it throws a useful error if you invoke it wrong`](assert) {
+      this.addTemplate('application', `<LinkTo>Index</LinkTo>`);
 
       return assert.rejectsAssertion(
         this.visit('/'),
@@ -22,94 +22,104 @@ moduleFor(
       );
     }
 
-    ['@test should be able to be inserted in DOM when the router is not present']() {
+    async ['@test it should be able to be inserted in DOM when the router is not present']() {
       this.addTemplate('application', `<LinkTo @route='index'>Go to Index</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        this.assertText('Go to Index');
-      });
+      await this.visit('/');
+
+      this.assertText('Go to Index');
     }
 
-    ['@test re-renders when title changes']() {
+    async ['@test it re-renders when title changes']() {
       let controller;
 
       this.addTemplate('application', `<LinkTo @route='index'>{{this.title}}</LinkTo>`);
 
       this.add(
         'controller:application',
-        Controller.extend({
-          init() {
-            this._super(...arguments);
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
             controller = this;
-          },
-          title: 'foo',
-        })
+          }
+
+          title = 'foo';
+        }
       );
 
-      return this.visit('/').then(() => {
-        this.assertText('foo');
-        runTask(() => set(controller, 'title', 'bar'));
-        this.assertText('bar');
-      });
+      await this.visit('/');
+
+      this.assertText('foo');
+
+      runTask(() => set(controller, 'title', 'bar'));
+
+      this.assertText('bar');
     }
 
-    ['@test re-computes active class when params change'](assert) {
+    async ['@test it re-computes active class when params change'](assert) {
       let controller;
 
       this.addTemplate('application', '<LinkTo @route={{this.routeName}}>foo</LinkTo>');
 
       this.add(
         'controller:application',
-        Controller.extend({
-          init() {
-            this._super(...arguments);
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
             controller = this;
-          },
-          routeName: 'index',
-        })
+          }
+
+          routeName = 'index';
+        }
       );
 
       this.router.map(function () {
         this.route('bar', { path: '/bar' });
       });
 
-      return this.visit('/bar').then(() => {
-        assert.equal(this.firstChild.classList.contains('active'), false);
-        runTask(() => set(controller, 'routeName', 'bar'));
-        assert.equal(this.firstChild.classList.contains('active'), true);
-      });
+      await this.visit('/bar');
+
+      assert.equal(this.firstChild.classList.contains('active'), false);
+
+      runTask(() => set(controller, 'routeName', 'bar'));
+
+      assert.equal(this.firstChild.classList.contains('active'), true);
     }
 
-    ['@test able to safely extend the built-in component and use the normal path']() {
+    async ['@test able to safely extend the built-in component and use the normal path']() {
       this.addComponent('custom-link-to', {
-        ComponentClass: LinkComponent.extend(),
+        ComponentClass: class extends LinkComponent {},
       });
 
       this.addTemplate('application', `<CustomLinkTo @route='index'>{{this.title}}</CustomLinkTo>`);
 
       this.add(
         'controller:application',
-        Controller.extend({
-          title: 'Hello',
-        })
+        class extends Controller {
+          title = 'Hello';
+        }
       );
 
-      return this.visit('/').then(() => {
-        this.assertText('Hello');
-      });
+      await this.visit('/');
+
+      this.assertText('Hello');
     }
 
-    ['@test able to pupolate innermost dynamic segment when immediate parent route is active']() {
+    async ['@test able to pupolate innermost dynamic segment when immediate parent route is active']() {
       this.addTemplate('application', '{{outlet}}');
+
       this.addTemplate('parents', '{{outlet}}');
+
       this.addTemplate(
         'parents.parent',
         '<LinkTo @route="parents.parent.child" @model=1>Link To Child</LinkTo>'
       );
+
       this.addTemplate(
         'parents.parent.child',
         '<LinkTo @route="parents.parent">Link To Parent</LinkTo>'
       );
+
       this.add(
         'route:parents.parent',
         class extends Route {
@@ -118,6 +128,7 @@ moduleFor(
           }
         }
       );
+
       this.router.map(function () {
         this.route('parents', function () {
           this.route('parent', { path: '/:parent_id' }, function () {
@@ -126,9 +137,10 @@ moduleFor(
           });
         });
       });
-      return this.visit('/parents/1').then(() => {
-        this.assertText('Link To Child');
-      });
+
+      await this.visit('/parents/1');
+
+      this.assertText('Link To Child');
     }
   }
 );
@@ -136,7 +148,7 @@ moduleFor(
 moduleFor(
   '<LinkTo /> component (rendering tests, without router)',
   class extends RenderingTestCase {
-    ['@test should be able to be inserted in DOM when the router is not present - block']() {
+    ['@test it should be able to be inserted in DOM when the router is not present - block']() {
       this.render(`<LinkTo @route='index'>Go to Index</LinkTo>`);
 
       this.assertComponentElement(this.element.firstChild, {
@@ -151,26 +163,31 @@ moduleFor(
 moduleFor(
   '<LinkTo /> component (rendering tests, with router not started)',
   class extends RouterNonApplicationTestCase {
-    constructor() {
-      super(...arguments);
+    constructor(...args) {
+      super(...args);
+
       this.resolver.add('router:main', Router.extend(this.routerOptions));
+
       this.router.map(function () {
         this.route('dynamicWithChild', { path: '/dynamic-with-child/:dynamic_id' }, function () {
           this.route('child');
         });
       });
     }
+
     get routerOptions() {
       return {
         location: 'none',
       };
     }
+
     get router() {
       return this.owner.resolveRegistration('router:main');
     }
 
-    ['@test should be able to be inserted in DOM when initial transition not started']() {
+    ['@test it should be able to be inserted in DOM when initial transition not started']() {
       this.render(`<LinkTo @route="dynamicWithChild.child">Link</LinkTo>`);
+
       this.assertComponentElement(this.element.firstChild, {
         tagName: 'a',
         attrs: {
@@ -180,8 +197,9 @@ moduleFor(
       });
     }
 
-    ['@test should be able to be inserted in DOM with valid href when complete models are passed even if initial transition is not started']() {
+    ['@test it should be able to be inserted in DOM with valid href when complete models are passed even if initial transition is not started']() {
       this.render(`<LinkTo @route="dynamicWithChild.child" @model="1">Link</LinkTo>`);
+
       this.assertComponentElement(this.element.firstChild, {
         tagName: 'a',
         attrs: {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
@@ -7,137 +7,149 @@ import { LinkComponent } from '@ember/-internals/glimmer';
 moduleFor(
   '{{link-to}} component (rendering tests)',
   class extends ApplicationTestCase {
-    [`@test throws a useful error if you invoke it wrong`](assert) {
+    [`@test it throws a useful error if you invoke it wrong`](assert) {
       assert.expect(1);
 
       expectAssertion(() => {
-        this.addTemplate('application', `{{#link-to id='the-link'}}Index{{/link-to}}`);
+        this.addTemplate('application', `{{#link-to}}Index{{/link-to}}`);
       }, /You must provide one or more parameters to the `{{link-to}}` component\. \('my-app\/templates\/application\.hbs' @ L1:C0\)/);
     }
 
-    ['@test should be able to be inserted in DOM when the router is not present']() {
+    async ['@test it should be able to be inserted in DOM when the router is not present']() {
       this.addTemplate('application', `{{#link-to route='index'}}Go to Index{{/link-to}}`);
 
-      return this.visit('/').then(() => {
-        this.assertText('Go to Index');
-      });
+      await this.visit('/');
+
+      this.assertText('Go to Index');
     }
 
-    ['@test re-renders when title changes']() {
+    async ['@test it re-renders when title changes']() {
       let controller;
 
       this.addTemplate('application', `{{#link-to route='index'}}{{this.title}}{{/link-to}}`);
 
       this.add(
         'controller:application',
-        Controller.extend({
-          init() {
-            this._super(...arguments);
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
             controller = this;
-          },
-          title: 'foo',
-        })
+          }
+
+          title = 'foo';
+        }
       );
 
-      return this.visit('/').then(() => {
-        this.assertText('foo');
-        runTask(() => set(controller, 'title', 'bar'));
-        this.assertText('bar');
-      });
+      await this.visit('/');
+
+      this.assertText('foo');
+
+      runTask(() => set(controller, 'title', 'bar'));
+
+      this.assertText('bar');
     }
 
-    ['@test re-computes active class when params change'](assert) {
+    async ['@test it re-computes active class when params change'](assert) {
       let controller;
 
       this.addTemplate('application', '{{#link-to route=this.routeName}}foo{{/link-to}}');
 
       this.add(
         'controller:application',
-        Controller.extend({
-          init() {
-            this._super(...arguments);
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
             controller = this;
-          },
-          routeName: 'index',
-        })
+          }
+
+          routeName = 'index';
+        }
       );
 
       this.router.map(function () {
         this.route('bar', { path: '/bar' });
       });
 
-      return this.visit('/bar').then(() => {
-        assert.equal(this.firstChild.classList.contains('active'), false);
-        runTask(() => set(controller, 'routeName', 'bar'));
-        assert.equal(this.firstChild.classList.contains('active'), true);
-      });
+      await this.visit('/bar');
+
+      assert.equal(this.firstChild.classList.contains('active'), false);
+
+      runTask(() => set(controller, 'routeName', 'bar'));
+
+      assert.equal(this.firstChild.classList.contains('active'), true);
     }
 
-    ['@test [DEPRECATED] escaped inline form (double curlies) escapes link title']() {
+    async ['@test [DEPRECATED] escaped inline form (double curlies) escapes link title']() {
       expectDeprecation(() => {
         this.addTemplate('application', `{{link-to this.title 'index'}}`);
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+
       this.add(
         'controller:application',
-        Controller.extend({
-          title: '<b>blah</b>',
-        })
+        class extends Controller {
+          title = '<b>blah</b>';
+        }
       );
 
-      return this.visit('/').then(() => {
-        this.assertText('<b>blah</b>');
-      });
+      await this.visit('/');
+
+      this.assertText('<b>blah</b>');
     }
 
-    ['@test [DEPRECATED] unescaped inline form (triple curlies) does not escape link title'](
+    async ['@test [DEPRECATED] unescaped inline form (triple curlies) does not escape link title'](
       assert
     ) {
       expectDeprecation(() => {
         this.addTemplate('application', `{{{link-to this.title 'index'}}}`);
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+
       this.add(
         'controller:application',
-        Controller.extend({
-          title: '<b>blah</b>',
-        })
+        class extends Controller {
+          title = '<b>blah</b>';
+        }
       );
 
-      return this.visit('/').then(() => {
-        this.assertText('blah');
-        assert.equal(this.$('b').length, 1);
-      });
+      await this.visit('/');
+
+      this.assertText('blah');
+      assert.equal(this.$('b').length, 1);
     }
 
-    ['@test able to safely extend the built-in component and use the normal path']() {
+    async ['@test able to safely extend the built-in component and use the normal path']() {
       this.addComponent('custom-link-to', {
-        ComponentClass: LinkComponent.extend(),
+        ComponentClass: class extends LinkComponent {},
       });
+
       this.addTemplate(
         'application',
         `{{#custom-link-to route='index'}}{{this.title}}{{/custom-link-to}}`
       );
+
       this.add(
         'controller:application',
-        Controller.extend({
-          title: 'Hello',
-        })
+        class extends Controller {
+          title = 'Hello';
+        }
       );
 
-      return this.visit('/').then(() => {
-        this.assertText('Hello');
-      });
+      await this.visit('/');
+
+      this.assertText('Hello');
     }
 
     async ['@test [DEPRECATED] [GH#13432] able to safely extend the built-in component and invoke it inline']() {
       this.addComponent('custom-link-to', {
-        ComponentClass: LinkComponent.extend(),
+        ComponentClass: class extends LinkComponent {},
       });
+
       this.addTemplate('application', `{{custom-link-to this.title 'index'}}`);
+
       this.add(
         'controller:application',
-        Controller.extend({
-          title: 'Hello',
-        })
+        class extends Controller {
+          title = 'Hello';
+        }
       );
 
       await expectDeprecationAsync(
@@ -153,13 +165,13 @@ moduleFor(
 moduleFor(
   '{{link-to}} component (rendering tests, without router)',
   class extends RenderingTestCase {
-    ['@test should be able to be inserted in DOM when the router is not present - block']() {
+    ['@test it should be able to be inserted in DOM when the router is not present - block']() {
       this.render(`{{#link-to route='index'}}Go to Index{{/link-to}}`);
 
       this.assertText('Go to Index');
     }
 
-    ['@test [DEPRECATED] should be able to be inserted in DOM when the router is not present - inline']() {
+    ['@test [DEPRECATED] it should be able to be inserted in DOM when the router is not present - inline']() {
       expectDeprecation(() => {
         this.render(`{{link-to 'Go to Index' 'index'}}`);
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -2,12 +2,10 @@ import {
   ApplicationTestCase,
   ModuleBasedTestResolver,
   moduleFor,
-  runLoopSettled,
   runTask,
 } from 'internal-test-helpers';
 import Controller, { inject as injectController } from '@ember/controller';
 import { A as emberA, RSVP } from '@ember/-internals/runtime';
-import { alias } from '@ember/-internals/metal';
 import { subscribe, reset } from '@ember/instrumentation';
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
@@ -61,50 +59,48 @@ moduleFor(
       );
     }
 
-    ['@test The <LinkTo /> component navigates into the named route'](assert) {
-      return this.visit('/')
-        .then(() => {
-          assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-          assert.equal(
-            this.$('#self-link.active').length,
-            1,
-            'The self-link was rendered with active class'
-          );
-          assert.equal(
-            this.$('#about-link:not(.active)').length,
-            1,
-            'The other link was rendered without active class'
-          );
+    async ['@test it navigates into the named route'](assert) {
+      await this.visit('/');
 
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
-          assert.equal(
-            this.$('#self-link.active').length,
-            1,
-            'The self-link was rendered with active class'
-          );
-          assert.equal(
-            this.$('#home-link:not(.active)').length,
-            1,
-            'The other link was rendered without active class'
-          );
-        });
+      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.equal(
+        this.$('#self-link.active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#about-link:not(.active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
+
+      await this.click('#about-link');
+
+      assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
+      assert.equal(
+        this.$('#self-link.active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#home-link:not(.active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
-    [`@test the <LinkTo /> component doesn't add an href when the tagName isn't 'a'`](assert) {
+    async [`@test it doesn't add an href when the tagName isn't 'a'`](assert) {
       this.addTemplate(
         'index',
         `<LinkTo @route='about' id='about-link' @tagName='div'>About</LinkTo>`
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#about-link').attr('href'), undefined, 'there is no href attribute');
-      });
+      await this.visit('/');
+
+      assert.strictEqual(this.$('#about-link').attr('href'), null, 'there is no href attribute');
     }
 
-    [`@test the <LinkTo /> component applies a 'disabled' class when disabled`](assert) {
+    async [`@test it applies a 'disabled' class when disabled`](assert) {
       this.addTemplate(
         'index',
         `
@@ -113,66 +109,70 @@ moduleFor(
         `
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          shouldDisable: true,
-          dynamicDisabledWhen: 'shouldDisable',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          shouldDisable = true;
+          dynamicDisabledWhen = 'shouldDisable';
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link-static.disabled').length,
-          1,
-          'The static link is disabled when its disabledWhen is true'
-        );
-        assert.equal(
-          this.$('#about-link-dynamic.disabled').length,
-          1,
-          'The dynamic link is disabled when its disabledWhen is true'
-        );
+      await this.visit('/');
 
-        let controller = this.applicationInstance.lookup('controller:index');
-        runTask(() => controller.set('dynamicDisabledWhen', false));
+      assert.equal(
+        this.$('#about-link-static.disabled').length,
+        1,
+        'The static link is disabled when its disabledWhen is true'
+      );
+      assert.equal(
+        this.$('#about-link-dynamic.disabled').length,
+        1,
+        'The dynamic link is disabled when its disabledWhen is true'
+      );
 
-        assert.equal(
-          this.$('#about-link-dynamic.disabled').length,
-          0,
-          'The dynamic link is re-enabled when its disabledWhen becomes false'
-        );
-      });
+      runTask(() => controller.set('dynamicDisabledWhen', false));
+
+      assert.equal(
+        this.$('#about-link-dynamic.disabled').length,
+        0,
+        'The dynamic link is re-enabled when its disabledWhen becomes false'
+      );
     }
 
-    [`@test the <LinkTo /> component doesn't apply a 'disabled' class if disabledWhen is not provided`](
-      assert
-    ) {
+    async [`@test it doesn't apply a 'disabled' class if disabledWhen is not provided`](assert) {
       this.addTemplate('index', `<LinkTo id="about-link" @route="about">About</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        assert.ok(
-          !this.$('#about-link').hasClass('disabled'),
-          'The link is not disabled if disabledWhen not provided'
-        );
-      });
+      await this.visit('/');
+
+      assert.ok(
+        !this.$('#about-link').hasClass('disabled'),
+        'The link is not disabled if disabledWhen not provided'
+      );
     }
 
-    [`@test the <LinkTo /> component supports a custom disabledClass`](assert) {
+    async [`@test it supports a custom disabledClass`](assert) {
       this.addTemplate(
         'index',
         `<LinkTo id="about-link" @route="about" @disabledWhen={{true}} @disabledClass="do-not-want">About</LinkTo>`
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link.do-not-want').length,
-          1,
-          'The link can apply a custom disabled class'
-        );
-      });
+      await this.visit('/');
+
+      assert.equal(
+        this.$('#about-link.do-not-want').length,
+        1,
+        'The link can apply a custom disabled class'
+      );
     }
 
-    [`@test the <LinkTo /> component supports a custom disabledClass set via bound param`](assert) {
+    async [`@test it supports a custom disabledClass set via bound param`](assert) {
       this.addTemplate(
         'index',
         `<LinkTo id="about-link" @route="about" @disabledWhen={{true}} @disabledClass={{this.disabledClass}}>About</LinkTo>`
@@ -180,144 +180,138 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          disabledClass: 'do-not-want',
-        })
+        class extends Controller {
+          disabledClass = 'do-not-want';
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link.do-not-want').length,
-          1,
-          'The link can apply a custom disabled class via bound param'
-        );
-      });
+      await this.visit('/');
+
+      assert.equal(
+        this.$('#about-link.do-not-want').length,
+        1,
+        'The link can apply a custom disabled class via bound param'
+      );
     }
 
-    [`@test the <LinkTo /> component does not respond to clicks when disabledWhen`](assert) {
+    async [`@test it does not respond to clicks when disabledWhen`](assert) {
       this.addTemplate(
         'index',
         `<LinkTo id="about-link" @route="about" @disabledWhen={{true}}>About</LinkTo>`
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 0, 'Transitioning did not occur');
-        });
+      await this.visit('/');
+
+      await this.click('#about-link');
+
+      assert.strictEqual(this.$('h3.about').length, 0, 'Transitioning did not occur');
     }
 
-    [`@test the <LinkTo /> component does not respond to clicks when disabled`](assert) {
+    async [`@test it does not respond to clicks when disabled`](assert) {
       this.addTemplate(
         'index',
         `<LinkTo id="about-link" @route="about" @disabled={{true}}>About</LinkTo>`
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 0, 'Transitioning did not occur');
-        });
+      await this.visit('/');
+
+      await this.click('#about-link');
+
+      assert.strictEqual(this.$('h3.about').length, 0, 'Transitioning did not occur');
     }
 
-    [`@test the <LinkTo /> component responds to clicks according to its disabledWhen bound param`](
-      assert
-    ) {
+    async [`@test it responds to clicks according to its disabledWhen bound param`](assert) {
       this.addTemplate(
         'index',
         `<LinkTo id="about-link" @route="about" @disabledWhen={{this.disabledWhen}}>About</LinkTo>`
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          disabledWhen: true,
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          disabledWhen = true;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 0, 'Transitioning did not occur');
+      await this.visit('/');
 
-          let controller = this.applicationInstance.lookup('controller:index');
-          controller.set('disabledWhen', false);
+      await this.click('#about-link');
 
-          return runLoopSettled();
-        })
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('h3.about').length,
-            1,
-            'Transitioning did occur when disabledWhen became false'
-          );
-        });
+      assert.strictEqual(this.$('h3.about').length, 0, 'Transitioning did not occur');
+
+      runTask(() => controller.set('disabledWhen', false));
+
+      await this.click('#about-link');
+
+      assert.equal(
+        this.$('h3.about').length,
+        1,
+        'Transitioning did occur when disabledWhen became false'
+      );
     }
 
-    [`@test The <LinkTo /> component supports a custom activeClass`](assert) {
+    async [`@test it supports a custom activeClass`](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        <LinkTo id='about-link' @route='about'>About</LinkTo>
+        <LinkTo id='about-link' @route='about' @activeClass='zomg-active'>About</LinkTo>
         <LinkTo id='self-link' @route='index' @activeClass='zomg-active'>Self</LinkTo>
         `
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-        assert.equal(
-          this.$('#self-link.zomg-active').length,
-          1,
-          'The self-link was rendered with active class'
-        );
-        assert.equal(
-          this.$('#about-link:not(.active)').length,
-          1,
-          'The other link was rendered without active class'
-        );
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.equal(
+        this.$('#self-link.zomg-active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#about-link:not(.zomg-active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
-    [`@test The <LinkTo /> component supports a custom activeClass from a bound param`](assert) {
+    async [`@test it supports a custom activeClass from a bound param`](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        <LinkTo id='about-link' @route='about'>About</LinkTo>
+        <LinkTo id='about-link' @route='about' @activeClass={{this.activeClass}}>About</LinkTo>
         <LinkTo id='self-link' @route='index' @activeClass={{this.activeClass}}>Self</LinkTo>
         `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          activeClass: 'zomg-active',
-        })
+        class extends Controller {
+          activeClass = 'zomg-active';
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-        assert.equal(
-          this.$('#self-link.zomg-active').length,
-          1,
-          'The self-link was rendered with active class'
-        );
-        assert.equal(
-          this.$('#about-link:not(.active)').length,
-          1,
-          'The other link was rendered without active class'
-        );
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.equal(
+        this.$('#self-link.zomg-active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#about-link:not(.zomg-active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
     async ['@test Using <LinkTo> inside a non-routable engine errors'](assert) {
@@ -535,18 +529,19 @@ moduleFor(
       this.replaceCount = 0;
 
       let testContext = this;
+
       this.add(
         'location:none',
-        NoneLocation.extend({
-          setURL() {
+        class extends NoneLocation {
+          setURL(...args) {
             testContext.updateCount++;
-            return this._super(...arguments);
-          },
-          replaceURL() {
+            return super.setURL(...args);
+          }
+          replaceURL(...args) {
             testContext.replaceCount++;
-            return this._super(...arguments);
-          },
-        })
+            return super.setURL(...args);
+          }
+        }
       );
 
       this.router.map(function () {
@@ -571,14 +566,14 @@ moduleFor(
       );
     }
 
-    visit() {
-      return super.visit(...arguments).then(() => {
-        this.updateCountAfterVisit = this.updateCount;
-        this.replaceCountAfterVisit = this.replaceCount;
-      });
+    async visit(...args) {
+      await super.visit(...args);
+
+      this.updateCountAfterVisit = this.updateCount;
+      this.replaceCountAfterVisit = this.replaceCount;
     }
 
-    ['@test The <LinkTo /> component supports URL replacement'](assert) {
+    async ['@test it supports URL replacement'](assert) {
       this.addTemplate(
         'index',
         `
@@ -587,23 +582,19 @@ moduleFor(
         `
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
-          assert.equal(
-            this.replaceCount,
-            this.replaceCountAfterVisit + 1,
-            'replaceURL should be called once'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#about-link');
+
+      assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
+      assert.equal(
+        this.replaceCount,
+        this.replaceCountAfterVisit + 1,
+        'replaceURL should be called once'
+      );
     }
 
-    ['@test The <LinkTo /> component supports URL replacement via replace=boundTruthyThing'](
-      assert
-    ) {
+    async ['@test it supports URL replacement via replace=boundTruthyThing'](assert) {
       this.addTemplate(
         'index',
         `
@@ -614,26 +605,24 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundTruthyThing: true,
-        })
+        class extends Controller {
+          boundTruthyThing = true;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
-          assert.equal(
-            this.replaceCount,
-            this.replaceCountAfterVisit + 1,
-            'replaceURL should be called once'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#about-link');
+
+      assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
+      assert.equal(
+        this.replaceCount,
+        this.replaceCountAfterVisit + 1,
+        'replaceURL should be called once'
+      );
     }
 
-    ['@test The <LinkTo /> component supports setting replace=boundFalseyThing'](assert) {
+    async ['@test it supports setting replace=boundFalseyThing'](assert) {
       this.addTemplate(
         'index',
         `
@@ -644,23 +633,21 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundFalseyThing: false,
-        })
+        class extends Controller {
+          boundFalseyThing = false;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.updateCount, this.updateCountAfterVisit + 1, 'setURL should be called');
-          assert.equal(
-            this.replaceCount,
-            this.replaceCountAfterVisit,
-            'replaceURL should not be called'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#about-link');
+
+      assert.equal(this.updateCount, this.updateCountAfterVisit + 1, 'setURL should be called');
+      assert.equal(
+        this.replaceCount,
+        this.replaceCountAfterVisit,
+        'replaceURL should not be called'
+      );
     }
   }
 );
@@ -704,53 +691,55 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
         return super.afterEach();
       }
 
-      ['@test The <LinkTo /> component fires an interaction event'](assert) {
-        assert.expect(2);
+      async ['@test it fires an interaction event'](assert) {
+        let before = 0;
+        let after = 0;
 
         subscribe('interaction.link-to', {
           before() {
-            assert.ok(true, 'instrumentation subscriber was called');
+            before++;
           },
           after() {
-            assert.ok(true, 'instrumentation subscriber was called');
+            after++;
           },
         });
 
-        return this.click('#about-link');
+        assert.strictEqual(before, 0, 'instrumentation subscriber (before) was not called');
+        assert.strictEqual(after, 0, 'instrumentation subscriber (after) was not called');
+
+        await this.click('#about-link');
+
+        assert.strictEqual(before, 1, 'instrumentation subscriber (before) was called');
+        assert.strictEqual(after, 1, 'instrumentation subscriber (after) was called');
       }
 
-      ['@test The <LinkTo /> component interaction event includes the route name'](assert) {
-        assert.expect(2);
+      async ['@test it interaction event includes the route name and transition object'](assert) {
+        let before = 0;
+        let after = 0;
 
         subscribe('interaction.link-to', {
           before(name, timestamp, { routeName }) {
+            before++;
             assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
           },
-          after(name, timestamp, { routeName }) {
+          after(name, timestamp, { routeName, transition }) {
+            after++;
             assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
-          },
-        });
-
-        return this.click('#about-link');
-      }
-
-      ['@test The <LinkTo /> component interaction event includes the transition in the after hook'](
-        assert
-      ) {
-        assert.expect(1);
-
-        subscribe('interaction.link-to', {
-          before() {},
-          after(name, timestamp, { transition }) {
             assert.equal(
               transition.targetName,
               'about',
-              'instrumentation subscriber was passed route name'
+              'instrumentation subscriber was passed transition object in the after hook'
             );
           },
         });
 
-        return this.click('#about-link');
+        assert.strictEqual(before, 0, 'instrumentation subscriber (before) was not called');
+        assert.strictEqual(after, 0, 'instrumentation subscriber (after) was not called');
+
+        await this.click('#about-link');
+
+        assert.strictEqual(before, 1, 'instrumentation subscriber (before) was called');
+        assert.strictEqual(after, 1, 'instrumentation subscriber (after) was called');
       }
     }
   );
@@ -759,7 +748,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 moduleFor(
   'The <LinkTo /> component - nested routes and link-to arguments',
   class extends ApplicationTestCase {
-    ['@test The <LinkTo /> component supports leaving off .index for nested routes'](assert) {
+    async ['@test it supports leaving off .index for nested routes'](assert) {
       this.router.map(function () {
         this.route('about', function () {
           this.route('item');
@@ -770,12 +759,12 @@ moduleFor(
       this.addTemplate('about.index', `<div id='index'>Index</div>`);
       this.addTemplate('about.item', `<div id='item'><LinkTo @route='about'>About</LinkTo></div>`);
 
-      return this.visit('/about/item').then(() => {
-        assert.equal(normalizeUrl(this.$('#item a').attr('href')), '/about');
-      });
+      await this.visit('/about/item');
+
+      assert.equal(normalizeUrl(this.$('#item a').attr('href')), '/about');
     }
 
-    [`@test The <LinkTo /> component supports custom, nested, current-when`](assert) {
+    async [`@test it supports custom, nested, current-when`](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -790,16 +779,16 @@ moduleFor(
         `<LinkTo id='other-link' @route='item' @current-when='index'>ITEM</LinkTo>`
       );
 
-      return this.visit('/about').then(() => {
-        assert.equal(
-          this.$('#other-link.active').length,
-          1,
-          'The link is active since current-when is a parent route'
-        );
-      });
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#other-link.active').length,
+        1,
+        'The link is active since current-when is a parent route'
+      );
     }
 
-    [`@test The <LinkTo /> component does not disregard current-when when it is given explicitly for a route`](
+    async [`@test it does not disregard current-when when it is given explicitly for a route`](
       assert
     ) {
       this.router.map(function () {
@@ -818,18 +807,16 @@ moduleFor(
         `<LinkTo id='other-link' @route='items' @current-when='index'>ITEM</LinkTo>`
       );
 
-      return this.visit('/about').then(() => {
-        assert.equal(
-          this.$('#other-link.active').length,
-          1,
-          'The link is active when current-when is given for explicitly for a route'
-        );
-      });
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#other-link.active').length,
+        1,
+        'The link is active when current-when is given for explicitly for a route'
+      );
     }
 
-    ['@test The <LinkTo /> component does not disregard current-when when it is set via a bound param'](
-      assert
-    ) {
+    async ['@test it does not disregard current-when when it is set via a bound param'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -842,9 +829,9 @@ moduleFor(
 
       this.add(
         'controller:index.about',
-        Controller.extend({
-          currentWhen: 'index',
-        })
+        class extends Controller {
+          currentWhen = 'index';
+        }
       );
 
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
@@ -853,16 +840,16 @@ moduleFor(
         `<LinkTo id='other-link' @route='items' @current-when={{this.currentWhen}}>ITEM</LinkTo>`
       );
 
-      return this.visit('/about').then(() => {
-        assert.equal(
-          this.$('#other-link.active').length,
-          1,
-          'The link is active when current-when is given for explicitly for a route'
-        );
-      });
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#other-link.active').length,
+        1,
+        'The link is active when current-when is given for explicitly for a route'
+      );
     }
 
-    ['@test The <LinkTo /> component supports multiple current-when routes'](assert) {
+    async ['@test it supports multiple current-when routes'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -885,35 +872,32 @@ moduleFor(
         `<LinkTo id='link3' @route='item' @current-when='item index'>ITEM</LinkTo>`
       );
 
-      return this.visit('/about')
-        .then(() => {
-          assert.equal(
-            this.$('#link1.active').length,
-            1,
-            'The link is active since current-when contains the parent route'
-          );
+      await this.visit('/about');
 
-          return this.visit('/item');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#link2.active').length,
-            1,
-            'The link is active since you are on the active route'
-          );
+      assert.equal(
+        this.$('#link1.active').length,
+        1,
+        'The link is active since current-when contains the parent route'
+      );
 
-          return this.visit('/foo');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#link3.active').length,
-            0,
-            'The link is not active since current-when does not contain the active route'
-          );
-        });
+      await this.visit('/item');
+
+      assert.equal(
+        this.$('#link2.active').length,
+        1,
+        'The link is active since you are on the active route'
+      );
+
+      await this.visit('/foo');
+
+      assert.equal(
+        this.$('#link3.active').length,
+        0,
+        'The link is not active since current-when does not contain the active route'
+      );
     }
 
-    ['@test The <LinkTo /> component supports boolean values for current-when'](assert) {
+    async ['@test it supports boolean values for current-when'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -929,33 +913,44 @@ moduleFor(
         `
       );
 
-      this.add('controller:index.about', Controller.extend({ isCurrent: false }));
+      let controller;
 
-      return this.visit('/about').then(() => {
-        assert.ok(
-          this.$('#about-link').hasClass('active'),
-          'The link is active since current-when is true'
-        );
-        assert.notOk(
-          this.$('#index-link').hasClass('active'),
-          'The link is not active since current-when is false'
-        );
+      this.add(
+        'controller:index.about',
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
 
-        let controller = this.applicationInstance.lookup('controller:index.about');
-        runTask(() => controller.set('isCurrent', true));
+          isCurrent = false;
+        }
+      );
 
-        assert.ok(
-          this.$('#index-link').hasClass('active'),
-          'The link is active since current-when is true'
-        );
-      });
+      await this.visit('/about');
+
+      assert.ok(
+        this.$('#about-link').hasClass('active'),
+        'The link is active since current-when is true'
+      );
+      assert.notOk(
+        this.$('#index-link').hasClass('active'),
+        'The link is not active since current-when is false'
+      );
+
+      runTask(() => controller.set('isCurrent', true));
+
+      assert.ok(
+        this.$('#index-link').hasClass('active'),
+        'The link is active since current-when is true'
+      );
     }
 
-    ['@test The <LinkTo /> component defaults to bubbling'](assert) {
+    async ['@test it defaults to bubbling'](assert) {
       this.addTemplate(
         'about',
         `
-        <div {{action 'hide'}}>
+        <div {{action this.hide}}>
           <LinkTo id='about-contact' @route='about.contact'>About</LinkTo>
         </div>
         {{outlet}}
@@ -973,32 +968,28 @@ moduleFor(
       let hidden = 0;
 
       this.add(
-        'route:about',
-        Route.extend({
-          actions: {
-            hide() {
-              hidden++;
-            },
-          },
-        })
+        'controller:about',
+        class extends Controller {
+          hide() {
+            hidden++;
+          }
+        }
       );
 
-      return this.visit('/about')
-        .then(() => {
-          return this.click('#about-contact');
-        })
-        .then(() => {
-          assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      await this.visit('/about');
 
-          assert.equal(hidden, 1, 'The link bubbles');
-        });
+      await this.click('#about-contact');
+
+      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+
+      assert.equal(hidden, 1, 'The link bubbles');
     }
 
-    [`@test The <LinkTo /> component supports bubbles=false`](assert) {
+    async [`@test it supports bubbles=false`](assert) {
       this.addTemplate(
         'about',
         `
-        <div {{action 'hide'}}>
+        <div {{action this.hide}}>
           <LinkTo id='about-contact' @route='about.contact' @bubbles={{false}}>
             About
           </LinkTo>
@@ -1018,32 +1009,28 @@ moduleFor(
       let hidden = 0;
 
       this.add(
-        'route:about',
-        Route.extend({
-          actions: {
-            hide() {
-              hidden++;
-            },
-          },
-        })
+        'controller:about',
+        class extends Controller {
+          hide() {
+            hidden++;
+          }
+        }
       );
 
-      return this.visit('/about')
-        .then(() => {
-          return this.click('#about-contact');
-        })
-        .then(() => {
-          assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      await this.visit('/about');
 
-          assert.equal(hidden, 0, "The link didn't bubble");
-        });
+      await this.click('#about-contact');
+
+      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+
+      assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
 
-    [`@test The <LinkTo /> component supports bubbles=boundFalseyThing`](assert) {
+    async [`@test it supports bubbles=boundFalseyThing`](assert) {
       this.addTemplate(
         'about',
         `
-        <div {{action 'hide'}}>
+        <div {{action this.hide}}>
           <LinkTo id='about-contact' @route='about.contact' @bubbles={{this.boundFalseyThing}}>
             About
           </LinkTo>
@@ -1054,11 +1041,17 @@ moduleFor(
 
       this.addTemplate('about.contact', `<h1 id='contact'>Contact</h1>`);
 
+      let hidden = 0;
+
       this.add(
         'controller:about',
-        Controller.extend({
-          boundFalseyThing: false,
-        })
+        class extends Controller {
+          boundFalseyThing = false;
+
+          hide() {
+            hidden++;
+          }
+        }
       );
 
       this.router.map(function () {
@@ -1067,30 +1060,15 @@ moduleFor(
         });
       });
 
-      let hidden = 0;
+      await this.visit('/about');
 
-      this.add(
-        'route:about',
-        Route.extend({
-          actions: {
-            hide() {
-              hidden++;
-            },
-          },
-        })
-      );
+      await this.click('#about-contact');
 
-      return this.visit('/about')
-        .then(() => {
-          return this.click('#about-contact');
-        })
-        .then(() => {
-          assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
-          assert.equal(hidden, 0, "The link didn't bubble");
-        });
+      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
 
-    async [`@test The <LinkTo /> component moves into the named route with context`](assert) {
+    async [`@test it moves into the named route with context`](assert) {
       this.router.map(function () {
         this.route('about');
         this.route('item', { path: '/item/:id' });
@@ -1132,15 +1110,15 @@ moduleFor(
 
       this.add(
         'route:about',
-        Route.extend({
+        class extends Route {
           model() {
             return [
               { id: 'yehuda', name: 'Yehuda Katz' },
               { id: 'tom', name: 'Tom Dale' },
               { id: 'erik', name: 'Erik Brynroflsson' },
             ];
-          },
-        })
+          }
+        }
       );
 
       await this.visit('/about');
@@ -1171,7 +1149,7 @@ moduleFor(
       assert.equal(this.$('p').text(), 'Erik Brynroflsson', 'The name is correct');
     }
 
-    [`@test The <LinkTo /> component binds some anchor html tag common attributes`](assert) {
+    async [`@test it binds some anchor html tag common attributes`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1182,15 +1160,15 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        let link = this.$('#self-link');
-        assert.equal(link.attr('title'), 'title-attr', 'The self-link contains title attribute');
-        assert.equal(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
-        assert.equal(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
-      });
+      await this.visit('/');
+
+      let link = this.$('#self-link');
+      assert.equal(link.attr('title'), 'title-attr', 'The self-link contains title attribute');
+      assert.equal(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
+      assert.equal(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
     }
 
-    [`@test The <LinkTo /> component supports 'target' attribute`](assert) {
+    async [`@test it supports 'target' attribute`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1199,15 +1177,13 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        let link = this.$('#self-link');
-        assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
-      });
+      await this.visit('/');
+
+      let link = this.$('#self-link');
+      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
     }
 
-    [`@test The <LinkTo /> component supports 'target' attribute specified as a bound param`](
-      assert
-    ) {
+    async [`@test it supports 'target' attribute specified as a bound param`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1218,30 +1194,30 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundLinkTarget: '_blank',
-        })
+        class extends Controller {
+          boundLinkTarget = '_blank';
+        }
       );
 
-      return this.visit('/').then(() => {
-        let link = this.$('#self-link');
-        assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
-      });
+      await this.visit('/');
+
+      let link = this.$('#self-link');
+      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
     }
 
-    [`@test the <LinkTo /> component calls preventDefault`](assert) {
+    async [`@test it calls preventDefault`](assert) {
       this.router.map(function () {
         this.route('about');
       });
 
       this.addTemplate('index', `<LinkTo @route='about' id='about-link'>About</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: true }, () => this.$('#about-link').click(), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: true }, () => this.$('#about-link').click(), assert);
     }
 
-    [`@test the <LinkTo /> component does not call preventDefault if '@preventDefault={{false}}' is passed as an option`](
+    async [`@test it does not call preventDefault if '@preventDefault={{false}}' is passed as an option`](
       assert
     ) {
       this.router.map(function () {
@@ -1253,12 +1229,12 @@ moduleFor(
         `<LinkTo id='about-link' @route='about' @preventDefault={{false}}>About</LinkTo>`
       );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
     }
 
-    [`@test the <LinkTo /> component does not call preventDefault if '@preventDefault={{this.boundFalseyThing}}' is passed as an option`](
+    async [`@test it does not call preventDefault if '@preventDefault={{this.boundFalseyThing}}' is passed as an option`](
       assert
     ) {
       this.router.map(function () {
@@ -1272,19 +1248,17 @@ moduleFor(
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundFalseyThing: false,
-        })
+        class extends Controller {
+          boundFalseyThing = false;
+        }
       );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
     }
 
-    [`@test The <LinkTo /> component does not call preventDefault if 'target' attribute is provided`](
-      assert
-    ) {
+    async [`@test it does not call preventDefault if 'target' attribute is provided`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1293,12 +1267,12 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#self-link').click(), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: false }, () => this.$('#self-link').click(), assert);
     }
 
-    [`@test The <LinkTo /> component should preventDefault when 'target = _self'`](assert) {
+    async [`@test it should preventDefault when 'target = _self'`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1307,14 +1281,12 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: true }, () => this.$('#self-link').click(), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: true }, () => this.$('#self-link').click(), assert);
     }
 
-    [`@test The <LinkTo /> component should not transition if target is not equal to _self or empty`](
-      assert
-    ) {
+    async [`@test it should not transition if target is not equal to _self or empty`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1328,23 +1300,23 @@ moduleFor(
         this.route('about');
       });
 
-      return this.visit('/')
-        .then(() => this.click('#about-link'))
-        .then(() => {
-          expectDeprecation(() => {
-            let currentRouteName = this.applicationInstance
-              .lookup('controller:application')
-              .get('currentRouteName');
-            assert.notEqual(
-              currentRouteName,
-              'about',
-              'link-to should not transition if target is not equal to _self or empty'
-            );
-          }, 'Accessing `currentRouteName` on `controller:application` is deprecated, use the `currentRouteName` property on `service:router` instead.');
-        });
+      await this.visit('/');
+
+      await this.click('#about-link');
+
+      expectDeprecation(() => {
+        let currentRouteName = this.applicationInstance
+          .lookup('controller:application')
+          .get('currentRouteName');
+        assert.notEqual(
+          currentRouteName,
+          'about',
+          'link-to should not transition if target is not equal to _self or empty'
+        );
+      }, 'Accessing `currentRouteName` on `controller:application` is deprecated, use the `currentRouteName` property on `service:router` instead.');
     }
 
-    [`@test The <LinkTo /> component accepts string/numeric arguments`](assert) {
+    async [`@test it accepts string/numeric arguments`](assert) {
       this.router.map(function () {
         this.route('filter', { path: '/filters/:filter' });
         this.route('post', { path: '/post/:post_id' });
@@ -1353,11 +1325,11 @@ moduleFor(
 
       this.add(
         'controller:filter',
-        Controller.extend({
-          filter: 'unpopular',
-          repo: { owner: 'ember', name: 'ember.js' },
-          post_id: 123,
-        })
+        class extends Controller {
+          filter = 'unpopular';
+          repo = { owner: 'ember', name: 'ember.js' };
+          post_id = 123;
+        }
       );
 
       this.addTemplate(
@@ -1372,22 +1344,18 @@ moduleFor(
         `
       );
 
-      return this.visit('/filters/popular').then(() => {
-        assert.equal(normalizeUrl(this.$('#link').attr('href')), '/filters/unpopular');
-        assert.equal(normalizeUrl(this.$('#path-link').attr('href')), '/filters/unpopular');
-        assert.equal(normalizeUrl(this.$('#post-path-link').attr('href')), '/post/123');
-        assert.equal(normalizeUrl(this.$('#post-number-link').attr('href')), '/post/123');
-        assert.equal(
-          normalizeUrl(this.$('#repo-object-link').attr('href')),
-          '/repo/ember/ember.js'
-        );
-      });
+      await this.visit('/filters/popular');
+
+      assert.equal(normalizeUrl(this.$('#link').attr('href')), '/filters/unpopular');
+      assert.equal(normalizeUrl(this.$('#path-link').attr('href')), '/filters/unpopular');
+      assert.equal(normalizeUrl(this.$('#post-path-link').attr('href')), '/post/123');
+      assert.equal(normalizeUrl(this.$('#post-number-link').attr('href')), '/post/123');
+      assert.equal(normalizeUrl(this.$('#repo-object-link').attr('href')), '/repo/ember/ember.js');
     }
 
-    [`@test Issue 4201 - Shorthand for route.index shouldn't throw errors about context arguments`](
+    async [`@test [GH#4201] Shorthand for route.index shouldn't throw errors about context arguments`](
       assert
     ) {
-      assert.expect(2);
       this.router.map(function () {
         this.route('lobby', function () {
           this.route('index', { path: ':lobby_id' });
@@ -1397,12 +1365,12 @@ moduleFor(
 
       this.add(
         'route:lobby.index',
-        Route.extend({
+        class extends Route {
           model(params) {
             assert.equal(params.lobby_id, 'foobar');
             return params.lobby_id;
-          },
-        })
+          }
+        }
       );
 
       this.addTemplate(
@@ -1415,12 +1383,14 @@ moduleFor(
         `<LinkTo id='lobby-link' @route='lobby' @model='foobar'>Lobby</LinkTo>`
       );
 
-      return this.visit('/lobby/list')
-        .then(() => this.click('#lobby-link'))
-        .then(() => shouldBeActive(assert, this.$('#lobby-link')));
+      await this.visit('/lobby/list');
+
+      await this.click('#lobby-link');
+
+      shouldBeActive(assert, this.$('#lobby-link'));
     }
 
-    [`@test Quoteless route param performs property lookup`](assert) {
+    async [`@test Quoteless route param performs property lookup`](assert) {
       this.router.map(function () {
         this.route('about');
       });
@@ -1433,11 +1403,18 @@ moduleFor(
         `
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          foo: 'index',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          foo = 'index';
+        }
       );
 
       let assertEquality = (href) => {
@@ -1445,17 +1422,16 @@ moduleFor(
         assert.equal(normalizeUrl(this.$('#path-link').attr('href')), href);
       };
 
-      return this.visit('/').then(() => {
-        assertEquality('/');
+      await this.visit('/');
 
-        let controller = this.applicationInstance.lookup('controller:index');
-        runTask(() => controller.set('foo', 'about'));
+      assertEquality('/');
 
-        assertEquality('/about');
-      });
+      runTask(() => controller.set('foo', 'about'));
+
+      assertEquality('/about');
     }
 
-    [`@test The <LinkTo /> component refreshes href element when one of params changes`](assert) {
+    async [`@test it refreshes href element when one of params changes`](assert) {
       this.router.map(function () {
         this.route('post', { path: '/posts/:post_id' });
       });
@@ -1468,37 +1444,46 @@ moduleFor(
         `<LinkTo id="post" @route="post" @model={{this.post}}>post</LinkTo>`
       );
 
-      this.add('controller:index', Controller.extend());
+      let controller;
 
-      return this.visit('/').then(() => {
-        let indexController = this.applicationInstance.lookup('controller:index');
-        runTask(() => indexController.set('post', post));
+      this.add(
+        'controller:index',
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+        }
+      );
 
-        assert.equal(
-          normalizeUrl(this.$('#post').attr('href')),
-          '/posts/1',
-          'precond - Link has rendered href attr properly'
-        );
+      await this.visit('/');
 
-        runTask(() => indexController.set('post', secondPost));
+      runTask(() => controller.set('post', post));
 
-        assert.equal(
-          this.$('#post').attr('href'),
-          '/posts/2',
-          'href attr was updated after one of the params had been changed'
-        );
+      assert.equal(
+        normalizeUrl(this.$('#post').attr('href')),
+        '/posts/1',
+        'precond - Link has rendered href attr properly'
+      );
 
-        runTask(() => indexController.set('post', null));
+      runTask(() => controller.set('post', secondPost));
 
-        assert.equal(
-          this.$('#post').attr('href'),
-          '#',
-          'href attr becomes # when one of the arguments in nullified'
-        );
-      });
+      assert.equal(
+        this.$('#post').attr('href'),
+        '/posts/2',
+        'href attr was updated after one of the params had been changed'
+      );
+
+      runTask(() => controller.set('post', null));
+
+      assert.equal(
+        this.$('#post').attr('href'),
+        '#',
+        'href attr becomes # when one of the arguments in nullified'
+      );
     }
 
-    [`@test The <LinkTo /> component is active when a route is active`](assert) {
+    async [`@test it is active when a route is active`](assert) {
       this.router.map(function () {
         this.route('about', function () {
           this.route('item');
@@ -1516,33 +1501,38 @@ moduleFor(
         `
       );
 
-      return this.visit('/about')
-        .then(() => {
-          assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
-          assert.equal(this.$('#item-link.active').length, 0, 'The item route link is inactive');
+      await this.visit('/about');
 
-          return this.visit('/about/item');
-        })
-        .then(() => {
-          assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
-          assert.equal(this.$('#item-link.active').length, 1, 'The item route link is active');
-        });
+      assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
+      assert.equal(this.$('#item-link.active').length, 0, 'The item route link is inactive');
+
+      await this.visit('/about/item');
+
+      assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
+      assert.equal(this.$('#item-link.active').length, 1, 'The item route link is active');
     }
 
-    [`@test The <LinkTo /> component works in an #each'd array of string route names`](assert) {
+    async [`@test it works in an #each'd array of string route names`](assert) {
       this.router.map(function () {
         this.route('foo');
         this.route('bar');
         this.route('rar');
       });
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          routeNames: emberA(['foo', 'bar', 'rar']),
-          route1: 'bar',
-          route2: 'foo',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          routeNames = emberA(['foo', 'bar', 'rar']);
+          route1 = 'bar';
+          route2 = 'foo';
+        }
       );
 
       this.addTemplate(
@@ -1574,21 +1564,20 @@ moduleFor(
         }
       };
 
-      return this.visit('/').then(() => {
-        linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/bar', '/foo']);
+      await this.visit('/');
 
-        let indexController = this.applicationInstance.lookup('controller:index');
-        runTask(() => indexController.set('route1', 'rar'));
+      linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/bar', '/foo']);
 
-        linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/rar', '/foo']);
+      runTask(() => controller.set('route1', 'rar'));
 
-        runTask(() => indexController.routeNames.shiftObject());
+      linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/rar', '/foo']);
 
-        linksEqual(this.$('a'), ['/bar', '/rar', '/bar', '/rar', '/rar', '/foo']);
-      });
+      runTask(() => controller.routeNames.shiftObject());
+
+      linksEqual(this.$('a'), ['/bar', '/rar', '/bar', '/rar', '/rar', '/foo']);
     }
 
-    async [`@test the <LinkTo /> component throws a useful error if you invoke it wrong`](assert) {
+    async [`@test it throws a useful error if you invoke it wrong`](assert) {
       if (!DEBUG) {
         assert.expect(0);
         return;
@@ -1606,7 +1595,7 @@ moduleFor(
       );
     }
 
-    [`@test the <LinkTo /> component does not throw an error if its route has exited`](assert) {
+    async [`@test it does not throw an error if its route has exited`](assert) {
       assert.expect(0);
 
       this.router.map(function () {
@@ -1626,37 +1615,39 @@ moduleFor(
 
       this.add(
         'controller:application',
-        Controller.extend({
-          defaultPost: { id: 1 },
-          postController: injectController('post'),
-          currentPost: alias('postController.model'),
-        })
+        class extends Controller {
+          defaultPost = { id: 1 };
+
+          @injectController('post') postController;
+
+          get currentPost() {
+            return this.postController.model;
+          }
+        }
       );
 
-      this.add('controller:post', Controller.extend());
+      this.add('controller:post', class extends Controller {});
 
       this.add(
         'route:post',
-        Route.extend({
+        class extends Route {
           model() {
             return { id: 2 };
-          },
+          }
           serialize(model) {
             return { post_id: model.id };
-          },
-        })
+          }
+        }
       );
 
-      return this.visit('/')
-        .then(() => this.click('#default-post-link'))
-        .then(() => this.click('#home-link'))
-        .then(() => this.click('#current-post-link'))
-        .then(() => this.click('#home-link'));
+      await this.visit('/');
+      await this.click('#default-post-link');
+      await this.click('#home-link');
+      await this.click('#current-post-link');
+      await this.click('#home-link');
     }
 
-    [`@test the <LinkTo /> component's active property respects changing parent route context`](
-      assert
-    ) {
+    async [`@test its active property respects changing parent route context`](assert) {
       this.router.map(function () {
         this.route('things', { path: '/things/:name' }, function () {
           this.route('other');
@@ -1671,46 +1662,44 @@ moduleFor(
         `
       );
 
-      return this.visit('/things/omg')
-        .then(() => {
-          shouldBeActive(assert, this.$('#omg-link'));
-          shouldNotBeActive(assert, this.$('#lol-link'));
+      await this.visit('/things/omg');
 
-          return this.visit('/things/omg/other');
-        })
-        .then(() => {
-          shouldBeActive(assert, this.$('#omg-link'));
-          shouldNotBeActive(assert, this.$('#lol-link'));
-        });
+      shouldBeActive(assert, this.$('#omg-link'));
+      shouldNotBeActive(assert, this.$('#lol-link'));
+
+      await this.visit('/things/omg/other');
+
+      shouldBeActive(assert, this.$('#omg-link'));
+      shouldNotBeActive(assert, this.$('#lol-link'));
     }
 
-    [`@test the <LinkTo /> component populates href with default query param values even without query-params object`](
+    async [`@test it populates href with default query param values even without query-params object`](
       assert
     ) {
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['foo'],
-          foo: '123',
-        })
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = '123';
+        }
       );
 
       this.addTemplate('index', `<LinkTo id='the-link' @route='index'>Index</LinkTo>`);
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
     }
 
-    [`@test the <LinkTo /> component populates href with default query param values with empty query-params object`](
+    async [`@test it populates href with default query param values with empty query-params object`](
       assert
     ) {
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['foo'],
-          foo: '123',
-        })
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = '123';
+        }
       );
 
       this.addTemplate(
@@ -1718,25 +1707,23 @@ moduleFor(
         `<LinkTo id='the-link' @route='index' @query={{hash}}>Index</LinkTo>`
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
     }
 
-    [`@test the <LinkTo /> component with only query-params and a block updates when route changes`](
-      assert
-    ) {
+    async [`@test it updates when route changes with only query-params and a block`](assert) {
       this.router.map(function () {
         this.route('about');
       });
 
       this.add(
         'controller:application',
-        Controller.extend({
-          queryParams: ['foo', 'bar'],
-          foo: '123',
-          bar: 'yes',
-        })
+        class extends Controller {
+          queryParams = ['foo', 'bar'];
+          foo = '123';
+          bar = 'yes';
+        }
       );
 
       this.addTemplate(
@@ -1744,39 +1731,33 @@ moduleFor(
         `<LinkTo id='the-link' @query={{hash foo='456' bar='NAW'}}>Index</LinkTo>`
       );
 
-      return this.visit('/')
-        .then(() => {
-          assert.equal(
-            this.$('#the-link').attr('href'),
-            '/?bar=NAW&foo=456',
-            'link has right href'
-          );
+      await this.visit('/');
 
-          return this.visit('/about');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#the-link').attr('href'),
-            '/about?bar=NAW&foo=456',
-            'link has right href'
-          );
-        });
+      assert.equal(this.$('#the-link').attr('href'), '/?bar=NAW&foo=456', 'link has right href');
+
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#the-link').attr('href'),
+        '/about?bar=NAW&foo=456',
+        'link has right href'
+      );
     }
 
-    ['@test [GH#17018] passing model to <LinkTo /> with `hash` helper works']() {
+    async ['@test [GH#17018] passing model to <LinkTo /> with `hash` helper works']() {
       this.router.map(function () {
         this.route('post', { path: '/posts/:post_id' });
       });
 
       this.add(
         'route:index',
-        Route.extend({
+        class extends Route {
           model() {
             return RSVP.hash({
               user: { name: 'Papa Smurf' },
             });
-          },
-        })
+          }
+        }
       );
 
       this.addTemplate(
@@ -1786,19 +1767,17 @@ moduleFor(
 
       this.addTemplate('post', 'Post: {{@model.user.name}}');
 
-      return this.visit('/')
-        .then(() => {
-          this.assertComponentElement(this.firstChild, {
-            tagName: 'a',
-            attrs: { href: '/posts/someId' },
-            content: 'Post',
-          });
+      await this.visit('/');
 
-          return this.click('a');
-        })
-        .then(() => {
-          this.assertText('Post: Papa Smurf');
-        });
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/posts/someId' },
+        content: 'Post',
+      });
+
+      await this.click('a');
+
+      this.assertText('Post: Papa Smurf');
     }
 
     async [`@test [DEPRECATED] The <LinkTo /> component can use dynamic params`](assert) {
@@ -1807,14 +1786,18 @@ moduleFor(
         this.route('bar', { path: 'bar/:some/:thing/:else' });
       });
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          init() {
-            this._super(...arguments);
-            this.dynamicLinkParams = ['foo', 'one', 'two'];
-          },
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          dynamicLinkParams = ['foo', 'one', 'two'];
+        }
       );
 
       this.addTemplate(
@@ -1834,22 +1817,17 @@ moduleFor(
 
       assert.equal(link.attr('href'), '/foo/one/two');
 
-      let controller = this.applicationInstance.lookup('controller:index');
-
-      expectDeprecation(() => {
-        runTask(() => {
-          controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three']);
-        });
-      }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+      expectDeprecation(
+        () => runTask(() => controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three'])),
+        /Invoking the `<LinkTo>` component with positional arguments is deprecated/
+      );
 
       assert.equal(link.attr('href'), '/bar/one/two/three');
     }
 
-    [`@test GJ: <LinkTo /> to a parent root model hook which performs a 'transitionTo' has correct active class #13256`](
+    async [`@test [GH#13256]: <LinkTo /> to a parent root model hook which performs a 'transitionTo' has correct active class`](
       assert
     ) {
-      assert.expect(3);
-
       this.router.map(function () {
         this.route('parent', function () {
           this.route('child');
@@ -1858,24 +1836,22 @@ moduleFor(
 
       this.add(
         'route:parent',
-        Route.extend({
+        class extends Route {
           afterModel() {
             expectDeprecation(() => {
               this.transitionTo('parent.child');
             }, /Calling transitionTo on a route is deprecated/);
-          },
-        })
+          }
+        }
       );
 
       this.addTemplate('application', `<LinkTo id='parent-link' @route='parent'>Parent</LinkTo>`);
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#parent-link');
-        })
-        .then(() => {
-          shouldBeActive(assert, this.$('#parent-link'));
-        });
+      await this.visit('/');
+
+      await this.click('#parent-link');
+
+      shouldBeActive(assert, this.$('#parent-link'));
     }
   }
 );
@@ -1883,8 +1859,9 @@ moduleFor(
 moduleFor(
   'The <LinkTo /> component - loading states and warnings',
   class extends ApplicationTestCase {
-    [`@test <LinkTo /> with null/undefined dynamic parameters are put in a loading state`](assert) {
-      assert.expect(19);
+    async [`@test <LinkTo /> with null/undefined dynamic parameters are put in a loading state`](
+      assert
+    ) {
       let warningMessage =
         'This link is in an inactive loading state because at least one of its models currently has a null/undefined value, or the provided route name is invalid.';
 
@@ -1905,22 +1882,31 @@ moduleFor(
         `
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          destinationRoute: null,
-          routeContext: null,
-          loadingClass: 'i-am-loading',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          destinationRoute = null;
+          routeContext = null;
+          loadingClass = 'i-am-loading';
+        }
       );
+
+      let activate = 0;
 
       this.add(
         'route:about',
-        Route.extend({
+        class extends Route {
           activate() {
-            assert.ok(true, 'About was entered');
-          },
-        })
+            activate++;
+          }
+        }
       );
 
       function assertLinkStatus(link, url) {
@@ -1933,55 +1919,45 @@ moduleFor(
         }
       }
 
-      let contextLink, staticLink, controller;
+      await this.visit('/');
 
-      return this.visit('/')
-        .then(() => {
-          contextLink = this.$('#context-link');
-          staticLink = this.$('#static-link');
-          controller = this.applicationInstance.lookup('controller:index');
+      let contextLink = this.$('#context-link');
+      let staticLink = this.$('#static-link');
 
-          assertLinkStatus(contextLink);
-          assertLinkStatus(staticLink);
+      assertLinkStatus(contextLink);
+      assertLinkStatus(staticLink);
 
-          return expectWarning(() => {
-            return this.click(contextLink[0]);
-          }, warningMessage);
-        })
-        .then(() => {
-          // Set the destinationRoute (context is still null).
-          runTask(() => controller.set('destinationRoute', 'thing'));
-          assertLinkStatus(contextLink);
+      await expectWarning(() => this.click(contextLink[0]), warningMessage);
 
-          // Set the routeContext to an id
-          runTask(() => controller.set('routeContext', '456'));
-          assertLinkStatus(contextLink, '/thing/456');
+      // Set the destinationRoute (context is still null).
+      runTask(() => controller.set('destinationRoute', 'thing'));
+      assertLinkStatus(contextLink);
 
-          // Test that 0 isn't interpreted as falsy.
-          runTask(() => controller.set('routeContext', 0));
-          assertLinkStatus(contextLink, '/thing/0');
+      // Set the routeContext to an id
+      runTask(() => controller.set('routeContext', '456'));
+      assertLinkStatus(contextLink, '/thing/456');
 
-          // Set the routeContext to an object
-          runTask(() => {
-            controller.set('routeContext', { id: 123 });
-          });
-          assertLinkStatus(contextLink, '/thing/123');
+      // Test that 0 isn't interpreted as falsy.
+      runTask(() => controller.set('routeContext', 0));
+      assertLinkStatus(contextLink, '/thing/0');
 
-          // Set the destinationRoute back to null.
-          runTask(() => controller.set('destinationRoute', null));
-          assertLinkStatus(contextLink);
+      // Set the routeContext to an object
+      runTask(() => controller.set('routeContext', { id: 123 }));
+      assertLinkStatus(contextLink, '/thing/123');
 
-          return expectWarning(() => {
-            return this.click(staticLink[0]);
-          }, warningMessage);
-        })
-        .then(() => {
-          runTask(() => controller.set('secondRoute', 'about'));
-          assertLinkStatus(staticLink, '/about');
+      // Set the destinationRoute back to null.
+      runTask(() => controller.set('destinationRoute', null));
+      assertLinkStatus(contextLink);
 
-          // Click the now-active link
-          return this.click(staticLink[0]);
-        });
+      await expectWarning(() => this.click(staticLink[0]), warningMessage);
+
+      runTask(() => controller.set('secondRoute', 'about'));
+      assertLinkStatus(staticLink, '/about');
+
+      // Click the now-active link
+      await this.click(staticLink[0]);
+
+      assert.equal(activate, 1, 'About route was entered');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -2,12 +2,10 @@ import {
   ApplicationTestCase,
   ModuleBasedTestResolver,
   moduleFor,
-  runLoopSettled,
   runTask,
 } from 'internal-test-helpers';
 import Controller, { inject as injectController } from '@ember/controller';
 import { A as emberA, RSVP } from '@ember/-internals/runtime';
-import { alias } from '@ember/-internals/metal';
 import { subscribe, reset } from '@ember/instrumentation';
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
@@ -47,319 +45,326 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link'}}About{{/link-to}}
-        {{#link-to route='index' id='self-link'}}Self{{/link-to}}
+        <div id="about-link">{{#link-to route='about'}}About{{/link-to}}</div>
+        <div id="self-link">{{#link-to route='index'}}Self{{/link-to}}</div>
         `
       );
       this.addTemplate(
         'about',
         `
         <h3 class="about">About</h3>
-        {{#link-to route='index' id='home-link'}}Home{{/link-to}}
-        {{#link-to route='about' id='self-link'}}Self{{/link-to}}
+        <div id="home-link">{{#link-to route='index'}}Home{{/link-to}}</div>
+        <div id="self-link">{{#link-to route='about'}}Self{{/link-to}}</div>
         `
       );
     }
 
-    ['@test The {{link-to}} component navigates into the named route'](assert) {
-      return this.visit('/')
-        .then(() => {
-          assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-          assert.equal(
-            this.$('#self-link.active').length,
-            1,
-            'The self-link was rendered with active class'
-          );
-          assert.equal(
-            this.$('#about-link:not(.active)').length,
-            1,
-            'The other link was rendered without active class'
-          );
+    async ['@test it navigates into the named route'](assert) {
+      await this.visit('/');
 
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
-          assert.equal(
-            this.$('#self-link.active').length,
-            1,
-            'The self-link was rendered with active class'
-          );
-          assert.equal(
-            this.$('#home-link:not(.active)').length,
-            1,
-            'The other link was rendered without active class'
-          );
-        });
-    }
-
-    [`@test the {{link-to}} component doesn't add an href when the tagName isn't 'a'`](assert) {
-      this.addTemplate(
-        'index',
-        `{{#link-to route='about' id='about-link' tagName='div'}}About{{/link-to}}`
+      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.equal(
+        this.$('#self-link a.active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#about-link > a:not(.active)').length,
+        1,
+        'The other link was rendered without active class'
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#about-link').attr('href'), undefined, 'there is no href attribute');
-      });
+      await this.click('#about-link > a');
+
+      assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
+      assert.equal(
+        this.$('#self-link > a.active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#home-link > a:not(.active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
-    [`@test the {{link-to}} component applies a 'disabled' class when disabled`](assert) {
+    async [`@test it doesn't add an href when the tagName isn't 'a'`](assert) {
+      this.addTemplate(
+        'index',
+        `<div id='about-link'>{{#link-to route='about' tagName='div'}}About{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      assert.strictEqual(
+        this.$('#about-link > div').attr('href'),
+        null,
+        'there is no href attribute'
+      );
+    }
+
+    async [`@test it applies a 'disabled' class when disabled`](assert) {
       this.addTemplate(
         'index',
         `
-        {{#link-to route="about" id="about-link-static" disabledWhen="shouldDisable"}}About{{/link-to}}
-        {{#link-to route="about" id="about-link-dynamic" disabledWhen=this.dynamicDisabledWhen}}About{{/link-to}}
+        <div id="about-link-static">{{#link-to route="about" disabledWhen="shouldDisable"}}About{{/link-to}}</div>
+        <div id="about-link-dynamic">{{#link-to route="about" disabledWhen=this.dynamicDisabledWhen}}About{{/link-to}}</div>
         `
       );
 
-      this.add(
-        'controller:index',
-        Controller.extend({
-          shouldDisable: true,
-          dynamicDisabledWhen: 'shouldDisable',
-        })
-      );
-
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link-static.disabled').length,
-          1,
-          'The static link is disabled when its disabledWhen is true'
-        );
-        assert.equal(
-          this.$('#about-link-dynamic.disabled').length,
-          1,
-          'The dynamic link is disabled when its disabledWhen is true'
-        );
-
-        let controller = this.applicationInstance.lookup('controller:index');
-        runTask(() => controller.set('dynamicDisabledWhen', false));
-
-        assert.equal(
-          this.$('#about-link-dynamic.disabled').length,
-          0,
-          'The dynamic link is re-enabled when its disabledWhen becomes false'
-        );
-      });
-    }
-
-    [`@test the {{link-to}} component doesn't apply a 'disabled' class if disabledWhen is not provided`](
-      assert
-    ) {
-      this.addTemplate('index', `{{#link-to route="about" id="about-link"}}About{{/link-to}}`);
-
-      return this.visit('/').then(() => {
-        assert.ok(
-          !this.$('#about-link').hasClass('disabled'),
-          'The link is not disabled if disabledWhen not provided'
-        );
-      });
-    }
-
-    [`@test the {{link-to}} component supports a custom disabledClass`](assert) {
-      this.addTemplate(
-        'index',
-        `{{#link-to route="about" id="about-link" disabledWhen=true disabledClass="do-not-want"}}About{{/link-to}}`
-      );
-
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link.do-not-want').length,
-          1,
-          'The link can apply a custom disabled class'
-        );
-      });
-    }
-
-    [`@test the {{link-to}} component supports a custom disabledClass set via bound param`](
-      assert
-    ) {
-      this.addTemplate(
-        'index',
-        `{{#link-to route="about" id="about-link" disabledWhen=true disabledClass=this.disabledClass}}About{{/link-to}}`
-      );
+      let controller;
 
       this.add(
         'controller:index',
-        Controller.extend({
-          disabledClass: 'do-not-want',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          shouldDisable = true;
+          dynamicDisabledWhen = 'shouldDisable';
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link.do-not-want').length,
-          1,
-          'The link can apply a custom disabled class via bound param'
-        );
-      });
-    }
+      await this.visit('/');
 
-    [`@test the {{link-to}} component does not respond to clicks when disabledWhen`](assert) {
-      this.addTemplate(
-        'index',
-        `{{#link-to route="about" id="about-link" disabledWhen=true}}About{{/link-to}}`
+      assert.equal(
+        this.$('#about-link-static > a.disabled').length,
+        1,
+        'The static link is disabled when its disabledWhen is true'
+      );
+      assert.equal(
+        this.$('#about-link-dynamic > a.disabled').length,
+        1,
+        'The dynamic link is disabled when its disabledWhen is true'
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 0, 'Transitioning did not occur');
-        });
+      runTask(() => controller.set('dynamicDisabledWhen', false));
+
+      assert.equal(
+        this.$('#about-link-dynamic > a.disabled').length,
+        0,
+        'The dynamic link is re-enabled when its disabledWhen becomes false'
+      );
     }
 
-    [`@test the {{link-to}} component does not respond to clicks when disabled`](assert) {
+    async [`@test it doesn't apply a 'disabled' class if disabledWhen is not provided`](assert) {
       this.addTemplate(
         'index',
-        `{{#link-to route="about" id="about-link" disabled=true}}About{{/link-to}}`
+        `<div id="about-link">{{#link-to route="about"}}About{{/link-to}}</div>`
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 0, 'Transitioning did not occur');
-        });
+      await this.visit('/');
+
+      assert.ok(
+        !this.$('#about-link > a').hasClass('disabled'),
+        'The link is not disabled if disabledWhen not provided'
+      );
     }
 
-    [`@test the {{link-to}} component responds to clicks according to its disabledWhen bound param`](
-      assert
-    ) {
+    async [`@test it supports a custom disabledClass`](assert) {
       this.addTemplate(
         'index',
-        `{{#link-to route="about" id="about-link" disabledWhen=this.disabledWhen}}About{{/link-to}}`
+        `<div id="about-link">{{#link-to route="about" disabledWhen=true disabledClass="do-not-want"}}About{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      assert.equal(
+        this.$('#about-link > a.do-not-want').length,
+        1,
+        'The link can apply a custom disabled class'
+      );
+    }
+
+    async [`@test it supports a custom disabledClass set via bound param`](assert) {
+      this.addTemplate(
+        'index',
+        `<div id="about-link">{{#link-to route="about" disabledWhen=true disabledClass=this.disabledClass}}About{{/link-to}}</div>`
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          disabledWhen: true,
-        })
+        class extends Controller {
+          disabledClass = 'do-not-want';
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.about').length, 0, 'Transitioning did not occur');
+      await this.visit('/');
 
-          let controller = this.applicationInstance.lookup('controller:index');
-          controller.set('disabledWhen', false);
-
-          return runLoopSettled();
-        })
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('h3.about').length,
-            1,
-            'Transitioning did occur when disabledWhen became false'
-          );
-        });
+      assert.equal(
+        this.$('#about-link > a.do-not-want').length,
+        1,
+        'The link can apply a custom disabled class via bound param'
+      );
     }
 
-    [`@test The {{link-to}} component supports a custom activeClass`](assert) {
+    async [`@test it does not respond to clicks when disabledWhen`](assert) {
+      this.addTemplate(
+        'index',
+        `<div id="about-link">{{#link-to route="about" disabledWhen=true}}About{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      assert.strictEqual(this.$('h3.about').length, 0, 'Transitioning did not occur');
+    }
+
+    async [`@test it does not respond to clicks when disabled`](assert) {
+      this.addTemplate(
+        'index',
+        `<div id="about-link">{{#link-to route="about" disabled=true}}About{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      assert.strictEqual(this.$('h3.about').length, 0, 'Transitioning did not occur');
+    }
+
+    async [`@test it responds to clicks according to its disabledWhen bound param`](assert) {
+      this.addTemplate(
+        'index',
+        `<div id="about-link">{{#link-to route="about" disabledWhen=this.disabledWhen}}About{{/link-to}}</div>`
+      );
+
+      let controller;
+
+      this.add(
+        'controller:index',
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          disabledWhen = true;
+        }
+      );
+
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      assert.strictEqual(this.$('h3.about').length, 0, 'Transitioning did not occur');
+
+      runTask(() => controller.set('disabledWhen', false));
+
+      await this.click('#about-link > a');
+
+      assert.equal(
+        this.$('h3.about').length,
+        1,
+        'Transitioning did occur when disabledWhen became false'
+      );
+    }
+
+    async [`@test it supports a custom activeClass`](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link'}}About{{/link-to}}
-        {{#link-to route='index' id='self-link' activeClass='zomg-active'}}Self{{/link-to}}
+        <div id="about-link">{{#link-to route='about' activeClass='zomg-active'}}About{{/link-to}}</div>
+        <div id="self-link">{{#link-to route='index' activeClass='zomg-active'}}Self{{/link-to}}</div>
         `
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-        assert.equal(
-          this.$('#self-link.zomg-active').length,
-          1,
-          'The self-link was rendered with active class'
-        );
-        assert.equal(
-          this.$('#about-link:not(.active)').length,
-          1,
-          'The other link was rendered without active class'
-        );
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.equal(
+        this.$('#self-link > a.zomg-active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#about-link > a:not(.zomg-active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
-    [`@test The {{link-to}} component supports a custom activeClass from a bound param`](assert) {
+    async [`@test it supports a custom activeClass from a bound param`](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link'}}About{{/link-to}}
-        {{#link-to route='index' id='self-link' activeClass=this.activeClass}}Self{{/link-to}}
+        <div id="about-link">{{#link-to route='about' activeClass=this.activeClass}}About{{/link-to}}</div>
+        <div id="self-link">{{#link-to route='index' activeClass=this.activeClass}}Self{{/link-to}}</div>
         `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          activeClass: 'zomg-active',
-        })
+        class extends Controller {
+          activeClass = 'zomg-active';
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-        assert.equal(
-          this.$('#self-link.zomg-active').length,
-          1,
-          'The self-link was rendered with active class'
-        );
-        assert.equal(
-          this.$('#about-link:not(.active)').length,
-          1,
-          'The other link was rendered without active class'
-        );
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.equal(
+        this.$('#self-link > a.zomg-active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#about-link > a:not(.zomg-active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
-    [`@test The {{link-to}} component supports 'classNameBindings' with custom values [GH #11699]`](
+    async [`@test [DEPRECATED] it supports 'classNameBindings' with custom values [GH #11699]`](
       assert
     ) {
       expectDeprecation(
-        "Passing the `classNameBindings` property as an argument within templates has been deprecated. Instead, you can pass the class argument and use concatenation to produce the class value dynamically. ('my-app/templates/index.hbs' @ L3:C8) "
+        "Passing the `classNameBindings` property as an argument within templates has been deprecated. Instead, you can pass the class argument and use concatenation to produce the class value dynamically. ('my-app/templates/index.hbs' @ L3:C29) "
       );
 
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link' classNameBindings='this.foo:foo-is-true:foo-is-false'}}About{{/link-to}}
+        <div id="about-link">{{#link-to route='about' classNameBindings='this.foo:foo-is-true:foo-is-false'}}About{{/link-to}}</div>
         `
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          foo: false,
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          foo = false;
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(
-          this.$('#about-link.foo-is-false').length,
-          1,
-          'The about-link was rendered with the falsy class'
-        );
+      await this.visit('/');
 
-        let controller = this.applicationInstance.lookup('controller:index');
-        runTask(() => controller.set('foo', true));
+      assert.equal(
+        this.$('#about-link > a.foo-is-false').length,
+        1,
+        'The about-link was rendered with the falsy class'
+      );
 
-        assert.equal(
-          this.$('#about-link.foo-is-true').length,
-          1,
-          'The about-link was rendered with the truthy class after toggling the property'
-        );
-      });
+      runTask(() => controller.set('foo', true));
+
+      assert.equal(
+        this.$('#about-link > a.foo-is-true').length,
+        1,
+        'The about-link was rendered with the truthy class after toggling the property'
+      );
     }
 
     async ['@test Using {{link-to}} inside a non-routable engine errors'](assert) {
@@ -404,7 +409,7 @@ moduleFor(
                 `
                 <h2 id='engine-layout'>Routable Engine</h2>
                 {{outlet}}
-                {{#link-to route='application' id='engine-application-link'}}Engine Application{{/link-to}}
+                <div id="engine-application-link">{{#link-to route='application'}}Engine Application{{/link-to}}</div>
                 `,
                 {
                   moduleName: 'routable/templates/application.hbs',
@@ -416,8 +421,8 @@ moduleFor(
               compile(
                 `
                 <h3 class='engine-home'>Engine Home</h3>
-                {{#link-to route='about' id='engine-about-link'}}Engine About{{/link-to}}
-                {{#link-to route='index' id='engine-self-link'}}Engine Self{{/link-to}}
+                <div id="engine-about-link">{{#link-to route='about'}}Engine About{{/link-to}}</div>
+                <div id="engine-self-link">{{#link-to route='index'}}Engine Self{{/link-to}}</div>
                 `,
                 {
                   moduleName: 'routable/templates/index.hbs',
@@ -429,8 +434,8 @@ moduleFor(
               compile(
                 `
                 <h3 class='engine-about'>Engine About</h3>
-                {{#link-to route='index' id='engine-home-link'}}Engine Home{{/link-to}}
-                {{#link-to route='about' id='engine-self-link'}}Engine Self{{/link-to}}
+                <div id="engine-home-link">{{#link-to route='index'}}Engine Home{{/link-to}}</div>
+                <div id="engine-self-link">{{#link-to route='about'}}Engine Self{{/link-to}}</div>
                 `,
                 {
                   moduleName: 'routable/templates/about.hbs',
@@ -454,8 +459,8 @@ moduleFor(
         `
         <h1 id="application-layout">Application</h1>
         {{outlet}}
-        {{#link-to route='application' id='application-link'}}Appliction{{/link-to}}
-        {{#link-to route='routable' id='engine-link'}}Engine{{/link-to}}
+        <div id="application-link">{{#link-to route='application'}}Appliction{{/link-to}}</div>
+        <div id="engine-link">{{#link-to route='routable'}}Engine{{/link-to}}</div>
         `
       );
 
@@ -463,103 +468,163 @@ moduleFor(
 
       assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+      assert.equal(
+        this.$('#application-link > a.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.equal(
+        this.$('#engine-link > a:not(.active)').length,
+        1,
+        'The engine link is not active'
+      );
 
       assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
-      assert.equal(this.$('#self-link.active').length, 1, 'The application index link is active');
       assert.equal(
-        this.$('#about-link:not(.active)').length,
+        this.$('#self-link > a.active').length,
+        1,
+        'The application index link is active'
+      );
+      assert.equal(
+        this.$('#about-link > a:not(.active)').length,
         1,
         'The application about link is not active'
       );
 
-      await this.click('#about-link');
+      await this.click('#about-link > a');
 
       assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+      assert.equal(
+        this.$('#application-link > a.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.equal(
+        this.$('#engine-link > a:not(.active)').length,
+        1,
+        'The engine link is not active'
+      );
 
       assert.equal(this.$('h3.about').length, 1, 'The application about page is rendered');
-      assert.equal(this.$('#self-link.active').length, 1, 'The application about link is active');
       assert.equal(
-        this.$('#home-link:not(.active)').length,
+        this.$('#self-link > a.active').length,
+        1,
+        'The application about link is active'
+      );
+      assert.equal(
+        this.$('#home-link > a:not(.active)').length,
         1,
         'The application home link is not active'
       );
 
-      await this.click('#engine-link');
+      await this.click('#engine-link > a');
 
       assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
       assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
       assert.equal(
-        this.$('#engine-application-link.active').length,
+        this.$('#application-link > a.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.equal(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
+      assert.equal(
+        this.$('#engine-application-link > a.active').length,
         1,
         'The engine application link is active'
       );
 
       assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
-      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine index link is active');
       assert.equal(
-        this.$('#engine-about-link:not(.active)').length,
+        this.$('#engine-self-link > a.active').length,
+        1,
+        'The engine index link is active'
+      );
+      assert.equal(
+        this.$('#engine-about-link > a:not(.active)').length,
         1,
         'The engine about link is not active'
       );
 
-      await this.click('#engine-about-link');
+      await this.click('#engine-about-link > a');
 
       assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
       assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
       assert.equal(
-        this.$('#engine-application-link.active').length,
+        this.$('#application-link > a.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.equal(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
+      assert.equal(
+        this.$('#engine-application-link > a.active').length,
         1,
         'The engine application link is active'
       );
 
       assert.equal(this.$('h3.engine-about').length, 1, 'The engine about page is rendered');
-      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine about link is active');
       assert.equal(
-        this.$('#engine-home-link:not(.active)').length,
+        this.$('#engine-self-link > a.active').length,
+        1,
+        'The engine about link is active'
+      );
+      assert.equal(
+        this.$('#engine-home-link > a:not(.active)').length,
         1,
         'The engine home link is not active'
       );
 
-      await this.click('#engine-application-link');
+      await this.click('#engine-application-link > a');
 
       assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
       assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
       assert.equal(
-        this.$('#engine-application-link.active').length,
+        this.$('#application-link > a.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.equal(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
+      assert.equal(
+        this.$('#engine-application-link > a.active').length,
         1,
         'The engine application link is active'
       );
 
       assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
-      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine index link is active');
       assert.equal(
-        this.$('#engine-about-link:not(.active)').length,
+        this.$('#engine-self-link > a.active').length,
+        1,
+        'The engine index link is active'
+      );
+      assert.equal(
+        this.$('#engine-about-link > a:not(.active)').length,
         1,
         'The engine about link is not active'
       );
 
-      await this.click('#application-link');
+      await this.click('#application-link > a');
 
       assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+      assert.equal(
+        this.$('#application-link > a.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.equal(
+        this.$('#engine-link > a:not(.active)').length,
+        1,
+        'The engine link is not active'
+      );
 
       assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
-      assert.equal(this.$('#self-link.active').length, 1, 'The application index link is active');
       assert.equal(
-        this.$('#about-link:not(.active)').length,
+        this.$('#self-link > a.active').length,
+        1,
+        'The application index link is active'
+      );
+      assert.equal(
+        this.$('#about-link > a:not(.active)').length,
         1,
         'The application about link is not active'
       );
@@ -577,18 +642,19 @@ moduleFor(
       this.replaceCount = 0;
 
       let testContext = this;
+
       this.add(
         'location:none',
-        NoneLocation.extend({
-          setURL() {
+        class extends NoneLocation {
+          setURL(...args) {
             testContext.updateCount++;
-            return this._super(...arguments);
-          },
-          replaceURL() {
+            return super.setURL(...args);
+          }
+          replaceURL(...args) {
             testContext.replaceCount++;
-            return this._super(...arguments);
-          },
-        })
+            return super.setURL(...args);
+          }
+        }
       );
 
       this.router.map(function () {
@@ -599,110 +665,102 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link'}}About{{/link-to}}
-        {{#link-to route='index' id='self-link'}}Self{{/link-to}}
+        <div id="about-link">{{#link-to route='about'}}About{{/link-to}}</div>
+        <div id="self-link">{{#link-to route='index'}}Self{{/link-to}}</div>
         `
       );
       this.addTemplate(
         'about',
         `
         <h3 class="about">About</h3>
-        {{#link-to route='index' id='home-link'}}Home{{/link-to}}
-        {{#link-to route='about' id='self-link'}}Self{{/link-to}}
+        <div id="home-link">{{#link-to route='index'}}Home{{/link-to}}</div>
+        <div id="self-link">{{#link-to route='about'}}Self{{/link-to}}</div>
         `
       );
     }
 
-    visit() {
-      return super.visit(...arguments).then(() => {
-        this.updateCountAfterVisit = this.updateCount;
-        this.replaceCountAfterVisit = this.replaceCount;
-      });
+    async visit(...args) {
+      await super.visit(...args);
+
+      this.updateCountAfterVisit = this.updateCount;
+      this.replaceCountAfterVisit = this.replaceCount;
     }
 
-    ['@test The {{link-to}} component supports URL replacement'](assert) {
+    async ['@test it supports URL replacement'](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link' replace=true}}About{{/link-to}}
+        <div id="about-link">{{#link-to route='about' replace=true}}About{{/link-to}}</div>
         `
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
-          assert.equal(
-            this.replaceCount,
-            this.replaceCountAfterVisit + 1,
-            'replaceURL should be called once'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
+      assert.equal(
+        this.replaceCount,
+        this.replaceCountAfterVisit + 1,
+        'replaceURL should be called once'
+      );
     }
 
-    ['@test The {{link-to}} component supports URL replacement via replace=boundTruthyThing'](
-      assert
-    ) {
+    async ['@test it supports URL replacement via replace=boundTruthyThing'](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link' replace=this.boundTruthyThing}}About{{/link-to}}
+        <div id="about-link">{{#link-to route='about' replace=this.boundTruthyThing}}About{{/link-to}}</div>
         `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundTruthyThing: true,
-        })
+        class extends Controller {
+          boundTruthyThing = true;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
-          assert.equal(
-            this.replaceCount,
-            this.replaceCountAfterVisit + 1,
-            'replaceURL should be called once'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      assert.equal(this.updateCount, this.updateCountAfterVisit, 'setURL should not be called');
+      assert.equal(
+        this.replaceCount,
+        this.replaceCountAfterVisit + 1,
+        'replaceURL should be called once'
+      );
     }
 
-    ['@test The {{link-to}} component supports setting replace=this.boundFalseyThing'](assert) {
+    async ['@test it supports setting replace=boundFalseyThing'](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link' replace=this.boundFalseyThing}}About{{/link-to}}
+        <div id="about-link">{{#link-to route='about' replace=this.boundFalseyThing}}About{{/link-to}}</div>
         `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundFalseyThing: false,
-        })
+        class extends Controller {
+          boundFalseyThing = false;
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#about-link');
-        })
-        .then(() => {
-          assert.equal(this.updateCount, this.updateCountAfterVisit + 1, 'setURL should be called');
-          assert.equal(
-            this.replaceCount,
-            this.replaceCountAfterVisit,
-            'replaceURL should not be called'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      assert.equal(this.updateCount, this.updateCountAfterVisit + 1, 'setURL should be called');
+      assert.equal(
+        this.replaceCount,
+        this.replaceCountAfterVisit,
+        'replaceURL should not be called'
+      );
     }
   }
 );
@@ -722,16 +780,16 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
           'index',
           `
           <h3 class="home">Home</h3>
-          {{#link-to route='about' id='about-link'}}About{{/link-to}}
-          {{#link-to route='index' id='self-link'}}Self{{/link-to}}
+          <div id="about-link">{{#link-to route='about'}}About{{/link-to}}</div>
+          <div id="self-link">{{#link-to route='index'}}Self{{/link-to}}</div>
           `
         );
         this.addTemplate(
           'about',
           `
           <h3 class="about">About</h3>
-          {{#link-to route='index' id='home-link'}}Home{{/link-to}}
-          {{#link-to route='about' id='self-link'}}Self{{/link-to}}
+          <div id="home-link">{{#link-to route='index'}}Home{{/link-to}}</div>
+          <div id="self-link">{{#link-to route='about'}}Self{{/link-to}}</div>
           `
         );
       }
@@ -746,53 +804,55 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
         return super.afterEach();
       }
 
-      ['@test The {{link-to}} component fires an interaction event'](assert) {
-        assert.expect(2);
+      async ['@test it fires an interaction event'](assert) {
+        let before = 0;
+        let after = 0;
 
         subscribe('interaction.link-to', {
           before() {
-            assert.ok(true, 'instrumentation subscriber was called');
+            before++;
           },
           after() {
-            assert.ok(true, 'instrumentation subscriber was called');
+            after++;
           },
         });
 
-        return this.click('#about-link');
+        assert.strictEqual(before, 0, 'instrumentation subscriber (before) was not called');
+        assert.strictEqual(after, 0, 'instrumentation subscriber (after) was not called');
+
+        await this.click('#about-link > a');
+
+        assert.strictEqual(before, 1, 'instrumentation subscriber (before) was called');
+        assert.strictEqual(after, 1, 'instrumentation subscriber (after) was called');
       }
 
-      ['@test The {{link-to}} component interaction event includes the route name'](assert) {
-        assert.expect(2);
+      async ['@test it interaction event includes the route name and transition object'](assert) {
+        let before = 0;
+        let after = 0;
 
         subscribe('interaction.link-to', {
           before(name, timestamp, { routeName }) {
+            before++;
             assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
           },
-          after(name, timestamp, { routeName }) {
+          after(name, timestamp, { routeName, transition }) {
+            after++;
             assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
-          },
-        });
-
-        return this.click('#about-link');
-      }
-
-      ['@test The {{link-to}} component interaction event includes the transition in the after hook'](
-        assert
-      ) {
-        assert.expect(1);
-
-        subscribe('interaction.link-to', {
-          before() {},
-          after(name, timestamp, { transition }) {
             assert.equal(
               transition.targetName,
               'about',
-              'instrumentation subscriber was passed route name'
+              'instrumentation subscriber was passed transition object in the after hook'
             );
           },
         });
 
-        return this.click('#about-link');
+        assert.strictEqual(before, 0, 'instrumentation subscriber (before) was not called');
+        assert.strictEqual(after, 0, 'instrumentation subscriber (after) was not called');
+
+        await this.click('#about-link > a');
+
+        assert.strictEqual(before, 1, 'instrumentation subscriber (before) was called');
+        assert.strictEqual(after, 1, 'instrumentation subscriber (after) was called');
       }
     }
   );
@@ -801,7 +861,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 moduleFor(
   'The {{link-to}} component - nested routes and link-to arguments',
   class extends ApplicationTestCase {
-    ['@test The {{link-to}} component supports leaving off .index for nested routes'](assert) {
+    async ['@test it supports leaving off .index for nested routes'](assert) {
       this.router.map(function () {
         this.route('about', function () {
           this.route('item');
@@ -815,12 +875,12 @@ moduleFor(
         `<div id='item'>{{#link-to route='about'}}About{{/link-to}}</div>`
       );
 
-      return this.visit('/about/item').then(() => {
-        assert.equal(normalizeUrl(this.$('#item a').attr('href')), '/about');
-      });
+      await this.visit('/about/item');
+
+      assert.equal(normalizeUrl(this.$('#item a').attr('href')), '/about');
     }
 
-    [`@test The {{link-to}} component supports custom, nested, current-when`](assert) {
+    async [`@test it supports custom, nested, current-when`](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -832,19 +892,19 @@ moduleFor(
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
       this.addTemplate(
         'index.about',
-        `{{#link-to route='item' id='other-link' current-when='index'}}ITEM{{/link-to}}`
+        `<div id="other-link">{{#link-to route='item' current-when='index'}}ITEM{{/link-to}}</div>`
       );
 
-      return this.visit('/about').then(() => {
-        assert.equal(
-          this.$('#other-link.active').length,
-          1,
-          'The link is active since current-when is a parent route'
-        );
-      });
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#other-link > a.active').length,
+        1,
+        'The link is active since current-when is a parent route'
+      );
     }
 
-    [`@test The {{link-to}} component does not disregard current-when when it is given explicitly for a route`](
+    async [`@test it does not disregard current-when when it is given explicitly for a route`](
       assert
     ) {
       this.router.map(function () {
@@ -860,21 +920,19 @@ moduleFor(
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
       this.addTemplate(
         'index.about',
-        `{{#link-to route='items' id='other-link' current-when='index'}}ITEM{{/link-to}}`
+        `<div id="other-link">{{#link-to route='items' current-when='index'}}ITEM{{/link-to}}</div>`
       );
 
-      return this.visit('/about').then(() => {
-        assert.equal(
-          this.$('#other-link.active').length,
-          1,
-          'The link is active when current-when is given for explicitly for a route'
-        );
-      });
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#other-link > a.active').length,
+        1,
+        'The link is active when current-when is given for explicitly for a route'
+      );
     }
 
-    ['@test The {{link-to}} component does not disregard current-when when it is set via a bound param'](
-      assert
-    ) {
+    async ['@test it does not disregard current-when when it is set via a bound param'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -887,27 +945,27 @@ moduleFor(
 
       this.add(
         'controller:index.about',
-        Controller.extend({
-          currentWhen: 'index',
-        })
+        class extends Controller {
+          currentWhen = 'index';
+        }
       );
 
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
       this.addTemplate(
         'index.about',
-        `{{#link-to route='items' id='other-link' current-when=this.currentWhen}}ITEM{{/link-to}}`
+        `<div id="other-link">{{#link-to route='items' current-when=this.currentWhen}}ITEM{{/link-to}}</div>`
       );
 
-      return this.visit('/about').then(() => {
-        assert.equal(
-          this.$('#other-link.active').length,
-          1,
-          'The link is active when current-when is given for explicitly for a route'
-        );
-      });
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#other-link > a.active').length,
+        1,
+        'The link is active when current-when is given for explicitly for a route'
+      );
     }
 
-    ['@test The {{link-to}} component supports multiple current-when routes'](assert) {
+    async ['@test it supports multiple current-when routes'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -919,46 +977,43 @@ moduleFor(
       this.addTemplate('index', `<h3 class="home">Home</h3>{{outlet}}`);
       this.addTemplate(
         'index.about',
-        `{{#link-to route='item' id='link1' current-when='item index'}}ITEM{{/link-to}}`
+        `<div id="link1">{{#link-to route='item' current-when='item index'}}ITEM{{/link-to}}</div>`
       );
       this.addTemplate(
         'item',
-        `{{#link-to route='item' id='link2' current-when='item index'}}ITEM{{/link-to}}`
+        `<div id="link2">{{#link-to route='item' current-when='item index'}}ITEM{{/link-to}}</div>`
       );
       this.addTemplate(
         'foo',
-        `{{#link-to route='item' id='link3' current-when='item index'}}ITEM{{/link-to}}`
+        `<div id="link3">{{#link-to route='item' current-when='item index'}}ITEM{{/link-to}}</div>`
       );
 
-      return this.visit('/about')
-        .then(() => {
-          assert.equal(
-            this.$('#link1.active').length,
-            1,
-            'The link is active since current-when contains the parent route'
-          );
+      await this.visit('/about');
 
-          return this.visit('/item');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#link2.active').length,
-            1,
-            'The link is active since you are on the active route'
-          );
+      assert.equal(
+        this.$('#link1 > a.active').length,
+        1,
+        'The link is active since current-when contains the parent route'
+      );
 
-          return this.visit('/foo');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#link3.active').length,
-            0,
-            'The link is not active since current-when does not contain the active route'
-          );
-        });
+      await this.visit('/item');
+
+      assert.equal(
+        this.$('#link2 > a.active').length,
+        1,
+        'The link is active since you are on the active route'
+      );
+
+      await this.visit('/foo');
+
+      assert.equal(
+        this.$('#link3 > a.active').length,
+        0,
+        'The link is not active since current-when does not contain the active route'
+      );
     }
 
-    ['@test The {{link-to}} component supports boolean values for current-when'](assert) {
+    async ['@test it supports boolean values for current-when'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {
           this.route('about');
@@ -969,39 +1024,50 @@ moduleFor(
       this.addTemplate(
         'index.about',
         `
-        {{#link-to route='index' id='index-link' current-when=this.isCurrent}}index{{/link-to}}
-        {{#link-to route='item' id='about-link' current-when=true}}ITEM{{/link-to}}
+        <div id="index-link">{{#link-to route='index' current-when=this.isCurrent}}index{{/link-to}}</div>
+        <div id="about-link">{{#link-to route='item' current-when=true}}ITEM{{/link-to}}</div>
         `
       );
 
-      this.add('controller:index.about', Controller.extend({ isCurrent: false }));
+      let controller;
 
-      return this.visit('/about').then(() => {
-        assert.ok(
-          this.$('#about-link').hasClass('active'),
-          'The link is active since current-when is true'
-        );
-        assert.notOk(
-          this.$('#index-link').hasClass('active'),
-          'The link is not active since current-when is false'
-        );
+      this.add(
+        'controller:index.about',
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
 
-        let controller = this.applicationInstance.lookup('controller:index.about');
-        runTask(() => controller.set('isCurrent', true));
+          isCurrent = false;
+        }
+      );
 
-        assert.ok(
-          this.$('#index-link').hasClass('active'),
-          'The link is active since current-when is true'
-        );
-      });
+      await this.visit('/about');
+
+      assert.ok(
+        this.$('#about-link > a').hasClass('active'),
+        'The link is active since current-when is true'
+      );
+      assert.notOk(
+        this.$('#index-link > a').hasClass('active'),
+        'The link is not active since current-when is false'
+      );
+
+      runTask(() => controller.set('isCurrent', true));
+
+      assert.ok(
+        this.$('#index-link > a').hasClass('active'),
+        'The link is active since current-when is true'
+      );
     }
 
-    ['@test The {{link-to}} component defaults to bubbling'](assert) {
+    async ['@test it defaults to bubbling'](assert) {
       this.addTemplate(
         'about',
         `
-        <div {{action 'hide'}}>
-          {{#link-to route='about.contact' id='about-contact'}}About{{/link-to}}
+        <div {{action this.hide}}>
+          <div id="about-contact">{{#link-to route='about.contact'}}About{{/link-to}}</div>
         </div>
         {{outlet}}
         `
@@ -1016,94 +1082,39 @@ moduleFor(
       });
 
       let hidden = 0;
-
-      this.add(
-        'route:about',
-        Route.extend({
-          actions: {
-            hide() {
-              hidden++;
-            },
-          },
-        })
-      );
-
-      return this.visit('/about')
-        .then(() => {
-          return this.click('#about-contact');
-        })
-        .then(() => {
-          assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
-
-          assert.equal(hidden, 1, 'The link bubbles');
-        });
-    }
-
-    [`@test The {{link-to}} component supports bubbles=false`](assert) {
-      this.addTemplate(
-        'about',
-        `
-        <div {{action 'hide'}}>
-          {{#link-to route='about.contact' id='about-contact' bubbles=false}}
-            About
-          {{/link-to}}
-        </div>
-        {{outlet}}
-        `
-      );
-      this.addTemplate('about.contact', `<h1 id='contact'>Contact</h1>`);
-
-      this.router.map(function () {
-        this.route('about', function () {
-          this.route('contact');
-        });
-      });
-
-      let hidden = 0;
-
-      this.add(
-        'route:about',
-        Route.extend({
-          actions: {
-            hide() {
-              hidden++;
-            },
-          },
-        })
-      );
-
-      return this.visit('/about')
-        .then(() => {
-          return this.click('#about-contact');
-        })
-        .then(() => {
-          assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
-
-          assert.equal(hidden, 0, "The link didn't bubble");
-        });
-    }
-
-    [`@test The {{link-to}} component supports bubbles=boundFalseyThing`](assert) {
-      this.addTemplate(
-        'about',
-        `
-        <div {{action 'hide'}}>
-          {{#link-to route='about.contact' id='about-contact' bubbles=this.boundFalseyThing}}
-            About
-          {{/link-to}}
-        </div>
-        {{outlet}}
-        `
-      );
-
-      this.addTemplate('about.contact', `<h1 id='contact'>Contact</h1>`);
 
       this.add(
         'controller:about',
-        Controller.extend({
-          boundFalseyThing: false,
-        })
+        class extends Controller {
+          hide() {
+            hidden++;
+          }
+        }
       );
+
+      await this.visit('/about');
+
+      await this.click('#about-contact > a');
+
+      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+
+      assert.equal(hidden, 1, 'The link bubbles');
+    }
+
+    async [`@test it supports bubbles=false`](assert) {
+      this.addTemplate(
+        'about',
+        `
+        <div id='about-contact' {{action this.hide}}>
+          {{#link-to route='about.contact' bubbles=false}}
+            About
+          {{/link-to}}
+        </div>
+        {{outlet}}
+        `
+      );
+
+      this.addTemplate('about.contact', `<h1 id='contact'>Contact</h1>`);
 
       this.router.map(function () {
         this.route('about', function () {
@@ -1114,27 +1125,66 @@ moduleFor(
       let hidden = 0;
 
       this.add(
-        'route:about',
-        Route.extend({
-          actions: {
-            hide() {
-              hidden++;
-            },
-          },
-        })
+        'controller:about',
+        class extends Controller {
+          hide() {
+            hidden++;
+          }
+        }
       );
 
-      return this.visit('/about')
-        .then(() => {
-          return this.click('#about-contact');
-        })
-        .then(() => {
-          assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
-          assert.equal(hidden, 0, "The link didn't bubble");
-        });
+      await this.visit('/about');
+
+      await this.click('#about-contact > a');
+
+      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+
+      assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
 
-    async [`@test The {{link-to}} component moves into the named route with context`](assert) {
+    async [`@test it supports bubbles=boundFalseyThing`](assert) {
+      this.addTemplate(
+        'about',
+        `
+        <div id='about-contact' {{action this.hide}}>
+          {{#link-to route='about.contact' bubbles=this.boundFalseyThing}}
+            About
+          {{/link-to}}
+        </div>
+        {{outlet}}
+        `
+      );
+
+      this.addTemplate('about.contact', `<h1 id='contact'>Contact</h1>`);
+
+      let hidden = 0;
+
+      this.add(
+        'controller:about',
+        class extends Controller {
+          boundFalseyThing = false;
+
+          hide() {
+            hidden++;
+          }
+        }
+      );
+
+      this.router.map(function () {
+        this.route('about', function () {
+          this.route('contact');
+        });
+      });
+
+      await this.visit('/about');
+
+      await this.click('#about-contact > a');
+
+      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(hidden, 0, "The link didn't bubble");
+    }
+
+    async [`@test it moves into the named route with context`](assert) {
       this.router.map(function () {
         this.route('about');
         this.route('item', { path: '/item/:id' });
@@ -1146,14 +1196,14 @@ moduleFor(
         <h3 class="list">List</h3>
         <ul>
           {{#each @model as |person|}}
-            <li>
-              {{#link-to route='item' model=person id=person.id}}
+            <li id={{person.id}}>
+              {{#link-to route='item' model=person}}
                 {{person.name}}
               {{/link-to}}
             </li>
           {{/each}}
         </ul>
-        {{#link-to route='index' id='home-link'}}Home{{/link-to}}
+        <div id='home-link'>{{#link-to route='index'}}Home{{/link-to}}</div>
         `
       );
 
@@ -1162,7 +1212,7 @@ moduleFor(
         `
         <h3 class="item">Item</h3>
         <p>{{@model.name}}</p>
-        {{#link-to route='index' id='home-link'}}Home{{/link-to}}
+        <div id='home-link'>{{#link-to route='index'}}Home{{/link-to}}</div>
         `
       );
 
@@ -1170,7 +1220,7 @@ moduleFor(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='about' id='about-link'}}About{{/link-to}}
+        <div id='about-link'>{{#link-to route='about'}}About{{/link-to}}</div>
         `
       );
 
@@ -1191,31 +1241,31 @@ moduleFor(
 
       assert.equal(this.$('h3.list').length, 1, 'The home template was rendered');
       assert.equal(
-        normalizeUrl(this.$('#home-link').attr('href')),
+        normalizeUrl(this.$('#home-link > a').attr('href')),
         '/',
         'The home link points back at /'
       );
 
-      await this.click('#yehuda');
+      await this.click('#yehuda > a');
 
       assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
       assert.equal(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
 
-      await this.click('#home-link');
+      await this.click('#home-link > a');
 
-      await this.click('#about-link');
+      await this.click('#about-link > a');
 
-      assert.equal(normalizeUrl(this.$('li a#yehuda').attr('href')), '/item/yehuda');
-      assert.equal(normalizeUrl(this.$('li a#tom').attr('href')), '/item/tom');
-      assert.equal(normalizeUrl(this.$('li a#erik').attr('href')), '/item/erik');
+      assert.equal(normalizeUrl(this.$('li#yehuda > a').attr('href')), '/item/yehuda');
+      assert.equal(normalizeUrl(this.$('li#tom > a').attr('href')), '/item/tom');
+      assert.equal(normalizeUrl(this.$('li#erik > a').attr('href')), '/item/erik');
 
-      await this.click('#erik');
+      await this.click('#erik > a');
 
       assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
       assert.equal(this.$('p').text(), 'Erik Brynroflsson', 'The name is correct');
     }
 
-    [`@test The {{link-to}} component binds some anchor html tag common attributes`](assert) {
+    async [`@test it binds some anchor html tag common attributes`](assert) {
       this.addTemplate(
         'index',
         `
@@ -1226,63 +1276,67 @@ moduleFor(
         `
       );
 
-      return this.visit('/').then(() => {
-        let link = this.$('#self-link');
-        assert.equal(link.attr('title'), 'title-attr', 'The self-link contains title attribute');
-        assert.equal(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
-        assert.equal(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
-      });
+      await this.visit('/');
+
+      let link = this.$('#self-link');
+      assert.equal(link.attr('title'), 'title-attr', 'The self-link contains title attribute');
+      assert.equal(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
+      assert.equal(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
     }
 
-    [`@test The {{link-to}} component supports 'target' attribute`](assert) {
+    async [`@test it supports 'target' attribute`](assert) {
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to route='index' id='self-link' target='_blank'}}Self{{/link-to}}
+        <div id='self-link'>{{#link-to route='index' target='_blank'}}Self{{/link-to}}</div>
         `
       );
 
-      return this.visit('/').then(() => {
-        let link = this.$('#self-link');
-        assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
-      });
+      await this.visit('/');
+
+      let link = this.$('#self-link > a');
+      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
     }
 
-    [`@test The {{link-to}} component supports 'target' attribute specified as a bound param`](
-      assert
-    ) {
+    async [`@test it supports 'target' attribute specified as a bound param`](assert) {
       this.addTemplate(
         'index',
-        `<h3 class="home">Home</h3>{{#link-to route='index' id='self-link' target=this.boundLinkTarget}}Self{{/link-to}}`
+        `
+        <h3 class="home">Home</h3>
+        <div id='self-link'>{{#link-to route='index' target=this.boundLinkTarget}}Self{{/link-to}}</div>
+        `
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundLinkTarget: '_blank',
-        })
+        class extends Controller {
+          boundLinkTarget = '_blank';
+        }
       );
 
-      return this.visit('/').then(() => {
-        let link = this.$('#self-link');
-        assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
-      });
+      await this.visit('/');
+
+      let link = this.$('#self-link > a');
+      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
     }
 
-    [`@test the {{link-to}} component calls preventDefault`](assert) {
+    async [`@test it calls preventDefault`](assert) {
       this.router.map(function () {
         this.route('about');
       });
 
-      this.addTemplate('index', `{{#link-to route='about' id='about-link'}}About{{/link-to}}`);
+      this.addTemplate(
+        'index',
+        `<div id='about-link'>{{#link-to route='about'}}About{{/link-to}}</div>`
+      );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: true }, () => this.$('#about-link').click(), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: true }, () => this.$('#about-link > a').click(), assert);
     }
 
-    [`@test the {{link-to}} component does not call preventDefault if 'preventDefault=false' is passed as an option`](
+    async [`@test it does not call preventDefault if 'preventDefault=false' is passed as an option`](
       assert
     ) {
       this.router.map(function () {
@@ -1291,15 +1345,15 @@ moduleFor(
 
       this.addTemplate(
         'index',
-        `{{#link-to route='about' id='about-link' preventDefault=false}}About{{/link-to}}`
+        `<div id='about-link'>{{#link-to route='about' preventDefault=false}}About{{/link-to}}</div>`
       );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: false }, () => this.$('#about-link > a').trigger('click'), assert);
     }
 
-    [`@test the {{link-to}} component does not call preventDefault if 'preventDefault=this.boundFalseyThing' is passed as an option`](
+    async [`@test it does not call preventDefault if 'preventDefault=this.boundFalseyThing' is passed as an option`](
       assert
     ) {
       this.router.map(function () {
@@ -1308,19 +1362,19 @@ moduleFor(
 
       this.addTemplate(
         'index',
-        `{{#link-to route='about' id='about-link' preventDefault=this.boundFalseyThing}}About{{/link-to}}`
+        `<div id='about-link'>{{#link-to route='about' preventDefault=this.boundFalseyThing}}About{{/link-to}}</div>`
       );
 
       this.add(
         'controller:index',
-        Controller.extend({
-          boundFalseyThing: false,
-        })
+        class extends Controller {
+          boundFalseyThing = false;
+        }
       );
 
-      return this.visit('/').then(() => {
-        assertNav({ prevented: false }, () => this.$('#about-link').trigger('click'), assert);
-      });
+      await this.visit('/');
+
+      assertNav({ prevented: false }, () => this.$('#about-link > a').trigger('click'), assert);
     }
 
     [`@test The {{link-to}} component does not call preventDefault if 'target' attribute is provided`](
@@ -1353,15 +1407,15 @@ moduleFor(
       });
     }
 
-    [`@test The {{link-to}} component should not transition if target is not equal to _self or empty`](
-      assert
-    ) {
+    async [`@test it should not transition if target is not equal to _self or empty`](assert) {
       this.addTemplate(
         'index',
         `
-        {{#link-to route='about' id='about-link' replace=true target='_blank'}}
-          About
-        {{/link-to}}
+        <div id='about-link'>
+          {{#link-to route='about' replace=true target='_blank'}}
+            About
+          {{/link-to}}
+        </div>
         `
       );
 
@@ -1369,23 +1423,23 @@ moduleFor(
         this.route('about');
       });
 
-      return this.visit('/')
-        .then(() => this.click('#about-link'))
-        .then(() => {
-          expectDeprecation(() => {
-            let currentRouteName = this.applicationInstance
-              .lookup('controller:application')
-              .get('currentRouteName');
-            assert.notEqual(
-              currentRouteName,
-              'about',
-              'link-to should not transition if target is not equal to _self or empty'
-            );
-          }, 'Accessing `currentRouteName` on `controller:application` is deprecated, use the `currentRouteName` property on `service:router` instead.');
-        });
+      await this.visit('/');
+
+      await this.click('#about-link > a');
+
+      expectDeprecation(() => {
+        let currentRouteName = this.applicationInstance
+          .lookup('controller:application')
+          .get('currentRouteName');
+        assert.notEqual(
+          currentRouteName,
+          'about',
+          'link-to should not transition if target is not equal to _self or empty'
+        );
+      }, 'Accessing `currentRouteName` on `controller:application` is deprecated, use the `currentRouteName` property on `service:router` instead.');
     }
 
-    [`@test The {{link-to}} component accepts string/numeric arguments`](assert) {
+    async [`@test it accepts string/numeric arguments`](assert) {
       this.router.map(function () {
         this.route('filter', { path: '/filters/:filter' });
         this.route('post', { path: '/post/:post_id' });
@@ -1394,41 +1448,40 @@ moduleFor(
 
       this.add(
         'controller:filter',
-        Controller.extend({
-          filter: 'unpopular',
-          repo: { owner: 'ember', name: 'ember.js' },
-          post_id: 123,
-        })
+        class extends Controller {
+          filter = 'unpopular';
+          repo = { owner: 'ember', name: 'ember.js' };
+          post_id = 123;
+        }
       );
 
       this.addTemplate(
         'filter',
         `
         <p>{{this.filter}}</p>
-        {{#link-to route="filter" model="unpopular" id="link"}}Unpopular{{/link-to}}
-        {{#link-to route="filter" model=this.filter id="path-link"}}Unpopular{{/link-to}}
-        {{#link-to route="post" model=this.post_id id="post-path-link"}}Post{{/link-to}}
-        {{#link-to route="post" model=123 id="post-number-link"}}Post{{/link-to}}
-        {{#link-to route="repo" model=this.repo id="repo-object-link"}}Repo{{/link-to}}
+        <div id="link">{{#link-to route="filter" model="unpopular"}}Unpopular{{/link-to}}</div>
+        <div id="path-link">{{#link-to route="filter" model=this.filter}}Unpopular{{/link-to}}</div>
+        <div id="post-path-link">{{#link-to route="post" model=this.post_id}}Post{{/link-to}}</div>
+        <div id="post-number-link">{{#link-to route="post" model=123}}Post{{/link-to}}</div>
+        <div id="repo-object-link">{{#link-to route="repo" model=this.repo}}Repo{{/link-to}}</div>
         `
       );
 
-      return this.visit('/filters/popular').then(() => {
-        assert.equal(normalizeUrl(this.$('#link').attr('href')), '/filters/unpopular');
-        assert.equal(normalizeUrl(this.$('#path-link').attr('href')), '/filters/unpopular');
-        assert.equal(normalizeUrl(this.$('#post-path-link').attr('href')), '/post/123');
-        assert.equal(normalizeUrl(this.$('#post-number-link').attr('href')), '/post/123');
-        assert.equal(
-          normalizeUrl(this.$('#repo-object-link').attr('href')),
-          '/repo/ember/ember.js'
-        );
-      });
+      await this.visit('/filters/popular');
+
+      assert.equal(normalizeUrl(this.$('#link > a').attr('href')), '/filters/unpopular');
+      assert.equal(normalizeUrl(this.$('#path-link > a').attr('href')), '/filters/unpopular');
+      assert.equal(normalizeUrl(this.$('#post-path-link > a').attr('href')), '/post/123');
+      assert.equal(normalizeUrl(this.$('#post-number-link > a').attr('href')), '/post/123');
+      assert.equal(
+        normalizeUrl(this.$('#repo-object-link > a').attr('href')),
+        '/repo/ember/ember.js'
+      );
     }
 
-    [`@test Issue 4201 - Shorthand for route.index shouldn't throw errors about context arguments`](
+    async [`@test [GH#4201] Shorthand for route.index shouldn't throw errors about context arguments`](
       assert
     ) {
-      assert.expect(2);
       this.router.map(function () {
         this.route('lobby', function () {
           this.route('index', { path: ':lobby_id' });
@@ -1438,30 +1491,32 @@ moduleFor(
 
       this.add(
         'route:lobby.index',
-        Route.extend({
+        class extends Route {
           model(params) {
             assert.equal(params.lobby_id, 'foobar');
             return params.lobby_id;
-          },
-        })
+          }
+        }
       );
 
       this.addTemplate(
         'lobby.index',
-        `{{#link-to route='lobby' model='foobar' id='lobby-link'}}Lobby{{/link-to}}`
+        `<div id='lobby-link'>{{#link-to route='lobby' model='foobar'}}Lobby{{/link-to}}</div>`
       );
 
       this.addTemplate(
         'lobby.list',
-        `{{#link-to route='lobby' model='foobar' id='lobby-link'}}Lobby{{/link-to}}`
+        `<div id='lobby-link'>{{#link-to route='lobby' model='foobar'}}Lobby{{/link-to}}</div>`
       );
 
-      return this.visit('/lobby/list')
-        .then(() => this.click('#lobby-link'))
-        .then(() => shouldBeActive(assert, this.$('#lobby-link')));
+      await this.visit('/lobby/list');
+
+      await this.click('#lobby-link > a');
+
+      shouldBeActive(assert, this.$('#lobby-link > a'));
     }
 
-    [`@test Quoteless route param performs property lookup`](assert) {
+    async [`@test Quoteless route param performs property lookup`](assert) {
       this.router.map(function () {
         this.route('about');
       });
@@ -1469,34 +1524,40 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to route='index' id='string-link'}}string{{/link-to}}
-        {{#link-to route=this.foo id='path-link'}}path{{/link-to}}
+        <div id='string-link'>{{#link-to route='index'}}string{{/link-to}}</div>
+        <div id='path-link'>{{#link-to route=this.foo}}path{{/link-to}}</div>
         `
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          foo: 'index',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          foo = 'index';
+        }
       );
 
       let assertEquality = (href) => {
-        assert.equal(normalizeUrl(this.$('#string-link').attr('href')), '/');
-        assert.equal(normalizeUrl(this.$('#path-link').attr('href')), href);
+        assert.equal(normalizeUrl(this.$('#string-link > a').attr('href')), '/');
+        assert.equal(normalizeUrl(this.$('#path-link > a').attr('href')), href);
       };
 
-      return this.visit('/').then(() => {
-        assertEquality('/');
+      await this.visit('/');
 
-        let controller = this.applicationInstance.lookup('controller:index');
-        runTask(() => controller.set('foo', 'about'));
+      assertEquality('/');
 
-        assertEquality('/about');
-      });
+      runTask(() => controller.set('foo', 'about'));
+
+      assertEquality('/about');
     }
 
-    [`@test The {{link-to}} component refreshes href element when one of params changes`](assert) {
+    async [`@test it refreshes href element when one of params changes`](assert) {
       this.router.map(function () {
         this.route('post', { path: '/posts/:post_id' });
       });
@@ -1506,40 +1567,49 @@ moduleFor(
 
       this.addTemplate(
         'index',
-        `{{#link-to route="post" model=this.post id="post"}}post{{/link-to}}`
+        `<div id="post">{{#link-to route="post" model=this.post}}post{{/link-to}}</div>`
       );
 
-      this.add('controller:index', Controller.extend());
+      let controller;
 
-      return this.visit('/').then(() => {
-        let indexController = this.applicationInstance.lookup('controller:index');
-        runTask(() => indexController.set('post', post));
+      this.add(
+        'controller:index',
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+        }
+      );
 
-        assert.equal(
-          normalizeUrl(this.$('#post').attr('href')),
-          '/posts/1',
-          'precond - Link has rendered href attr properly'
-        );
+      await this.visit('/');
 
-        runTask(() => indexController.set('post', secondPost));
+      runTask(() => controller.set('post', post));
 
-        assert.equal(
-          this.$('#post').attr('href'),
-          '/posts/2',
-          'href attr was updated after one of the params had been changed'
-        );
+      assert.equal(
+        normalizeUrl(this.$('#post > a').attr('href')),
+        '/posts/1',
+        'precond - Link has rendered href attr properly'
+      );
 
-        runTask(() => indexController.set('post', null));
+      runTask(() => controller.set('post', secondPost));
 
-        assert.equal(
-          this.$('#post').attr('href'),
-          '#',
-          'href attr becomes # when one of the arguments in nullified'
-        );
-      });
+      assert.equal(
+        this.$('#post > a').attr('href'),
+        '/posts/2',
+        'href attr was updated after one of the params had been changed'
+      );
+
+      runTask(() => controller.set('post', null));
+
+      assert.equal(
+        this.$('#post > a').attr('href'),
+        '#',
+        'href attr becomes # when one of the arguments in nullified'
+      );
     }
 
-    [`@test The {{link-to}} component is active when a route is active`](assert) {
+    async [`@test it is active when a route is active`](assert) {
       this.router.map(function () {
         this.route('about', function () {
           this.route('item');
@@ -1550,40 +1620,45 @@ moduleFor(
         'about',
         `
         <div id='about'>
-          {{#link-to route='about' id='about-link'}}About{{/link-to}}
-          {{#link-to route='about.item' id='item-link'}}Item{{/link-to}}
+          <div id='about-link'>{{#link-to route='about'}}About{{/link-to}}</div>
+          <div id='item-link'>{{#link-to route='about.item'}}Item{{/link-to}}</div>
           {{outlet}}
         </div>
         `
       );
 
-      return this.visit('/about')
-        .then(() => {
-          assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
-          assert.equal(this.$('#item-link.active').length, 0, 'The item route link is inactive');
+      await this.visit('/about');
 
-          return this.visit('/about/item');
-        })
-        .then(() => {
-          assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
-          assert.equal(this.$('#item-link.active').length, 1, 'The item route link is active');
-        });
+      assert.equal(this.$('#about-link > a.active').length, 1, 'The about route link is active');
+      assert.equal(this.$('#item-link > a.active').length, 0, 'The item route link is inactive');
+
+      await this.visit('/about/item');
+
+      assert.equal(this.$('#about-link > a.active').length, 1, 'The about route link is active');
+      assert.equal(this.$('#item-link > a.active').length, 1, 'The item route link is active');
     }
 
-    [`@test The {{link-to}} component works in an #each'd array of string route names`](assert) {
+    async [`@test it works in an #each'd array of string route names`](assert) {
       this.router.map(function () {
         this.route('foo');
         this.route('bar');
         this.route('rar');
       });
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          routeNames: emberA(['foo', 'bar', 'rar']),
-          route1: 'bar',
-          route2: 'foo',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          routeNames = emberA(['foo', 'bar', 'rar']);
+          route1 = 'bar';
+          route2 = 'foo';
+        }
       );
 
       this.addTemplate(
@@ -1615,24 +1690,22 @@ moduleFor(
         }
       };
 
-      return this.visit('/').then(() => {
-        linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/bar', '/foo']);
+      await this.visit('/');
 
-        let indexController = this.applicationInstance.lookup('controller:index');
-        runTask(() => indexController.set('route1', 'rar'));
+      linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/bar', '/foo']);
 
-        linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/rar', '/foo']);
+      runTask(() => controller.set('route1', 'rar'));
 
-        runTask(() => indexController.routeNames.shiftObject());
+      linksEqual(this.$('a'), ['/foo', '/bar', '/rar', '/foo', '/bar', '/rar', '/rar', '/foo']);
 
-        linksEqual(this.$('a'), ['/bar', '/rar', '/bar', '/rar', '/rar', '/foo']);
-      });
+      runTask(() => controller.routeNames.shiftObject());
+
+      linksEqual(this.$('a'), ['/bar', '/rar', '/bar', '/rar', '/rar', '/foo']);
     }
 
-    [`@test [DEPRECATED] The non-block form {{link-to}} component moves into the named route`](
+    async [`@test [DEPRECATED] The non-block form {{link-to}} component moves into the named route`](
       assert
     ) {
-      assert.expect(5);
       this.router.map(function () {
         this.route('contact');
       });
@@ -1642,54 +1715,59 @@ moduleFor(
           'index',
           `
           <h3 class="home">Home</h3>
-          {{link-to 'Contact us' 'contact' id='contact-link'}}
-          {{#link-to route='index' id='self-link'}}Self{{/link-to}}
+          <div id='contact-link'>{{link-to 'Contact us' 'contact'}}</div>
+          <div id='self-link'>{{#link-to route='index'}}Self{{/link-to}}</div>
           `
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+
       expectDeprecation(() => {
         this.addTemplate(
           'contact',
           `
           <h3 class="contact">Contact</h3>
-          {{link-to 'Home' 'index' id='home-link'}}
-          {{link-to 'Self' 'contact' id='self-link'}}
+          <div id='home-link'>{{link-to 'Home' 'index'}}</div>
+          <div id='self-link'>{{link-to 'Self' 'contact'}}</div>
           `
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#contact-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.contact').length, 1, 'The contact template was rendered');
-          assert.equal(
-            this.$('#self-link.active').length,
-            1,
-            'The self-link was rendered with active class'
-          );
-          assert.equal(
-            this.$('#home-link:not(.active)').length,
-            1,
-            'The other link was rendered without active class'
-          );
-        });
+      await this.visit('/');
+
+      await this.click('#contact-link > a');
+
+      assert.equal(this.$('h3.contact').length, 1, 'The contact template was rendered');
+      assert.equal(
+        this.$('#self-link > a.active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#home-link > a:not(.active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
     }
 
-    [`@test [DEPRECATED] The non-block form {{link-to}} component updates the link text when it is a binding`](
+    async [`@test [DEPRECATED] The non-block form {{link-to}} component updates the link text when it is a binding`](
       assert
     ) {
-      assert.expect(10);
       this.router.map(function () {
         this.route('contact');
       });
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          contactName: 'Jane',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          contactName = 'Jane';
+        }
       );
 
       expectDeprecation(() => {
@@ -1697,94 +1775,89 @@ moduleFor(
           'index',
           `
           <h3 class="home">Home</h3>
-          {{link-to this.contactName 'contact' id='contact-link'}}
-          {{#link-to route='index' id='self-link'}}Self{{/link-to}}
+          <div id='contact-link'>{{link-to this.contactName 'contact'}}</div>
+          <div id='self-link'>{{#link-to route='index'}}Self{{/link-to}}</div>
           `
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+
       expectDeprecation(() => {
         this.addTemplate(
           'contact',
           `
           <h3 class="contact">Contact</h3>
-          {{link-to 'Home' 'index' id='home-link'}}
-          {{link-to 'Self' 'contact' id='self-link'}}
+          <div id='home-link'>{{link-to 'Home' 'index'}}</div>
+          <div id='self-link'>{{link-to 'Self' 'contact'}}</div>
           `
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
 
-      return this.visit('/')
-        .then(() => {
-          assert.equal(
-            this.$('#contact-link').text(),
-            'Jane',
-            'The link title is correctly resolved'
-          );
+      await this.visit('/');
 
-          let controller = this.applicationInstance.lookup('controller:index');
-          runTask(() => controller.set('contactName', 'Joe'));
+      assert.equal(
+        this.$('#contact-link > a').text(),
+        'Jane',
+        'The link title is correctly resolved'
+      );
 
-          assert.equal(
-            this.$('#contact-link').text(),
-            'Joe',
-            'The link title is correctly updated when the bound property changes'
-          );
+      runTask(() => controller.set('contactName', 'Joe'));
 
-          runTask(() => controller.set('contactName', 'Robert'));
+      assert.equal(
+        this.$('#contact-link > a').text(),
+        'Joe',
+        'The link title is correctly updated when the bound property changes'
+      );
 
-          assert.equal(
-            this.$('#contact-link').text(),
-            'Robert',
-            'The link title is correctly updated when the bound property changes a second time'
-          );
+      runTask(() => controller.set('contactName', 'Robert'));
 
-          return this.click('#contact-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.contact').length, 1, 'The contact template was rendered');
-          assert.equal(
-            this.$('#self-link.active').length,
-            1,
-            'The self-link was rendered with active class'
-          );
-          assert.equal(
-            this.$('#home-link:not(.active)').length,
-            1,
-            'The other link was rendered without active class'
-          );
+      assert.equal(
+        this.$('#contact-link > a').text(),
+        'Robert',
+        'The link title is correctly updated when the bound property changes a second time'
+      );
 
-          return this.click('#home-link');
-        })
-        .then(() => {
-          assert.equal(this.$('h3.home').length, 1, 'The index template was rendered');
-          assert.equal(
-            this.$('#contact-link').text(),
-            'Robert',
-            'The link title is correctly updated when the route changes'
-          );
-        });
+      await this.click('#contact-link > a');
+
+      assert.equal(this.$('h3.contact').length, 1, 'The contact template was rendered');
+      assert.equal(
+        this.$('#self-link > a.active').length,
+        1,
+        'The self-link was rendered with active class'
+      );
+      assert.equal(
+        this.$('#home-link > a:not(.active)').length,
+        1,
+        'The other link was rendered without active class'
+      );
+
+      await this.click('#home-link > a');
+
+      assert.equal(this.$('h3.home').length, 1, 'The index template was rendered');
+      assert.equal(
+        this.$('#contact-link > a').text(),
+        'Robert',
+        'The link title is correctly updated when the route changes'
+      );
     }
 
     async [`@test [DEPRECATED] The non-block form {{link-to}} component moves into the named route with context`](
       assert
     ) {
-      assert.expect(6);
-
       this.router.map(function () {
         this.route('item', { path: '/item/:id' });
       });
 
       this.add(
         'route:index',
-        Route.extend({
+        class extends Route {
           model() {
             return [
               { id: 'yehuda', name: 'Yehuda Katz' },
               { id: 'tom', name: 'Tom Dale' },
               { id: 'erik', name: 'Erik Brynroflsson' },
             ];
-          },
-        })
+          }
+        }
       );
 
       expectDeprecation(() => {
@@ -1794,38 +1867,39 @@ moduleFor(
           <h3 class="home">Home</h3>
           <ul>
             {{#each @model as |person|}}
-              <li>
-                {{link-to person.name 'item' person id=person.id}}
+              <li id={{person.id}}>
+                {{link-to person.name 'item' person}}
               </li>
             {{/each}}
           </ul>
           `
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+
       this.addTemplate(
         'item',
         `
         <h3 class="item">Item</h3>
         <p>{{@model.name}}</p>
-        {{#link-to route='index' id='home-link'}}Home{{/link-to}}
+        <div id='home-link'>{{#link-to route='index'}}Home{{/link-to}}</div>
         `
       );
 
       await this.visit('/');
 
-      await this.click('#yehuda');
+      await this.click('#yehuda > a');
 
       assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
       assert.equal(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
 
-      await this.click('#home-link');
+      await this.click('#home-link > a');
 
-      assert.equal(normalizeUrl(this.$('li a#yehuda').attr('href')), '/item/yehuda');
-      assert.equal(normalizeUrl(this.$('li a#tom').attr('href')), '/item/tom');
-      assert.equal(normalizeUrl(this.$('li a#erik').attr('href')), '/item/erik');
+      assert.equal(normalizeUrl(this.$('li#yehuda > a').attr('href')), '/item/yehuda');
+      assert.equal(normalizeUrl(this.$('li#tom > a').attr('href')), '/item/tom');
+      assert.equal(normalizeUrl(this.$('li#erik > a').attr('href')), '/item/erik');
     }
 
-    [`@test [DEPRECATED] The non-block form {{link-to}} performs property lookup`](assert) {
+    async [`@test [DEPRECATED] The non-block form {{link-to}} performs property lookup`](assert) {
       this.router.map(function () {
         this.route('about');
       });
@@ -1840,52 +1914,64 @@ moduleFor(
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          foo: 'index',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          foo = 'index';
+        }
       );
 
-      return this.visit('/').then(() => {
-        let assertEquality = (href) => {
-          assert.equal(normalizeUrl(this.$('#string-link').attr('href')), '/');
-          assert.equal(normalizeUrl(this.$('#path-link').attr('href')), href);
-        };
+      await this.visit('/');
 
-        assertEquality('/');
+      let assertEquality = (href) => {
+        assert.equal(normalizeUrl(this.$('#string-link').attr('href')), '/');
+        assert.equal(normalizeUrl(this.$('#path-link').attr('href')), href);
+      };
 
-        let controller = this.applicationInstance.lookup('controller:index');
-        runTask(() => controller.set('foo', 'about'));
+      assertEquality('/');
 
-        assertEquality('/about');
-      });
+      runTask(() => controller.set('foo', 'about'));
+
+      assertEquality('/about');
     }
 
-    [`@test [DEPRECATED] The non-block form {{link-to}} protects against XSS`](assert) {
+    async [`@test [DEPRECATED] The non-block form {{link-to}} protects against XSS`](assert) {
       expectDeprecation(() => {
         this.addTemplate('application', `{{link-to this.display 'index' id='link'}}`);
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
 
+      let controller;
+
       this.add(
         'controller:application',
-        Controller.extend({
-          display: 'blahzorz',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          display = 'blahzorz';
+        }
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#link').text(), 'blahzorz');
+      await this.visit('/');
 
-        let controller = this.applicationInstance.lookup('controller:application');
-        runTask(() => controller.set('display', '<b>BLAMMO</b>'));
+      assert.equal(this.$('#link').text(), 'blahzorz');
 
-        assert.equal(this.$('#link').text(), '<b>BLAMMO</b>');
-        assert.equal(this.$('b').length, 0);
-      });
+      runTask(() => controller.set('display', '<b>BLAMMO</b>'));
+
+      assert.equal(this.$('#link').text(), '<b>BLAMMO</b>');
+      assert.strictEqual(this.$('b').length, 0);
     }
 
-    async [`@test the {{link-to}} component throws a useful error if you invoke it wrong`](assert) {
+    async [`@test it throws a useful error if you invoke it wrong`](assert) {
       if (!DEBUG) {
         assert.expect(0);
         return;
@@ -1903,7 +1989,7 @@ moduleFor(
       );
     }
 
-    [`@test the {{link-to}} component does not throw an error if its route has exited`](assert) {
+    async [`@test it does not throw an error if its route has exited`](assert) {
       assert.expect(0);
 
       this.router.map(function () {
@@ -1913,45 +1999,49 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-        {{#link-to route='index' id='home-link'}}Home{{/link-to}}
-        {{#link-to route='post' model=this.defaultPost id='default-post-link'}}Default Post{{/link-to}}
+        <div id='home-link'>{{#link-to route='index'}}Home{{/link-to}}</div>
+        <div id='default-post-link'>{{#link-to route='post' model=this.defaultPost}}Default Post{{/link-to}}</div>
         {{#if this.currentPost}}
-          {{#link-to route='post' model=this.currentPost id='current-post-link'}}Current Post{{/link-to}}
+          <div id='current-post-link'>{{#link-to route='post' model=this.currentPost}}Current Post{{/link-to}}</div>
         {{/if}}
         `
       );
 
       this.add(
         'controller:application',
-        Controller.extend({
-          defaultPost: { id: 1 },
-          postController: injectController('post'),
-          currentPost: alias('postController.model'),
-        })
+        class extends Controller {
+          defaultPost = { id: 1 };
+
+          @injectController('post') postController;
+
+          get currentPost() {
+            return this.postController.model;
+          }
+        }
       );
 
-      this.add('controller:post', Controller.extend());
+      this.add('controller:post', class extends Controller {});
 
       this.add(
         'route:post',
-        Route.extend({
+        class extends Route {
           model() {
             return { id: 2 };
-          },
+          }
           serialize(model) {
             return { post_id: model.id };
-          },
-        })
+          }
+        }
       );
 
-      return this.visit('/')
-        .then(() => this.click('#default-post-link'))
-        .then(() => this.click('#home-link'))
-        .then(() => this.click('#current-post-link'))
-        .then(() => this.click('#home-link'));
+      await this.visit('/');
+      await this.click('#default-post-link > a');
+      await this.click('#home-link > a');
+      await this.click('#current-post-link > a');
+      await this.click('#home-link > a');
     }
 
-    [`@test {{link-to}} active property respects changing parent route context`](assert) {
+    async [`@test its active property respects changing parent route context`](assert) {
       this.router.map(function () {
         this.route('things', { path: '/things/:name' }, function () {
           this.route('other');
@@ -1961,102 +2051,101 @@ moduleFor(
       this.addTemplate(
         'application',
         `
-        {{#link-to route='things' model='omg' id='omg-link'}}OMG{{/link-to}}
-        {{#link-to route='things' model='lol' id='lol-link'}}LOL{{/link-to}}
+        <div id='omg-link'>{{#link-to route='things' model='omg'}}OMG{{/link-to}}</div>
+        <div id='lol-link'>{{#link-to route='things' model='lol'}}LOL{{/link-to}}</div>
         `
       );
 
-      return this.visit('/things/omg')
-        .then(() => {
-          shouldBeActive(assert, this.$('#omg-link'));
-          shouldNotBeActive(assert, this.$('#lol-link'));
+      await this.visit('/things/omg');
 
-          return this.visit('/things/omg/other');
-        })
-        .then(() => {
-          shouldBeActive(assert, this.$('#omg-link'));
-          shouldNotBeActive(assert, this.$('#lol-link'));
-        });
+      shouldBeActive(assert, this.$('#omg-link > a'));
+      shouldNotBeActive(assert, this.$('#lol-link > a'));
+
+      await this.visit('/things/omg/other');
+
+      shouldBeActive(assert, this.$('#omg-link > a'));
+      shouldNotBeActive(assert, this.$('#lol-link > a'));
     }
 
-    [`@test {{link-to}} populates href with default query param values even without query-params object`](
+    async [`@test it populates href with default query param values even without query-params object`](
       assert
     ) {
       this.add(
         'controller:index',
-        Controller.extend({
-          queryParams: ['foo'],
-          foo: '123',
-        })
-      );
-
-      this.addTemplate('index', `{{#link-to route='index' id='the-link'}}Index{{/link-to}}`);
-
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
-      });
-    }
-
-    [`@test {{link-to}} populates href with default query param values with empty query-params object`](
-      assert
-    ) {
-      this.add(
-        'controller:index',
-        Controller.extend({
-          queryParams: ['foo'],
-          foo: '123',
-        })
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = '123';
+        }
       );
 
       this.addTemplate(
         'index',
-        `{{#link-to route='index' query=(hash) id='the-link'}}Index{{/link-to}}`
+        `<div id='the-link'>{{#link-to route='index'}}Index{{/link-to}}</div>`
       );
 
-      return this.visit('/').then(() => {
-        assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
-      });
+      await this.visit('/');
+
+      assert.equal(this.$('#the-link > a').attr('href'), '/', 'link has right href');
     }
 
-    [`@test {{link-to}} with only query-params and a block updates when route changes`](assert) {
+    async [`@test it populates href with default query param values with empty query-params object`](
+      assert
+    ) {
+      this.add(
+        'controller:index',
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = '123';
+        }
+      );
+
+      this.addTemplate(
+        'index',
+        `<div id='the-link'>{{#link-to route='index' query=(hash)}}Index{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      assert.equal(this.$('#the-link > a').attr('href'), '/', 'link has right href');
+    }
+
+    async [`@test it updates when route changes with only query-params and a block`](assert) {
       this.router.map(function () {
         this.route('about');
       });
 
       this.add(
         'controller:application',
-        Controller.extend({
-          queryParams: ['foo', 'bar'],
-          foo: '123',
-          bar: 'yes',
-        })
+        class extends Controller {
+          queryParams = ['foo', 'bar'];
+          foo = '123';
+          bar = 'yes';
+        }
       );
 
       this.addTemplate(
         'application',
-        `{{#link-to query=(hash foo='456' bar='NAW') id='the-link'}}Index{{/link-to}}`
+        `<div id='the-link'>{{#link-to query=(hash foo='456' bar='NAW')}}Index{{/link-to}}</div>`
       );
 
-      return this.visit('/')
-        .then(() => {
-          assert.equal(
-            this.$('#the-link').attr('href'),
-            '/?bar=NAW&foo=456',
-            'link has right href'
-          );
+      await this.visit('/');
 
-          return this.visit('/about');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#the-link').attr('href'),
-            '/about?bar=NAW&foo=456',
-            'link has right href'
-          );
-        });
+      assert.equal(
+        this.$('#the-link > a').attr('href'),
+        '/?bar=NAW&foo=456',
+        'link has right href'
+      );
+
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#the-link > a').attr('href'),
+        '/about?bar=NAW&foo=456',
+        'link has right href'
+      );
     }
 
-    [`@test [DEPRECATED] Block-less {{link-to}} with only query-params updates when route changes`](
+    async [`@test [DEPRECATED] it updates when route changes with only query-params but without a block`](
       assert
     ) {
       this.router.map(function () {
@@ -2075,64 +2164,61 @@ moduleFor(
       expectDeprecation(() => {
         this.addTemplate(
           'application',
-          `{{link-to "Index" (query-params foo='456' bar='NAW') id='the-link'}}`
+          `<div id='the-link'>{{link-to "Index" (query-params foo='456' bar='NAW')}}</div>`
         );
       }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
 
-      return this.visit('/')
-        .then(() => {
-          assert.equal(
-            this.$('#the-link').attr('href'),
-            '/?bar=NAW&foo=456',
-            'link has right href'
-          );
+      await this.visit('/');
 
-          return this.visit('/about');
-        })
-        .then(() => {
-          assert.equal(
-            this.$('#the-link').attr('href'),
-            '/about?bar=NAW&foo=456',
-            'link has right href'
-          );
-        });
+      assert.equal(
+        this.$('#the-link > a').attr('href'),
+        '/?bar=NAW&foo=456',
+        'link has right href'
+      );
+
+      await this.visit('/about');
+
+      assert.equal(
+        this.$('#the-link > a').attr('href'),
+        '/about?bar=NAW&foo=456',
+        'link has right href'
+      );
     }
 
-    ['@test [GH#17018] passing model to link-to with `hash` helper works']() {
+    async ['@test [GH#17018] passing model to {{link-to}} with `hash` helper works']() {
       this.router.map(function () {
         this.route('post', { path: '/posts/:post_id' });
       });
 
       this.add(
         'route:index',
-        Route.extend({
+        class extends Route {
           model() {
             return RSVP.hash({
               user: { name: 'Papa Smurf' },
             });
-          },
-        })
+          }
+        }
       );
 
       this.addTemplate(
         'index',
         `{{#link-to route='post' model=(hash id="someId" user=@model.user)}}Post{{/link-to}}`
       );
+
       this.addTemplate('post', 'Post: {{@model.user.name}}');
 
-      return this.visit('/')
-        .then(() => {
-          this.assertComponentElement(this.firstChild, {
-            tagName: 'a',
-            attrs: { href: '/posts/someId' },
-            content: 'Post',
-          });
+      await this.visit('/');
 
-          return this.click('a');
-        })
-        .then(() => {
-          this.assertText('Post: Papa Smurf');
-        });
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/posts/someId' },
+        content: 'Post',
+      });
+
+      await this.click('a');
+
+      this.assertText('Post: Papa Smurf');
     }
 
     async [`@test [DEPRECATED] The {{link-to}} component can use dynamic params`](assert) {
@@ -2141,21 +2227,25 @@ moduleFor(
         this.route('bar', { path: 'bar/:some/:thing/:else' });
       });
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          init() {
-            this._super(...arguments);
-            this.dynamicLinkParams = ['foo', 'one', 'two'];
-          },
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          dynamicLinkParams = ['foo', 'one', 'two'];
+        }
       );
 
       this.addTemplate(
         'index',
         `
         <h3 class="home">Home</h3>
-        {{#link-to params=this.dynamicLinkParams id="dynamic-link"}}Dynamic{{/link-to}}
+        <div id="dynamic-link">{{#link-to params=this.dynamicLinkParams}}Dynamic{{/link-to}}</div>
         `
       );
 
@@ -2164,26 +2254,21 @@ moduleFor(
         /Invoking the `<LinkTo>` component with positional arguments is deprecated/
       );
 
-      let link = this.$('#dynamic-link');
+      let link = this.$('#dynamic-link > a');
 
       assert.equal(link.attr('href'), '/foo/one/two');
 
-      let controller = this.applicationInstance.lookup('controller:index');
-
-      expectDeprecation(() => {
-        runTask(() => {
-          controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three']);
-        });
-      }, /Invoking the `<LinkTo>` component with positional arguments is deprecated/);
+      expectDeprecation(
+        () => runTask(() => controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three'])),
+        /Invoking the `<LinkTo>` component with positional arguments is deprecated/
+      );
 
       assert.equal(link.attr('href'), '/bar/one/two/three');
     }
 
-    [`@test GJ: {{link-to}} to a parent root model hook which performs a 'transitionTo' has correct active class #13256`](
+    async [`@test [GH#13256]: {{link-to}} to a parent root model hook which performs a 'transitionTo' has correct active class`](
       assert
     ) {
-      assert.expect(3);
-
       this.router.map(function () {
         this.route('parent', function () {
           this.route('child');
@@ -2192,26 +2277,25 @@ moduleFor(
 
       this.add(
         'route:parent',
-        Route.extend({
+        class extends Route {
           afterModel() {
             expectDeprecation(() => {
               this.transitionTo('parent.child');
             }, /Calling transitionTo on a route is deprecated/);
-          },
-        })
-      );
-      this.addTemplate(
-        'application',
-        `{{#link-to route='parent' id='parent-link'}}Parent{{/link-to}}`
+          }
+        }
       );
 
-      return this.visit('/')
-        .then(() => {
-          return this.click('#parent-link');
-        })
-        .then(() => {
-          shouldBeActive(assert, this.$('#parent-link'));
-        });
+      this.addTemplate(
+        'application',
+        `<div id='parent-link'>{{#link-to route='parent'}}Parent{{/link-to}}</div>`
+      );
+
+      await this.visit('/');
+
+      await this.click('#parent-link > a');
+
+      shouldBeActive(assert, this.$('#parent-link > a'));
     }
   }
 );
@@ -2219,10 +2303,9 @@ moduleFor(
 moduleFor(
   'The {{link-to}} component - loading states and warnings',
   class extends ApplicationTestCase {
-    [`@test {{link-to}} with null/undefined dynamic parameters are put in a loading state`](
+    async [`@test {{link-to}} with null/undefined dynamic parameters are put in a loading state`](
       assert
     ) {
-      assert.expect(19);
       let warningMessage =
         'This link is in an inactive loading state because at least one of its models currently has a null/undefined value, or the provided route name is invalid.';
 
@@ -2234,31 +2317,44 @@ moduleFor(
       this.addTemplate(
         'index',
         `
-        {{#link-to route=this.destinationRoute model=this.routeContext loadingClass='i-am-loading' id='context-link'}}
-          string
-        {{/link-to}}
-        {{#link-to route=this.secondRoute loadingClass=this.loadingClass id='static-link'}}
-          string
-        {{/link-to}}
+        <div id='context-link'>
+          {{#link-to route=this.destinationRoute model=this.routeContext loadingClass='i-am-loading'}}
+            string
+          {{/link-to}}
+        </div>
+        <div id='static-link'>
+          {{#link-to route=this.secondRoute loadingClass=this.loadingClass}}
+            string
+          {{/link-to}}
+        </div>
         `
       );
 
+      let controller;
+
       this.add(
         'controller:index',
-        Controller.extend({
-          destinationRoute: null,
-          routeContext: null,
-          loadingClass: 'i-am-loading',
-        })
+        class extends Controller {
+          constructor(...args) {
+            super(...args);
+            controller = this;
+          }
+
+          destinationRoute = null;
+          routeContext = null;
+          loadingClass = 'i-am-loading';
+        }
       );
+
+      let activate = 0;
 
       this.add(
         'route:about',
-        Route.extend({
+        class extends Route {
           activate() {
-            assert.ok(true, 'About was entered');
-          },
-        })
+            activate++;
+          }
+        }
       );
 
       function assertLinkStatus(link, url) {
@@ -2271,55 +2367,45 @@ moduleFor(
         }
       }
 
-      let contextLink, staticLink, controller;
+      await this.visit('/');
 
-      return this.visit('/')
-        .then(() => {
-          contextLink = this.$('#context-link');
-          staticLink = this.$('#static-link');
-          controller = this.applicationInstance.lookup('controller:index');
+      let contextLink = this.$('#context-link > a');
+      let staticLink = this.$('#static-link > a');
 
-          assertLinkStatus(contextLink);
-          assertLinkStatus(staticLink);
+      assertLinkStatus(contextLink);
+      assertLinkStatus(staticLink);
 
-          return expectWarning(() => {
-            return this.click(contextLink[0]);
-          }, warningMessage);
-        })
-        .then(() => {
-          // Set the destinationRoute (context is still null).
-          runTask(() => controller.set('destinationRoute', 'thing'));
-          assertLinkStatus(contextLink);
+      await expectWarning(() => this.click(contextLink[0]), warningMessage);
 
-          // Set the routeContext to an id
-          runTask(() => controller.set('routeContext', '456'));
-          assertLinkStatus(contextLink, '/thing/456');
+      // Set the destinationRoute (context is still null).
+      runTask(() => controller.set('destinationRoute', 'thing'));
+      assertLinkStatus(contextLink);
 
-          // Test that 0 isn't interpreted as falsy.
-          runTask(() => controller.set('routeContext', 0));
-          assertLinkStatus(contextLink, '/thing/0');
+      // Set the routeContext to an id
+      runTask(() => controller.set('routeContext', '456'));
+      assertLinkStatus(contextLink, '/thing/456');
 
-          // Set the routeContext to an object
-          runTask(() => {
-            controller.set('routeContext', { id: 123 });
-          });
-          assertLinkStatus(contextLink, '/thing/123');
+      // Test that 0 isn't interpreted as falsy.
+      runTask(() => controller.set('routeContext', 0));
+      assertLinkStatus(contextLink, '/thing/0');
 
-          // Set the destinationRoute back to null.
-          runTask(() => controller.set('destinationRoute', null));
-          assertLinkStatus(contextLink);
+      // Set the routeContext to an object
+      runTask(() => controller.set('routeContext', { id: 123 }));
+      assertLinkStatus(contextLink, '/thing/123');
 
-          return expectWarning(() => {
-            return this.click(staticLink[0]);
-          }, warningMessage);
-        })
-        .then(() => {
-          runTask(() => controller.set('secondRoute', 'about'));
-          assertLinkStatus(staticLink, '/about');
+      // Set the destinationRoute back to null.
+      runTask(() => controller.set('destinationRoute', null));
+      assertLinkStatus(contextLink);
 
-          // Click the now-active link
-          return this.click(staticLink[0]);
-        });
+      await expectWarning(() => this.click(staticLink[0]), warningMessage);
+
+      runTask(() => controller.set('secondRoute', 'about'));
+      assertLinkStatus(staticLink, '/about');
+
+      // Click the now-active link
+      await this.click(staticLink[0]);
+
+      assert.equal(activate, 1, 'About route was entered');
     }
   }
 );


### PR DESCRIPTION
* use async functions
* shortern the test names
* avoid `assert.expect`
* avoid soon-to-be-deprecated `@id` argument
