### PR TITLE
Fix glimmer-component-docs.ts typo in Markdown

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
@@ -158,7 +158,7 @@
   to `{{yield}}`. Whenever you invoke a component without passing explicitly
   named blocks, the passed block is considered the `default` block.
 
-  ### Passing parameters to named bxlocks
+  ### Passing parameters to named blocks
 
   You can also pass parameters to named blocks:
 


### PR DESCRIPTION
Was also affecting a heading anchor link. Kudos to @kaermorchen.