### PR TITLE
Add deprecation for `Route#renderTemplate`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -181,6 +181,7 @@ if (ENV._DEBUG_RENDER_TREE) {
       }
 
       async '@test named outlets'() {
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
         this.addTemplate(
           'application',
           strip`

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -440,6 +440,7 @@ moduleFor(
     }
 
     ['@test it can render into named outlets']() {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.router.map(function () {
         this.route('colors');
       });
@@ -599,6 +600,7 @@ moduleFor(
     }
 
     ['@test it should update correctly when the controller changes']() {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.router.map(function () {
         this.route('color', { path: '/colors/:color' });
       });
@@ -643,6 +645,7 @@ moduleFor(
     }
 
     ['@test it should produce a stable DOM when two routes render the same template']() {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.router.map(function () {
         this.route('a');
         this.route('b');

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1507,6 +1507,17 @@ class Route extends EmberObject implements IRoute {
     @public
   */
   renderTemplate(_controller: any, _model: {}) {
+    if (this.renderTemplate !== Route.prototype.renderTemplate) {
+      deprecate('Usage of `renderTemplate` is deprecated.', false, {
+        id: 'route-render-template',
+        until: '4.0.0',
+        url: 'https://deprecations.emberjs.com/v3.x/#toc_route-render-template',
+        for: 'ember-source',
+        since: {
+          enabled: '3.27.0',
+        },
+      });
+    }
     // eslint-disable-line no-unused-vars
     this.render();
   }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -988,6 +988,19 @@ class Route extends EmberObject implements IRoute {
     this.setupController(controller, context, transition);
 
     if (this._environment.options.shouldRender) {
+      deprecate(
+        'Usage of `renderTemplate` is deprecated.',
+        this.renderTemplate === Route.prototype.renderTemplate,
+        {
+          id: 'route-render-template',
+          until: '4.0.0',
+          url: 'https://deprecations.emberjs.com/v3.x/#toc_route-render-template',
+          for: 'ember-source',
+          since: {
+            enabled: '3.27.0',
+          },
+        }
+      );
       this.renderTemplate(controller, context);
     }
 
@@ -1507,17 +1520,6 @@ class Route extends EmberObject implements IRoute {
     @public
   */
   renderTemplate(_controller: any, _model: {}) {
-    if (this.renderTemplate !== Route.prototype.renderTemplate) {
-      deprecate('Usage of `renderTemplate` is deprecated.', false, {
-        id: 'route-render-template',
-        until: '4.0.0',
-        url: 'https://deprecations.emberjs.com/v3.x/#toc_route-render-template',
-        for: 'ember-source',
-        since: {
-          enabled: '3.27.0',
-        },
-      });
-    }
     // eslint-disable-line no-unused-vars
     this.render();
   }

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -51,6 +51,7 @@ if (!jQueryDisabled) {
             'route:posts',
             Route.extend({
               renderTemplate() {
+                expectDeprecation('Usage of `renderTemplate` is deprecated.');
                 testContext.currentRoute = 'posts';
                 this._super(...arguments);
               },
@@ -73,6 +74,7 @@ if (!jQueryDisabled) {
             'route:comments',
             Route.extend({
               renderTemplate() {
+                expectDeprecation('Usage of `renderTemplate` is deprecated.');
                 testContext.currentRoute = 'comments';
                 this._super(...arguments);
               },
@@ -125,7 +127,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test helpers can be chained with then`](assert) {
-        assert.expect(6);
+        assert.expect(8);
 
         window
           .visit('/posts')
@@ -164,7 +166,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test helpers can be chained to each other (legacy)`](assert) {
-        assert.expect(7);
+        assert.expect(10);
 
         window
           .visit('/posts')
@@ -192,7 +194,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test helpers don't need to be chained`](assert) {
-        assert.expect(5);
+        assert.expect(8);
 
         window.visit('/posts');
 
@@ -219,7 +221,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Nested async helpers`](assert) {
-        assert.expect(5);
+        assert.expect(8);
 
         window.visit('/posts');
 
@@ -247,7 +249,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Multiple nested async helpers`](assert) {
-        assert.expect(3);
+        assert.expect(5);
 
         window.visit('/posts');
 
@@ -270,7 +272,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Helpers nested in thens`](assert) {
-        assert.expect(5);
+        assert.expect(8);
 
         window.visit('/posts').then(() => {
           window.click('a:first', '#comments-link');
@@ -311,7 +313,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Unhandled exceptions are logged via Ember.Test.adapter#exception`](assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         console.error = () => {}; // eslint-disable-line no-console
         let asyncHandled;
@@ -343,7 +345,7 @@ if (!jQueryDisabled) {
       [`@test Unhandled exceptions in 'andThen' are logged via Ember.Test.adapter#exception`](
         assert
       ) {
-        assert.expect(1);
+        assert.expect(2);
 
         console.error = () => {}; // eslint-disable-line no-console
         Test.adapter = QUnitAdapter.create({
@@ -364,7 +366,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test should not start routing on the root URL when visiting another`](assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         window.visit('/posts');
 
@@ -427,7 +429,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test visiting a URL that causes another transition should yield the correct URL`](assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         window.visit('/redirect');
 
@@ -439,7 +441,7 @@ if (!jQueryDisabled) {
       [`@test visiting a URL and then visiting a second URL with a transition should yield the correct URL`](
         assert
       ) {
-        assert.expect(3);
+        assert.expect(5);
 
         window.visit('/posts');
 

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -51,7 +51,6 @@ if (!jQueryDisabled) {
             'route:posts',
             Route.extend({
               renderTemplate() {
-                expectDeprecation('Usage of `renderTemplate` is deprecated.');
                 testContext.currentRoute = 'posts';
                 this._super(...arguments);
               },
@@ -74,7 +73,6 @@ if (!jQueryDisabled) {
             'route:comments',
             Route.extend({
               renderTemplate() {
-                expectDeprecation('Usage of `renderTemplate` is deprecated.');
                 testContext.currentRoute = 'comments';
                 this._super(...arguments);
               },
@@ -127,7 +125,8 @@ if (!jQueryDisabled) {
       }
 
       [`@test helpers can be chained with then`](assert) {
-        assert.expect(8);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(7);
 
         window
           .visit('/posts')
@@ -166,7 +165,8 @@ if (!jQueryDisabled) {
       }
 
       [`@test helpers can be chained to each other (legacy)`](assert) {
-        assert.expect(10);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(8);
 
         window
           .visit('/posts')
@@ -194,7 +194,8 @@ if (!jQueryDisabled) {
       }
 
       [`@test helpers don't need to be chained`](assert) {
-        assert.expect(8);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(6);
 
         window.visit('/posts');
 
@@ -221,7 +222,8 @@ if (!jQueryDisabled) {
       }
 
       [`@test Nested async helpers`](assert) {
-        assert.expect(8);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(6);
 
         window.visit('/posts');
 
@@ -249,7 +251,8 @@ if (!jQueryDisabled) {
       }
 
       [`@test Multiple nested async helpers`](assert) {
-        assert.expect(5);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(4);
 
         window.visit('/posts');
 
@@ -272,7 +275,8 @@ if (!jQueryDisabled) {
       }
 
       [`@test Helpers nested in thens`](assert) {
-        assert.expect(8);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(6);
 
         window.visit('/posts').then(() => {
           window.click('a:first', '#comments-link');
@@ -313,6 +317,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test Unhandled exceptions are logged via Ember.Test.adapter#exception`](assert) {
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
         assert.expect(3);
 
         console.error = () => {}; // eslint-disable-line no-console
@@ -345,6 +350,7 @@ if (!jQueryDisabled) {
       [`@test Unhandled exceptions in 'andThen' are logged via Ember.Test.adapter#exception`](
         assert
       ) {
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
         assert.expect(2);
 
         console.error = () => {}; // eslint-disable-line no-console
@@ -366,6 +372,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test should not start routing on the root URL when visiting another`](assert) {
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
         assert.expect(5);
 
         window.visit('/posts');
@@ -429,6 +436,7 @@ if (!jQueryDisabled) {
       }
 
       [`@test visiting a URL that causes another transition should yield the correct URL`](assert) {
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
         assert.expect(3);
 
         window.visit('/redirect');
@@ -441,7 +449,8 @@ if (!jQueryDisabled) {
       [`@test visiting a URL and then visiting a second URL with a transition should yield the correct URL`](
         assert
       ) {
-        assert.expect(5);
+        expectDeprecation('Usage of `renderTemplate` is deprecated.');
+        assert.expect(4);
 
         window.visit('/posts');
 

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -919,6 +919,7 @@ moduleFor(
     }
 
     ['@test Router accounts for rootURL on page load when using history location'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       let rootURL = window.location.pathname + '/app';
       let postsTemplateRendered = false;
       let setHistory;

--- a/packages/ember/tests/routing/model_loading_test.js
+++ b/packages/ember/tests/routing/model_loading_test.js
@@ -204,6 +204,7 @@ moduleFor(
     }
 
     [`@test The route controller specified via controllerName is used in render`](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.router.map(function () {
         this.route('home', { path: '/' });
       });
@@ -484,6 +485,7 @@ moduleFor(
     }
 
     ['@test Nested callbacks are not exited when moving to siblings'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       let rootSetup = 0;
       let rootRender = 0;
       let rootModel = 0;

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -305,7 +305,7 @@ moduleFor(
     }
 
     ['@test Generated names can be customized when providing routes with dot notation'](assert) {
-      assert.expect(4);
+      assert.expect(5);
 
       this.addTemplate('index', '<div>Index</div>');
       this.addTemplate('application', "<h1>Home</h1><div class='main'>{{outlet}}</div>");
@@ -325,6 +325,7 @@ moduleFor(
         'route:foo',
         Route.extend({
           renderTemplate() {
+            expectDeprecation('Usage of `renderTemplate` is deprecated.');
             assert.ok(true, 'FooBarRoute was called');
             return this._super(...arguments);
           },

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -71,6 +71,7 @@ moduleFor(
     }
 
     [`@test The Homepage with explicit template name in renderTemplate`](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.add(
         'route:home',
         Route.extend({
@@ -87,6 +88,7 @@ moduleFor(
     }
 
     async [`@test an alternate template will pull in an alternate controller`](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.add(
         'route:home',
         Route.extend({
@@ -113,6 +115,7 @@ moduleFor(
     async [`@test An alternate template will pull in an alternate controller instead of controllerName`](
       assert
     ) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.add(
         'route:home',
         Route.extend({
@@ -147,6 +150,7 @@ moduleFor(
     }
 
     async [`@test The template will pull in an alternate controller via key/value`](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.router.map(function () {
         this.route('homepage', { path: '/' });
       });
@@ -181,6 +185,7 @@ moduleFor(
     async [`@test The Homepage with explicit template name in renderTemplate and controller`](
       assert
     ) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.add(
         'controller:home',
         Controller.extend({
@@ -205,6 +210,7 @@ moduleFor(
     }
 
     async [`@test Model passed via renderTemplate model is set as controller's model`](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate(
         'bio',
         '<p>Model: {{@model.name}}</p><p>Controller: {{this.model.name}}</p>'
@@ -284,6 +290,7 @@ moduleFor(
     }
 
     ['@test templateName is still used when calling render with no name and options'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('alert', `<div class='alert-box'>Invader!</div>`);
       this.addTemplate('home', `<p>THIS IS THE REAL HOME</p>{{outlet 'alert'}}`);
 
@@ -305,6 +312,7 @@ moduleFor(
     }
 
     ['@test Generated names can be customized when providing routes with dot notation'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       assert.expect(5);
 
       this.addTemplate('index', '<div>Index</div>');
@@ -325,7 +333,6 @@ moduleFor(
         'route:foo',
         Route.extend({
           renderTemplate() {
-            expectDeprecation('Usage of `renderTemplate` is deprecated.');
             assert.ok(true, 'FooBarRoute was called');
             return this._super(...arguments);
           },
@@ -394,6 +401,7 @@ moduleFor(
     }
 
     ['@test Child routes render into specified template'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('index', '<div>Index</div>');
       this.addTemplate('application', "<h1>Home</h1><div class='main'>{{outlet}}</div>");
       this.addTemplate('top', "<div class='middle'>{{outlet}}</div>");
@@ -434,6 +442,7 @@ moduleFor(
     }
 
     ['@test Rendering into specified template with slash notation'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('person.profile', 'profile {{outlet}}');
       this.addTemplate('person.details', 'details!');
 
@@ -462,6 +471,7 @@ moduleFor(
     }
 
     ['@test Only use route rendered into main outlet for default into property on child'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', "{{outlet 'menu'}}{{outlet}}");
       this.addTemplate('posts', '{{outlet}}');
       this.addTemplate('posts.index', '<p class="posts-index">postsIndex</p>');
@@ -601,6 +611,7 @@ moduleFor(
     ['@test The template is not re-rendered when two routes present the exact same template & controller'](
       assert
     ) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.router.map(function () {
         this.route('first');
         this.route('second');
@@ -679,6 +690,7 @@ moduleFor(
     }
 
     ['@test Route should tear down multiple outlets'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', "{{outlet 'menu'}}{{outlet}}{{outlet 'footer'}}");
       this.addTemplate('posts', '{{outlet}}');
       this.addTemplate('users', 'users');
@@ -1000,7 +1012,8 @@ moduleFor(
     }
 
     ['@test Specifying non-existent controller name in route#render throws'](assert) {
-      assert.expect(1);
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
+      assert.expect(2);
 
       this.router.map(function () {
         this.route('home', { path: '/' });
@@ -1050,6 +1063,7 @@ moduleFor(
     }
 
     ['@test Can render into a named outlet at the top level'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', 'A-{{outlet}}-B-{{outlet "other"}}-C');
       this.addTemplate('modal', 'Hello world');
       this.addTemplate('index', 'The index');
@@ -1080,6 +1094,7 @@ moduleFor(
     }
 
     ['@test Can disconnect a named outlet at the top level'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', 'A-{{outlet}}-B-{{outlet "other"}}-C');
       this.addTemplate('modal', 'Hello world');
       this.addTemplate('index', 'The index');
@@ -1126,6 +1141,7 @@ moduleFor(
     }
 
     ['@test Can render into a named outlet at the top level, with empty main outlet'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', 'A-{{outlet}}-B-{{outlet "other"}}-C');
       this.addTemplate('modal', 'Hello world');
 
@@ -1186,6 +1202,7 @@ moduleFor(
     }
 
     ["@test Can render routes with no 'main' outlet and their children"](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', '<div id="application">{{outlet "app"}}</div>');
       this.addTemplate(
         'app',
@@ -1298,6 +1315,7 @@ moduleFor(
     }
 
     ['@test Renders child into parent with non-default template name'](assert) {
+      expectDeprecation('Usage of `renderTemplate` is deprecated.');
       this.addTemplate('application', '<div class="a">{{outlet}}</div>');
       this.addTemplate('exports.root', '<div class="b">{{outlet}}</div>');
       this.addTemplate('exports.index', '<div class="c"></div>');


### PR DESCRIPTION
Adds deprecation for `Route#renderTemplate`. See [RFC 418](https://emberjs.github.io/rfcs/0418-deprecate-route-render-methods.html) for more info.

I'm not going to lie, this was a bit rough with the amount of failing tests which needed to be fixed and then a few rebases in between 😅 

```js
id: 'route-render-template'
until: '4.0.0',
url: 'https://deprecations.emberjs.com/v3.x/#toc_route-render-template'
for: 'ember-source',
since: {
  enabled: '3.27.0',
},
```