### PR TITLE
Add automated publishing of weekly alpha releases to NPM

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -1,0 +1,60 @@
+name: Alpha Releases
+
+on:
+  schedule:
+    - cron:  '0 20 * * 1' # weekly (Monday)
+
+jobs:
+  test:
+    name: Basic Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ci-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: build
+        env:
+          DISABLE_SOURCE_MAPS: true
+          BROCCOLI_ENV: production
+        run: yarn ember build
+      - name: test
+        env:
+          TEST_SUITE: each-package
+        run: yarn test
+
+  release:
+    name: Tag + Release
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ci-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: tag the next alpha
+        run: npm version prerelease --preid alpha
+      - name: build for publish
+        env:
+          BUILD_TYPE: alpha
+          OVERRIDE_FEATURES: ''
+        run: node bin/build-for-publishing.js
+      - name: publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: push branch + tag
+        run: git push origin HEAD --follow-tags


### PR DESCRIPTION
By default the ember-cli blueprint uses ember-try to download the `npm pack` result of the most recent canary build from Amazon S3 (this is usually setup to run in that addon's CI configuration). Unfortunately, some organizations have security restrictions **preventing** access to the internet during CI jobs. They often have customized NPM mirrors that do work (otherwise how would they ever build / test JS code), but block access to the rest of the internet. Up until this change, those organizations simply **could not** be early testers of our canary builds.

This change adds a new CI job to auto-publish a new `-alpha.x` release to NPM once a week (on Mondays). This will allow folks to leverage their normal `npm install` infrastructure to be able to test canary Ember builds once a week (though we could in theory decide to make more publish). However, since the process is automated these alphas will not include changelog entries. It is theoretically possible that we would prefer to leverage this infrastructure for testing addons against published tags (instead of using `ember-source-channel-url`), but that would reduce our speed of identifying regressions.
