### PR TITLE
Setup git user in alpha publishing script.

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -2,7 +2,7 @@ name: Alpha Releases
 
 on:
   schedule:
-    - cron:  '0 20 * * 1' # weekly (Monday)
+    - cron:  '0 20 * * 3' # weekly (Wednesday)
 
 jobs:
   test:
@@ -45,6 +45,10 @@ jobs:
           key: ci-modules-${{ hashFiles('**/yarn.lock') }}
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
+      - name: setup git
+        run: |
+          git config --local user.email 'tomster@emberjs.com'
+          git config --local user.name 'Ember.js Alpha Releaser'
       - name: tag the next alpha
         run: npm version prerelease --preid alpha
       - name: build for publish


### PR DESCRIPTION
The alpha publishing script failed, due to running `git commit` without a user setup. This sets the git username/email and also updates to run Wednesdays (I'm too lazy to wait a fully week :P ).
