### PR TITLE
Don't refresh a parent route's model when the query param doesn't change

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1077,8 +1077,7 @@ class EmberRouter<R extends Route = Route> extends EmberObject.extend(Evented) i
     this._processActiveTransitionQueryParams(targetRouteName, models, queryParams, _queryParams);
 
     Object.assign(queryParams, _queryParams);
-
-    this._prepareQueryParams(targetRouteName, models, queryParams, Boolean(_fromRouterService));
+    this._prepareQueryParams(targetRouteName, models, queryParams, Boolean(_fromRouterService), true);
 
     let transition = this._routerMicrolib.transitionTo(targetRouteName, ...models, { queryParams });
 
@@ -1132,13 +1131,14 @@ class EmberRouter<R extends Route = Route> extends EmberObject.extend(Evented) i
     targetRouteName: string,
     models: ModelFor<R>[],
     queryParams: Record<string, unknown>,
-    _fromRouterService?: boolean
+    _fromRouterService: boolean = false,
+    _pruneDefaultQueryParamValues: boolean = !_fromRouterService
   ) {
     let state = calculatePostTransitionState(this, targetRouteName, models);
-    this._hydrateUnsuppliedQueryParams(state, queryParams, Boolean(_fromRouterService));
+    this._hydrateUnsuppliedQueryParams(state, queryParams, _fromRouterService);
     this._serializeQueryParams(state.routeInfos, queryParams);
 
-    if (!_fromRouterService) {
+    if (_pruneDefaultQueryParamValues) {
       this._pruneDefaultQueryParamValues(state.routeInfos, queryParams);
     }
   }


### PR DESCRIPTION
Test case for https://github.com/emberjs/ember.js/issues/17494
Plus a potential (if a bit messy) fix.

Routes that have a query param with a default value and `refreshModel: true`, will be refreshed each time a transition happens - but only if that transition is invoke from the router service.

This works as expected if you invoke the transition using the internal router. This is because a some of the internal router's related behaviour is explicitly bimodal - there's a boolean parameter named `_fromRouterService` that controls this.

The root of the problem seems to be in the `_pruneDefaultQueryParamValues` method. If a transition is invoked from the router service, this currently strips default query params. This means that when later compared to the current state, the query params appear unequal, resulting in a refresh.

I've added a fix which prevents the default param values from being stripped for this specific invocation - with yet another boolean param (named `_pruneDefaultQueryParamValues `). Not ideal.