### PR TITLE
Add deprecation for the Ember Global

### DIFF
--- a/packages/@ember/-internals/bootstrap/index.js
+++ b/packages/@ember/-internals/bootstrap/index.js
@@ -1,5 +1,6 @@
 import require from 'require';
 import { context } from '@ember/-internals/environment';
+import { deprecate } from '@ember/debug';
 
 (function () {
   let Ember;
@@ -12,6 +13,20 @@ import { context } from '@ember/-internals/environment';
         if (!Ember) {
           Ember = require('ember').default;
         }
+
+        deprecate(
+          'Usage of the Ember Global is deprecated. You should import the Ember module or the specific API instead.',
+          false,
+          {
+            id: 'ember-global',
+            until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-global',
+            for: 'ember-source',
+            since: {
+              enabled: '3.27.0',
+            },
+          }
+        );
 
         return Ember;
       },

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -12,7 +12,7 @@ export default class DefaultResolverApplicationTestCase extends AbstractApplicat
     let application;
     expectDeprecation(() => {
       application = this.application = Application.create(this.applicationOptions);
-    }, /Using the globals resolver is deprecated/);
+    }, /(Using the globals resolver is deprecated|Usage of the Ember Global is deprecated)/);
 
     // If the test expects a certain number of assertions, increment that number
     let { assert } = QUnit.config.current;


### PR DESCRIPTION
Towards [RFC 706](https://github.com/emberjs/rfcs/pull/706)

Adds a deprecation for the Ember Global

```js
{
  id: 'ember-global',
  until: '4.0.0',
  url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-global',
  for: 'ember-source',
  since: {
    enabled: '3.27.0',
  },
}
```

Can this PR be merged as-is or do we need to wait for a new release of ember-cli-babel with https://github.com/babel/ember-cli-babel/pull/382/?