### PR TITLE
[FEATURE] Add remaining Ember modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ module.exports = {
   name: 'ember-source',
   paths,
   absolutePaths,
+  _jqueryIntegrationEnabled: true,
 
   included() {
     this._super.included.apply(this, arguments);
@@ -151,7 +152,10 @@ module.exports = {
       }
     }
 
-    if (optionalFeaturesMissing || optionalFeatures.isFeatureEnabled('jquery-integration')) {
+    this._jqueryIntegrationEnabled =
+      optionalFeaturesMissing || optionalFeatures.isFeatureEnabled('jquery-integration');
+
+    if (this._jqueryIntegrationEnabled) {
       this.ui.writeWarnLine(
         'Setting the `jquery-integration` optional feature flag to `true`, or not providing a setting at all, has been deprecated. You must add the `@ember/optional-features` addon and set this feature to `false`. This warning will become an error in Ember 4.0.0.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-jquery-integration'
       );
@@ -218,7 +222,10 @@ module.exports = {
       false
     );
 
-    let exclude = isProduction ? ['ember-testing/**'] : [];
+    let exclude = [
+      isProduction ? 'ember-testing/**' : null,
+      !this._jqueryIntegrationEnabled ? 'jquery' : null,
+    ].filter((value) => value !== null);
 
     let emberFiles = new MergeTrees([new Funnel(packages, { exclude }), dependencies, headerFiles]);
 

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -75,7 +75,7 @@ export function escapeExpression(string: any): string {
   @return {SafeString} A string that will not be HTML escaped by Handlebars.
   @public
 */
-export function htmlSafe(str: string) {
+export function htmlSafe(str: string): SafeString {
   if (str === null || str === undefined) {
     str = '';
   } else if (typeof str !== 'string') {

--- a/packages/@ember/application/deprecations.ts
+++ b/packages/@ember/application/deprecations.ts
@@ -1,0 +1,39 @@
+import {
+  deprecate as _deprecate,
+  deprecateFunc as _deprecateFunc,
+  DeprecationOptions,
+} from '@ember/debug';
+
+export function deprecate(message: string, condition: boolean, options: DeprecationOptions): void {
+  deprecate(
+    "`import { deprecate } from '@ember/application/deprecations';` has been deprecated, please update to `import { deprecate } from '@ember/debug';`",
+    false,
+    {
+      id: 'old-deprecate-method-paths',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        enabled: '3.0.0',
+      },
+    }
+  );
+
+  _deprecate(message, condition, options);
+}
+
+export function deprecateFunc(message: string, options: DeprecationOptions, func: Function): void {
+  deprecate(
+    "`import { deprecateFunc } from '@ember/application/deprecations';` has been deprecated, please update to `import { deprecateFunc } from '@ember/debug';`",
+    false,
+    {
+      id: 'old-deprecate-method-paths',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        enabled: '3.0.0',
+      },
+    }
+  );
+
+  _deprecateFunc(message, options, func);
+}

--- a/packages/@ember/application/namespace.js
+++ b/packages/@ember/application/namespace.js
@@ -1,0 +1,1 @@
+export { Namespace as default } from '@ember/-internals/runtime';

--- a/packages/@ember/application/resolver.js
+++ b/packages/@ember/application/resolver.js
@@ -1,0 +1,1 @@
+export { default } from './globals-resolver';

--- a/packages/@ember/array/index.js
+++ b/packages/@ember/array/index.js
@@ -1,0 +1,2 @@
+export { Array as default, isArray, A } from '@ember/-internals/runtime';
+export { makeArray } from '@ember/-internals/utils';

--- a/packages/@ember/array/mutable.js
+++ b/packages/@ember/array/mutable.js
@@ -1,0 +1,1 @@
+export { MutableArray as default } from '@ember/-internals/runtime';

--- a/packages/@ember/array/proxy.js
+++ b/packages/@ember/array/proxy.js
@@ -1,0 +1,1 @@
+export { ArrayProxy as default } from '@ember/-internals/runtime';

--- a/packages/@ember/component/checkbox.ts
+++ b/packages/@ember/component/checkbox.ts
@@ -1,0 +1,21 @@
+import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
+import { deprecate } from '@ember/debug';
+
+if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
+  deprecate(
+    `Using Ember.Checkbox or importing from 'Checkbox' has been deprecated, install the ` +
+      `\`ember-legacy-built-in-components\` addon and use \`import { Checkbox } from ` +
+      `'ember-legacy-built-in-components';\` instead`,
+    false,
+    {
+      id: 'ember.legacy-built-in-components',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        // TODO: update this when enabling the feature
+      },
+    }
+  );
+}
+
+export { Checkbox as default } from '@ember/-internals/glimmer';

--- a/packages/@ember/component/helper.ts
+++ b/packages/@ember/component/helper.ts
@@ -1,0 +1,1 @@
+export { Helper as default, helper } from '@ember/-internals/glimmer';

--- a/packages/@ember/component/index.ts
+++ b/packages/@ember/component/index.ts
@@ -1,1 +1,6 @@
-export { Component } from '@ember/-internals/glimmer';
+export { setComponentTemplate, getComponentTemplate } from '@glimmer/manager';
+export { Component as default, Input } from '@ember/-internals/glimmer';
+export {
+  componentCapabilities as capabilities,
+  setComponentManager,
+} from '@ember/-internals/glimmer';

--- a/packages/@ember/component/text-area.ts
+++ b/packages/@ember/component/text-area.ts
@@ -1,0 +1,21 @@
+import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
+import { deprecate } from '@ember/debug';
+
+if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
+  deprecate(
+    `Using Ember.TextArea or importing from 'TextArea' has been deprecated, install the ` +
+      `\`ember-legacy-built-in-components\` addon and use \`import { TextArea } from ` +
+      `'ember-legacy-built-in-components';\` instead`,
+    false,
+    {
+      id: 'ember.legacy-built-in-components',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        // TODO: update this when enabling the feature
+      },
+    }
+  );
+}
+
+export { TextArea as default } from '@ember/-internals/glimmer';

--- a/packages/@ember/component/text-field.ts
+++ b/packages/@ember/component/text-field.ts
@@ -1,0 +1,21 @@
+import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
+import { deprecate } from '@ember/debug';
+
+if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
+  deprecate(
+    `Using Ember.TextField or importing from 'TextField' has been deprecated, install the ` +
+      `\`ember-legacy-built-in-components\` addon and use \`import { TextField } from ` +
+      `'ember-legacy-built-in-components';\` instead`,
+    false,
+    {
+      id: 'ember.legacy-built-in-components',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        // TODO: update this when enabling the feature
+      },
+    }
+  );
+}
+
+export { TextField as default } from '@ember/-internals/glimmer';

--- a/packages/@ember/debug/container-debug-adapter.js
+++ b/packages/@ember/debug/container-debug-adapter.js
@@ -1,0 +1,1 @@
+export { ContainerDebugAdapter as default } from '@ember/-internals/extension-support';

--- a/packages/@ember/debug/data-adapter.js
+++ b/packages/@ember/debug/data-adapter.js
@@ -1,0 +1,1 @@
+export { DataAdapter as default } from '@ember/-internals/extension-support';

--- a/packages/@ember/debug/index.ts
+++ b/packages/@ember/debug/index.ts
@@ -5,10 +5,12 @@ import _deprecate, { DeprecateFunc, DeprecationOptions } from './lib/deprecate';
 import { isTesting } from './lib/testing';
 import _warn, { WarnFunc } from './lib/warn';
 
+export { inspect } from '@ember/-internals/utils';
 export { registerHandler as registerWarnHandler } from './lib/warn';
 export { registerHandler as registerDeprecationHandler } from './lib/deprecate';
 export { isTesting, setTesting } from './lib/testing';
 export { default as captureRenderTree } from './lib/capture-render-tree';
+export { DeprecationOptions } from './lib/deprecate';
 
 export type DebugFunctionType =
   | 'assert'

--- a/packages/@ember/enumerable/index.js
+++ b/packages/@ember/enumerable/index.js
@@ -1,0 +1,1 @@
+export { Enumerable as default } from '@ember/-internals/runtime';

--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -304,5 +304,5 @@
   @public
 */
 
-export { setHelperManager, helperCapabilities as capabilties } from '@glimmer/manager';
-export { invokeHelper } from '@glimmer/runtime';
+export { setHelperManager, helperCapabilities as capabilities } from '@glimmer/manager';
+export { invokeHelper, hash, array, concat, get, on, fn } from '@glimmer/runtime';

--- a/packages/@ember/modifier/index.ts
+++ b/packages/@ember/modifier/index.ts
@@ -1,1 +1,2 @@
-export { setModifierManager, modifierCapabilities as capabilties } from '@glimmer/manager';
+export { setModifierManager } from '@glimmer/manager';
+export { modifierCapabilities as capabilities } from '@ember/-internals/glimmer';

--- a/packages/@ember/object/computed.js
+++ b/packages/@ember/object/computed.js
@@ -1,3 +1,5 @@
+export { ComputedProperty as default, expandProperties, alias } from '@ember/-internals/metal';
+
 export {
   empty,
   notEmpty,
@@ -11,6 +13,7 @@ export {
   lt,
   lte,
   oneWay,
+  oneWay as reads,
   readOnly,
   deprecatingAlias,
   and,

--- a/packages/@ember/object/core.js
+++ b/packages/@ember/object/core.js
@@ -1,0 +1,1 @@
+export { CoreObject as default } from '@ember/-internals/runtime';

--- a/packages/@ember/object/evented.js
+++ b/packages/@ember/object/evented.js
@@ -1,0 +1,2 @@
+export { Evented as default } from '@ember/-internals/runtime';
+export { on } from '@ember/-internals/metal';

--- a/packages/@ember/object/events.js
+++ b/packages/@ember/object/events.js
@@ -1,0 +1,1 @@
+export { addListener, removeListener, sendEvent } from '@ember/-internals/metal';

--- a/packages/@ember/object/index.js
+++ b/packages/@ember/object/index.js
@@ -2,6 +2,22 @@ import { assert } from '@ember/debug';
 import { assign } from '@ember/polyfills';
 import { isElementDescriptor, setClassicDecorator } from '@ember/-internals/metal';
 
+export { Object as default } from '@ember/-internals/runtime';
+
+export {
+  notifyPropertyChange,
+  defineProperty,
+  get,
+  set,
+  getProperties,
+  setProperties,
+  getWithDefault,
+  observer,
+  computed,
+  trySet,
+  aliasMethod,
+} from '@ember/-internals/metal';
+
 /**
   Decorator that turns the target function into an Action which can be accessed
   directly by reference.

--- a/packages/@ember/object/internals.js
+++ b/packages/@ember/object/internals.js
@@ -1,0 +1,3 @@
+export { getCachedValueFor as cacheFor } from '@ember/-internals/metal';
+export { copy } from '@ember/-internals/runtime';
+export { guidFor } from '@ember/-internals/utils';

--- a/packages/@ember/object/mixin.js
+++ b/packages/@ember/object/mixin.js
@@ -1,0 +1,1 @@
+export { Mixin as default } from '@ember/-internals/metal';

--- a/packages/@ember/object/observable.js
+++ b/packages/@ember/object/observable.js
@@ -1,0 +1,1 @@
+export { Observable as default } from '@ember/-internals/runtime';

--- a/packages/@ember/object/observers.js
+++ b/packages/@ember/object/observers.js
@@ -1,0 +1,1 @@
+export { addObserver, removeObserver } from '@ember/-internals/metal';

--- a/packages/@ember/object/promise-proxy-mixin.js
+++ b/packages/@ember/object/promise-proxy-mixin.js
@@ -1,0 +1,1 @@
+export { PromiseProxyMixin as default } from '@ember/-internals/runtime';

--- a/packages/@ember/object/proxy.js
+++ b/packages/@ember/object/proxy.js
@@ -1,0 +1,1 @@
+export { ObjectProxy as default } from '@ember/-internals/runtime';

--- a/packages/@ember/polyfills/index.ts
+++ b/packages/@ember/polyfills/index.ts
@@ -6,3 +6,5 @@ let merge = MERGE ? deprecatedMerge : undefined;
 // Export `assignPolyfill` for testing
 export { default as assign, assign as assignPolyfill } from './lib/assign';
 export { merge };
+
+export const hasPropertyAccessors = true;

--- a/packages/@ember/routing/auto-location.js
+++ b/packages/@ember/routing/auto-location.js
@@ -1,0 +1,1 @@
+export { AutoLocation as default } from '@ember/-internals/routing';

--- a/packages/@ember/routing/hash-location.js
+++ b/packages/@ember/routing/hash-location.js
@@ -1,0 +1,1 @@
+export { HashLocation as default } from '@ember/-internals/routing';

--- a/packages/@ember/routing/history-location.js
+++ b/packages/@ember/routing/history-location.js
@@ -1,0 +1,1 @@
+export { HistoryLocation as default } from '@ember/-internals/routing';

--- a/packages/@ember/routing/index.ts
+++ b/packages/@ember/routing/index.ts
@@ -1,0 +1,1 @@
+export { LinkComponent as LinkTo } from '@ember/-internals/glimmer';

--- a/packages/@ember/routing/link-component.ts
+++ b/packages/@ember/routing/link-component.ts
@@ -1,0 +1,21 @@
+import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
+import { deprecate } from '@ember/debug';
+
+if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
+  deprecate(
+    `Using Ember.LinkComponent or importing from 'LinkComponent' has been deprecated, install the ` +
+      `\`ember-legacy-built-in-components\` addon and use \`import { LinkComponent } from ` +
+      `'ember-legacy-built-in-components';\` instead`,
+    false,
+    {
+      id: 'ember.legacy-built-in-components',
+      until: '4.0.0',
+      for: 'ember-source',
+      since: {
+        // TODO: update this when enabling the feature
+      },
+    }
+  );
+}
+
+export { LinkComponent as default } from '@ember/-internals/glimmer';

--- a/packages/@ember/routing/location.js
+++ b/packages/@ember/routing/location.js
@@ -1,0 +1,1 @@
+export { Location as default } from '@ember/-internals/routing';

--- a/packages/@ember/routing/none-location.js
+++ b/packages/@ember/routing/none-location.js
@@ -1,0 +1,1 @@
+export { NoneLocation as default } from '@ember/-internals/routing';

--- a/packages/@ember/routing/route.js
+++ b/packages/@ember/routing/route.js
@@ -1,0 +1,1 @@
+export { Route as default } from '@ember/-internals/routing';

--- a/packages/@ember/routing/router.js
+++ b/packages/@ember/routing/router.js
@@ -1,0 +1,1 @@
+export { Router as default } from '@ember/-internals/routing';

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -9,6 +9,12 @@ import { Cache } from '@ember/-internals/utils';
 import { deprecate } from '@ember/debug';
 import { getString } from './lib/string_registry';
 
+import {
+  htmlSafe as internalHtmlSafe,
+  isHTMLSafe as internalIsHtmlSafe,
+  SafeString,
+} from '@ember/-internals/glimmer';
+
 const STRING_DASHERIZE_REGEXP = /[ _]/g;
 
 const STRING_DASHERIZE_CACHE = new Cache<string, string>(1000, (key) =>
@@ -292,6 +298,35 @@ export function underscore(str: string): string {
 */
 export function capitalize(str: string): string {
   return CAPITALIZE_CACHE.get(str);
+}
+
+function deprecateImportFromString(
+  name: string,
+  message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
+) {
+  // Disabling this deprecation due to unintended errors in 3.25
+  // See https://github.com/emberjs/ember.js/issues/19393 fo more information.
+  deprecate(message, true, {
+    id: 'ember-string.htmlsafe-ishtmlsafe',
+    for: 'ember-source',
+    since: {
+      enabled: '3.25',
+    },
+    until: '4.0.0',
+    url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
+  });
+}
+
+export function htmlSafe(str: string): SafeString {
+  deprecateImportFromString('htmlSafe');
+
+  return internalHtmlSafe(str);
+}
+
+export function isHTMLSafe(str: any | null | undefined): str is SafeString {
+  deprecateImportFromString('isHTMLSafe');
+
+  return internalIsHtmlSafe(str);
 }
 
 if (ENV.EXTEND_PROTOTYPES.String) {

--- a/packages/@ember/template-compilation/index.js
+++ b/packages/@ember/template-compilation/index.js
@@ -1,0 +1,13 @@
+import { DEBUG } from '@glimmer/env';
+
+export { compile as compileTemplate } from 'ember-template-compiler';
+
+export let precompileTemplate;
+
+if (DEBUG) {
+  precompileTemplate = () => {
+    throw new Error(
+      'Attempted to call `precompileTemplate` at runtime, but this API is meant to be used at compile time. You should use `compileTemplate` instead.'
+    );
+  };
+}

--- a/packages/@ember/template-factory/index.js
+++ b/packages/@ember/template-factory/index.js
@@ -1,0 +1,1 @@
+export { templateFactory as createTemplateFactory } from '@glimmer/opcode-compiler';

--- a/packages/@ember/template/index.ts
+++ b/packages/@ember/template/index.ts
@@ -1,0 +1,1 @@
+export { htmlSafe, isHTMLSafe } from '@ember/-internals/glimmer';

--- a/packages/@ember/test/adapter.js
+++ b/packages/@ember/test/adapter.js
@@ -1,0 +1,3 @@
+import { Test } from 'ember-testing';
+
+export default Test.Adapter;

--- a/packages/@ember/test/index.js
+++ b/packages/@ember/test/index.js
@@ -1,0 +1,11 @@
+import { Test } from 'ember-testing';
+
+const {
+  registerAsyncHelper,
+  registerHelper,
+  registerWaiter,
+  unregisterHelper,
+  unregisterWaiter,
+} = Test;
+
+export { registerAsyncHelper, registerHelper, registerWaiter, unregisterHelper, unregisterWaiter };

--- a/packages/@ember/utils/index.js
+++ b/packages/@ember/utils/index.js
@@ -1,0 +1,3 @@
+export { isNone, isBlank, isEmpty, isPresent } from '@ember/-internals/metal';
+export { tryInvoke } from '@ember/-internals/utils';
+export { compare, isEqual, typeOf } from '@ember/-internals/runtime';

--- a/packages/@ember/version/index.js
+++ b/packages/@ember/version/index.js
@@ -1,0 +1,1 @@
+export { default as VERSION } from 'ember/version';

--- a/packages/@glimmer/tracking/index.ts
+++ b/packages/@glimmer/tracking/index.ts
@@ -1,0 +1,1 @@
+export { tracked } from '@ember/-internals/metal';

--- a/packages/@glimmer/tracking/primitives/cache.ts
+++ b/packages/@glimmer/tracking/primitives/cache.ts
@@ -1,0 +1,1 @@
+export { createCache, getValue, isConst } from '@ember/-internals/metal';

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -336,7 +336,6 @@ Object.defineProperty(Ember.run, 'currentRunLoop', {
 
 // ****@ember/-internals/metal****
 
-// Using _globalsComputed here so that mutating the function is only available
 // in globals builds
 const computed = metal._globalsComputed;
 Ember.computed = computed;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -1,15 +1,12 @@
 import Ember from '../index';
 import require from 'require';
-import {
-  FEATURES,
-  EMBER_GLIMMER_HELPER_MANAGER,
-  EMBER_GLIMMER_INVOKE_HELPER,
-  EMBER_MODERNIZED_BUILT_IN_COMPONENTS,
-} from '@ember/canary-features';
+import { FEATURES, EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { confirmExport } from 'internal-test-helpers';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { jQueryDisabled, jQuery } from '@ember/-internals/views';
 import Resolver from '@ember/application/globals-resolver';
+import { DEBUG } from '@glimmer/env';
+import { ENV } from '@ember/-internals/environment';
 
 moduleFor(
   'ember reexports',
@@ -152,84 +149,250 @@ if (!jQueryDisabled) {
 }
 
 let allExports = [
-  // @glimmer/runtime
-  ['_templateOnlyComponent', '@glimmer/runtime', 'templateOnlyComponent'],
-  ['_on', '@glimmer/runtime', 'on'],
-  ['_fn', '@glimmer/runtime', 'fn'],
-  ['_array', '@glimmer/runtime', 'array'],
-  ['_hash', '@glimmer/runtime', 'hash'],
-  ['_get', '@glimmer/runtime', 'get'],
-  ['_concat', '@glimmer/runtime', 'concat'],
-
-  // @ember/-internals/environment
-  ['ENV', '@ember/-internals/environment', { get: 'getENV' }],
-  ['lookup', '@ember/-internals/environment', { get: 'getLookup', set: 'setLookup' }],
-
+  // @ember/application
+  ['Application', '@ember/application', 'default'],
   ['getOwner', '@ember/application', 'getOwner'],
+  ['onLoad', '@ember/application', 'onLoad'],
+  ['runLoadHooks', '@ember/application', 'runLoadHooks'],
   ['setOwner', '@ember/application', 'setOwner'],
-  ['assign', '@ember/polyfills'],
 
-  // @ember/-internals/utils
-  ['GUID_KEY', '@ember/-internals/utils'],
-  ['uuid', '@ember/-internals/utils'],
-  ['generateGuid', '@ember/-internals/utils'],
-  ['guidFor', '@ember/-internals/utils'],
-  ['inspect', '@ember/-internals/utils'],
-  ['makeArray', '@ember/-internals/utils'],
-  ['canInvoke', '@ember/-internals/utils'],
-  ['tryInvoke', '@ember/-internals/utils'],
-  ['wrap', '@ember/-internals/utils'],
+  // @ember/application/deprecations
+  [null, '@ember/application/deprecations', 'deprecate'],
+  [null, '@ember/application/deprecations', 'deprecateFunc'],
 
-  // @ember/-internals/container
-  ['Registry', '@ember/-internals/container', 'Registry'],
-  ['Container', '@ember/-internals/container', 'Container'],
+  // @ember/application/instance
+  ['ApplicationInstance', '@ember/application/instance', 'default'],
+
+  // @ember/application/namespace
+  ['Namespace', '@ember/application/namespace', 'default'],
+
+  // @ember/array
+  ['Array', '@ember/array', 'default'],
+  ['A', '@ember/array', 'A'],
+  ['isArray', '@ember/array', 'isArray'],
+  ['makeArray', '@ember/array', 'makeArray'],
+
+  // @ember/array/mutable
+  ['MutableArray', '@ember/array/mutable', 'default'],
+
+  // @ember/array/proxy
+  ['ArrayProxy', '@ember/array/proxy', 'default'],
+
+  // @ember/canary-features
+  ['FEATURES.isEnabled', '@ember/canary-features', 'isEnabled'],
+
+  // @ember/component
+  ['Component', '@ember/component', 'default'],
+  ['_Input', '@ember/component', 'Input'],
+  ['_componentManagerCapabilities', '@ember/component', 'capabilities'],
+  ['_getComponentTemplate', '@ember/component', 'getComponentTemplate'],
+  ['_setComponentManager', '@ember/component', 'setComponentManager'],
+  ['_setComponentTemplate', '@ember/component', 'setComponentTemplate'],
+
+  // @ember/component/checkbox
+  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['Checkbox', '@ember/component/checkbox'],
+
+  // @ember/component/helper
+  ['Helper', '@ember/component/helper', 'default'],
+  ['Helper.helper', '@ember/component/helper', 'helper'],
+
+  // @ember/component/template-only
+  ['_templateOnlyComponent', '@ember/component/template-only', 'default'],
+
+  // @ember/component/text-area
+  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['TextArea', '@ember/-component/text-area'],
+
+  // @ember/component/text-field
+  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['TextField', '@ember/component/text-field'],
+
+  // @ember/controller
+  ['Controller', '@ember/controller', 'default'],
+  ['inject.controller', '@ember/controller', 'inject'],
 
   // @ember/debug
-  ['deprecateFunc', '@ember/debug'],
-  ['deprecate', '@ember/debug'],
-  ['assert', '@ember/debug'],
-  ['warn', '@ember/debug'],
-  ['debug', '@ember/debug'],
-  ['runInDebug', '@ember/debug'],
+  ['deprecateFunc', '@ember/debug', 'deprecateFunc'],
+  ['deprecate', '@ember/debug', 'deprecate'],
+  ['assert', '@ember/debug', 'assert'],
+  ['debug', '@ember/debug', 'debug'],
+  ['inspect', '@ember/debug', 'inspect'],
   ['Debug.registerDeprecationHandler', '@ember/debug', 'registerDeprecationHandler'],
   ['Debug.registerWarnHandler', '@ember/debug', 'registerWarnHandler'],
+  ['runInDebug', '@ember/debug', 'runInDebug'],
+  ['warn', '@ember/debug', 'warn'],
+  ['testing', '@ember/debug', { get: 'isTesting', set: 'setTesting' }],
+  ['_captureRenderTree', '@ember/debug', 'captureRenderTree'],
+
+  // @ember/debug/container-debug-adapter
+  ['ContainerDebugAdapter', '@ember/debug/container-debug-adapter', 'default'],
+
+  // @ember/debug/data-adapter
+  ['DataAdapter', '@ember/debug/data-adapter', 'default'],
+
+  // @ember/destroyable
+  DEBUG
+    ? ['_assertDestroyablesDestroyed', '@ember/destroyable', 'assertDestroyablesDestroyed']
+    : null,
+  ['_associateDestroyableChild', '@ember/destroyable', 'associateDestroyableChild'],
+  ['destroy', '@ember/destroyable', 'destroy'],
+  DEBUG ? ['_enableDestroyableTracking', '@ember/destroyable', 'enableDestroyableTracking'] : null,
+  ['_isDestroyed', '@ember/destroyable', 'isDestroyed'],
+  ['_isDestroying', '@ember/destroyable', 'isDestroying'],
+  ['_registerDestructor', '@ember/destroyable', 'registerDestructor'],
+  ['_unregisterDestructor', '@ember/destroyable', 'unregisterDestructor'],
+
+  // @ember/engine
+  ['Engine', '@ember/engine', 'default'],
+
+  // @ember/engine/instance
+  ['EngineInstance', '@ember/engine/instance', 'default'],
+
+  // @ember/enumerable
+  ['Enumerable', '@ember/enumerable', 'default'],
+
+  // @ember/error
   ['Error', '@ember/error', 'default'],
 
-  // @ember/-internals/metal
-  ['computed', '@ember/-internals/metal', '_globalsComputed'],
-  ['_descriptor', '@ember/-internals/metal', 'nativeDescDecorator'],
-  ['_tracked', '@ember/-internals/metal', 'tracked'],
-  ['computed.alias', '@ember/-internals/metal', 'alias'],
-  ['ComputedProperty', '@ember/-internals/metal'],
-  ['_setClassicDecorator', '@ember/-internals/metal', 'setClassicDecorator'],
-  ['cacheFor', '@ember/-internals/metal', 'getCachedValueFor'],
-  ['merge', '@ember/polyfills'],
-  ['instrument', '@ember/instrumentation'],
+  // @ember/instrumentation
+  ['instrument', '@ember/instrumentation', 'instrument'],
   ['subscribe', '@ember/instrumentation', 'subscribe'],
   ['Instrumentation.instrument', '@ember/instrumentation', 'instrument'],
+  ['Instrumentation.reset', '@ember/instrumentation', 'reset'],
   ['Instrumentation.subscribe', '@ember/instrumentation', 'subscribe'],
   ['Instrumentation.unsubscribe', '@ember/instrumentation', 'unsubscribe'],
-  ['Instrumentation.reset', '@ember/instrumentation', 'reset'],
-  ['testing', '@ember/debug', { get: 'isTesting', set: 'setTesting' }],
-  ['onerror', '@ember/-internals/error-handling', { get: 'getOnerror', set: 'setOnerror' }],
-  ['FEATURES.isEnabled', '@ember/canary-features', 'isEnabled'],
-  ['meta', '@ember/-internals/meta'],
-  ['get', '@ember/-internals/metal'],
-  ['set', '@ember/-internals/metal'],
-  ['_getPath', '@ember/-internals/metal'],
-  ['getWithDefault', '@ember/-internals/metal'],
-  ['trySet', '@ember/-internals/metal'],
-  ['_Cache', '@ember/-internals/utils', 'Cache'],
-  ['on', '@ember/-internals/metal'],
-  ['addListener', '@ember/-internals/metal'],
-  ['removeListener', '@ember/-internals/metal'],
-  ['sendEvent', '@ember/-internals/metal'],
-  ['hasListeners', '@ember/-internals/metal'],
-  ['isNone', '@ember/-internals/metal'],
-  ['isEmpty', '@ember/-internals/metal'],
-  ['isBlank', '@ember/-internals/metal'],
-  ['isPresent', '@ember/-internals/metal'],
-  ['_Backburner', 'backburner', 'default'],
+
+  // @ember/modifier
+  ['_modifierManagerCapabilities', '@ember/modifier', 'capabilities'],
+  ['_setModifierManager', '@ember/modifier', 'setModifierManager'],
+
+  // @ember/helper
+  ['_helperManagerCapabilities', '@ember/helper', 'capabilities'],
+  ['_setHelperManager', '@ember/helper', 'setHelperManager'],
+  ['_invokeHelper', '@ember/helper', 'invokeHelper'],
+  ['_on', '@ember/helper', 'on'],
+  ['_fn', '@ember/helper', 'fn'],
+  ['_array', '@ember/helper', 'array'],
+  ['_hash', '@ember/helper', 'hash'],
+  ['_get', '@ember/helper', 'get'],
+  ['_concat', '@ember/helper', 'concat'],
+
+  // @ember/object
+  ['Object', '@ember/object', 'default'],
+  ['_action', '@ember/object', 'action'],
+  ['aliasMethod', '@ember/object', 'aliasMethod'],
+  [null, '@ember/object', 'computed'],
+  ['defineProperty', '@ember/object', 'defineProperty'],
+  ['get', '@ember/object', 'get'],
+  ['getProperties', '@ember/object', 'getProperties'],
+  ['getWithDefault', '@ember/object', 'getWithDefault'],
+  ['notifyPropertyChange', '@ember/object', 'notifyPropertyChange'],
+  ['observer', '@ember/object', 'observer'],
+  ['set', '@ember/object', 'set'],
+  ['setProperties', '@ember/object', 'setProperties'],
+  ['trySet', '@ember/object', 'trySet'],
+
+  // @ember/object/compat
+  ['_dependentKeyCompat', '@ember/object/compat', 'dependentKeyCompat'],
+
+  // @ember/object/computed
+  ['ComputedProperty', '@ember/object/computed', 'default'],
+  ['computed.alias', '@ember/object/computed', 'alias'],
+  ['computed.and', '@ember/object/computed', 'and'],
+  ['computed.bool', '@ember/object/computed', 'bool'],
+  ['computed.collect', '@ember/object/computed', 'collect'],
+  ['computed.deprecatingAlias', '@ember/object/computed', 'deprecatingAlias'],
+  ['computed.empty', '@ember/object/computed', 'empty'],
+  ['computed.equal', '@ember/object/computed', 'equal'],
+  ['expandProperties', '@ember/object/computed', 'expandProperties'],
+  ['computed.filter', '@ember/object/computed', 'filter'],
+  ['computed.filterBy', '@ember/object/computed', 'filterBy'],
+  ['computed.gt', '@ember/object/computed', 'gt'],
+  ['computed.gte', '@ember/object/computed', 'gte'],
+  ['computed.intersect', '@ember/object/computed', 'intersect'],
+  ['computed.lt', '@ember/object/computed', 'lt'],
+  ['computed.lte', '@ember/object/computed', 'lte'],
+  ['computed.map', '@ember/object/computed', 'map'],
+  ['computed.mapBy', '@ember/object/computed', 'mapBy'],
+  ['computed.match', '@ember/object/computed', 'match'],
+  ['computed.max', '@ember/object/computed', 'max'],
+  ['computed.min', '@ember/object/computed', 'min'],
+  ['computed.none', '@ember/object/computed', 'none'],
+  ['computed.not', '@ember/object/computed', 'not'],
+  ['computed.notEmpty', '@ember/object/computed', 'notEmpty'],
+  ['computed.oneWay', '@ember/object/computed', 'oneWay'],
+  ['computed.or', '@ember/object/computed', 'or'],
+  ['computed.readOnly', '@ember/object/computed', 'readOnly'],
+  ['computed.reads', '@ember/object/computed', 'reads'],
+  ['computed.setDiff', '@ember/object/computed', 'setDiff'],
+  ['computed.sort', '@ember/object/computed', 'sort'],
+  ['computed.sum', '@ember/object/computed', 'sum'],
+  ['computed.union', '@ember/object/computed', 'union'],
+  ['computed.uniq', '@ember/object/computed', 'uniq'],
+  ['computed.uniqBy', '@ember/object/computed', 'uniqBy'],
+
+  // @ember/object/core
+  ['CoreObject', '@ember/object/core', 'default'],
+
+  // @ember/object/evented
+  ['Evented', '@ember/object/evented', 'default'],
+  ['on', '@ember/object/evented', 'on'],
+
+  // @ember/object/events
+  ['addListener', '@ember/object/events', 'addListener'],
+  ['removeListener', '@ember/object/events', 'removeListener'],
+  ['sendEvent', '@ember/object/events', 'sendEvent'],
+
+  // @ember/object/internals
+  ['cacheFor', '@ember/object/internals', 'cacheFor'],
+  ['copy', '@ember/object/internals', 'copy'],
+  ['guidFor', '@ember/object/internals', 'guidFor'],
+
+  // @ember/object/mixin
+  ['Mixin', '@ember/object/mixin', 'default'],
+
+  // @ember/object/observable
+  ['Observable', '@ember/object/observable', 'default'],
+
+  // @ember/object/observers
+  ['addObserver', '@ember/object/observers', 'addObserver'],
+  ['removeObserver', '@ember/object/observers', 'removeObserver'],
+
+  // @ember/object/promise-proxy-mixin
+  ['PromiseProxyMixin', '@ember/object/promise-proxy-mixin', 'default'],
+
+  // @ember/object/proxy
+  ['ObjectProxy', '@ember/object/proxy', 'default'],
+
+  // @ember/polyfills
+  ['assign', '@ember/polyfills', 'assign'],
+  ['platform.hasPropertyAccessors', '@ember/polyfills', 'hasPropertyAccessors'],
+  ['merge', '@ember/polyfills', 'merge'],
+
+  // @ember/routing/auto-location
+  ['AutoLocation', '@ember/routing/auto-location', 'default'],
+
+  // @ember/routing/hash-location
+  ['HashLocation', '@ember/routing/hash-location', 'default'],
+
+  // @ember/routing/history-location
+  ['HistoryLocation', '@ember/routing/history-location', 'default'],
+
+  // @ember/routing/link-component
+  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['LinkComponent', '@ember/-internals/glimmer'],
+
+  // @ember/routing/location
+  ['Location', '@ember/routing/location', 'default'],
+
+  // @ember/routing/none-location
+  ['NoneLocation', '@ember/routing/none-location', 'default'],
+
+  // @ember/routing/route
+  ['Route', '@ember/routing/route', 'default'],
+
+  // @ember/routing/router
+  ['Router', '@ember/routing/router', 'default'],
+
+  // @ember/runloop
+  [null, '@ember/runloop', 'run'],
   ['run', '@ember/runloop', '_globalsRun'],
   ['run.backburner', '@ember/runloop', 'backburner'],
   ['run.begin', '@ember/runloop', 'begin'],
@@ -247,24 +410,103 @@ let allExports = [
   ['run.throttle', '@ember/runloop', 'throttle'],
   ['run.currentRunLoop', '@ember/runloop', { get: 'getCurrentRunLoop' }],
   ['run.cancelTimers', '@ember/runloop', 'cancelTimers'],
-  ['notifyPropertyChange', '@ember/-internals/metal'],
+
+  // @ember/service
+  ['Service', '@ember/service', 'default'],
+  ['inject.service', '@ember/service', 'inject'],
+
+  // @ember/string
+  ['String.camelize', '@ember/string', 'camelize'],
+  ['String.capitalize', '@ember/string', 'capitalize'],
+  ['String.classify', '@ember/string', 'classify'],
+  ['String.dasherize', '@ember/string', 'dasherize'],
+  ['String.decamelize', '@ember/string', 'decamelize'],
+  ['String.htmlSafe', '@ember/-internals/glimmer', 'htmlSafe'],
+  ['String.isHTMLSafe', '@ember/-internals/glimmer', 'isHTMLSafe'],
+  ['String.loc', '@ember/string', 'loc'],
+  ['String.underscore', '@ember/string', 'underscore'],
+  ['String.w', '@ember/string', 'w'],
+  ['STRINGS', '@ember/string', { get: '_getStrings', set: '_setStrings' }],
+
+  // @ember/template
+  ['String.htmlSafe', '@ember/template', 'htmlSafe'],
+  ['String.isHTMLSafe', '@ember/template', 'isHTMLSafe'],
+
+  // @ember/template-compilation
+  ['HTMLBars.compile', '@ember/template-compilation', 'compileTemplate'],
+
+  // @ember/template-factory
+  ['Handlebars.template', '@ember/template-factory', 'createTemplateFactory'],
+  ['HTMLBars.template', '@ember/template-factory', 'createTemplateFactory'],
+
+  // @ember/test
+  ['Test.registerAsyncHelper', '@ember/test', 'registerAsyncHelper'],
+  ['Test.registerHelper', '@ember/test', 'registerHelper'],
+  ['Test.registerWaiter', '@ember/test', 'registerWaiter'],
+  ['Test.unregisterHelper', '@ember/test', 'unregisterHelper'],
+  ['Test.unregisterWaiter', '@ember/test', 'unregisterWaiter'],
+
+  // @ember/test/adapter
+  ['Test.Adapter', '@ember/test/adapter', 'default'],
+
+  // @ember/utils
+  ['compare', '@ember/utils', 'compare'],
+  ['isBlank', '@ember/utils', 'isBlank'],
+  ['isEmpty', '@ember/utils', 'isEmpty'],
+  ['isEqual', '@ember/utils', 'isEqual'],
+  ['isNone', '@ember/utils', 'isNone'],
+  ['isPresent', '@ember/utils', 'isPresent'],
+  ['tryInvoke', '@ember/utils', 'tryInvoke'],
+  ['typeOf', '@ember/utils', 'typeOf'],
+
+  // @ember/version
+  ['VERSION', '@ember/version', 'VERSION'],
+
+  // @glimmer/tracking
+  ['_tracked', '@glimmer/tracking', 'tracked'],
+
+  // @glimmer/tracking/primitives/cache
+  ['_createCache', '@glimmer/tracking/primitives/cache', 'createCache'],
+  ['_cacheGetValue', '@glimmer/tracking/primitives/cache', 'getValue'],
+  ['_cacheIsConst', '@glimmer/tracking/primitives/cache', 'isConst'],
+
+  // @ember/-internals/environment
+  ['ENV', '@ember/-internals/environment', { get: 'getENV' }],
+  ['lookup', '@ember/-internals/environment', { get: 'getLookup', set: 'setLookup' }],
+
+  // @ember/-internals/utils
+  ['GUID_KEY', '@ember/-internals/utils'],
+  ['uuid', '@ember/-internals/utils'],
+  ['generateGuid', '@ember/-internals/utils'],
+  ['canInvoke', '@ember/-internals/utils'],
+  ['wrap', '@ember/-internals/utils'],
+  ['_Cache', '@ember/-internals/utils', 'Cache'],
+
+  // @ember/-internals/container
+  ['Registry', '@ember/-internals/container', 'Registry'],
+  ['Container', '@ember/-internals/container', 'Container'],
+
+  // @ember/-internals/metal
+  ['computed', '@ember/-internals/metal', '_globalsComputed'],
+  ['_descriptor', '@ember/-internals/metal', 'nativeDescDecorator'],
+  ['_setClassicDecorator', '@ember/-internals/metal', 'setClassicDecorator'],
+  ['_getPath', '@ember/-internals/metal'],
+  ['hasListeners', '@ember/-internals/metal'],
   ['beginPropertyChanges', '@ember/-internals/metal'],
   ['endPropertyChanges', '@ember/-internals/metal'],
   ['changeProperties', '@ember/-internals/metal'],
-  ['platform.defineProperty', null, { value: true }],
-  ['platform.hasPropertyAccessors', null, { value: true }],
-  ['defineProperty', '@ember/-internals/metal'],
-  ['destroy', '@glimmer/destroyable', 'destroy'],
   ['libraries', '@ember/-internals/metal'],
-  ['getProperties', '@ember/-internals/metal'],
-  ['setProperties', '@ember/-internals/metal'],
-  ['expandProperties', '@ember/-internals/metal'],
-  ['addObserver', '@ember/-internals/metal'],
-  ['removeObserver', '@ember/-internals/metal'],
-  ['aliasMethod', '@ember/-internals/metal'],
-  ['observer', '@ember/-internals/metal'],
-  ['mixin', '@ember/-internals/metal'],
-  ['Mixin', '@ember/-internals/metal'],
+  [
+    'BOOTED',
+    '@ember/-internals/metal',
+    { get: 'isNamespaceSearchDisabled', set: 'setNamespaceSearchDisabled' },
+  ],
+
+  // @ember/-internals/error-handling
+  ['onerror', '@ember/-internals/error-handling', { get: 'getOnerror', set: 'setOnerror' }],
+
+  // @ember/-internals/meta
+  ['meta', '@ember/-internals/meta'],
 
   // @ember/-internals/console
   ['Logger', '@ember/-internals/console', 'default'],
@@ -284,139 +526,52 @@ let allExports = [
   ['EventDispatcher', '@ember/-internals/views'],
 
   // @ember/-internals/glimmer
-  ['Component', '@ember/-internals/glimmer', 'Component'],
-  ['Helper', '@ember/-internals/glimmer', 'Helper'],
-  ['Helper.helper', '@ember/-internals/glimmer', 'helper'],
-  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['Checkbox', '@ember/-internals/glimmer'],
-  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['LinkComponent', '@ember/-internals/glimmer'],
-  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['TextArea', '@ember/-internals/glimmer'],
-  EMBER_MODERNIZED_BUILT_IN_COMPONENTS ? null : ['TextField', '@ember/-internals/glimmer'],
   ['TEMPLATES', '@ember/-internals/glimmer', { get: 'getTemplates', set: 'setTemplates' }],
-  ['Handlebars.template', '@ember/-internals/glimmer', 'template'],
-  ['HTMLBars.template', '@ember/-internals/glimmer', 'template'],
   ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression'],
-  ['_setComponentManager', '@ember/-internals/glimmer', 'setComponentManager'],
-  ['_componentManagerCapabilities', '@ember/-internals/glimmer', 'componentCapabilities'],
-  ['_setModifierManager', '@glimmer/manager', 'setModifierManager'],
-  ['_modifierManagerCapabilities', '@ember/-internals/glimmer', 'modifierCapabilities'],
-  ['_setComponentTemplate', '@glimmer/manager', 'setComponentTemplate'],
-  ['_getComponentTemplate', '@glimmer/manager', 'getComponentTemplate'],
-  EMBER_GLIMMER_HELPER_MANAGER
-    ? ['_setHelperManager', '@glimmer/manager', 'setHelperManager']
-    : null,
-  EMBER_GLIMMER_HELPER_MANAGER
-    ? ['_helperManagerCapabilities', '@glimmer/manager', 'helperCapabilities']
-    : null,
-  EMBER_GLIMMER_INVOKE_HELPER ? ['_invokeHelper', '@glimmer/runtime', 'invokeHelper'] : null,
-  ['_captureRenderTree', '@ember/debug', 'captureRenderTree'],
-  ['_Input', '@ember/-internals/glimmer', 'Input'],
 
   // @ember/-internals/runtime
-  ['A', '@ember/-internals/runtime'],
   ['_RegistryProxyMixin', '@ember/-internals/runtime', 'RegistryProxyMixin'],
   ['_ContainerProxyMixin', '@ember/-internals/runtime', 'ContainerProxyMixin'],
-  ['Object', '@ember/-internals/runtime'],
-  ['String.loc', '@ember/string', 'loc'],
-  ['String.w', '@ember/string', 'w'],
-  ['String.dasherize', '@ember/string', 'dasherize'],
-  ['String.decamelize', '@ember/string', 'decamelize'],
-  ['String.camelize', '@ember/string', 'camelize'],
-  ['String.classify', '@ember/string', 'classify'],
-  ['String.underscore', '@ember/string', 'underscore'],
-  ['String.capitalize', '@ember/string', 'capitalize'],
-  ['compare', '@ember/-internals/runtime'],
-  ['copy', '@ember/-internals/runtime'],
-  ['isEqual', '@ember/-internals/runtime'],
-  ['inject.controller', '@ember/controller', 'inject'],
-  ['inject.service', '@ember/service', 'inject'],
-  ['Array', '@ember/-internals/runtime'],
   ['Comparable', '@ember/-internals/runtime'],
-  ['Namespace', '@ember/-internals/runtime'],
-  ['Enumerable', '@ember/-internals/runtime'],
-  ['ArrayProxy', '@ember/-internals/runtime'],
-  ['ObjectProxy', '@ember/-internals/runtime'],
   ['ActionHandler', '@ember/-internals/runtime'],
-  ['CoreObject', '@ember/-internals/runtime'],
   ['NativeArray', '@ember/-internals/runtime'],
   ['Copyable', '@ember/-internals/runtime'],
   ['MutableEnumerable', '@ember/-internals/runtime'],
-  ['MutableArray', '@ember/-internals/runtime'],
   EMBER_MODERNIZED_BUILT_IN_COMPONENTS
     ? null
     : ['TargetActionSupport', '@ember/-internals/runtime'],
-  ['Evented', '@ember/-internals/runtime'],
-  ['PromiseProxyMixin', '@ember/-internals/runtime'],
-  ['Observable', '@ember/-internals/runtime'],
-  ['typeOf', '@ember/-internals/runtime'],
-  ['isArray', '@ember/-internals/runtime'],
-  ['Object', '@ember/-internals/runtime'],
-  ['onLoad', '@ember/application'],
-  ['runLoadHooks', '@ember/application'],
-  ['Controller', '@ember/controller', 'default'],
   ['ControllerMixin', '@ember/controller/lib/controller_mixin', 'default'],
-  ['Service', '@ember/service', 'default'],
   ['_ProxyMixin', '@ember/-internals/runtime'],
-  ['RSVP', '@ember/-internals/runtime'],
-  ['STRINGS', '@ember/string', { get: '_getStrings', set: '_setStrings' }],
-  [
-    'BOOTED',
-    '@ember/-internals/metal',
-    { get: 'isNamespaceSearchDisabled', set: 'setNamespaceSearchDisabled' },
-  ],
-  ['_action', '@ember/object', 'action'],
-  ['_dependentKeyCompat', '@ember/object/compat', 'dependentKeyCompat'],
-  ['computed.empty', '@ember/object/computed', 'empty'],
-  ['computed.notEmpty', '@ember/object/computed', 'notEmpty'],
-  ['computed.none', '@ember/object/computed', 'none'],
-  ['computed.not', '@ember/object/computed', 'not'],
-  ['computed.bool', '@ember/object/computed', 'bool'],
-  ['computed.match', '@ember/object/computed', 'match'],
-  ['computed.equal', '@ember/object/computed', 'equal'],
-  ['computed.gt', '@ember/object/computed', 'gt'],
-  ['computed.gte', '@ember/object/computed', 'gte'],
-  ['computed.lt', '@ember/object/computed', 'lt'],
-  ['computed.lte', '@ember/object/computed', 'lte'],
-  ['computed.oneWay', '@ember/object/computed', 'oneWay'],
-  ['computed.reads', '@ember/object/computed', 'oneWay'],
-  ['computed.readOnly', '@ember/object/computed', 'readOnly'],
-  ['computed.deprecatingAlias', '@ember/object/computed', 'deprecatingAlias'],
-  ['computed.and', '@ember/object/computed', 'and'],
-  ['computed.or', '@ember/object/computed', 'or'],
-  ['computed.sum', '@ember/object/computed', 'sum'],
-  ['computed.min', '@ember/object/computed', 'min'],
-  ['computed.max', '@ember/object/computed', 'max'],
-  ['computed.map', '@ember/object/computed', 'map'],
-  ['computed.sort', '@ember/object/computed', 'sort'],
-  ['computed.setDiff', '@ember/object/computed', 'setDiff'],
-  ['computed.mapBy', '@ember/object/computed', 'mapBy'],
-  ['computed.filter', '@ember/object/computed', 'filter'],
-  ['computed.filterBy', '@ember/object/computed', 'filterBy'],
-  ['computed.uniq', '@ember/object/computed', 'uniq'],
-  ['computed.uniqBy', '@ember/object/computed', 'uniqBy'],
-  ['computed.union', '@ember/object/computed', 'union'],
-  ['computed.intersect', '@ember/object/computed', 'intersect'],
-  ['computed.collect', '@ember/object/computed', 'collect'],
 
   // @ember/-internals/routing
-  ['Location', '@ember/-internals/routing'],
-  ['AutoLocation', '@ember/-internals/routing'],
-  ['HashLocation', '@ember/-internals/routing'],
-  ['HistoryLocation', '@ember/-internals/routing'],
-  ['NoneLocation', '@ember/-internals/routing'],
   ['controllerFor', '@ember/-internals/routing'],
   ['generateControllerFactory', '@ember/-internals/routing'],
   ['generateController', '@ember/-internals/routing'],
   ['RouterDSL', '@ember/-internals/routing'],
-  ['Router', '@ember/-internals/routing'],
-  ['Route', '@ember/-internals/routing'],
 
-  // ember-application
-  ['Application', '@ember/application', 'default'],
-  ['ApplicationInstance', '@ember/application/instance', 'default'],
-  ['Engine', '@ember/engine', 'default'],
-  ['EngineInstance', '@ember/engine/instance', 'default'],
+  // backburner
+  ['_Backburner', 'backburner', 'default'],
 
-  // @ember/-internals/extension-support
-  ['DataAdapter', '@ember/-internals/extension-support'],
-  ['ContainerDebugAdapter', '@ember/-internals/extension-support'],
+  // jquery
+  ENV._JQUERY_INTEGRATION ? [null, 'jquery', 'default'] : null,
+
+  // rsvp
+  [null, 'rsvp', 'default'],
+  [null, 'rsvp', 'Promise'],
+  [null, 'rsvp', 'all'],
+  [null, 'rsvp', 'allSettled'],
+  [null, 'rsvp', 'defer'],
+  [null, 'rsvp', 'denodeify'],
+  [null, 'rsvp', 'filter'],
+  [null, 'rsvp', 'hash'],
+  [null, 'rsvp', 'hashSettled'],
+  [null, 'rsvp', 'map'],
+  [null, 'rsvp', 'off'],
+  [null, 'rsvp', 'on'],
+  [null, 'rsvp', 'race'],
+  [null, 'rsvp', 'reject'],
+  [null, 'rsvp', 'resolve'],
+
+  // misc.
+  ['platform.defineProperty', null, { value: true }],
 ].filter(Boolean);

--- a/packages/internal-test-helpers/lib/confirm-export.js
+++ b/packages/internal-test-helpers/lib/confirm-export.js
@@ -16,10 +16,19 @@ function getDescriptor(obj, path) {
 
 export default function confirmExport(Ember, assert, path, moduleId, exportName) {
   try {
-    let desc = getDescriptor(Ember, path);
-    assert.ok(desc, `the ${path} property exists on the Ember global`);
+    let desc;
 
-    if (typeof exportName === 'string') {
+    if (path !== null) {
+      desc = getDescriptor(Ember, path);
+      assert.ok(desc, `the ${path} property exists on the Ember global`);
+    } else {
+      desc = null;
+    }
+
+    if (desc === null) {
+      let mod = require(moduleId);
+      assert.notEqual(mod[exportName], undefined, `${moduleId}#${exportName} is not \`undefined\``);
+    } else if (typeof exportName === 'string') {
       let mod = require(moduleId);
       let value = 'value' in desc ? desc.value : desc.get.call(Ember);
       assert.equal(value, mod[exportName], `Ember.${path} is exported correctly`);

--- a/packages/jquery/index.js
+++ b/packages/jquery/index.js
@@ -1,0 +1,3 @@
+import { jQuery } from '@ember/-internals/views';
+
+export default jQuery;


### PR DESCRIPTION
Adds all of the remaining Ember modules so that we can remove the
API polyfill. Also updates the tests for re-exporting modules so they
are organized by exported module and also test re-exporting the external
module and not any internal one.