### PR TITLE
[BUGFIX] Use getter for `currentRunLoop`

### DIFF
--- a/packages/@ember/runloop/index.js
+++ b/packages/@ember/runloop/index.js
@@ -741,15 +741,15 @@ export function throttle() {
   return backburner.throttle(...arguments);
 }
 
+export let _deprecatedGlobalGetCurrentRunLoop;
+
 // eslint-disable-next-line no-undef
 if (DEBUG) {
-  let defineDeprecatedRunloopFunc = (key, func, alt) => {
+  let defineDeprecatedRunloopFunc = (key, func) => {
     Object.defineProperty(run, key, {
       get() {
         deprecate(
-          `Using \`run.${key}\` has been deprecated. Instead, import the value directly from @ember/runloop:\n\n  import { ${
-            alt || key
-          } } from '@ember/runloop';`,
+          `Using \`run.${key}\` has been deprecated. Instead, import the value directly from @ember/runloop:\n\n  import { ${key} } from '@ember/runloop';`,
           false,
           {
             id: 'deprecated-run-loop-and-computed-dot-access',
@@ -764,6 +764,23 @@ if (DEBUG) {
         return func;
       },
     });
+  };
+
+  _deprecatedGlobalGetCurrentRunLoop = () => {
+    deprecate(
+      `Using \`run.currentRunLoop\` has been deprecated. Instead, import the getCurrentRunLoop() directly from @ember/runloop:\n\n  import { getCurrentRunLoop } from '@ember/runloop';`,
+      false,
+      {
+        id: 'deprecated-run-loop-and-computed-dot-access',
+        until: '4.0.0',
+        for: 'ember-source',
+        since: {
+          enabled: '3.27.0',
+        },
+      }
+    );
+
+    return getCurrentRunLoop();
   };
 
   defineDeprecatedRunloopFunc('backburner', backburner);
@@ -781,7 +798,10 @@ if (DEBUG) {
   defineDeprecatedRunloopFunc('scheduleOnce', scheduleOnce);
   defineDeprecatedRunloopFunc('throttle', throttle);
   defineDeprecatedRunloopFunc('cancelTimers', cancelTimers);
-  defineDeprecatedRunloopFunc('currentRunLoop', getCurrentRunLoop, 'getCurrentRunLoop');
+  Object.defineProperty(run, 'currentRunLoop', {
+    get: _deprecatedGlobalGetCurrentRunLoop,
+    enumerable: false,
+  });
 } else {
   run.backburner = backburner;
   run.begin = begin;
@@ -798,5 +818,8 @@ if (DEBUG) {
   run.scheduleOnce = scheduleOnce;
   run.throttle = throttle;
   run.cancelTimers = cancelTimers;
-  run.currentRunLoop = getCurrentRunLoop;
+  Object.defineProperty(run, 'currentRunLoop', {
+    get: getCurrentRunLoop,
+    enumerable: false,
+  });
 }

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -415,7 +415,12 @@ let allExports = [
   ['run.schedule', '@ember/runloop', 'schedule', true],
   ['run.scheduleOnce', '@ember/runloop', 'scheduleOnce', true],
   ['run.throttle', '@ember/runloop', 'throttle', true],
-  ['run.currentRunLoop', '@ember/runloop', 'getCurrentRunLoop', true],
+  [
+    'run.currentRunLoop',
+    '@ember/runloop',
+    { get: DEBUG ? '_deprecatedGlobalGetCurrentRunLoop' : 'getCurrentRunLoop' },
+    true,
+  ],
   ['run.cancelTimers', '@ember/runloop', 'cancelTimers', true],
 
   // @ember/service


### PR DESCRIPTION
The `currentRunLoop` property on the global run was a getter, not a
value. I missed this when doing the conversion, and it doesn't appear
that we had a test for the behavior of that property, other than the
re-export test (which I also changed, mistakenly). This restores
the previous behavior, which deprecating it.