### PR TITLE
[BUGFIX] Rename private runloop functions

### DIFF
--- a/packages/@ember/-internals/extension-support/lib/data_adapter.js
+++ b/packages/@ember/-internals/extension-support/lib/data_adapter.js
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/-internals/owner';
-import { backburner } from '@ember/runloop';
+import { _backburner } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
 import { dasherize } from '@ember/string';
 import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
@@ -364,10 +364,10 @@ export default EmberObject.extend({
           this.recordsWatchers.forEach((watcher) => watcher.revalidate());
         };
 
-        backburner.on('end', this.flushWatchers);
+        _backburner.on('end', this.flushWatchers);
       }
     } else if (this.typeWatchers.size === 0 && this.recordsWatchers.size === 0) {
-      backburner.off('end', this.flushWatchers);
+      _backburner.off('end', this.flushWatchers);
       this.flushWatchers = null;
     }
   },
@@ -386,7 +386,7 @@ export default EmberObject.extend({
     this.releaseMethods.forEach((fn) => fn());
 
     if (this.flushWatchers) {
-      backburner.off('end', this.flushWatchers);
+      _backburner.off('end', this.flushWatchers);
     }
   },
 

--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -5,7 +5,7 @@ import { getDebugName } from '@ember/-internals/utils';
 import { constructStyleDeprecationMessage } from '@ember/-internals/views';
 import { assert, deprecate, warn } from '@ember/debug';
 import { DeprecationOptions } from '@ember/debug/lib/deprecate';
-import { backburner, schedule } from '@ember/runloop';
+import { _backburner, schedule } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import setGlobalContext from '@glimmer/global-context';
 import { EnvironmentDelegate } from '@glimmer/runtime';
@@ -20,7 +20,7 @@ import toBool from './utils/to-bool';
 
 setGlobalContext({
   scheduleRevalidate() {
-    backburner.ensureInstance();
+    _backburner.ensureInstance();
   },
 
   toBool,

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -2,7 +2,7 @@ import { ENV } from '@ember/-internals/environment';
 import { getOwner, Owner } from '@ember/-internals/owner';
 import { getViewElement, getViewId } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
-import { backburner, getCurrentRunLoop } from '@ember/runloop';
+import { _backburner, _getCurrentRunLoop } from '@ember/runloop';
 import { destroy } from '@glimmer/destroyable';
 import { DEBUG } from '@glimmer/env';
 import {
@@ -229,9 +229,9 @@ export function renderSettled() {
     renderSettledDeferred = RSVP.defer();
     // if there is no current runloop, the promise created above will not have
     // a chance to resolve (because its resolved in backburner's "end" event)
-    if (!getCurrentRunLoop()) {
+    if (!_getCurrentRunLoop()) {
       // ensure a runloop has been kicked off
-      backburner.schedule('actions', null, K);
+      _backburner.schedule('actions', null, K);
     }
   }
 
@@ -243,7 +243,7 @@ function resolveRenderPromise() {
     let resolve = renderSettledDeferred.resolve;
     renderSettledDeferred = null;
 
-    backburner.join(null, resolve);
+    _backburner.join(null, resolve);
   }
 }
 
@@ -258,15 +258,15 @@ function loopEnd() {
         throw new Error('infinite rendering invalidation detected');
       }
       loops++;
-      return backburner.join(null, K);
+      return _backburner.join(null, K);
     }
   }
   loops = 0;
   resolveRenderPromise();
 }
 
-backburner.on('begin', loopBegin);
-backburner.on('end', loopEnd);
+_backburner.on('begin', loopBegin);
+_backburner.on('end', loopEnd);
 
 interface ViewRegistry {
   [viewId: string]: unknown;
@@ -574,7 +574,7 @@ export class Renderer {
   }
 
   _scheduleRevalidate(): void {
-    backburner.scheduleOnce('render', this, this._revalidate);
+    _backburner.scheduleOnce('render', this, this._revalidate);
   }
 
   _isValid(): boolean {

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -1,7 +1,7 @@
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { Component } from '../utils/helpers';
-import { getCurrentRunLoop, run } from '@ember/runloop';
+import { _getCurrentRunLoop, run } from '@ember/runloop';
 import {
   subscribe as instrumentationSubscribe,
   reset as instrumentationReset,
@@ -164,7 +164,7 @@ moduleFor(
       this.registerComponent('x-foo', {
         ComponentClass: Component.extend({
           change() {
-            assert.ok(getCurrentRunLoop(), 'a run loop should have started');
+            assert.ok(_getCurrentRunLoop(), 'a run loop should have started');
           },
         }),
         template: `<input id="is-done" type="checkbox">`,

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -4,7 +4,7 @@ import {
   subscribe as instrumentationSubscribe,
   unsubscribe as instrumentationUnsubscribe,
 } from '@ember/instrumentation';
-import { getCurrentRunLoop } from '@ember/runloop';
+import { _getCurrentRunLoop } from '@ember/runloop';
 import { set, computed } from '@ember/-internals/metal';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
 
@@ -1019,7 +1019,7 @@ moduleFor(
       let OuterComponent = Component.extend({
         actions: {
           submit() {
-            capturedRunLoop = getCurrentRunLoop();
+            capturedRunLoop = _getCurrentRunLoop();
           },
         },
       });

--- a/packages/@ember/-internals/runtime/lib/ext/rsvp.js
+++ b/packages/@ember/-internals/runtime/lib/ext/rsvp.js
@@ -1,14 +1,14 @@
 import * as RSVP from 'rsvp';
-import { backburner, _rsvpErrorQueue } from '@ember/runloop';
+import { _backburner, _rsvpErrorQueue } from '@ember/runloop';
 import { getDispatchOverride } from '@ember/-internals/error-handling';
 import { assert } from '@ember/debug';
 
 RSVP.configure('async', (callback, promise) => {
-  backburner.schedule('actions', null, callback, promise);
+  _backburner.schedule('actions', null, callback, promise);
 });
 
 RSVP.configure('after', (cb) => {
-  backburner.schedule(_rsvpErrorQueue, null, cb);
+  _backburner.schedule(_rsvpErrorQueue, null, cb);
 });
 
 RSVP.on('error', onerrorDefault);

--- a/packages/@ember/runloop/index.d.ts
+++ b/packages/@ember/runloop/index.d.ts
@@ -1,6 +1,6 @@
 import { Backburner, DeferredActionQueues, Timer } from 'backburner.js';
 
-export const backburner: Backburner;
+export const _backburner: Backburner;
 
 export const run = Backburner.run;
 export const schedule = Backburner.schedule;
@@ -9,7 +9,7 @@ export const join = Backburner.join;
 export const cancel = Backburner.cancel;
 export const scheduleOnce = Backburner.scheduleOnce;
 
-export function getCurrentRunLoop(): DeferredActionQueues;
+export function _getCurrentRunLoop(): DeferredActionQueues;
 
 export function once(method: Function): Timer;
 export function once<T, U extends keyof T>(target: T, method: U, ...args): Timer;

--- a/packages/@ember/runloop/index.js
+++ b/packages/@ember/runloop/index.js
@@ -5,7 +5,7 @@ import { flushAsyncObservers } from '@ember/-internals/metal';
 import Backburner from 'backburner';
 
 let currentRunLoop = null;
-export function getCurrentRunLoop() {
+export function _getCurrentRunLoop() {
   return currentRunLoop;
 }
 
@@ -40,7 +40,7 @@ export const _rsvpErrorQueue = `${Math.random()}${Date.now()}`.replace('.', '');
   @default ['actions', 'destroy']
   @private
 */
-export const queues = [
+export const _queues = [
   'actions',
 
   // used in router transitions to prevent unnecessary loading state entry
@@ -56,7 +56,7 @@ export const queues = [
   _rsvpErrorQueue,
 ];
 
-export const backburner = new Backburner(queues, {
+export const _backburner = new Backburner(_queues, {
   defaultQueue: 'actions',
   onBegin,
   onEnd,
@@ -101,7 +101,7 @@ export const backburner = new Backburner(queues, {
   @public
 */
 export function run() {
-  return backburner.run(...arguments);
+  return _backburner.run(...arguments);
 }
 
 /**
@@ -149,7 +149,7 @@ export function run() {
   @public
 */
 export function join() {
-  return backburner.join(...arguments);
+  return _backburner.join(...arguments);
 }
 
 /**
@@ -259,7 +259,7 @@ export const bind = (...curried) => {
   @public
 */
 export function begin() {
-  backburner.begin();
+  _backburner.begin();
 }
 
 /**
@@ -282,7 +282,7 @@ export function begin() {
   @public
 */
 export function end() {
-  backburner.end();
+  _backburner.end();
 }
 
 /**
@@ -327,17 +327,17 @@ export function end() {
   @public
 */
 export function schedule(/* queue, target, method */) {
-  return backburner.schedule(...arguments);
+  return _backburner.schedule(...arguments);
 }
 
 // Used by global test teardown
-export function hasScheduledTimers() {
-  return backburner.hasTimers();
+export function _hasScheduledTimers() {
+  return _backburner.hasTimers();
 }
 
 // Used by global test teardown
-export function cancelTimers() {
-  backburner.cancelTimers();
+export function _cancelTimers() {
+  _backburner.cancelTimers();
 }
 
 /**
@@ -371,7 +371,7 @@ export function cancelTimers() {
   @public
 */
 export function later(/*target, method*/) {
-  return backburner.later(...arguments);
+  return _backburner.later(...arguments);
 }
 
 /**
@@ -391,7 +391,7 @@ export function later(/*target, method*/) {
 */
 export function once(...args) {
   args.unshift('actions');
-  return backburner.scheduleOnce(...args);
+  return _backburner.scheduleOnce(...args);
 }
 
 /**
@@ -467,7 +467,7 @@ export function once(...args) {
   @public
 */
 export function scheduleOnce(/* queue, target, method*/) {
-  return backburner.scheduleOnce(...arguments);
+  return _backburner.scheduleOnce(...arguments);
 }
 
 /**
@@ -542,7 +542,7 @@ export function scheduleOnce(/* queue, target, method*/) {
 */
 export function next(...args) {
   args.push(1);
-  return backburner.later(...args);
+  return _backburner.later(...args);
 }
 
 /**
@@ -613,7 +613,7 @@ export function next(...args) {
   @public
 */
 export function cancel(timer) {
-  return backburner.cancel(timer);
+  return _backburner.cancel(timer);
 }
 
 /**
@@ -691,7 +691,7 @@ export function cancel(timer) {
   @public
 */
 export function debounce() {
-  return backburner.debounce(...arguments);
+  return _backburner.debounce(...arguments);
 }
 
 /**
@@ -738,7 +738,7 @@ export function debounce() {
   @public
 */
 export function throttle() {
-  return backburner.throttle(...arguments);
+  return _backburner.throttle(...arguments);
 }
 
 export let _deprecatedGlobalGetCurrentRunLoop;
@@ -780,16 +780,16 @@ if (DEBUG) {
       }
     );
 
-    return getCurrentRunLoop();
+    return _getCurrentRunLoop();
   };
 
-  defineDeprecatedRunloopFunc('backburner', backburner);
+  defineDeprecatedRunloopFunc('backburner', _backburner);
   defineDeprecatedRunloopFunc('begin', begin);
   defineDeprecatedRunloopFunc('bind', bind);
   defineDeprecatedRunloopFunc('cancel', cancel);
   defineDeprecatedRunloopFunc('debounce', debounce);
   defineDeprecatedRunloopFunc('end', end);
-  defineDeprecatedRunloopFunc('hasScheduledTimers', hasScheduledTimers);
+  defineDeprecatedRunloopFunc('hasScheduledTimers', _hasScheduledTimers);
   defineDeprecatedRunloopFunc('join', join);
   defineDeprecatedRunloopFunc('later', later);
   defineDeprecatedRunloopFunc('next', next);
@@ -797,19 +797,19 @@ if (DEBUG) {
   defineDeprecatedRunloopFunc('schedule', schedule);
   defineDeprecatedRunloopFunc('scheduleOnce', scheduleOnce);
   defineDeprecatedRunloopFunc('throttle', throttle);
-  defineDeprecatedRunloopFunc('cancelTimers', cancelTimers);
+  defineDeprecatedRunloopFunc('cancelTimers', _cancelTimers);
   Object.defineProperty(run, 'currentRunLoop', {
     get: _deprecatedGlobalGetCurrentRunLoop,
     enumerable: false,
   });
 } else {
-  run.backburner = backburner;
+  run.backburner = _backburner;
   run.begin = begin;
   run.bind = bind;
   run.cancel = cancel;
   run.debounce = debounce;
   run.end = end;
-  run.hasScheduledTimers = hasScheduledTimers;
+  run.hasScheduledTimers = _hasScheduledTimers;
   run.join = join;
   run.later = later;
   run.next = next;
@@ -817,9 +817,9 @@ if (DEBUG) {
   run.schedule = schedule;
   run.scheduleOnce = scheduleOnce;
   run.throttle = throttle;
-  run.cancelTimers = cancelTimers;
+  run.cancelTimers = _cancelTimers;
   Object.defineProperty(run, 'currentRunLoop', {
-    get: getCurrentRunLoop,
+    get: _getCurrentRunLoop,
     enumerable: false,
   });
 }

--- a/packages/@ember/runloop/tests/later_test.js
+++ b/packages/@ember/runloop/tests/later_test.js
@@ -1,14 +1,14 @@
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { assign } from '@ember/polyfills';
-import { run, later, backburner, hasScheduledTimers, getCurrentRunLoop } from '..';
+import { run, later, _backburner, _hasScheduledTimers, _getCurrentRunLoop } from '..';
 
 const originalSetTimeout = window.setTimeout;
 const originalDateValueOf = Date.prototype.valueOf;
-const originalPlatform = backburner._platform;
+const originalPlatform = _backburner._platform;
 
 function wait(callback, maxWaitCount = 100) {
   originalSetTimeout(() => {
-    if (maxWaitCount > 0 && (hasScheduledTimers() || getCurrentRunLoop())) {
+    if (maxWaitCount > 0 && (_hasScheduledTimers() || _getCurrentRunLoop())) {
       wait(callback, maxWaitCount - 1);
 
       return;
@@ -35,7 +35,7 @@ moduleFor(
   'run.later',
   class extends AbstractTestCase {
     teardown() {
-      backburner._platform = originalPlatform;
+      _backburner._platform = originalPlatform;
       window.setTimeout = originalSetTimeout;
       Date.prototype.valueOf = originalDateValueOf;
     }
@@ -101,13 +101,13 @@ moduleFor(
       let firstRunLoop, secondRunLoop;
 
       run(() => {
-        firstRunLoop = getCurrentRunLoop();
+        firstRunLoop = _getCurrentRunLoop();
 
         later(
           obj,
           function (amt) {
             this.invoked += amt;
-            secondRunLoop = getCurrentRunLoop();
+            secondRunLoop = _getCurrentRunLoop();
           },
           10,
           1
@@ -117,7 +117,7 @@ moduleFor(
       });
 
       assert.ok(firstRunLoop, 'first run loop captured');
-      assert.ok(!getCurrentRunLoop(), "shouldn't be in a run loop after flush");
+      assert.ok(!_getCurrentRunLoop(), "shouldn't be in a run loop after flush");
       assert.equal(obj.invoked, 0, "shouldn't have invoked later item yet");
 
       wait(() => {
@@ -191,19 +191,19 @@ moduleFor(
       let runLoop, finished;
 
       run(() => {
-        runLoop = getCurrentRunLoop();
+        runLoop = _getCurrentRunLoop();
         assert.ok(runLoop);
 
         later(() => {
           assert.ok(
-            getCurrentRunLoop() && getCurrentRunLoop() !== runLoop,
+            _getCurrentRunLoop() && _getCurrentRunLoop() !== runLoop,
             'first later callback has own run loop'
           );
-          runLoop = getCurrentRunLoop();
+          runLoop = _getCurrentRunLoop();
 
           later(() => {
             assert.ok(
-              getCurrentRunLoop() && getCurrentRunLoop() !== runLoop,
+              _getCurrentRunLoop() && _getCurrentRunLoop() !== runLoop,
               'second later callback has own run loop'
             );
             finished = true;
@@ -226,7 +226,7 @@ moduleFor(
       // happens when an expired timer callback takes a while to run,
       // which is what we simulate here.
       let newSetTimeoutUsed;
-      backburner._platform = assign({}, originalPlatform, {
+      _backburner._platform = assign({}, originalPlatform, {
         setTimeout() {
           let wait = arguments[arguments.length - 1];
           newSetTimeoutUsed = true;

--- a/packages/@ember/runloop/tests/next_test.js
+++ b/packages/@ember/runloop/tests/next_test.js
@@ -1,4 +1,4 @@
-import { run, next, getCurrentRunLoop } from '..';
+import { run, next, _getCurrentRunLoop } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -22,8 +22,8 @@ moduleFor(
       let done = assert.async();
       let firstRunLoop, secondRunLoop;
       run(() => {
-        firstRunLoop = getCurrentRunLoop();
-        next(() => (secondRunLoop = getCurrentRunLoop()));
+        firstRunLoop = _getCurrentRunLoop();
+        next(() => (secondRunLoop = _getCurrentRunLoop()));
       });
 
       setTimeout(() => {
@@ -40,8 +40,8 @@ moduleFor(
       let done = assert.async();
       let secondRunLoop, thirdRunLoop;
       run(() => {
-        next(() => (secondRunLoop = getCurrentRunLoop()));
-        next(() => (thirdRunLoop = getCurrentRunLoop()));
+        next(() => (secondRunLoop = _getCurrentRunLoop()));
+        next(() => (thirdRunLoop = _getCurrentRunLoop()));
       });
 
       setTimeout(() => {

--- a/packages/@ember/runloop/tests/once_test.js
+++ b/packages/@ember/runloop/tests/once_test.js
@@ -1,4 +1,4 @@
-import { run, getCurrentRunLoop, once } from '..';
+import { run, _getCurrentRunLoop, once } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -55,7 +55,7 @@ moduleFor(
 
     ['@test should be inside of a runloop when running'](assert) {
       run(() => {
-        once(() => assert.ok(Boolean(getCurrentRunLoop()), 'should have a runloop'));
+        once(() => assert.ok(Boolean(_getCurrentRunLoop()), 'should have a runloop'));
       });
     }
   }

--- a/packages/@ember/runloop/tests/run_bind_test.js
+++ b/packages/@ember/runloop/tests/run_bind_test.js
@@ -1,4 +1,4 @@
-import { bind, getCurrentRunLoop } from '..';
+import { bind, _getCurrentRunLoop } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -10,7 +10,7 @@ moduleFor(
       let obj = {
         value: 0,
         increment(increment) {
-          assert.ok(getCurrentRunLoop(), 'expected a run-loop');
+          assert.ok(_getCurrentRunLoop(), 'expected a run-loop');
           return (this.value += increment);
         },
       };
@@ -24,7 +24,7 @@ moduleFor(
       assert.expect(4);
 
       function asyncCallback(increment, increment2, increment3) {
-        assert.ok(getCurrentRunLoop(), 'expected a run-loop');
+        assert.ok(_getCurrentRunLoop(), 'expected a run-loop');
         assert.equal(increment, 1);
         assert.equal(increment2, 2);
         assert.equal(increment3, 3);

--- a/packages/@ember/runloop/tests/schedule_test.js
+++ b/packages/@ember/runloop/tests/schedule_test.js
@@ -1,4 +1,4 @@
-import { run, cancel, schedule, getCurrentRunLoop } from '..';
+import { run, cancel, schedule, _getCurrentRunLoop } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -47,32 +47,32 @@ moduleFor(
       let order = [];
 
       run(() => {
-        let runLoop = getCurrentRunLoop();
+        let runLoop = _getCurrentRunLoop();
         assert.ok(runLoop, 'run loop present');
 
         schedule('actions', () => {
           order.push('actions');
-          assert.equal(runLoop, getCurrentRunLoop(), 'same run loop used');
+          assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
         });
 
         schedule('afterRender', () => {
           order.push('afterRender');
-          assert.equal(runLoop, getCurrentRunLoop(), 'same run loop used');
+          assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
 
           schedule('afterRender', () => {
             order.push('afterRender');
-            assert.equal(runLoop, getCurrentRunLoop(), 'same run loop used');
+            assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
           });
 
           schedule('actions', () => {
             order.push('actions');
-            assert.equal(runLoop, getCurrentRunLoop(), 'same run loop used');
+            assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
           });
         });
 
         schedule('destroy', () => {
           order.push('destroy');
-          assert.equal(runLoop, getCurrentRunLoop(), 'same run loop used');
+          assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
         });
       });
 

--- a/packages/@ember/runloop/tests/unwind_test.js
+++ b/packages/@ember/runloop/tests/unwind_test.js
@@ -1,4 +1,4 @@
-import { run, schedule, getCurrentRunLoop } from '..';
+import { run, schedule, _getCurrentRunLoop } from '..';
 import EmberError from '@ember/error';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -6,7 +6,7 @@ moduleFor(
   'system/run_loop/unwind_test',
   class extends AbstractTestCase {
     ['@test RunLoop unwinds despite unhandled exception'](assert) {
-      let initialRunLoop = getCurrentRunLoop();
+      let initialRunLoop = _getCurrentRunLoop();
 
       assert.throws(
         () => {
@@ -25,14 +25,14 @@ moduleFor(
       // flushed. I can't easily demonstrate this in a unit test because
       // autorun explicitly doesn't work in test mode. - ef4
       assert.equal(
-        getCurrentRunLoop(),
+        _getCurrentRunLoop(),
         initialRunLoop,
         'Previous run loop should be cleaned up despite exception'
       );
     }
 
     ['@test run unwinds despite unhandled exception'](assert) {
-      let initialRunLoop = getCurrentRunLoop();
+      let initialRunLoop = _getCurrentRunLoop();
 
       assert.throws(
         () => {
@@ -45,7 +45,7 @@ moduleFor(
       );
 
       assert.equal(
-        getCurrentRunLoop(),
+        _getCurrentRunLoop(),
         initialRunLoop,
         'Previous run loop should be cleaned up despite exception'
       );

--- a/packages/ember-testing/lib/ext/rsvp.js
+++ b/packages/ember-testing/lib/ext/rsvp.js
@@ -1,18 +1,18 @@
 import { RSVP } from '@ember/-internals/runtime';
-import { backburner } from '@ember/runloop';
+import { _backburner } from '@ember/runloop';
 import { isTesting } from '@ember/debug';
 import { asyncStart, asyncEnd } from '../test/adapter';
 
 RSVP.configure('async', function (callback, promise) {
   // if schedule will cause autorun, we need to inform adapter
-  if (isTesting() && !backburner.currentInstance) {
+  if (isTesting() && !_backburner.currentInstance) {
     asyncStart();
-    backburner.schedule('actions', () => {
+    _backburner.schedule('actions', () => {
       asyncEnd();
       callback(promise);
     });
   } else {
-    backburner.schedule('actions', () => callback(promise));
+    _backburner.schedule('actions', () => callback(promise));
   }
 });
 

--- a/packages/ember-testing/lib/helpers/wait.js
+++ b/packages/ember-testing/lib/helpers/wait.js
@@ -3,7 +3,7 @@
 */
 import { checkWaiters } from '../test/waiters';
 import { RSVP } from '@ember/-internals/runtime';
-import { getCurrentRunLoop, hasScheduledTimers, run } from '@ember/runloop';
+import { _getCurrentRunLoop, _hasScheduledTimers, run } from '@ember/runloop';
 import { pendingRequests } from '../test/pending_requests';
 
 /**
@@ -55,7 +55,7 @@ export default function wait(app, value) {
       }
 
       // 3. If there are scheduled timers or we are inside of a run loop, keep polling
-      if (hasScheduledTimers() || getCurrentRunLoop()) {
+      if (_hasScheduledTimers() || _getCurrentRunLoop()) {
         return;
       }
 

--- a/packages/ember-testing/lib/test/run.js
+++ b/packages/ember-testing/lib/test/run.js
@@ -1,7 +1,7 @@
-import { getCurrentRunLoop, run as emberRun } from '@ember/runloop';
+import { _getCurrentRunLoop, run as emberRun } from '@ember/runloop';
 
 export default function run(fn) {
-  if (!getCurrentRunLoop()) {
+  if (!_getCurrentRunLoop()) {
     return emberRun(fn);
   } else {
     return fn();

--- a/packages/ember-testing/tests/ext/rsvp_test.js
+++ b/packages/ember-testing/tests/ext/rsvp_test.js
@@ -1,7 +1,7 @@
 import RSVP from '../../lib/ext/rsvp';
 import { getAdapter, setAdapter } from '../../lib/test/adapter';
 import TestPromise, { getLastPromise } from '../../lib/test/promise';
-import { getCurrentRunLoop } from '@ember/runloop';
+import { _getCurrentRunLoop } from '@ember/runloop';
 import { isTesting, setTesting } from '@ember/debug';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -40,7 +40,7 @@ moduleFor(
       let done = assert.async();
       assert.expect(19);
 
-      assert.ok(!getCurrentRunLoop(), 'expect no run-loop');
+      assert.ok(!_getCurrentRunLoop(), 'expect no run-loop');
 
       setTesting(true);
 

--- a/packages/ember/tests/ember-test-helpers-test.js
+++ b/packages/ember/tests/ember-test-helpers-test.js
@@ -1,6 +1,6 @@
 import { Promise } from 'rsvp';
 import Application from '@ember/application';
-import { run, hasScheduledTimers, getCurrentRunLoop } from '@ember/runloop';
+import { run, _hasScheduledTimers, _getCurrentRunLoop } from '@ember/runloop';
 import { compile } from 'ember-template-compiler';
 import { ModuleBasedTestResolver } from 'internal-test-helpers';
 
@@ -22,7 +22,7 @@ module('@ember/test-helpers emulation test', function () {
     function settled() {
       return new Promise(function (resolve) {
         let watcher = setInterval(() => {
-          if (getCurrentRunLoop() || hasScheduledTimers()) {
+          if (_getCurrentRunLoop() || _hasScheduledTimers()) {
             return;
           }
 

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -401,13 +401,13 @@ let allExports = [
 
   // @ember/runloop
   ['run', '@ember/runloop', 'run'],
-  ['run.backburner', '@ember/runloop', 'backburner', true],
+  ['run.backburner', '@ember/runloop', '_backburner', true],
   ['run.begin', '@ember/runloop', 'begin', true],
   ['run.bind', '@ember/runloop', 'bind', true],
   ['run.cancel', '@ember/runloop', 'cancel', true],
   ['run.debounce', '@ember/runloop', 'debounce', true],
   ['run.end', '@ember/runloop', 'end', true],
-  ['run.hasScheduledTimers', '@ember/runloop', 'hasScheduledTimers', true],
+  ['run.hasScheduledTimers', '@ember/runloop', '_hasScheduledTimers', true],
   ['run.join', '@ember/runloop', 'join', true],
   ['run.later', '@ember/runloop', 'later', true],
   ['run.next', '@ember/runloop', 'next', true],
@@ -418,10 +418,10 @@ let allExports = [
   [
     'run.currentRunLoop',
     '@ember/runloop',
-    { get: DEBUG ? '_deprecatedGlobalGetCurrentRunLoop' : 'getCurrentRunLoop' },
+    { get: DEBUG ? '_deprecatedGlobalGetCurrentRunLoop' : '_getCurrentRunLoop' },
     true,
   ],
-  ['run.cancelTimers', '@ember/runloop', 'cancelTimers', true],
+  ['run.cancelTimers', '@ember/runloop', '_cancelTimers', true],
 
   // @ember/service
   ['Service', '@ember/service', 'default'],

--- a/packages/internal-test-helpers/lib/ember-dev/run-loop.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/run-loop.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
-import { cancelTimers, end, getCurrentRunLoop, hasScheduledTimers } from '@ember/runloop';
+import { _cancelTimers, _getCurrentRunLoop, _hasScheduledTimers, end } from '@ember/runloop';
 
 export function setupRunLoopCheck(hooks: NestedHooks) {
   hooks.afterEach(function (assert) {
-    if (getCurrentRunLoop() || hasScheduledTimers()) {
+    if (_getCurrentRunLoop() || _hasScheduledTimers()) {
       let done = assert.async();
       // use a setTimeout to allow the current run loop to flush via autorun
       setTimeout(() => {
@@ -14,16 +14,16 @@ export function setupRunLoopCheck(hooks: NestedHooks) {
 
         // if it is _still_ not completed, we have a problem and the test should be fixed
         assert.ok(
-          !hasScheduledTimers(),
+          !_hasScheduledTimers(),
           'Ember run should not have scheduled timers at end of test'
         );
-        assert.ok(!getCurrentRunLoop(), 'Should not be in a run loop at end of test');
+        assert.ok(!_getCurrentRunLoop(), 'Should not be in a run loop at end of test');
 
         // attempt to recover so the rest of the tests can run
-        while (getCurrentRunLoop()) {
+        while (_getCurrentRunLoop()) {
           end();
         }
-        cancelTimers();
+        _cancelTimers();
 
         done();
       }, 0);

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -1,7 +1,7 @@
 import {
-  getCurrentRunLoop,
+  _getCurrentRunLoop,
   // @ts-ignore
-  hasScheduledTimers,
+  _hasScheduledTimers,
   // @ts-ignore
   next,
   run,
@@ -35,7 +35,7 @@ export function runLoopSettled(event?: any): Promise<void> {
     // Every 5ms, poll for the async thing to have finished
     let watcher = setInterval(() => {
       // If there are scheduled timers or we are inside of a run loop, keep polling
-      if (hasScheduledTimers() || getCurrentRunLoop()) {
+      if (_hasScheduledTimers() || _getCurrentRunLoop()) {
         return;
       }
 


### PR DESCRIPTION
We currently export a few private functions from `@ember/runloop` for
packages like `@ember/test-helpers`. These functions are not public API,
but need to be accessible for these core packages. Previously they were
exposed on the private APIs of the global `run`, but now that we're
getting rid of the the modules transform these are now exposed directly,
so underscoring them should help make users aware that they are not
meant for public consumption.