### PR TITLE
[BUGFIX LTS] move LinkTo assertion into a method so LinkToExternal can override

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -645,7 +645,7 @@ const LinkComponent = EmberComponent.extend({
         'See https://ember-engines.com/docs/links for more info.',
       !this._isEngine || this._engineMountPoint !== undefined
     );
-  }
+  },
 
   _isActive(routerState: RouterState): boolean {
     if (this.loading) {

--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -499,12 +499,7 @@ const LinkComponent = EmberComponent.extend({
   init() {
     this._super(...arguments);
 
-    assert(
-      'You attempted to use the <LinkTo> component within a routeless engine, this is not supported. ' +
-        'If you are using the ember-engines addon, use the <LinkToExternal> component instead. ' +
-        'See https://ember-engines.com/docs/links for more info.',
-      !this._isEngine || this._engineMountPoint !== undefined
-    );
+    this.assertLinkToOrigin();
 
     // Map desired event name to invoke function
     let { eventName } = this;
@@ -635,6 +630,22 @@ const LinkComponent = EmberComponent.extend({
       return this._isActive(target);
     }
   ),
+
+  /**
+   * Method to assert that LinkTo is not used inside of a routeless engine. This method is
+   * overridden in ember-engines link-to-external component to just be a noop, since the
+   * link-to-external component extends the link-to component.
+   *
+   * @method assertLinkToOrigin
+   */
+  assertLinkToOrigin() {
+    assert(
+      'You attempted to use the <LinkTo> component within a routeless engine, this is not supported. ' +
+        'If you are using the ember-engines addon, use the <LinkToExternal> component instead. ' +
+        'See https://ember-engines.com/docs/links for more info.',
+      !this._isEngine || this._engineMountPoint !== undefined
+    );
+  }
 
   _isActive(routerState: RouterState): boolean {
     if (this.loading) {

--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -637,6 +637,7 @@ const LinkComponent = EmberComponent.extend({
    * link-to-external component extends the link-to component.
    *
    * @method assertLinkToOrigin
+   * @public
    */
   assertLinkToOrigin() {
     assert(

--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -637,7 +637,7 @@ const LinkComponent = EmberComponent.extend({
    * link-to-external component extends the link-to component.
    *
    * @method assertLinkToOrigin
-   * @public
+   * @private
    */
   assertLinkToOrigin() {
     assert(

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -92,6 +92,7 @@ module.exports = {
     'arrayContentWillChange',
     'assert',
     'assertDestroyablesDestroyed',
+    'assertLinkToOrigin',
     'assign',
     'associateDestroyableChild',
     'asyncEnd',


### PR DESCRIPTION
Part one of a fix for #19459. Once this lands I'll push a change in ember-engines to override this method to just be a noop.

First affected ember version is 3.24

Existing tests continue to pass.