### PR TITLE
[DOC] Remove extra argument from associateDestroyableChild

### DIFF
--- a/packages/@ember/destroyable/index.ts
+++ b/packages/@ember/destroyable/index.ts
@@ -48,7 +48,6 @@ import {
   @for @ember/destroyable
   @param {Object|Function} parent the destroyable to entangle the child destroyables lifetime with
   @param {Object|Function} child the destroyable to be entangled with the parents lifetime
-  @param {Function} destructor the destructor to run when the destroyable object is destroyed
   @returns {Object|Function} the child argument
   @static
   @public


### PR DESCRIPTION
According to implementation in https://github.com/glimmerjs/glimmer-vm/blob/v0.77.6/packages/@glimmer/destroyable/index.ts#L93 there are just two arguments (parent and child)