### PR TITLE
Change Typings for `setupController`

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1339,7 +1339,7 @@ class Route extends EmberObject implements IRoute {
     @since 1.0.0
     @public
   */
-  setupController(controller: Controller, context: {}, _transition: Transition) {
+  setupController(controller: Controller, context: {}, _transition?: Transition) {
     // eslint-disable-line no-unused-vars
     if (controller && context !== undefined) {
       set(controller, 'model', context);


### PR DESCRIPTION
As `_transition` is not used, it should not be required. I'd prefer to take it out completely, but in that case, I'm not sure if there are going to be other ramifications. Happy to investigate that if there's appetite.

Also, happy to be told I'm totally off base here!

Cheers!