### PR TITLE
make transition optional on setupController [19501]

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1335,11 +1335,11 @@ class Route extends EmberObject implements IRoute {
     @method setupController
     @param {Controller} controller instance
     @param {Object} model
-    @param {Object} transition
+    @param {Transition} [transition]
     @since 1.0.0
     @public
   */
-  setupController(controller: Controller, context: {}, _transition: Transition) {
+  setupController(controller: Controller, context: {}, _transition?: Transition) {
     // eslint-disable-line no-unused-vars
     if (controller && context !== undefined) {
       set(controller, 'model', context);


### PR DESCRIPTION
Closes #19501.

19501 notes that transition parameter was marked as required
on the API for the setupController (and would fail for Typescript
projects if not present).

This change makes transition optional as it is unused by
setupController and should therefore not break applications which
do not pass it in.

Removing the parameter would potentially break backwards
compatibility. As a compromise, it's marked as optional only.