### PR TITLE
Perf: Bugfix: Don't read before write for anything with a descriptor

### DIFF
--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -74,7 +74,7 @@ export function set<T = unknown>(obj: object, keyName: string, value: T, toleran
 export function _setProp(obj: object, keyName: string, value: any) {
   let descriptor = lookupDescriptor(obj, keyName);
 
-  if (descriptor !== null && COMPUTED_SETTERS.has(descriptor.set!)) {
+  if (descriptor !== null || COMPUTED_SETTERS.has(descriptor.set!)) {
     obj[keyName] = value;
     return value;
   }

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -74,7 +74,7 @@ export function set<T = unknown>(obj: object, keyName: string, value: T, toleran
 export function _setProp(obj: object, keyName: string, value: any) {
   let descriptor = lookupDescriptor(obj, keyName);
 
-  if (descriptor !== null || COMPUTED_SETTERS.has(descriptor.set!)) {
+  if (descriptor !== null) {
     obj[keyName] = value;
     return value;
   }

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -7,7 +7,6 @@ import {
 import { assert } from '@ember/debug';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
-import { COMPUTED_SETTERS } from './decorator';
 import { isPath } from './path_cache';
 import { notifyPropertyChange } from './property_events';
 import { _getPath as getPath, getPossibleMandatoryProxyValue } from './property_get';


### PR DESCRIPTION
Mostly opening this to see what tests fail. Currently when using `set` or `EmberObject.set` ember will first read a prop before writing to it unless that property happens to have a `COMPUTED_SETTER` which is only true for things that utilized `tracked` or `computed`. This causes performance issues and bugs when read before write is not expected.