### PR TITLE
Deprecate auto location

### DIFF
--- a/packages/@ember/-internals/routing/lib/location/api.ts
+++ b/packages/@ember/-internals/routing/lib/location/api.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 
 export interface EmberLocation {
   implementation: string;
@@ -109,6 +109,20 @@ export default {
     assert(
       `Location.create: ${implementation} is not a valid implementation`,
       Boolean(implementationClass)
+    );
+
+    deprecate(
+      "Calling `create` on Location class is deprecated. Instead, use `container.lookup('location:my-location')` to lookup the location you need.",
+      false,
+      {
+        id: 'deprecate-auto-location',
+        until: '5.0.0',
+        url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-auto-location',
+        for: 'ember-source',
+        since: {
+          enabled: '4.1.0',
+        },
+      }
     );
 
     return implementationClass.create(...arguments);

--- a/packages/@ember/-internals/routing/lib/location/none_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/none_location.ts
@@ -38,9 +38,14 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
   // Set in reopen so it can be overwritten with extend
   declare rootURL: string;
 
-  detect(): void {
+  initState(): void {
+    this._super(...arguments);
+
     let { rootURL } = this;
 
+    // This assert doesn't have anything to do with state initialization,
+    // but we're hijacking this method since it's called after the route has
+    // set the rootURL property on its Location instance.
     assert(
       'rootURL must end with a trailing forward slash e.g. "/app/"',
       rootURL.charAt(rootURL.length - 1) === '/'

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -896,6 +896,22 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
       // detecting history support. This gives it a chance to set its
       // `cancelRouterSetup` property which aborts routing.
       if (typeof location.detect === 'function') {
+        if (this.location !== 'auto') {
+          deprecate(
+            'The `detect` method on the Location object is deprecated. If you need detection you can run your detection code in app.js, before setting the location type.',
+            false,
+            {
+              id: 'deprecate-auto-location',
+              until: '5.0.0',
+              url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-auto-location',
+              for: 'ember-source',
+              since: {
+                enabled: '4.1.0',
+              },
+            }
+          );
+        }
+
         location.detect();
       }
 

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -859,6 +859,22 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     if ('string' === typeof location) {
       let resolvedLocation = owner.lookup<IEmberLocation>(`location:${location}`);
 
+      if (location === 'auto') {
+        deprecate(
+          "Router location 'auto' is deprecated. Most users will want to set `locationType` to 'history' in config/environment.js for no change in behavior. See deprecation docs for details.",
+          false,
+          {
+            id: 'deprecate-auto-location',
+            until: '5.0.0',
+            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-auto-location',
+            for: 'ember-source',
+            since: {
+              enabled: '4.1.0',
+            },
+          }
+        );
+      }
+
       if (resolvedLocation !== undefined) {
         location = set(this, 'location', resolvedLocation);
       } else {

--- a/packages/@ember/-internals/routing/tests/system/router_test.js
+++ b/packages/@ember/-internals/routing/tests/system/router_test.js
@@ -98,7 +98,7 @@ moduleFor(
     }
 
     ['@test replacePath should be called with the right path'](assert) {
-      assert.expect(1);
+      assert.expect(2);
 
       let location = owner.lookup('location:auto');
 
@@ -117,11 +117,13 @@ moduleFor(
       location.global = { onhashchange() {} };
       location.history = null;
 
-      createRouter({
-        settings: {
-          location: 'auto',
-          rootURL: '/rootdir/',
-        },
+      expectDeprecation(() => {
+        createRouter({
+          settings: {
+            location: 'auto',
+            rootURL: '/rootdir/',
+          },
+        });
       });
     }
 
@@ -177,7 +179,7 @@ moduleFor(
     }
 
     ["@test AutoLocation should replace the url when it's not in the preferred format"](assert) {
-      assert.expect(1);
+      assert.expect(2);
 
       let location = owner.lookup('location:auto');
 
@@ -191,16 +193,19 @@ moduleFor(
           assert.equal(url, 'http://test.com/rootdir/#/welcome');
         },
       };
+
       location.history = null;
       location.global = {
         onhashchange() {},
       };
 
-      createRouter({
-        settings: {
-          location: 'auto',
-          rootURL: '/rootdir/',
-        },
+      expectDeprecation(() => {
+        createRouter({
+          settings: {
+            location: 'auto',
+            rootURL: '/rootdir/',
+          },
+        });
       });
     }
 


### PR DESCRIPTION
Code to implement the [Deprecate Auto Location RFC](https://github.com/emberjs/rfcs/blob/master/text/0711-deprecate-auto-location.md).

### Open Questions
- [x] What's the strategy around failing tests? Right now, it seems like tests are failing due to the deprecation messages itself. What's the recommended approach there?

### TODO

- [x] Modify deprecation messages (if needed?)
- [x] Add an entry into the Ember deprecation table (guides repo?)

### Related PRs

- Here is the deprecation entry (https://github.com/ember-learn/deprecation-app/pull/882)

@rwjblue I know you have a bunch of stuff on your plate, but if you have time, feel free to have a look at this.