### PR TITLE
Improve internal types

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-qunit": "^4.0.0",
     "execa": "^2.0.4",
+    "expect-type": "^0.11.0",
     "express": "^4.17.1",
     "finalhandler": "^1.1.2",
     "fs-extra": "^9.0.1",
@@ -147,7 +148,8 @@
     "simple-dom": "^1.4.0",
     "testem": "^3.1.0",
     "testem-failure-only-reporter": "^0.0.1",
-    "tslint": "^5.20.1"
+    "tslint": "^5.20.1",
+    "typescript": "^4.2.4"
   },
   "engines": {
     "node": "10.* || >= 12.*"

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -550,10 +550,13 @@ moduleFor(
     }
 
     '@test positional parameters are not allowed'() {
+      let TestComponent = class extends Component {};
+      TestComponent.reopenClass({
+        positionalParams: ['first', 'second'],
+      });
+
       this.registerComponent('sample-component', {
-        ComponentClass: Component.extend().reopenClass({
-          positionalParams: ['first', 'second'],
-        }),
+        ComponentClass: TestComponent,
         template: '{{this.first}}{{this.second}}',
       });
 

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -275,7 +275,7 @@ function mergeMixins(
     } else {
       mergeProps(
         meta,
-        currentMixin as { [key: string]: any },
+        currentMixin as Record<string, unknown>,
         descs,
         values,
         base,

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -273,7 +273,15 @@ function mergeMixins(
         }
       }
     } else {
-      mergeProps(meta, currentMixin, descs, values, base, keys, keysWithSuper);
+      mergeProps(
+        meta,
+        currentMixin as { [key: string]: any },
+        descs,
+        values,
+        base,
+        keys,
+        keysWithSuper
+      );
     }
   }
 }

--- a/packages/@ember/-internals/routing/lib/location/api.ts
+++ b/packages/@ember/-internals/routing/lib/location/api.ts
@@ -10,6 +10,7 @@ export interface EmberLocation {
   formatURL(url: string): string;
   detect?(): void;
   initState?(): void;
+  destroy(): void;
 }
 
 export type UpdateCallback = (url: string) => void;

--- a/packages/@ember/-internals/routing/lib/location/auto_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/auto_location.ts
@@ -62,13 +62,94 @@ import {
   @protected
 */
 export default class AutoLocation extends EmberObject implements EmberLocation {
-  cancelRouterSetup?: boolean | undefined;
   getURL!: () => string;
   setURL!: (url: string) => void;
   onUpdateURL!: (callback: UpdateCallback) => void;
   formatURL!: (url: string) => string;
 
+  concreteImplementation?: EmberLocation;
+
   implementation = 'auto';
+
+  // FIXME: This is never set
+  // See https://github.com/emberjs/ember.js/issues/19515
+  documentMode: number | undefined;
+
+  /**
+    @private
+
+    Will be pre-pended to path upon state change.
+
+    @since 1.5.1
+    @property rootURL
+    @default '/'
+  */
+  // Added in reopen to allow overriding via extend
+  rootURL!: string;
+
+  /**
+    @private
+
+    The browser's `location` object. This is typically equivalent to
+    `window.location`, but may be overridden for testing.
+
+    @property location
+    @default environment.location
+  */
+  // Added in reopen to allow overriding via extend
+  location!: any;
+
+  /**
+    @private
+
+    The browser's `history` object. This is typically equivalent to
+    `window.history`, but may be overridden for testing.
+
+    @since 1.5.1
+    @property history
+    @default environment.history
+  */
+  // Added in reopen to allow overriding via extend
+  history!: any;
+
+  /**
+   @private
+
+    The user agent's global variable. In browsers, this will be `window`.
+
+    @since 1.11
+    @property global
+    @default window
+  */
+  // Added in reopen to allow overriding via extend
+  global!: any;
+
+  /**
+    @private
+
+    The browser's `userAgent`. This is typically equivalent to
+    `navigator.userAgent`, but may be overridden for testing.
+
+    @since 1.5.1
+    @property userAgent
+    @default environment.history
+  */
+  // Added in reopen to allow overriding via extend
+  userAgent!: any;
+
+  /**
+    @private
+
+    This property is used by the router to know whether to cancel the routing
+    setup process, which is needed while we redirect the browser.
+
+    @since 1.5.1
+    @property cancelRouterSetup
+    @default false
+  */
+  // Added in reopen to allow overriding via extend
+  cancelRouterSetup!: boolean | undefined;
+
   /**
    Called by the router to instruct the location to do any feature detection
    necessary. In the case of AutoLocation, we detect whether to use history
@@ -115,16 +196,8 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
 }
 
 AutoLocation.reopen({
-  /**
-    @private
-
-    Will be pre-pended to path upon state change.
-
-    @since 1.5.1
-    @property rootURL
-    @default '/'
-  */
   rootURL: '/',
+
   initState: delegateToConcreteImplementation('initState'),
   getURL: delegateToConcreteImplementation('getURL'),
   setURL: delegateToConcreteImplementation('setURL'),
@@ -132,62 +205,14 @@ AutoLocation.reopen({
   onUpdateURL: delegateToConcreteImplementation('onUpdateURL'),
   formatURL: delegateToConcreteImplementation('formatURL'),
 
-  /**
-    @private
-
-    The browser's `location` object. This is typically equivalent to
-    `window.location`, but may be overridden for testing.
-
-    @property location
-    @default environment.location
-  */
   location: location,
 
-  /**
-    @private
-
-    The browser's `history` object. This is typically equivalent to
-    `window.history`, but may be overridden for testing.
-
-    @since 1.5.1
-    @property history
-    @default environment.history
-  */
   history: history,
 
-  /**
-   @private
-
-   The user agent's global variable. In browsers, this will be `window`.
-
-   @since 1.11
-   @property global
-   @default window
-  */
   global: window,
 
-  /**
-    @private
-
-    The browser's `userAgent`. This is typically equivalent to
-    `navigator.userAgent`, but may be overridden for testing.
-
-    @since 1.5.1
-    @property userAgent
-    @default environment.history
-  */
   userAgent: userAgent,
 
-  /**
-    @private
-
-    This property is used by the router to know whether to cancel the routing
-    setup process, which is needed while we redirect the browser.
-
-    @since 1.5.1
-    @property cancelRouterSetup
-    @default false
-  */
   cancelRouterSetup: false,
 });
 
@@ -196,7 +221,7 @@ function delegateToConcreteImplementation(methodName: string) {
     let { concreteImplementation } = this;
     assert(
       "AutoLocation's detect() method should be called before calling any other hooks.",
-      Boolean(concreteImplementation)
+      concreteImplementation
     );
     return concreteImplementation[methodName]?.(...args);
   };

--- a/packages/@ember/-internals/routing/lib/location/auto_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/auto_location.ts
@@ -62,10 +62,10 @@ import {
   @protected
 */
 export default class AutoLocation extends EmberObject implements EmberLocation {
-  getURL!: () => string;
-  setURL!: (url: string) => void;
-  onUpdateURL!: (callback: UpdateCallback) => void;
-  formatURL!: (url: string) => string;
+  declare getURL: () => string;
+  declare setURL: (url: string) => void;
+  declare onUpdateURL: (callback: UpdateCallback) => void;
+  declare formatURL: (url: string) => string;
 
   concreteImplementation?: EmberLocation;
 
@@ -73,6 +73,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
 
   // FIXME: This is never set
   // See https://github.com/emberjs/ember.js/issues/19515
+  /** @internal */
   documentMode: number | undefined;
 
   /**
@@ -85,7 +86,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
     @default '/'
   */
   // Added in reopen to allow overriding via extend
-  rootURL!: string;
+  declare rootURL: string;
 
   /**
     @private
@@ -97,7 +98,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
     @default environment.location
   */
   // Added in reopen to allow overriding via extend
-  location!: any;
+  declare location: Location;
 
   /**
     @private
@@ -110,7 +111,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
     @default environment.history
   */
   // Added in reopen to allow overriding via extend
-  history!: any;
+  declare history: any;
 
   /**
    @private
@@ -122,7 +123,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
     @default window
   */
   // Added in reopen to allow overriding via extend
-  global!: any;
+  declare global: any;
 
   /**
     @private
@@ -135,7 +136,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
     @default environment.history
   */
   // Added in reopen to allow overriding via extend
-  userAgent!: any;
+  declare userAgent: string;
 
   /**
     @private
@@ -148,7 +149,7 @@ export default class AutoLocation extends EmberObject implements EmberLocation {
     @default false
   */
   // Added in reopen to allow overriding via extend
-  cancelRouterSetup!: boolean | undefined;
+  declare cancelRouterSetup: boolean;
 
   /**
    Called by the router to instruct the location to do any feature detection

--- a/packages/@ember/-internals/routing/lib/location/hash_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/hash_location.ts
@@ -40,8 +40,8 @@ export default class HashLocation extends EmberObject implements EmberLocation {
   implementation = 'hash';
   _hashchangeHandler?: EventListener;
 
-  private _location?: any;
-  declare location: any;
+  private _location?: Location;
+  declare location: Location;
 
   init(): void {
     set(this, 'location', this._location || window.location);

--- a/packages/@ember/-internals/routing/lib/location/hash_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/hash_location.ts
@@ -40,6 +40,9 @@ export default class HashLocation extends EmberObject implements EmberLocation {
   implementation = 'hash';
   _hashchangeHandler?: EventListener;
 
+  private _location?: any;
+  declare location: any;
+
   init(): void {
     set(this, 'location', this._location || window.location);
     this._hashchangeHandler = undefined;
@@ -113,6 +116,8 @@ export default class HashLocation extends EmberObject implements EmberLocation {
     this.location.replace(`#${path}`);
     set(this, 'lastSetURL', path);
   }
+
+  lastSetURL: string | null = null;
 
   /**
     Register a callback to be invoked when the hash changes. These

--- a/packages/@ember/-internals/routing/lib/location/history_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/history_location.ts
@@ -59,8 +59,8 @@ function _uuid() {
   @protected
 */
 export default class HistoryLocation extends EmberObject implements EmberLocation {
-  location!: any;
-  baseURL!: string;
+  declare location: Location;
+  declare baseURL: string;
 
   history?: any;
 

--- a/packages/@ember/-internals/routing/lib/location/history_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/history_location.ts
@@ -59,6 +59,11 @@ function _uuid() {
   @protected
 */
 export default class HistoryLocation extends EmberObject implements EmberLocation {
+  location!: any;
+  baseURL!: string;
+
+  history?: any;
+
   implementation = 'history';
   _previousURL?: string;
   _popstateHandler?: EventListener;
@@ -86,9 +91,9 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     this._super(...arguments);
 
     let base = document.querySelector('base');
-    let baseURL: string | null = '';
+    let baseURL = '';
     if (base !== null && base.hasAttribute('href')) {
-      baseURL = base.getAttribute('href');
+      baseURL = base.getAttribute('href') ?? '';
     }
 
     set(this, 'baseURL', baseURL);

--- a/packages/@ember/-internals/routing/lib/location/none_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/none_location.ts
@@ -25,6 +25,19 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
   updateCallback!: UpdateCallback;
   implementation = 'none';
 
+  // Set in reopen so it can be overwritten with extend
+  path!: string;
+
+  /**
+    Will be pre-pended to path.
+
+    @private
+    @property rootURL
+    @default '/'
+  */
+  // Set in reopen so it can be overwritten with extend
+  rootURL!: string;
+
   detect(): void {
     let { rootURL } = this;
 
@@ -114,13 +127,5 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
 
 NoneLocation.reopen({
   path: '',
-
-  /**
-    Will be pre-pended to path.
-
-    @private
-    @property rootURL
-    @default '/'
-  */
   rootURL: '/',
 });

--- a/packages/@ember/-internals/routing/lib/location/none_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/none_location.ts
@@ -22,11 +22,11 @@ import { EmberLocation, UpdateCallback } from './api';
   @protected
 */
 export default class NoneLocation extends EmberObject implements EmberLocation {
-  updateCallback!: UpdateCallback;
+  declare updateCallback: UpdateCallback;
   implementation = 'none';
 
   // Set in reopen so it can be overwritten with extend
-  path!: string;
+  declare path: string;
 
   /**
     Will be pre-pended to path.
@@ -36,7 +36,7 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
     @default '/'
   */
   // Set in reopen so it can be overwritten with extend
-  rootURL!: string;
+  declare rootURL: string;
 
   detect(): void {
     let { rootURL } = this;

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -108,8 +108,8 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
   private _names: unknown;
 
   _router!: EmberRouter;
-  _topLevelViewTemplate!: any;
-  _environment!: any;
+  declare _topLevelViewTemplate: any;
+  declare _environment: any;
 
   constructor(owner: Owner) {
     super(...arguments);
@@ -131,11 +131,11 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
   }
 
   // Implement Evented
-  on!: (name: string, method: ((...args: any[]) => void) | string) => this;
-  one!: (name: string, method: string | ((...args: any[]) => void)) => this;
-  trigger!: (name: string, ...args: any[]) => any;
-  off!: (name: string, method: string | ((...args: any[]) => void)) => this;
-  has!: (name: string) => boolean;
+  declare on: (name: string, method: ((...args: any[]) => void) | string) => this;
+  declare one: (name: string, method: string | ((...args: any[]) => void)) => this;
+  declare trigger: (name: string, ...args: any[]) => any;
+  declare off: (name: string, method: string | ((...args: any[]) => void)) => this;
+  declare has: (name: string) => boolean;
 
   serialize!: (
     model: {},
@@ -190,7 +190,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @public
   */
   // Set in reopen so it can be overriden with extend
-  queryParams!: any;
+  declare queryParams: Record<string, unknown>;
 
   /**
     The name of the template to use by default when rendering this routes
@@ -223,7 +223,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @public
   */
   // Set in reopen so it can be overriden with extend
-  templateName!: string | null;
+  declare templateName: string | null;
 
   /**
     The name of the controller to associate with this route.
@@ -246,7 +246,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @public
   */
   // Set in reopen so it can be overriden with extend
-  controllerName!: string | null;
+  declare controllerName: string | null;
 
   /**
     The controller associated with this route.
@@ -277,7 +277,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @since 1.6.0
     @public
   */
-  controller!: Controller;
+  declare controller: Controller;
 
   /**
     The name of the route, dot-delimited.
@@ -291,7 +291,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @since 1.0.0
     @public
   */
-  routeName!: string;
+  declare routeName: string;
 
   /**
     The name of the route, dot-delimited, including the engine prefix
@@ -306,7 +306,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @since 2.10.0
     @public
   */
-  fullRouteName!: string;
+  declare fullRouteName: string;
 
   /**
     Sets the name for this route, including a fully resolved name for routes
@@ -2207,7 +2207,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
   }
 
   // Set in reopen
-  actions!: Record<string, Function>;
+  declare actions: Record<string, (...args: any[]) => any>;
 
   /**
     Sends an action to the router, which will delegate it to the currently
@@ -2258,7 +2258,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @public
   */
   // Set with reopen to override parent behavior
-  send!: (name: string, ...args: any[]) => unknown;
+  declare send: (name: string, ...args: any[]) => unknown;
 }
 
 function parentRoute(route: Route) {
@@ -2271,7 +2271,7 @@ function routeInfoFor(route: Route, routeInfos: InternalRouteInfo<Route>[], offs
     return;
   }
 
-  let current: any;
+  let current: Route | undefined;
   for (let i = 0; i < routeInfos.length; i++) {
     current = routeInfos[i].route;
     if (current === route) {
@@ -2388,17 +2388,14 @@ export interface RenderOptions {
   into?: string;
   outlet: string;
   name: string;
-  controller: unknown;
+  controller: Controller | string | undefined;
   model: unknown;
   template: Template;
 }
 
-interface PartialRenderOptions {
-  into?: string;
-  outlet?: string;
-  controller?: string | any;
-  model?: {};
-}
+type PartialRenderOptions = Partial<
+  Pick<RenderOptions, 'into' | 'outlet' | 'controller' | 'model'>
+>;
 
 export function getFullQueryParams(router: EmberRouter, state: TransitionState<Route>) {
   if (state['fullQueryParams']) {

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -152,7 +152,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @public
   */
   // Set with reopen to allow overriding via extend
-  rootURL!: string;
+  declare rootURL: string;
 
   /**
    The `location` property determines the type of URL's that your
@@ -173,7 +173,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @public
   */
   // Set with reopen to allow overriding via extend
-  location!: string | IEmberLocation;
+  declare location: string | IEmberLocation;
 
   _routerMicrolib!: Router<Route>;
   _didSetupRouter = false;
@@ -200,11 +200,11 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
   private namespace: any;
 
   // Begin Evented
-  on!: (name: string, method: ((...args: any[]) => void) | string) => this;
-  one!: (name: string, method: string | ((...args: any[]) => void)) => this;
-  trigger!: (name: string, ...args: any[]) => any;
-  off!: (name: string, method: string | ((...args: any[]) => void)) => this;
-  has!: (name: string) => boolean;
+  declare on: (name: string, method: ((...args: any[]) => void) | string) => this;
+  declare one: (name: string, method: string | ((...args: any[]) => void)) => this;
+  declare trigger: (name: string, ...args: any[]) => unknown;
+  declare off: (name: string, method: string | ((...args: any[]) => void)) => this;
+  declare has: (name: string) => boolean;
   // End Evented
 
   // Set with reopenClass
@@ -1408,7 +1408,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @since 1.2.0
   */
   // Set with reopen to allow overriding via extend
-  didTransition!: typeof defaultDidTransition;
+  declare didTransition: typeof defaultDidTransition;
 
   /**
     Handles notifying any listeners of an impending URL
@@ -1421,7 +1421,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @since 1.11.0
   */
   // Set with reopen to allow overriding via extend
-  willTransition!: typeof defaultWillTransition;
+  declare willTransition: typeof defaultWillTransition;
 
   /**
    Represents the current URL.
@@ -1431,7 +1431,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @private
   */
   // Set with reopen to allow overriding via extend
-  url!: string;
+  declare url: string;
 }
 
 /*

--- a/packages/@ember/-internals/runtime/index.d.ts
+++ b/packages/@ember/-internals/runtime/index.d.ts
@@ -1,3 +1,8 @@
+import { EmberClassConstructor, Objectify, ObserverMethod } from './types/-private/types';
+import PublicCoreObject from './types/core';
+import Evented from './types/evented';
+import Observable from './types/observable';
+
 export const TargetActionSupport: any;
 export function isArray(arr: any): boolean;
 export const ControllerMixin: any;
@@ -10,13 +15,50 @@ export function deprecatingAlias(
   }
 ): any;
 
-export const CoreObject: any;
+// The public version doesn't export some deprecated methods.
+// However, these are still used internally. Returning `any` is
+// very loose, but it's essentially what was here before.
+export class CoreObject extends PublicCoreObject {
+  static extend<Statics, Instance>(
+    this: Statics & EmberClassConstructor<Instance>,
+    ...args: any[]
+  ): Objectify<Statics> & EmberClassConstructor<Instance>;
+  static reopen(...args: any[]): any;
+  static reopenClass(...args: any[]): any;
+}
+
 export const FrameworkObject: any;
-export const Object: any;
+
+export class Object extends CoreObject implements Observable {
+  get<K extends keyof this>(key: K): unknown;
+  getProperties<K extends keyof this>(list: K[]): Record<K, unknown>;
+  getProperties<K extends keyof this>(...list: K[]): Record<K, unknown>;
+  set<K extends keyof this>(key: K, value: this[K]): this[K];
+  set<T>(key: keyof this, value: T): T;
+  setProperties<K extends keyof this>(hash: Pick<this, K>): Record<K, unknown>;
+  setProperties<K extends keyof this>(
+    // tslint:disable-next-line:unified-signatures
+    hash: { [KK in K]: any }
+  ): Record<K, unknown>;
+  notifyPropertyChange(keyName: string): this;
+  addObserver<Target>(key: keyof this, target: Target, method: ObserverMethod<Target, this>): this;
+  addObserver(key: keyof this, method: ObserverMethod<this, this>): this;
+  removeObserver<Target>(
+    key: keyof this,
+    target: Target,
+    method: ObserverMethod<Target, this>
+  ): this;
+  removeObserver(key: keyof this, method: ObserverMethod<this, this>): this;
+  getWithDefault<K extends keyof this>(key: K, defaultValue: any): unknown;
+  incrementProperty(keyName: keyof this, increment?: number): number;
+  decrementProperty(keyName: keyof this, decrement?: number): number;
+  toggleProperty(keyName: keyof this): boolean;
+  cacheFor<K extends keyof this>(key: K): unknown;
+}
 
 export function _contentFor(proxy: any): any;
 
 export const A: any;
 export const ActionHandler: any;
-export const Evented: any;
+export { Evented };
 export function typeOf(obj: any): string;

--- a/packages/@ember/-internals/runtime/type-tests/core.test.ts
+++ b/packages/@ember/-internals/runtime/type-tests/core.test.ts
@@ -1,0 +1,25 @@
+import { expectTypeOf } from 'expect-type';
+import CoreObject from '../types/core';
+
+/** Newable tests */
+const co1 = new CoreObject();
+
+expectTypeOf(co1.concatenatedProperties).toEqualTypeOf<string[]>();
+expectTypeOf(co1.isDestroyed).toEqualTypeOf<boolean>();
+expectTypeOf(co1.isDestroying).toEqualTypeOf<boolean>();
+expectTypeOf(co1.destroy()).toEqualTypeOf<CoreObject>();
+expectTypeOf(co1.toString()).toEqualTypeOf<string>();
+
+/** .create tests */
+const co2 = CoreObject.create();
+expectTypeOf(co2.concatenatedProperties).toEqualTypeOf<string[]>();
+expectTypeOf(co2.isDestroyed).toEqualTypeOf<boolean>();
+expectTypeOf(co2.isDestroying).toEqualTypeOf<boolean>();
+expectTypeOf(co2.destroy()).toEqualTypeOf<CoreObject>();
+expectTypeOf(co2.toString()).toEqualTypeOf<string>();
+
+/** .create tests w/ initial instance data passed in */
+const co3 = CoreObject.create({ foo: '123', bar: 456 });
+
+expectTypeOf(co3.foo).toEqualTypeOf<string>();
+expectTypeOf(co3.bar).toEqualTypeOf<number>();

--- a/packages/@ember/-internals/runtime/types/-private/types.d.ts
+++ b/packages/@ember/-internals/runtime/types/-private/types.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Map type `T` to a plain object hash with the identity mapping.
+ *
+ * Discards any additional object identity like the ability to `new()` up the class.
+ * The `new()` capability is added back later by merging `EmberClassConstructor<T>`
+ *
+ * Implementation is carefully chosen for the reasons described in
+ * https://github.com/typed-ember/ember-typings/pull/29
+ */
+export type Objectify<T> = Readonly<T>;
+
+export type ExtractPropertyNamesOfType<T, S> = {
+  [K in keyof T]: T[K] extends S ? K : never;
+}[keyof T];
+
+/**
+ * Used to infer the type of ember classes of type `T`.
+ *
+ * Generally you would use `EmberClass.create()` instead of `new EmberClass()`.
+ *
+ * The single-arg constructor is required by the typescript compiler.
+ * The multi-arg constructor is included for better ergonomics.
+ *
+ * Implementation is carefully chosen for the reasons described in
+ * https://github.com/typed-ember/ember-typings/pull/29
+ */
+export type EmberClassConstructor<T> = (new (properties?: object) => T) &
+  (new (...args: any[]) => T);
+
+/**
+ * Check that any arguments to `create()` match the type's properties.
+ *
+ * Accept any additional properties and add merge them into the instance.
+ */
+export type EmberInstanceArguments<T> = Partial<T> & {
+  [key: string]: any;
+};
+
+export type ObserverMethod<Target, Sender> =
+  | keyof Target
+  | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);

--- a/packages/@ember/-internals/runtime/types/core.d.ts
+++ b/packages/@ember/-internals/runtime/types/core.d.ts
@@ -1,0 +1,87 @@
+import { EmberClassConstructor, EmberInstanceArguments, Objectify } from './-private/types';
+
+type MergeArray<Arr extends any[]> = Arr extends [infer T, ...infer Rest]
+  ? T & MergeArray<Rest>
+  : unknown; // TODO: Is this correct?
+
+export default class CoreObject {
+  /**
+   * CoreObject constructor takes initial object properties as an argument.
+   */
+  constructor(properties?: object);
+
+  _super(...args: any[]): any;
+
+  /**
+   * An overridable method called when objects are instantiated. By default,
+   * does nothing unless it is overridden during class definition.
+   */
+  init(): void;
+
+  /**
+   * Defines the properties that will be concatenated from the superclass (instead of overridden).
+   * @default null
+   */
+  concatenatedProperties: string[];
+
+  /**
+   * Destroyed object property flag. If this property is true the observers and bindings were
+   * already removed by the effect of calling the destroy() method.
+   * @default false
+   */
+  isDestroyed: boolean;
+  /**
+   * Destruction scheduled flag. The destroy() method has been called. The object stays intact
+   * until the end of the run loop at which point the isDestroyed flag is set.
+   * @default false
+   */
+  isDestroying: boolean;
+
+  /**
+   * Destroys an object by setting the `isDestroyed` flag and removing its
+   * metadata, which effectively destroys observers and bindings.
+   * If you try to set a property on a destroyed object, an exception will be
+   * raised.
+   * Note that destruction is scheduled for the end of the run loop and does not
+   * happen immediately.  It will set an isDestroying flag immediately.
+   * @return receiver
+   */
+  destroy(): CoreObject;
+
+  /**
+   * Override to implement teardown.
+   */
+  willDestroy(): void;
+
+  /**
+   * Returns a string representation which attempts to provide more information than Javascript's toString
+   * typically does, in a generic way for all Ember objects (e.g., "<App.Person:ember1024>").
+   * @return string representation
+   */
+  toString(): string;
+
+  static create<Class extends typeof CoreObject, Args extends Array<Record<string, any>>>(
+    this: Class,
+    ...args: Args
+  ): InstanceType<Class> & MergeArray<Args>;
+
+  static detect<Statics, Instance>(
+    this: Statics & EmberClassConstructor<Instance>,
+    obj: any
+  ): obj is Objectify<Statics> & EmberClassConstructor<Instance>;
+
+  static detectInstance<Instance>(this: EmberClassConstructor<Instance>, obj: any): obj is Instance;
+
+  /**
+   * Iterate over each computed property for the class, passing its name and any
+   * associated metadata (see metaForProperty) to the callback.
+   */
+  static eachComputedProperty(callback: (...args: any[]) => any, binding: {}): void;
+  /**
+   * Returns the original hash that was passed to meta().
+   * @param key property name
+   */
+  static metaForProperty(key: string): {};
+  static isClass: boolean;
+  static isMethod: boolean;
+}

--- a/packages/@ember/-internals/runtime/types/evented.d.ts
+++ b/packages/@ember/-internals/runtime/types/evented.d.ts
@@ -1,0 +1,48 @@
+import Mixin from '../../metal/lib/mixin';
+
+/**
+ * This mixin allows for Ember objects to subscribe to and emit events.
+ */
+interface Evented {
+  /**
+   * Subscribes to a named event with given function.
+   */
+  on<Target>(
+    name: string,
+    target: Target,
+    method: string | ((this: Target, ...args: any[]) => void)
+  ): this;
+  on(name: string, method: ((...args: any[]) => void) | string): this;
+  /**
+   * Subscribes a function to a named event and then cancels the subscription
+   * after the first time the event is triggered. It is good to use ``one`` when
+   * you only care about the first time an event has taken place.
+   */
+  one<Target>(
+    name: string,
+    target: Target,
+    method: string | ((this: Target, ...args: any[]) => void)
+  ): this;
+  one(name: string, method: string | ((...args: any[]) => void)): this;
+  /**
+   * Triggers a named event for the object. Any additional arguments
+   * will be passed as parameters to the functions that are subscribed to the
+   * event.
+   */
+  trigger(name: string, ...args: any[]): any;
+  /**
+   * Cancels subscription for given name, target, and method.
+   */
+  off<Target>(
+    name: string,
+    target: Target,
+    method: string | ((this: Target, ...args: any[]) => void)
+  ): this;
+  off(name: string, method: string | ((...args: any[]) => void)): this;
+  /**
+   * Checks to see if object has any subscriptions for named event.
+   */
+  has(name: string): boolean;
+}
+declare const Evented: Mixin;
+export default Evented;

--- a/packages/@ember/-internals/runtime/types/mixin.d.ts
+++ b/packages/@ember/-internals/runtime/types/mixin.d.ts
@@ -1,0 +1,3 @@
+import { Mixin } from '../../metal/lib/mixin';
+
+export default Mixin;

--- a/packages/@ember/-internals/runtime/types/observable.d.ts
+++ b/packages/@ember/-internals/runtime/types/observable.d.ts
@@ -1,0 +1,81 @@
+import { ObserverMethod } from './-private/types';
+
+/**
+ * This mixin provides properties and property observing functionality, core features of the Ember object model.
+ */
+interface Observable {
+  /**
+   * Retrieves the value of a property from the object.
+   */
+  get<K extends keyof this>(key: K): unknown;
+  // get<K extends keyof this>(key: K): UnwrapComputedPropertyGetter<this[K]>;
+  /**
+   * To get the values of multiple properties at once, call `getProperties`
+   * with a list of strings or an array:
+   */
+  getProperties<K extends keyof this>(list: K[]): Record<K, unknown>;
+  getProperties<K extends keyof this>(...list: K[]): Record<K, unknown>;
+  /**
+   * Sets the provided key or path to the value.
+   */
+  set<K extends keyof this>(key: K, value: this[K]): this[K];
+  set<T>(key: keyof this, value: T): T;
+  /**
+   * Sets a list of properties at once. These properties are set inside
+   * a single `beginPropertyChanges` and `endPropertyChanges` batch, so
+   * observers will be buffered.
+   */
+  setProperties<K extends keyof this>(hash: Pick<this, K>): Record<K, unknown>;
+  setProperties<K extends keyof this>(
+    // tslint:disable-next-line:unified-signatures
+    hash: { [KK in K]: any }
+  ): Record<K, unknown>;
+  /**
+   * Convenience method to call `propertyWillChange` and `propertyDidChange` in
+   * succession.
+   */
+  notifyPropertyChange(keyName: string): this;
+  /**
+   * Adds an observer on a property.
+   */
+  addObserver<Target>(key: keyof this, target: Target, method: ObserverMethod<Target, this>): this;
+  addObserver(key: keyof this, method: ObserverMethod<this, this>): this;
+  /**
+   * Remove an observer you have previously registered on this object. Pass
+   * the same key, target, and method you passed to `addObserver()` and your
+   * target will no longer receive notifications.
+   */
+  removeObserver<Target>(
+    key: keyof this,
+    target: Target,
+    method: ObserverMethod<Target, this>
+  ): this;
+  removeObserver(key: keyof this, method: ObserverMethod<this, this>): this;
+  /**
+   * Retrieves the value of a property, or a default value in the case that the
+   * property returns `undefined`.
+   */
+  getWithDefault<K extends keyof this>(key: K, defaultValue: any): unknown;
+  /**
+   * Set the value of a property to the current value plus some amount.
+   */
+  incrementProperty(keyName: keyof this, increment?: number): number;
+  /**
+   * Set the value of a property to the current value minus some amount.
+   */
+  decrementProperty(keyName: keyof this, decrement?: number): number;
+  /**
+   * Set the value of a boolean property to the opposite of its
+   * current value.
+   */
+  toggleProperty(keyName: keyof this): boolean;
+  /**
+   * Returns the cached value of a computed property, if it exists.
+   * This allows you to inspect the value of a computed property
+   * without accidentally invoking it if it is intended to be
+   * generated lazily.
+   */
+  cacheFor<K extends keyof this>(key: K): unknown;
+}
+// declare const Observable: Mixin<Observable, CoreObject>;
+export default Observable;

--- a/packages/@ember/object/index.d.ts
+++ b/packages/@ember/object/index.d.ts
@@ -1,1 +1,3 @@
 export let action: MethodDecorator;
+
+export { Object as default } from '@ember/-internals/runtime';

--- a/packages/@ember/object/type-tests/compat.test.ts
+++ b/packages/@ember/object/type-tests/compat.test.ts
@@ -1,4 +1,4 @@
 import { dependentKeyCompat } from '@ember/object/compat';
 import { expectTypeOf } from 'expect-type';
 
-expectTypeOf(dependentKeyCompat).toMatchTypeOf<Function>();
+expectTypeOf(dependentKeyCompat).toMatchTypeOf<PropertyDecorator>();

--- a/packages/@ember/object/type-tests/compat.test.ts
+++ b/packages/@ember/object/type-tests/compat.test.ts
@@ -1,0 +1,4 @@
+import { dependentKeyCompat } from '@ember/object/compat';
+import { expectTypeOf } from 'expect-type';
+
+expectTypeOf(dependentKeyCompat).toMatchTypeOf<Function>();

--- a/packages/@ember/object/type-tests/core.test.ts
+++ b/packages/@ember/object/type-tests/core.test.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf } from 'expect-type';
+
+import CoreObject from '@ember/object/core';
+
+expectTypeOf(CoreObject.create()).toEqualTypeOf<CoreObject>();

--- a/packages/@ember/object/type-tests/index.test.ts
+++ b/packages/@ember/object/type-tests/index.test.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf } from 'expect-type';
+
+import EmberObject from '@ember/object';
+
+expectTypeOf(EmberObject.create()).toEqualTypeOf<EmberObject>();

--- a/packages/@ember/object/type-tests/observable.test.ts
+++ b/packages/@ember/object/type-tests/observable.test.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf } from 'expect-type';
+
+import Observable from '@ember/object/observable';
+
+expectTypeOf<Observable['get']>().toEqualTypeOf<<K extends keyof Observable>(key: K) => unknown>();

--- a/packages/@ember/object/types/core.d.ts
+++ b/packages/@ember/object/types/core.d.ts
@@ -1,0 +1,1 @@
+export { CoreObject as default } from '../../-internals/runtime';

--- a/packages/@ember/object/types/observable.d.ts
+++ b/packages/@ember/object/types/observable.d.ts
@@ -1,0 +1,2 @@
+import Observable from '@ember/-internals/runtime/types/observable';
+export default Observable;

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -37,7 +37,6 @@ module.exports = {
     '_invoke',
     '_lazyInjections',
     '_logLookup',
-    '_names',
     '_normalizeCache',
     '_onLookup',
     '_options',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,17 +24,12 @@
     "allowJs": false,
 
     "paths": {
-      "@glimmer/*": ["../node_modules/@glimmer/*"]
+      "@glimmer/*": ["../node_modules/@glimmer/*"],
+      "@ember/object/*": ["@ember/object/*", "@ember/object/types/*"]
     }
   },
 
-  "include": [
-    "packages/**/*.ts",
-  ],
+  "include": ["packages/**/*.ts"],
 
-  "exclude": [
-    "dist",
-    "node_modules",
-    "tmp",
-  ]
+  "exclude": ["dist", "node_modules", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5007,6 +5007,11 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+expect-type@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.11.0.tgz#bce1a3e283f0334eedb39699b57dd27be7009cc1"
+  integrity sha512-hkObxepDKhTYloH/UZoxYTT2uUzdhvDEwAi0oqdk29XEkHF8p+5ZRpX/BZES2PtGN9YgyEqutIjXfnL9iMflMw==
+
 express@^4.10.7, express@^4.13.1, express@^4.16.4, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -10041,6 +10046,11 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 typescript@~4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Improve types for @ember/object

Includes:
  - Object, { action } from '@ember/object'
  - CoreObject from '@ember/object/core'
  - Observable from '@ember/object/observable'
  - { dependentKeyCompat } from '@ember/object/compat'

Note that types for `extend`, `reopen`, and `reopenClass` are not
exported. Also, `get` and `set` have naive types. All of these will
be deprecated in future releases.

Many types were copied from DT. We should make sure to give appropriate credit, but I suspect we may already be doing that.