### PR TITLE
[DOC release] fix passing params to named blocks examples

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
@@ -163,7 +163,7 @@
   You can also pass parameters to named blocks:
 
   ```app/templates/components/person-profile.hbs
-  <h1>{{yield to="title" @person.name}}</h1>
+  <h1>{{yield @person.name to="title"}}</h1>
   {{yield @person.signature}}
   ```
 
@@ -184,7 +184,7 @@
   ```app/templates/components/person-profile.hbs
   <h1>
     {{#if (has-block "title")}}
-      {{yield to="title" @person.name}}
+      {{yield @person.name to="title"}}
     {{else}}
       {{@person.name}}
     {{/if}}


### PR DESCRIPTION
I tried following the docs when first trying to pass parameters to named blocks.
Currently the docs state `{{yield to="title" @person.name}}` as being valid but this gave me an error.
I think the `to=` needs to be the last argument so the examples should be `{{yield @person.name  to="title"}}`