### PR TITLE
[BUGFIX release] Ensure ember-testing is loaded lazily

### DIFF
--- a/packages/@ember/test/index.js
+++ b/packages/@ember/test/index.js
@@ -1,11 +1,27 @@
-import { Test } from 'ember-testing';
+import require, { has } from 'require';
 
-const {
-  registerAsyncHelper,
-  registerHelper,
-  registerWaiter,
-  unregisterHelper,
-  unregisterWaiter,
-} = Test;
+export let registerAsyncHelper;
+export let registerHelper;
+export let registerWaiter;
+export let unregisterHelper;
+export let unregisterWaiter;
 
-export { registerAsyncHelper, registerHelper, registerWaiter, unregisterHelper, unregisterWaiter };
+if (has('ember-testing')) {
+  let { Test } = require('ember-testing');
+
+  registerAsyncHelper = Test.registerAsyncHelper;
+  registerHelper = Test.registerHelper;
+  registerWaiter = Test.registerWaiter;
+  unregisterHelper = Test.unregisterHelper;
+  unregisterWaiter = Test.unregisterWaiter;
+} else {
+  let testingNotAvailableMessage = () => {
+    throw new Error('Attempted to use test utilities, but `ember-testing` was not included');
+  };
+
+  registerAsyncHelper = testingNotAvailableMessage;
+  registerHelper = testingNotAvailableMessage;
+  registerWaiter = testingNotAvailableMessage;
+  unregisterHelper = testingNotAvailableMessage;
+  unregisterWaiter = testingNotAvailableMessage;
+}


### PR DESCRIPTION
The recently modules API update means we are now loading real modules,
not polyfills based on the global. This means that the modules
themselves are _eagerly required_, rather than being references to a
value on the global. For example, previously, this:

```js
import { registerWaiter } from '@ember/test';

if (someCondition) {
  registerWaiter(() => {});
}
```

Would become this:

```js
if (someCondition) {
  Ember.Test.registerWaiter(() => {});
}
```

In either example, `registerWaiter` may or may not be called based on
the state of `someCondition`. However, in the second case, if
`Ember.Test` is not defined at all, it's completely ok as long as
`someCondition` is `false`. It's never called, so we never get an error
telling us `Ember.Test` is undefined.

Without the transform, the module is eagerly required, along with all of
its dependencies. If no one included `ember-testing`, then that means
it will throw an error immediately.

This PR makes the `@ember/test` module load `ember-testing` lazily, and
if it's not available (e.g. in a production environment) it replaces the
values with a function that throws a helpful error.

Fixes #19538, https://github.com/babel/ember-cli-babel/issues/406