### PR TITLE
[BUGFIX release] 3.27 deprecation metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,7 +281,7 @@ module.exports = {
 
     if (targets.includes('ie 11')) {
       this.ui.writeWarnLine(
-        'Internet Explorer 11 is listed in your compilation targets, but it will no longer be supported in the next major version of Ember. Please update your targets to remove IE 11 and include new targets that are within the updated support policy. For details on the new browser support policy, see:\n\n - The official documentation: http://emberjs.com/browser-support\n - the deprecation guide: https://emberjs.com/deprecations/v3.x#toc_3-0-browser-support-policy\n'
+        'Internet Explorer 11 is listed in your compilation targets, but it will no longer be supported in the next major version of Ember. Please update your targets to remove IE 11 and include new targets that are within the updated support policy. For details on the new browser support policy, see:\n\n - The official documentation: http://emberjs.com/browser-support\n - the deprecation guide: https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy\n'
       );
     }
 

--- a/packages/@ember/-internals/console/index.js
+++ b/packages/@ember/-internals/console/index.js
@@ -6,7 +6,7 @@ import { LOGGER } from '@ember/deprecated-features';
 const DEPRECATION_MESSAGE = 'Use of Ember.Logger is deprecated. Please use `console` for logging.';
 const DEPRECATION_ID = 'ember-console.deprecate-logger';
 const DEPRECATION_URL =
-  'https://emberjs.com/deprecations/v3.x#toc_use-console-rather-than-ember-logger';
+  'https://deprecations.emberjs.com/v3.x#toc_use-console-rather-than-ember-logger';
 /**
    @module ember
 */

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -687,7 +687,7 @@ const Component = CoreView.extend(
         {
           id: 'ember-views.event-dispatcher.mouseenter-leave-move',
           until: '4.0.0',
-          url: 'https://emberjs.com/deprecations/v3.x#toc_component-mouseenter-leave-move',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_component-mouseenter-leave-move',
           for: 'ember-source',
           since: {
             enabled: '3.13.0-beta.1',
@@ -700,7 +700,7 @@ const Component = CoreView.extend(
         {
           id: 'ember-views.event-dispatcher.mouseenter-leave-move',
           until: '4.0.0',
-          url: 'https://emberjs.com/deprecations/v3.x#toc_component-mouseenter-leave-move',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_component-mouseenter-leave-move',
           for: 'ember-source',
           since: {
             enabled: '3.13.0-beta.1',
@@ -713,7 +713,7 @@ const Component = CoreView.extend(
         {
           id: 'ember-views.event-dispatcher.mouseenter-leave-move',
           until: '4.0.0',
-          url: 'https://emberjs.com/deprecations/v3.x#toc_component-mouseenter-leave-move',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_component-mouseenter-leave-move',
           for: 'ember-source',
           since: {
             enabled: '3.13.0-beta.1',

--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -1035,8 +1035,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 
@@ -1060,8 +1063,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 

--- a/packages/@ember/-internals/glimmer/lib/components/-textarea.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-textarea.ts
@@ -62,8 +62,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 
@@ -87,8 +90,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 

--- a/packages/@ember/-internals/glimmer/lib/components/abstract-input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/abstract-input.ts
@@ -239,7 +239,7 @@ export function handleDeprecatedFeatures(
               for: 'ember-source',
               since: {},
               until: '4.0.0',
-              url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+              url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
             }
           );
 
@@ -270,7 +270,7 @@ export function handleDeprecatedFeatures(
                 for: 'ember-source',
                 since: {},
                 until: '4.0.0',
-                url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
               }
             );
 

--- a/packages/@ember/-internals/glimmer/lib/components/checkbox.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/checkbox.ts
@@ -181,8 +181,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 
@@ -206,8 +209,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 

--- a/packages/@ember/-internals/glimmer/lib/components/internal.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/internal.ts
@@ -274,8 +274,12 @@ export function handleDeprecatedArguments(target: DeprecatingInternalComponentCo
         deprecate(`Passing the \`@${name}\` argument to <${angle}> is deprecated.`, false, {
           id: 'ember.built-in-components.legacy-arguments',
           for: 'ember-source',
-          since: {},
+          since: {
+            enabled: '3.27.0',
+          },
           until: '4.0.0',
+          url:
+            'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
         });
 
         this.modernized = false;
@@ -356,8 +360,12 @@ export function handleDeprecatedAttributeArguments(
               {
                 id: 'ember.built-in-components.legacy-attribute-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-attribute-arguments',
               }
             );
 
@@ -517,8 +525,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
             {
               id: 'ember.built-in-components.legacy-attribute-arguments',
               for: 'ember-source',
-              since: {},
+              since: {
+                enabled: '3.27.0',
+              },
               until: '4.0.0',
+              url:
+                'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-attribute-arguments',
             }
           );
 
@@ -530,8 +542,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
             {
               id: 'ember.built-in-components.legacy-attribute-arguments',
               for: 'ember-source',
-              since: {},
+              since: {
+                enabled: '3.27.0',
+              },
               until: '4.0.0',
+              url:
+                'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-attribute-arguments',
             }
           );
 

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -393,7 +393,6 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
     ['role', 'ariaRole'],
 
     // LinkTo
-    'href',
     'title',
     'rel',
     'tabindex',
@@ -401,6 +400,23 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
   ]);
 
   handleDeprecatedEventArguments(LinkTo);
+
+  // @href
+  {
+    let superOnUnsupportedArgument = prototype['onUnsupportedArgument'];
+
+    Object.defineProperty(prototype, 'onUnsupportedArgument', {
+      configurable: true,
+      enumerable: false,
+      value: function onUnsupportedArgument(this: LinkTo, name: string): void {
+        if (name === 'href') {
+          assert(`Passing the \`@href\` argument to <LinkTo> is not supported.`);
+        } else {
+          superOnUnsupportedArgument.call(this, name);
+        }
+      },
+    });
+  }
 
   // @tagName
   {
@@ -454,8 +470,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
               {
                 id: 'ember.built-in-components.legacy-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
               }
             );
 
@@ -472,8 +492,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
               {
                 id: 'ember.built-in-components.legacy-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
               }
             );
 
@@ -505,8 +529,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
               {
                 id: 'ember.built-in-components.legacy-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
               }
             );
           } else {
@@ -519,8 +547,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
               {
                 id: 'ember.built-in-components.legacy-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
               }
             );
 
@@ -540,8 +572,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
               {
                 id: 'ember.built-in-components.legacy-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
               }
             );
 
@@ -556,8 +592,12 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
               {
                 id: 'ember.built-in-components.legacy-arguments',
                 for: 'ember-source',
-                since: {},
+                since: {
+                  enabled: '3.27.0',
+                },
                 until: '4.0.0',
+                url:
+                  'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-arguments',
               }
             );
           }

--- a/packages/@ember/-internals/glimmer/lib/components/text-field.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/text-field.ts
@@ -225,8 +225,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 
@@ -250,8 +253,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.built-in-components.reopen',
             for: 'ember-source',
-            since: {},
+            since: {
+              enabled: '3.27.0',
+            },
             until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
           }
         );
 

--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -118,6 +118,7 @@ const VM_DEPRECATION_OVERRIDES: (DeprecationOptions & {
   },
   {
     id: 'argument-less-helper-paren-less-invocation',
+    url: 'https://deprecations.emberjs.com/v3.x#toc_argument-less-helper-paren-less-invocation',
     until: '4.0.0',
     for: 'ember-source',
     since: {

--- a/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
@@ -223,7 +223,7 @@ class ActionModifierManager implements InternalModifierManager<ActionState, obje
       {
         id: 'ember-views.event-dispatcher.mouseenter-leave-move',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_action-mouseenter-leave-move',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_action-mouseenter-leave-move',
         for: 'ember-source',
         since: {
           enabled: '3.13.0-beta.1',

--- a/packages/@ember/-internals/glimmer/lib/utils/managers.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/managers.ts
@@ -22,7 +22,7 @@ export function setComponentManager(
       {
         id: 'deprecate-string-based-component-manager',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x/#toc_component-manager-string-lookup',
+        url: 'https://deprecations.emberjs.com/v3.x/#toc_component-manager-string-lookup',
         for: 'ember-source',
         since: {
           enabled: '3.8.0',
@@ -49,7 +49,7 @@ if (DEBUG) {
       version === '3.13',
       {
         id: 'manager-capabilities.components-3-4',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_manager-capabilities-components-3-4',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-components-3-4',
         until: '4.0.0',
         for: 'ember-source',
         since: {
@@ -67,7 +67,7 @@ if (DEBUG) {
       version === '3.22',
       {
         id: 'manager-capabilities.modifiers-3-13',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_manager-capabilities-modifiers-3-13',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-modifiers-3-13',
         until: '4.0.0',
         for: 'ember-source',
         since: {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -9,6 +9,7 @@ import { Router, Route } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
 import { LinkComponent } from '@ember/-internals/glimmer';
+import { DEBUG } from '@glimmer/env';
 
 moduleFor(
   '<LinkTo /> component (rendering tests)',
@@ -20,6 +21,19 @@ moduleFor(
         this.visit('/'),
         /You must provide at least one of the `@route`, `@model`, `@models` or `@query` argument to `<LinkTo>`/
       );
+    }
+
+    async [`@test it throws a useful error if you pass the href argument`](assert) {
+      this.addTemplate('application', `<LinkTo @href="nope" @route="index">Index</LinkTo>`);
+
+      if (DEBUG) {
+        await assert.rejects(
+          this.visit('/'),
+          /Passing the `@href` argument to <LinkTo> is not supported\./
+        );
+      } else {
+        assert.expect(0);
+      }
     }
 
     async ['@test it should be able to be inserted in DOM when the router is not present']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
@@ -3,6 +3,7 @@ import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'inte
 import Controller from '@ember/controller';
 import { set } from '@ember/-internals/metal';
 import { LinkComponent } from '@ember/-internals/glimmer';
+import { DEBUG } from '@glimmer/env';
 
 moduleFor(
   '{{link-to}} component (rendering tests)',
@@ -13,6 +14,19 @@ moduleFor(
       expectAssertion(() => {
         this.addTemplate('application', `{{#link-to}}Index{{/link-to}}`);
       }, /You must provide one or more parameters to the `{{link-to}}` component\. \('my-app\/templates\/application\.hbs' @ L1:C0\)/);
+    }
+
+    async [`@test it throws a useful error if you pass the href argument`](assert) {
+      this.addTemplate('application', `{{#link-to href="nope" route="index"}}Index{{/link-to}}`);
+
+      if (DEBUG) {
+        await assert.rejects(
+          this.visit('/'),
+          /Passing the `@href` argument to <LinkTo> is not supported\./
+        );
+      } else {
+        assert.expect(0);
+      }
     }
 
     async ['@test it should be able to be inserted in DOM when the router is not present']() {

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -510,7 +510,7 @@ export class ComputedProperty extends ComputedDescriptor {
       {
         id: 'computed-property.override',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_computed-property-override',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_computed-property-override',
         for: 'ember-source',
         since: {
           enabled: '3.9.0-beta.1',
@@ -722,7 +722,7 @@ class ComputedDecoratorImpl extends Function {
       {
         id: 'computed-property.volatile',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_computed-property-volatile',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_computed-property-volatile',
         for: 'ember-source',
         since: {
           enabled: '3.9.0-beta.1',
@@ -797,7 +797,7 @@ class ComputedDecoratorImpl extends Function {
       {
         id: 'computed-property.property',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_computed-property-property',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_computed-property-property',
         for: 'ember-source',
         since: {
           enabled: '3.9.0-beta.1',

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -841,7 +841,7 @@ if (ALIAS_METHOD) {
       {
         id: 'object.alias-method',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_object-alias-method',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_object-alias-method',
         for: 'ember-source',
         since: {
           enabled: '3.9.0',

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -2725,7 +2725,7 @@ if (ROUTER_EVENTS) {
           {
             id: 'deprecate-router-events',
             until: '4.0.0',
-            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_deprecate-router-events',
             for: 'ember-source',
             since: {
               enabled: '3.11.0',
@@ -2741,7 +2741,7 @@ if (ROUTER_EVENTS) {
           {
             id: 'deprecate-router-events',
             until: '4.0.0',
-            url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_deprecate-router-events',
             for: 'ember-source',
             since: {
               enabled: '3.11.0',

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -259,7 +259,7 @@ class EmberRouter extends EmberObject {
               {
                 id: 'deprecate-router-events',
                 until: '4.0.0',
-                url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+                url: 'https://deprecations.emberjs.com/v3.x#toc_deprecate-router-events',
                 for: 'ember-source',
                 since: {
                   enabled: '3.11.0',
@@ -284,7 +284,7 @@ class EmberRouter extends EmberObject {
               {
                 id: 'deprecate-router-events',
                 until: '4.0.0',
-                url: 'https://emberjs.com/deprecations/v3.x#toc_deprecate-router-events',
+                url: 'https://deprecations.emberjs.com/v3.x#toc_deprecate-router-events',
                 for: 'ember-source',
                 since: {
                   enabled: '3.11.0',
@@ -1552,7 +1552,7 @@ function updatePaths(router: EmberRouter) {
               id: 'application-controller.router-properties',
               until: '4.0.0',
               url:
-                'https://emberjs.com/deprecations/v3.x#toc_application-controller-router-properties',
+                'https://deprecations.emberjs.com/v3.x#toc_application-controller-router-properties',
               for: 'ember-source',
               since: {
                 enabled: '3.10.0-beta.1',
@@ -1575,7 +1575,7 @@ function updatePaths(router: EmberRouter) {
               id: 'application-controller.router-properties',
               until: '4.0.0',
               url:
-                'https://emberjs.com/deprecations/v3.x#toc_application-controller-router-properties',
+                'https://deprecations.emberjs.com/v3.x#toc_application-controller-router-properties',
               for: 'ember-source',
               since: {
                 enabled: '3.10.0-beta.1',

--- a/packages/@ember/-internals/runtime/lib/copy.js
+++ b/packages/@ember/-internals/runtime/lib/copy.js
@@ -100,7 +100,7 @@ export default function copy(obj, deep) {
   deprecate('Use ember-copy addon instead of copy method and Copyable mixin.', false, {
     id: 'ember-runtime.deprecate-copy-copyable',
     until: '4.0.0',
-    url: 'https://emberjs.com/deprecations/v3.x/#toc_ember-runtime-deprecate-copy-copyable',
+    url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-runtime-deprecate-copy-copyable',
     for: 'ember-source',
     since: {
       enabled: '3.3.0',

--- a/packages/@ember/-internals/runtime/lib/mixins/target_action_support.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/target_action_support.js
@@ -170,8 +170,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
         deprecate('Reopening Ember.TargetActionSupport is deprecated.', false, {
           id: 'ember.built-in-components.reopen',
           for: 'ember-source',
-          since: {},
+          since: {
+            enabled: '3.27.0',
+          },
           until: '4.0.0',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
         });
 
         TargetActionSupport._wasReopened = true;

--- a/packages/@ember/-internals/views/lib/mixins/action_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/action_support.js
@@ -135,7 +135,7 @@ if (SEND_ACTION) {
       {
         id: 'ember-component.send-action',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
         for: 'ember-source',
         since: {
           enabled: '3.4.0',

--- a/packages/@ember/-internals/views/lib/mixins/text_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/text_support.js
@@ -365,8 +365,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
         deprecate('Reopening Ember.TextSupport is deprecated.', false, {
           id: 'ember.built-in-components.reopen',
           for: 'ember-source',
-          since: {},
+          since: {
+            enabled: '3.27.0',
+          },
           until: '4.0.0',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-reopen',
         });
 
         TextSupport._wasReopened = true;

--- a/packages/@ember/-internals/views/lib/mixins/text_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/text_support.js
@@ -328,7 +328,7 @@ function sendAction(eventName, view, event) {
     deprecate(message, false, {
       id: 'ember-component.send-action',
       until: '4.0.0',
-      url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+      url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
       for: 'ember-source',
       since: {
         enabled: '3.4.0',

--- a/packages/@ember/-internals/views/lib/mixins/view_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/view_support.js
@@ -449,7 +449,7 @@ if (JQUERY_INTEGRATION) {
       {
         id: 'ember-views.curly-components.jquery-element',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-apis',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_jquery-apis',
         for: 'ember-source',
         since: {
           enabled: '3.9.0',

--- a/packages/@ember/-internals/views/lib/system/jquery_event_deprecation.js
+++ b/packages/@ember/-internals/views/lib/system/jquery_event_deprecation.js
@@ -30,7 +30,7 @@ export default function addJQueryEventDeprecation(jqEvent) {
               {
                 id: 'ember-views.event-dispatcher.jquery-event',
                 until: '4.0.0',
-                url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-event',
+                url: 'https://deprecations.emberjs.com/v3.x#toc_jquery-event',
                 for: 'ember-source',
                 since: {
                   enabled: '3.9.0',

--- a/packages/@ember/-internals/views/lib/system/utils.ts
+++ b/packages/@ember/-internals/views/lib/system/utils.ts
@@ -22,7 +22,7 @@ export function constructStyleDeprecationMessage(affectedStyle: string): string 
     'Binding style attributes may introduce cross-site scripting vulnerabilities; ' +
     'please ensure that values being bound are properly escaped. For more information, ' +
     'including how to disable this warning, see ' +
-    'https://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes. ' +
+    'https://deprecations.emberjs.com/v1.x/#toc_binding-style-attributes. ' +
     'Style affected: "' +
     affectedStyle +
     '"'

--- a/packages/@ember/component/checkbox.ts
+++ b/packages/@ember/component/checkbox.ts
@@ -4,16 +4,17 @@ import { deprecate } from '@ember/debug';
 if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
   deprecate(
     `Using Ember.Checkbox or importing from 'Checkbox' has been deprecated, install the ` +
-      `\`ember-legacy-built-in-components\` addon and use \`import { Checkbox } from ` +
-      `'ember-legacy-built-in-components';\` instead`,
+      `\`@ember/legacy-built-in-components\` addon and use \`import { Checkbox } from ` +
+      `'@ember/legacy-built-in-components';\` instead`,
     false,
     {
-      id: 'ember.legacy-built-in-components',
+      id: 'ember.built-in-components.import',
       until: '4.0.0',
       for: 'ember-source',
       since: {
-        // TODO: update this when enabling the feature
+        enabled: '3.27.0',
       },
+      url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-import',
     }
   );
 }

--- a/packages/@ember/component/text-area.ts
+++ b/packages/@ember/component/text-area.ts
@@ -4,16 +4,17 @@ import { deprecate } from '@ember/debug';
 if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
   deprecate(
     `Using Ember.TextArea or importing from 'TextArea' has been deprecated, install the ` +
-      `\`ember-legacy-built-in-components\` addon and use \`import { TextArea } from ` +
-      `'ember-legacy-built-in-components';\` instead`,
+      `\`@ember/legacy-built-in-components\` addon and use \`import { TextArea } from ` +
+      `'@ember/legacy-built-in-components';\` instead`,
     false,
     {
-      id: 'ember.legacy-built-in-components',
+      id: 'ember.built-in-components.import',
       until: '4.0.0',
       for: 'ember-source',
       since: {
-        // TODO: update this when enabling the feature
+        enabled: '3.27.0',
       },
+      url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-import',
     }
   );
 }

--- a/packages/@ember/component/text-field.ts
+++ b/packages/@ember/component/text-field.ts
@@ -4,16 +4,17 @@ import { deprecate } from '@ember/debug';
 if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
   deprecate(
     `Using Ember.TextField or importing from 'TextField' has been deprecated, install the ` +
-      `\`ember-legacy-built-in-components\` addon and use \`import { TextField } from ` +
-      `'ember-legacy-built-in-components';\` instead`,
+      `\`@ember/legacy-built-in-components\` addon and use \`import { TextField } from ` +
+      `'@ember/legacy-built-in-components';\` instead`,
     false,
     {
-      id: 'ember.legacy-built-in-components',
+      id: 'ember.built-in-components.import',
       until: '4.0.0',
       for: 'ember-source',
       since: {
-        // TODO: update this when enabling the feature
+        enabled: '3.27.0',
       },
+      url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-import',
     }
   );
 }

--- a/packages/@ember/polyfills/lib/merge.ts
+++ b/packages/@ember/polyfills/lib/merge.ts
@@ -31,7 +31,7 @@ function merge(original: object, updates: object) {
   deprecate('Use of `merge` has been deprecated. Please use `assign` instead.', false, {
     id: 'ember-polyfills.deprecate-merge',
     until: '4.0.0',
-    url: 'https://emberjs.com/deprecations/v3.x/#toc_ember-polyfills-deprecate-merge',
+    url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-polyfills-deprecate-merge',
     for: 'ember-source',
     since: {
       enabled: '3.6.0-beta.1',

--- a/packages/@ember/routing/link-component.ts
+++ b/packages/@ember/routing/link-component.ts
@@ -4,16 +4,17 @@ import { deprecate } from '@ember/debug';
 if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
   deprecate(
     `Using Ember.LinkComponent or importing from 'LinkComponent' has been deprecated, install the ` +
-      `\`ember-legacy-built-in-components\` addon and use \`import { LinkComponent } from ` +
-      `'ember-legacy-built-in-components';\` instead`,
+      `\`@ember/legacy-built-in-components\` addon and use \`import { LinkComponent } from ` +
+      `'@ember/legacy-built-in-components';\` instead`,
     false,
     {
-      id: 'ember.legacy-built-in-components',
+      id: 'ember.built-in-components.import',
       until: '4.0.0',
       for: 'ember-source',
       since: {
-        // TODO: update this when enabling the feature
+        enabled: '3.27.0',
       },
+      url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-import',
     }
   );
 }

--- a/packages/ember-template-compiler/lib/plugins/deprecate-send-action.ts
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-send-action.ts
@@ -48,7 +48,7 @@ export default function deprecateSendAction(env: EmberASTPluginEnvironment): AST
                   deprecate(deprecationMessage(node, eventName, value.chars), false, {
                     id: 'ember-component.send-action',
                     until: '4.0.0',
-                    url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                    url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
                     for: 'ember-source',
                     since: {
                       enabled: '3.4.0',
@@ -61,7 +61,7 @@ export default function deprecateSendAction(env: EmberASTPluginEnvironment): AST
                   deprecate(deprecationMessage(node, eventName, value.path.original), false, {
                     id: 'ember-component.send-action',
                     until: '4.0.0',
-                    url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                    url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
                     for: 'ember-source',
                     since: {
                       enabled: '3.4.0',
@@ -83,7 +83,7 @@ export default function deprecateSendAction(env: EmberASTPluginEnvironment): AST
               deprecate(deprecationMessage(node, pair.key, pair.value.original), false, {
                 id: 'ember-component.send-action',
                 until: '4.0.0',
-                url: 'https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action',
+                url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-send-action',
                 for: 'ember-source',
                 since: {
                   enabled: '3.4.0',

--- a/packages/ember-template-compiler/lib/plugins/transform-has-block-syntax.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-has-block-syntax.ts
@@ -42,7 +42,7 @@ export default function transformHasBlockSyntax(env: EmberASTPluginEnvironment):
       {
         id: 'has-block-and-has-block-params',
         until: '4.0.0',
-        url: 'https://emberjs.com/deprecations/v3.x#toc_has-block-and-has-block-params',
+        url: 'https://deprecations.emberjs.com/v3.x#toc_has-block-and-has-block-params',
         for: 'ember-source',
         since: {
           enabled: '3.25.0',

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -143,7 +143,7 @@ deprecate(
   !isIE,
   {
     id: '3-0-browser-support-policy',
-    url: 'https://emberjs.com/deprecations/v3.x#toc_3-0-browser-support-policy',
+    url: 'https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy',
     until: '4.0.0',
     for: 'ember-source',
     since: {
@@ -645,7 +645,7 @@ if (JQUERY_INTEGRATION && !views.jQueryDisabled) {
         {
           id: 'ember-views.curly-components.jquery-element',
           until: '4.0.0',
-          url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-apis',
+          url: 'https://deprecations.emberjs.com/v3.x#toc_jquery-apis',
           for: 'ember-source',
           since: {
             enabled: '3.9.0',

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -513,17 +513,18 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
 
         if (availableInLegacyAddon) {
           message +=
-            ` Install the \`ember-legacy-built-in-components\` addon and use ` +
-            `\`import { ${name} } from 'ember-legacy-built-in-components';\` instead.`;
+            ` Install the \`@ember/legacy-built-in-components\` addon and use ` +
+            `\`import { ${name} } from '@ember/legacy-built-in-components';\` instead.`;
         }
 
         deprecate(message, false, {
-          id: 'ember.built-in-components.legacy-import',
+          id: 'ember.built-in-components.import',
           until: '4.0.0',
           for: 'ember-source',
           since: {
-            // TODO: update this when enabling the feature
+            enabled: '3.27.0',
           },
+          url: 'https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-import',
         });
 
         return value;
@@ -533,7 +534,7 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
       enumerable: true,
     });
 
-    // Expose a non-deprecated version for tests and the ember-legacy-built-in-components addon
+    // Expose a non-deprecated version for tests and the @ember/legacy-built-in-components addon
     Ember[`_Legacy${name}`] = value;
   });
 } else {

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -66,7 +66,7 @@ moduleFor(
               ),
             publicPath === null
               ? `Using Ember.${name} is deprecated.`
-              : `Using Ember.${name} or importing from '${publicPath}' is deprecated. Install the \`ember-legacy-built-in-components\` addon and use \`import { ${name} } from 'ember-legacy-built-in-components';\` instead.`
+              : `Using Ember.${name} or importing from '${publicPath}' is deprecated. Install the \`@ember/legacy-built-in-components\` addon and use \`import { ${name} } from '@ember/legacy-built-in-components';\` instead.`
           );
         } catch (error) {
           assert.pushResult({


### PR DESCRIPTION
Dependent on https://github.com/ember-learn/deprecation-app/pull/855

* Unify deprecation ids
* Add missing `url` and `since`
* Correctly reference `@ember/legacy-built-in-components` addon
* Error instead for `<LinkTo @href=...>`