### PR TITLE
[BUGFIX beta] pass module prefix to initializer test blueprints

### DIFF
--- a/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -1,27 +1,32 @@
 import Application from '@ember/application';
 
+import config from '<%= modulePrefix %>/config/environment';
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
-module('<%= friendlyTestName %>', function(hooks) {
-  hooks.beforeEach(function() {
-    this.TestApplication = class TestApplication extends Application {}
+module('<%= friendlyTestName %>', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
     this.TestApplication.initializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
 
-    this.application = this.TestApplication.create({ autoboot: false, Resolver });
+    this.application = this.TestApplication.create({ autoboot: false });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
   // TODO: Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function (assert) {
     await this.application.boot();
 
     assert.ok(true);

--- a/blueprints/instance-initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -1,27 +1,32 @@
 import Application from '@ember/application';
 
+import config from '<%= modulePrefix %>/config/environment';
 import { initialize } from '<%= modulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
-module('<%= friendlyTestName %>', function(hooks) {
-  hooks.beforeEach(function() {
-    this.TestApplication = class TestApplication extends Application {}
+module('<%= friendlyTestName %>', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
-    this.application = this.TestApplication.create({ autoboot: false, Resolver });
+    this.application = this.TestApplication.create({ autoboot: false });
     this.instance = this.application.buildInstance();
   });
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     <% if (destroyAppExists) { %>destroyApp(this.instance);<% } else { %>run(this.instance, 'destroy');<% } %>
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
   // TODO: Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function (assert) {
     await this.instance.boot();
 
     assert.ok(true);

--- a/node-tests/fixtures/initializer-test/rfc232.js
+++ b/node-tests/fixtures/initializer-test/rfc232.js
@@ -1,27 +1,32 @@
 import Application from '@ember/application';
 
+import config from 'my-app/config/environment';
 import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
 
-module('Unit | Initializer | foo', function(hooks) {
-  hooks.beforeEach(function() {
-    this.TestApplication = class TestApplication extends Application {}
+module('Unit | Initializer | foo', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
     this.TestApplication.initializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
 
-    this.application = this.TestApplication.create({ autoboot: false, Resolver });
+    this.application = this.TestApplication.create({ autoboot: false });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     run(this.application, 'destroy');
   });
 
   // TODO: Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function (assert) {
     await this.application.boot();
 
     assert.ok(true);

--- a/node-tests/fixtures/instance-initializer-test/rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/rfc232.js
@@ -1,27 +1,32 @@
 import Application from '@ember/application';
 
+import config from 'my-app/config/environment';
 import { initialize } from 'my-app/instance-initializers/foo';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
 
-module('Unit | Instance Initializer | foo', function(hooks) {
-  hooks.beforeEach(function() {
-    this.TestApplication = class TestApplication extends Application {}
+module('Unit | Instance Initializer | foo', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
-    this.application = this.TestApplication.create({ autoboot: false, Resolver });
+    this.application = this.TestApplication.create({ autoboot: false });
     this.instance = this.application.buildInstance();
   });
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     run(this.instance, 'destroy');
     run(this.application, 'destroy');
   });
 
   // TODO: Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('it works', async function (assert) {
     await this.instance.boot();
 
     assert.ok(true);


### PR DESCRIPTION
This fixes [this issue](https://ember-twiddle.com/60a33aedab9bc3f1a298e601c520f56b?openFiles=tests.unit.instance-initializers.my-initializer-test%5C.js%2C) with a newly generated (instance) initializer test:

```
Error: Assertion Failed: `modulePrefix` must be defined
```

This issue was introduced in fa35230d082e4b9667f04b214e77f314385d18e7