### PR TITLE
[BUGFIX lts] Backport {{hash}} laziness

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -9,6 +9,7 @@ import { isSimpleClick } from '@ember/-internals/views';
 import { assert, warn } from '@ember/debug';
 import { EngineInstance, getEngineParent } from '@ember/engine';
 import { flaggedInstrument } from '@ember/instrumentation';
+import { dependentKeyCompat } from '@ember/object/compat';
 import { inject as injectService } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import EmberComponent, { HAS_BLOCK } from '../component';
@@ -534,14 +535,16 @@ const LinkComponent = EmberComponent.extend({
     }
   }),
 
-  _query: computed('query', function computeLinkToComponentQuery(this: any) {
-    let { query } = this;
+  _query: dependentKeyCompat({
+    get(this: any) {
+      let { query } = this;
 
-    if (query === UNDEFINED) {
-      return EMPTY_QUERY_PARAMS;
-    } else {
-      return Object.assign({}, query);
-    }
+      if (query === UNDEFINED) {
+        return EMPTY_QUERY_PARAMS;
+      } else {
+        return Object.assign({}, query);
+      }
+    },
   }),
 
   /**

--- a/packages/@ember/-internals/glimmer/lib/helpers/hash.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/hash.ts
@@ -1,10 +1,101 @@
-import { Dict, VMArguments } from '@glimmer/interfaces';
-import { createComputeRef, Reference } from '@glimmer/reference';
-import { reifyNamed } from '@glimmer/runtime';
+import { CUSTOM_TAG_FOR } from '@ember/-internals/metal';
+import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
+import { assert } from '@ember/debug';
+import { CapturedNamedArguments, Dict, VMArguments } from '@glimmer/interfaces';
+import { createConstRef, Reference, valueForRef } from '@glimmer/reference';
 
+import { Tag, track } from '@glimmer/validator';
 /**
 @module ember
 */
+
+function tagForKey(named: CapturedNamedArguments, key: string): Tag {
+  return track(() => {
+    let ref = named[key];
+
+    if (ref !== undefined) {
+      valueForRef(ref);
+    }
+  });
+}
+
+let hashProxyFor: (args: CapturedNamedArguments) => Record<string, unknown>;
+
+class HashProxy implements ProxyHandler<Record<string, unknown>> {
+  private customTagFor: (obj: object, key: string) => Tag;
+
+  constructor(private named: CapturedNamedArguments) {
+    this.customTagFor = (_obj: object, key: string) => tagForKey(named, key);
+  }
+
+  get(target: Record<string, unknown>, prop: string | number, receiver: unknown) {
+    if (prop === CUSTOM_TAG_FOR) {
+      return this.customTagFor;
+    }
+
+    const ref = this.named[prop as string];
+
+    if (ref !== undefined) {
+      return valueForRef(ref);
+    } else {
+      return Reflect.get(target, prop, receiver);
+    }
+  }
+
+  set(target: Record<string, unknown>, prop: string | number, receiver: unknown) {
+    assert(
+      `You attempted to set the "${prop}" value on an object generated using the (hash) helper, but this is not supported because it was defined on the original hash and is a reference to the original value. You can set values which were _not_ defined on the hash, but you cannot set values defined on the original hash (e.g. {{hash myValue=123}})`,
+      !(prop in this.named)
+    );
+
+    return Reflect.set(target, prop, receiver);
+  }
+
+  has(target: Record<string, unknown>, prop: string | number) {
+    return prop in this.named || prop in target || prop === CUSTOM_TAG_FOR;
+  }
+
+  ownKeys(target: {}) {
+    return Reflect.ownKeys(this.named).concat(Reflect.ownKeys(target));
+  }
+
+  getOwnPropertyDescriptor(target: {}, prop: string | number) {
+    if (prop in this.named) {
+      return {
+        enumerable: true,
+        configurable: true,
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, prop);
+  }
+}
+
+if (HAS_NATIVE_PROXY) {
+  hashProxyFor = (named) => {
+    const proxy = new Proxy(Object.create(null), new HashProxy(named));
+
+    return proxy;
+  };
+} else {
+  hashProxyFor = (named) => {
+    let proxy = Object.create(null);
+
+    Object.keys(named).forEach((name) => {
+      Object.defineProperty(proxy, name, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          return valueForRef(named[name]);
+        },
+      });
+    });
+
+    proxy[CUSTOM_TAG_FOR] = (_obj: object, key: string) => tagForKey(named, key);
+
+    return proxy;
+  };
+}
 
 /**
    Use the `{{hash}}` helper to create a hash to pass as an option to your
@@ -44,8 +135,8 @@ import { reifyNamed } from '@glimmer/runtime';
    @since 2.3.0
    @public
  */
-export default function (args: VMArguments): Reference<Dict<unknown>> {
-  let positional = args.named.capture();
+export default function hash(args: VMArguments): Reference<Dict<unknown>> {
+  let named = args.named.capture();
 
-  return createComputeRef(() => reifyNamed(positional), null, 'hash');
+  return createConstRef(hashProxyFor(named), 'hash');
 }

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -95,7 +95,26 @@ export function outletHelper(args: VMArguments, vm: VM) {
 
       if (state !== null) {
         let named = dict<Reference>();
-        named.model = childRefFromParts(outletRef, ['render', 'model']);
+
+        // Create a ref for the model
+        let modelRef = childRefFromParts(outletRef, ['render', 'model']);
+
+        // Store the value of the model
+        let model = valueForRef(modelRef);
+
+        // Create a compute ref which we pass in as the `{{@model}}` reference
+        // for the outlet. This ref will update and return the value of the
+        // model _until_ the outlet itself changes. Once the outlet changes,
+        // dynamic scope also changes, and so the original model ref would not
+        // provide the correct updated value. So we stop updating and return
+        // the _last_ model value for that outlet.
+        named.model = createComputeRef(() => {
+          if (lastState === state) {
+            model = valueForRef(modelRef);
+          }
+
+          return model;
+        });
 
         if (DEBUG) {
           named.model = createDebugAliasRef!('@model', named.model);


### PR DESCRIPTION
Backports the fixes from https://github.com/emberjs/ember.js/pull/19511

The internal `_query` property of LinkTo had to be made into an autotracking
dependency using dependentKeyCompat in order to handle the fact
that hash never updates now. This was not an issue on master since
LinkTo has been refactored there.