### PR TITLE
[DOC] Link the `templateOnly` docs to the correct package

### DIFF
--- a/packages/@ember/component/template-only.ts
+++ b/packages/@ember/component/template-only.ts
@@ -23,8 +23,10 @@
   ```
 
   @public
+  @static
   @method templateOnly
   @param {String} moduleName the module name that the template only component represents, this will be used for debugging purposes
+  @for @ember/component/template-only
   @category EMBER_GLIMMER_SET_COMPONENT_TEMPLATE
 */
 export { templateOnlyComponent as default } from '@glimmer/runtime';


### PR DESCRIPTION
This makes sure the `templateOnly` documentation appears in the right place.

I tested it by running the whole api docs setup locally:
![image](https://user-images.githubusercontent.com/3533236/119394822-f1c05580-bcd2-11eb-8046-f9bbd097311d.png)


Closes #19325 