### PR TITLE
[CLEANUP] Remove IE11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
         env:
           DISABLE_SOURCE_MAPS: true
           BROCCOLI_ENV: production
+          SHOULD_TRANSPILE_FOR_NODE: true
         run: yarn ember build -prod
       - name: test
         run: yarn test:node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: yarn test
 
   browserstack-test:
-    name: Browserstack Tests (Safari, Edge, IE11)
+    name: Browserstack Tests (Safari, Edge)
     runs-on: ubuntu-latest
     needs: [basic-test, lint]
     steps:

--- a/config/browserlists.js
+++ b/config/browserlists.js
@@ -1,7 +1,7 @@
 const allSupportedBrowsers = [
   'last 2 Chrome versions',
   'last 2 Firefox versions',
-  'last 2 Safari versions',
+  'Safari 12',
   'last 2 Edge versions',
 ];
 

--- a/config/browserlists.js
+++ b/config/browserlists.js
@@ -3,7 +3,6 @@ const allSupportedBrowsers = [
   'last 2 Firefox versions',
   'last 2 Safari versions',
   'last 2 Edge versions',
-  'ie 11',
 ];
 
 const modernBrowsers = [

--- a/config/targets.js
+++ b/config/targets.js
@@ -6,4 +6,5 @@ const shouldTranspile = Boolean(process.env.SHOULD_TRANSPILE);
 
 module.exports = {
   browsers: isProduction || shouldTranspile ? allSupportedBrowsers : modernBrowsers,
+  ...(process.env.SHOULD_TRANSPILE_FOR_NODE ? { node: 'current' } : undefined),
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,12 +294,6 @@ module.exports = {
     let targets = (this.project && this.project.targets && this.project.targets.browsers) || [];
     let targetNode = (this.project && this.project.targets && this.project.targets.node) || false;
 
-    if (targets.includes('ie 11')) {
-      this.ui.writeWarnLine(
-        'Internet Explorer 11 is listed in your compilation targets, but it will no longer be supported in the next major version of Ember. Please update your targets to remove IE 11 and include new targets that are within the updated support policy. For details on the new browser support policy, see:\n\n - The official documentation: http://emberjs.com/browser-support\n - the deprecation guide: https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy\n'
-      );
-    }
-
     const isProduction = process.env.EMBER_ENV === 'production';
 
     if (

--- a/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
@@ -2,19 +2,6 @@
 @module ember
 */
 
-/*
-  Internet Explorer 11 does not support `once` and also does not support
-  passing `eventOptions`. In some situations it then throws a weird script
-  error, like:
-
-  ```
-  Could not complete the operation due to error 80020101
-  ```
-
-  This flag determines, whether `{ once: true }` and thus also event options in
-  general are supported.
-*/
-
 /**
   The `{{on}}` modifier lets you easily add event listeners (it uses
   [EventTarget.addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -32,8 +32,6 @@ function getActionIds(element) {
   );
 }
 
-const isIE11 = !window.ActiveXObject && 'ActiveXObject' in window;
-
 if (EMBER_IMPROVED_INSTRUMENTATION) {
   moduleFor(
     'Helpers test: element action instrumentation',
@@ -1144,11 +1142,7 @@ moduleFor(
           .trigger('click', { [prop]: value })[0];
         if (expected) {
           assert.ok(showCalled, `should call action with ${prop}:${value}`);
-
-          // IE11 does not allow simulated events to have a valid `defaultPrevented`
-          if (!isIE11) {
-            assert.ok(event.defaultPrevented, 'should prevent default');
-          }
+          assert.ok(event.defaultPrevented, 'should prevent default');
         } else {
           assert.notOk(showCalled, `should not call action with ${prop}:${value}`);
           assert.notOk(event.defaultPrevented, 'should not prevent default');
@@ -1486,10 +1480,7 @@ moduleFor(
         event = this.$('a').trigger('click')[0];
       });
 
-      // IE11 does not allow simulated events to have a valid `defaultPrevented`
-      if (!isIE11) {
-        this.assert.equal(event.defaultPrevented, true, 'should preventDefault');
-      }
+      this.assert.equal(event.defaultPrevented, true, 'should preventDefault');
     }
 
     ['@test it should target the proper component when `action` is in yielded block [GH #12409]']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -5,8 +5,6 @@ import { on } from '@glimmer/runtime';
 
 import { Component } from '../../utils/helpers';
 
-const isIE11 = !window.ActiveXObject && 'ActiveXObject' in window;
-
 moduleFor(
   '{{on}} Modifier',
   class extends RenderingTestCase {
@@ -41,8 +39,6 @@ moduleFor(
 
       if (isChrome || isFirefox) {
         assert.strictEqual(SUPPORTS_EVENT_OPTIONS, true, 'is true in chrome and firefox');
-      } else if (isIE11) {
-        assert.strictEqual(SUPPORTS_EVENT_OPTIONS, false, 'is false in IE11');
       } else {
         assert.expect(0);
       }
@@ -136,11 +132,7 @@ moduleFor(
       runTask(() => this.$('button').click());
       assert.equal(count, 1, 'has been called 1 times');
 
-      if (isIE11) {
-        this.assertCounts({ adds: 1, removes: 1 });
-      } else {
-        this.assertCounts({ adds: 1, removes: 0 });
-      }
+      this.assertCounts({ adds: 1, removes: 0 });
     }
 
     '@test changing from `once=false` to `once=true` ensures the callback can only be called once'(
@@ -169,11 +161,7 @@ moduleFor(
       runTask(() => this.$('button').click());
       assert.equal(count, 3, 'is not called again');
 
-      if (isIE11) {
-        this.assertCounts({ adds: 2, removes: 2 });
-      } else {
-        this.assertCounts({ adds: 2, removes: 1 });
-      }
+      this.assertCounts({ adds: 2, removes: 1 });
     }
 
     '@test by default bubbling is used (capture: false)'(assert) {

--- a/packages/@ember/-internals/utils/tests/inspect_test.js
+++ b/packages/@ember/-internals/utils/tests/inspect_test.js
@@ -36,12 +36,7 @@ moduleFor(
           return this;
         },
       };
-      // IE 11 doesn't have function name
-      if (obj.foo.name) {
-        assert.equal(inspect(obj), `{ foo: [Function:foo] }`);
-      } else {
-        assert.equal(inspect(obj), `{ foo: [Function] }`);
-      }
+      assert.equal(inspect(obj), `{ foo: [Function:foo] }`);
     }
 
     ['@test objects without a prototype'](assert) {

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,4 +1,4 @@
-import { moduleFor, AutobootApplicationTestCase, isIE11, runTask } from 'internal-test-helpers';
+import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 
 import { Route } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
@@ -343,20 +343,7 @@ if (!jQueryDisabled) {
               wrapper.addEventListener('mousedown', (e) => events.push(e.type));
               wrapper.addEventListener('mouseup', (e) => events.push(e.type));
               wrapper.addEventListener('click', (e) => events.push(e.type));
-              wrapper.addEventListener('focusin', (e) => {
-                // IE11 _sometimes_ triggers focusin **twice** in a row
-                // (we believe this is when it is under higher load)
-                //
-                // the goal here is to only push a single focusin when running on
-                // IE11
-                if (isIE11) {
-                  if (events[events.length - 1] !== 'focusin') {
-                    events.push(e.type);
-                  }
-                } else {
-                  events.push(e.type);
-                }
-              });
+              wrapper.addEventListener('focusin', (e) => events.push(e.type));
             },
           })
         );

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -135,22 +135,6 @@ import {
 
 const Ember = {};
 
-import { isIE } from '@ember/-internals/browser-environment';
-
-deprecate(
-  'Internet Explorer 11 will no longer be supported in the next major version of Ember. For details on the new browser support policy, see the official documentation: http://emberjs.com/browser-support',
-  !isIE,
-  {
-    id: '3-0-browser-support-policy',
-    url: 'https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy',
-    until: '4.0.0',
-    for: 'ember-source',
-    since: {
-      enabled: '3.26.0',
-    },
-  }
-);
-
 Ember.isNamespace = true;
 Ember.toString = function () {
   return 'Ember';

--- a/packages/internal-test-helpers/index.js
+++ b/packages/internal-test-helpers/index.js
@@ -38,5 +38,5 @@ export {
   ModuleBasedResolver as ModuleBasedTestResolver,
 } from './lib/test-resolver';
 
-export { isIE11, isEdge } from './lib/browser-detect';
+export { isEdge } from './lib/browser-detect';
 export { verifyInjection, verifyRegistration } from './lib/registry-check';

--- a/packages/internal-test-helpers/lib/browser-detect.ts
+++ b/packages/internal-test-helpers/lib/browser-detect.ts
@@ -1,11 +1,1 @@
-// `window.ActiveXObject` is "falsey" in IE11 (but not `undefined` or `false`)
-// `"ActiveXObject" in window` returns `true` in all IE versions
-// only IE11 will pass _both_ of these conditions
-
-declare global {
-  interface Window {
-    ActiveXObject: any;
-  }
-}
-export const isIE11 = !window.ActiveXObject && 'ActiveXObject' in window;
 export const isEdge = /Edge/.test(navigator.userAgent);

--- a/testem.browserstack.js
+++ b/testem.browserstack.js
@@ -37,24 +37,6 @@ const BrowserStackLaunchers = {
     ],
     protocol: 'browser',
   },
-  BS_IE_11: {
-    exe: 'node_modules/.bin/browserstack-launch',
-    args: [
-      '--os',
-      'Windows',
-      '--osv',
-      '10',
-      '--b',
-      'ie',
-      '--bv',
-      '11.0',
-      '-t',
-      '1500',
-      '--u',
-      '<url>',
-    ],
-    protocol: 'browser',
-  },
 };
 
 module.exports = {

--- a/testem.browserstack.js
+++ b/testem.browserstack.js
@@ -7,7 +7,7 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Big Sur',
+      'Mojave',
       '--b',
       'safari',
       '--bv',

--- a/testem.browserstack.js
+++ b/testem.browserstack.js
@@ -7,7 +7,7 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Mojave',
+      'Big Sur',
       '--b',
       'safari',
       '--bv',


### PR DESCRIPTION
Remove IE11 deprecation warnings and tests, as per RFC 685.

Removing the transpilation for IE11 unveiled some mismatch of other transpilation settings vs. the testing environments:
* Safari tests were failing, as babel settings were "last 2 Safari versions" (which according to latest caniuse data is 14.1 + 14), but BrowserStack was configured for Safari 12.1. Changed this to 14.
* node tests were as well failing with some syntax errors. Added a `node: 'current'` setting to targets, but only when running node tests, to keep browser tests untouched.