### PR TITLE
Reorganize tests, make future public types more accurate

### DIFF
--- a/packages/@ember/-internals/runtime/index.d.ts
+++ b/packages/@ember/-internals/runtime/index.d.ts
@@ -1,7 +1,7 @@
-import { EmberClassConstructor, Objectify, ObserverMethod } from './types/-private/types';
+import { EmberClassConstructor, Objectify } from './types/-private/types';
 import PublicCoreObject from './types/core';
+import PublicEmberObject from './types/index';
 import Evented from './types/evented';
-import Observable from './types/observable';
 
 export const TargetActionSupport: any;
 export function isArray(arr: any): boolean;
@@ -29,31 +29,16 @@ export class CoreObject extends PublicCoreObject {
 
 export const FrameworkObject: any;
 
-export class Object extends CoreObject implements Observable {
-  get<K extends keyof this>(key: K): unknown;
-  getProperties<K extends keyof this>(list: K[]): Record<K, unknown>;
-  getProperties<K extends keyof this>(...list: K[]): Record<K, unknown>;
-  set<K extends keyof this>(key: K, value: this[K]): this[K];
-  set<T>(key: keyof this, value: T): T;
-  setProperties<K extends keyof this>(hash: Pick<this, K>): Record<K, unknown>;
-  setProperties<K extends keyof this>(
-    // tslint:disable-next-line:unified-signatures
-    hash: { [KK in K]: any }
-  ): Record<K, unknown>;
-  notifyPropertyChange(keyName: string): this;
-  addObserver<Target>(key: keyof this, target: Target, method: ObserverMethod<Target, this>): this;
-  addObserver(key: keyof this, method: ObserverMethod<this, this>): this;
-  removeObserver<Target>(
-    key: keyof this,
-    target: Target,
-    method: ObserverMethod<Target, this>
-  ): this;
-  removeObserver(key: keyof this, method: ObserverMethod<this, this>): this;
-  getWithDefault<K extends keyof this>(key: K, defaultValue: any): unknown;
-  incrementProperty(keyName: keyof this, increment?: number): number;
-  decrementProperty(keyName: keyof this, decrement?: number): number;
-  toggleProperty(keyName: keyof this): boolean;
-  cacheFor<K extends keyof this>(key: K): unknown;
+// The public version doesn't export some deprecated methods.
+// However, these are still used internally. Returning `any` is
+// very loose, but it's essentially what was here before.
+export class Object extends PublicEmberObject {
+  static extend<Statics, Instance>(
+    this: Statics & EmberClassConstructor<Instance>,
+    ...args: any[]
+  ): Objectify<Statics> & EmberClassConstructor<Instance>;
+  static reopen(...args: any[]): any;
+  static reopenClass(...args: any[]): any;
 }
 
 export function _contentFor(proxy: any): any;

--- a/packages/@ember/-internals/runtime/types/index.d.ts
+++ b/packages/@ember/-internals/runtime/types/index.d.ts
@@ -1,0 +1,30 @@
+import { ObserverMethod } from './-private/types';
+import CoreObject from './core';
+import Observable from './observable';
+
+export default class Object extends CoreObject implements Observable {
+  get<K extends keyof this>(key: K): unknown;
+  getProperties<K extends keyof this>(list: K[]): Record<K, unknown>;
+  getProperties<K extends keyof this>(...list: K[]): Record<K, unknown>;
+  set<K extends keyof this>(key: K, value: this[K]): this[K];
+  set<T>(key: keyof this, value: T): T;
+  setProperties<K extends keyof this>(hash: Pick<this, K>): Record<K, unknown>;
+  setProperties<K extends keyof this>(
+    // tslint:disable-next-line:unified-signatures
+    hash: { [KK in K]: any }
+  ): Record<K, unknown>;
+  notifyPropertyChange(keyName: string): this;
+  addObserver<Target>(key: keyof this, target: Target, method: ObserverMethod<Target, this>): this;
+  addObserver(key: keyof this, method: ObserverMethod<this, this>): this;
+  removeObserver<Target>(
+    key: keyof this,
+    target: Target,
+    method: ObserverMethod<Target, this>
+  ): this;
+  removeObserver(key: keyof this, method: ObserverMethod<this, this>): this;
+  getWithDefault<K extends keyof this>(key: K, defaultValue: any): unknown;
+  incrementProperty(keyName: keyof this, increment?: number): number;
+  decrementProperty(keyName: keyof this, decrement?: number): number;
+  toggleProperty(keyName: keyof this): boolean;
+  cacheFor<K extends keyof this>(key: K): unknown;
+}

--- a/packages/@ember/object/index.d.ts
+++ b/packages/@ember/object/index.d.ts
@@ -1,3 +1,3 @@
 export let action: MethodDecorator;
 
-export { Object as default } from '@ember/-internals/runtime';
+export { default } from '@ember/-internals/runtime/types/index';

--- a/packages/@ember/object/type-tests/action.test.ts
+++ b/packages/@ember/object/type-tests/action.test.ts
@@ -1,0 +1,16 @@
+import { expectTypeOf } from 'expect-type';
+
+import { action } from '@ember/object';
+
+expectTypeOf(action).toEqualTypeOf<MethodDecorator>();
+
+class Foo {
+  // @ts-expect-error action is a method decorator
+  @action
+  bar!: string;
+
+  @action
+  foo() {}
+}
+
+new Foo();

--- a/packages/@ember/object/type-tests/compat.test.ts
+++ b/packages/@ember/object/type-tests/compat.test.ts
@@ -1,4 +1,0 @@
-import { dependentKeyCompat } from '@ember/object/compat';
-import { expectTypeOf } from 'expect-type';
-
-expectTypeOf(dependentKeyCompat).toMatchTypeOf<PropertyDecorator>();

--- a/packages/@ember/object/type-tests/compat/dependent-key-compat.test.ts
+++ b/packages/@ember/object/type-tests/compat/dependent-key-compat.test.ts
@@ -1,0 +1,17 @@
+import { dependentKeyCompat } from '@ember/object/compat';
+import { expectTypeOf } from 'expect-type';
+
+expectTypeOf(dependentKeyCompat).toMatchTypeOf<PropertyDecorator>();
+
+// Example (without irrelevant details) from https://api.emberjs.com/ember/3.18/functions/@ember%2Fobject%2Fcompat/dependentKeyCompat
+class Person {
+  firstName!: string;
+  lastName!: string;
+
+  @dependentKeyCompat
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+}
+
+new Person();

--- a/packages/@ember/object/type-tests/core.test.ts
+++ b/packages/@ember/object/type-tests/core.test.ts
@@ -1,5 +1,0 @@
-import { expectTypeOf } from 'expect-type';
-
-import CoreObject from '@ember/object/core';
-
-expectTypeOf(CoreObject.create()).toEqualTypeOf<CoreObject>();

--- a/packages/@ember/object/type-tests/core/index.test.ts
+++ b/packages/@ember/object/type-tests/core/index.test.ts
@@ -1,5 +1,8 @@
 import { expectTypeOf } from 'expect-type';
-import CoreObject from '../types/core';
+
+import CoreObject from '@ember/object/core';
+
+expectTypeOf(CoreObject.create()).toEqualTypeOf<CoreObject>();
 
 /** Newable tests */
 const co1 = new CoreObject();
@@ -23,3 +26,12 @@ const co3 = CoreObject.create({ foo: '123', bar: 456 });
 
 expectTypeOf(co3.foo).toEqualTypeOf<string>();
 expectTypeOf(co3.bar).toEqualTypeOf<number>();
+
+// @ts-expect-error extend is no longer available in the public API
+CoreObject.extend({ baz: 6 });
+
+// @ts-expect-error reopen is no longer available in the public API
+CoreObject.reopen({ baz: 6 });
+
+// @ts-expect-error reopenClass is no longer available in the public API
+CoreObject.reopenClass({ baz: 6 });

--- a/packages/@ember/object/type-tests/ember-object.test.ts
+++ b/packages/@ember/object/type-tests/ember-object.test.ts
@@ -1,0 +1,61 @@
+import { expectTypeOf } from 'expect-type';
+
+import EmberObject from '@ember/object';
+
+expectTypeOf(EmberObject.create()).toEqualTypeOf<EmberObject>();
+
+/**
+ * Zero-argument case
+ */
+const o = EmberObject.create();
+// create returns an object
+expectTypeOf(o).toMatchTypeOf<object>();
+
+// object returned by create type-checks as an instance of Ember.Object
+expectTypeOf(o.isDestroyed).toEqualTypeOf<boolean>(); // from instance
+expectTypeOf(o.isDestroying).toEqualTypeOf<boolean>(); // from instance
+expectTypeOf(o.get).toEqualTypeOf<(key: keyof EmberObject) => unknown>(); // from prototype
+
+/**
+ * One-argument case
+ */
+const o1 = EmberObject.create({ x: 9, y: 'hello', z: false });
+expectTypeOf(o1.x).toEqualTypeOf<number>();
+expectTypeOf(o1.y).toEqualTypeOf<string>();
+expectTypeOf(o1.z).toEqualTypeOf<boolean>();
+
+const obj = EmberObject.create({ a: 1 }, { b: 2 }, { c: 3 });
+expectTypeOf(obj.b).toEqualTypeOf<number>();
+expectTypeOf(obj.a).toEqualTypeOf<number>();
+expectTypeOf(obj.c).toEqualTypeOf<number>();
+
+export class Person extends EmberObject {
+  firstName!: string;
+  lastName!: string;
+  age!: number;
+}
+const p = new Person();
+
+expectTypeOf(p.firstName).toEqualTypeOf<string>();
+// get is deprecated and only returns unknown now
+expectTypeOf(p.get('firstName')).toEqualTypeOf<unknown>();
+// @ts-expect-error Can't get unknown properties
+p.get('invalid');
+
+const p2 = Person.create({ firstName: 'string' });
+expectTypeOf(p2.firstName).toEqualTypeOf<string>();
+
+const p2b = Person.create({}, { firstName: 'string' });
+expectTypeOf(p2b.firstName).toEqualTypeOf<string>();
+
+const p2c = Person.create({}, {}, { firstName: 'string' });
+expectTypeOf(p2c.firstName).toEqualTypeOf<string>();
+
+// @ts-expect-error extend is no longer available in the public API
+Person.extend({ fullName: 6 });
+
+// @ts-expect-error reopen is no longer available in the public API
+Person.reopen({ fullName: 6 });
+
+// @ts-expect-error reopenClass is no longer available in the public API
+Person.reopenClass({ fullName: 6 });

--- a/packages/@ember/object/type-tests/index.test.ts
+++ b/packages/@ember/object/type-tests/index.test.ts
@@ -1,5 +1,0 @@
-import { expectTypeOf } from 'expect-type';
-
-import EmberObject from '@ember/object';
-
-expectTypeOf(EmberObject.create()).toEqualTypeOf<EmberObject>();

--- a/packages/@ember/object/type-tests/observable/index.test.ts
+++ b/packages/@ember/object/type-tests/observable/index.test.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf } from 'expect-type';
+
+import Observable from '@ember/object/observable';
+
+expectTypeOf<Observable['get']>().toEqualTypeOf<<K extends keyof Observable>(key: K) => unknown>();

--- a/packages/@ember/object/types/core.d.ts
+++ b/packages/@ember/object/types/core.d.ts
@@ -1,1 +1,1 @@
-export { CoreObject as default } from '../../-internals/runtime';
+export { default } from '../../-internals/runtime/types/core';

--- a/tslint.json
+++ b/tslint.json
@@ -21,5 +21,10 @@
     "quotemark": {
       "options": ["single", "avoid-escape"]
     }
+  },
+  "linterOptions": {
+    "exclude": [
+      "**/type-tests/**/*.ts"
+    ]
   }
 }


### PR DESCRIPTION
Previously, we were exporting some details that should have been internal-only, such as reopen, reopenClass, and extend for CoreObject and EmberObject.