### PR TITLE
[CLEANUP] Remove internal Ember.assign usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,6 @@ module.exports = {
             require.resolve('@babel/plugin-transform-block-scoping'),
             { throwIfClosureRequired: true },
           ],
-          [require.resolve('@babel/plugin-transform-object-assign')],
         ],
       }),
     };

--- a/lib/transforms/inject-babel-helpers.js
+++ b/lib/transforms/inject-babel-helpers.js
@@ -21,9 +21,7 @@ function injectBabelHelpersPlugin(isEmberSource) {
   return {
     pre(file) {
       file.set('helperGenerator', function (name) {
-        if (name === 'extends') {
-          return addNamed(file.path, 'assign', '@ember/polyfills');
-        } else if (isEmberSource && name === 'asyncToGenerator') {
+        if (isEmberSource && name === 'asyncToGenerator') {
           // Returning a falsy value will cause the helper to be inlined,
           // which is fine for local tests
           return false;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@babel/helper-module-imports": "^7.8.3",
     "@babel/plugin-transform-block-scoping": "^7.8.3",
-    "@babel/plugin-transform-object-assign": "^7.8.3",
     "@ember/edition-utils": "^1.2.0",
     "@glimmer/vm-babel-plugins": "0.79.2",
     "babel-plugin-debug-macros": "^0.3.3",

--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -1,7 +1,6 @@
 import { Factory, LookupOptions, Owner, setOwner } from '@ember/-internals/owner';
 import { dictionary, HAS_NATIVE_PROXY, HAS_NATIVE_SYMBOL, symbol } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
 import Registry, { DebugRegistry, Injection } from './registry';
 
@@ -586,7 +585,7 @@ class FactoryManager<T, C> {
     }
 
     if (options !== undefined) {
-      props = assign({}, props, options);
+      props = Object.assign({}, props, options);
     }
 
     if (DEBUG) {

--- a/packages/@ember/-internals/container/lib/registry.ts
+++ b/packages/@ember/-internals/container/lib/registry.ts
@@ -1,7 +1,6 @@
 import { Factory } from '@ember/-internals/owner';
 import { dictionary, intern } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
 import Container, { ContainerOptions, LazyInjection } from './container';
 
@@ -607,7 +606,7 @@ export default class Registry implements IRegistry {
       resolverKnown = this.resolver.knownForType(type);
     }
 
-    return assign({}, fallbackKnown, localKnown, resolverKnown);
+    return Object.assign({}, fallbackKnown, localKnown, resolverKnown);
   }
 
   isValidFullName(fullName: string): boolean {

--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -1,5 +1,4 @@
 import { getOwner } from '@ember/-internals/owner';
-import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import { Registry } from '..';
@@ -831,7 +830,7 @@ moduleFor(
       class Component {
         static create(options) {
           let instance = new this();
-          assign(instance, options);
+          Object.assign(instance, options);
           return instance;
         }
       }

--- a/packages/@ember/-internals/extension-support/tests/container_debug_adapter_test.js
+++ b/packages/@ember/-internals/extension-support/tests/container_debug_adapter_test.js
@@ -1,5 +1,4 @@
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
-import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 import EmberController from '@ember/controller';
 import '../index'; // Must be required to export Ember.ContainerDebugAdapter.
@@ -17,7 +16,7 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         autoboot: true,
       });
     }

--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -4,7 +4,6 @@ import { addChildView, setElementView, setViewElement } from '@ember/-internals/
 import { assert, debugFreeze } from '@ember/debug';
 import { EMBER_COMPONENT_IS_VISIBLE } from '@ember/deprecated-features';
 import { _instrumentStart } from '@ember/instrumentation';
-import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
 import {
   Bounds,
@@ -219,11 +218,11 @@ export default class CurlyComponentManager
       named = {
         [positionalParams]: createComputeRef(() => reifyPositional(captured)),
       };
-      assign(named, args.named.capture());
+      Object.assign(named, args.named.capture());
     } else if (Array.isArray(positionalParams) && positionalParams.length > 0) {
       const count = Math.min(positionalParams.length, args.positional.length);
       named = {};
-      assign(named, args.named.capture());
+      Object.assign(named, args.named.capture());
 
       for (let i = 0; i < count; i++) {
         // As of TS 3.7, tsc is giving us the following error on this line without the type annotation

--- a/packages/@ember/-internals/glimmer/lib/component-managers/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/outlet.ts
@@ -4,7 +4,6 @@ import { guidFor } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
 import { _instrumentStart } from '@ember/instrumentation';
-import { assign } from '@ember/polyfills';
 import {
   CapturedArguments,
   CompilableProgram,
@@ -205,7 +204,7 @@ export class OutletComponentDefinition
 
 export function createRootOutlet(outletView: OutletView): OutletComponentDefinition {
   if (ENV._APPLICATION_TEMPLATE_WRAPPER) {
-    const WRAPPED_CAPABILITIES = assign({}, CAPABILITIES, {
+    const WRAPPED_CAPABILITIES = Object.assign({}, CAPABILITIES, {
       dynamicTag: true,
       elementHook: true,
       wrapped: true,

--- a/packages/@ember/-internals/glimmer/lib/helpers/query-param.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/query-param.ts
@@ -3,7 +3,6 @@
 */
 import { QueryParams } from '@ember/-internals/routing';
 import { assert, deprecate } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { CapturedArguments } from '@glimmer/interfaces';
 import { createComputeRef } from '@glimmer/reference';
 import { reifyNamed } from '@glimmer/runtime';
@@ -51,6 +50,6 @@ export default internalHelper(({ positional, named }: CapturedArguments) => {
       }
     );
 
-    return new QueryParams(assign({}, reifyNamed(named) as any));
+    return new QueryParams(Object.assign({}, reifyNamed(named) as any));
   });
 });

--- a/packages/@ember/-internals/glimmer/lib/views/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/views/outlet.ts
@@ -1,5 +1,4 @@
 import { getOwner, Owner } from '@ember/-internals/owner';
-import { assign } from '@ember/polyfills';
 import { schedule } from '@ember/runloop';
 import { Template } from '@glimmer/interfaces';
 import { createComputeRef, Reference, updateRef } from '@glimmer/reference';
@@ -22,7 +21,7 @@ export default class OutletView {
     return class extends OutletView {
       static create(options: any) {
         if (options) {
-          return super.create(assign({}, injections, options));
+          return super.create(Object.assign({}, injections, options));
         } else {
           return super.create(injections);
         }
@@ -31,7 +30,7 @@ export default class OutletView {
   }
 
   static reopenClass(injections: any): void {
-    assign(this, injections);
+    Object.assign(this, injections);
   }
 
   static create(options: any): OutletView {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -1,7 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'internal-test-helpers';
 
-import { assign } from '@ember/polyfills';
 import { isEmpty } from '@ember/-internals/metal';
 import { A as emberA } from '@ember/-internals/runtime';
 
@@ -1441,7 +1440,7 @@ class ContextualComponentMutableParamsTest extends RenderingTestCase {
   render(templateStr, context = {}) {
     super.render(
       `${templateStr}<span class="value">{{this.model.val2}}</span>`,
-      assign(context, { model: { val2: 8 } })
+      Object.assign(context, { model: { val2: 8 } })
     );
   }
 }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -1,7 +1,6 @@
 import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { action } from '@ember/object';
-import { assign } from '@ember/polyfills';
 import { Checkbox, TextArea, TextField } from '@ember/-internals/glimmer';
 import { set } from '@ember/-internals/metal';
 import { TargetActionSupport } from '@ember/-internals/runtime';
@@ -71,7 +70,7 @@ class InputRenderingTest extends RenderingTestCase {
   triggerEvent(type, options, selector) {
     let event = document.createEvent('Events');
     event.initEvent(type, true, true);
-    assign(event, options);
+    Object.assign(event, options);
 
     let element = this.$(selector || 'input')[0];
     runTask(() => {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -2,7 +2,6 @@ import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test
 
 import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { action } from '@ember/object';
-import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 import { jQueryDisabled, jQuery } from '@ember/-internals/views';
 
@@ -70,7 +69,7 @@ class InputRenderingTest extends RenderingTestCase {
   triggerEvent(type, options) {
     let event = document.createEvent('Events');
     event.initEvent(type, true, true);
-    assign(event, options);
+    Object.assign(event, options);
 
     let element = this.$input()[0];
     runTask(() => {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -6,7 +6,6 @@ import {
   runTask,
 } from 'internal-test-helpers';
 
-import { assign } from '@ember/polyfills';
 import { set, Mixin } from '@ember/-internals/metal';
 import Controller from '@ember/controller';
 import { Object as EmberObject } from '@ember/-internals/runtime';
@@ -45,7 +44,7 @@ moduleFor(
 
     renderDelegate(template = '{{action-delegate}}', context = {}) {
       let root = this;
-      context = assign(context, {
+      context = Object.assign(context, {
         send(actionName, ...args) {
           root.sendCount++;
           root.actionCounts[actionName] = root.actionCounts[actionName] || 0;

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
@@ -2,12 +2,11 @@ import { RenderingTestCase, moduleFor, classes, applyMixins, runTask } from 'int
 
 import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { action } from '@ember/object';
-import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 
 class TextAreaRenderingTest extends RenderingTestCase {
   assertTextArea({ attrs, value } = {}) {
-    let mergedAttrs = assign({ class: classes('ember-view ember-text-area') }, attrs);
+    let mergedAttrs = Object.assign({ class: classes('ember-view ember-text-area') }, attrs);
     this.assertComponentElement(this.firstChild, {
       tagName: 'textarea',
       attrs: mergedAttrs,
@@ -21,7 +20,7 @@ class TextAreaRenderingTest extends RenderingTestCase {
   triggerEvent(type, options = {}) {
     let event = document.createEvent('Events');
     event.initEvent(type, true, true);
-    assign(event, options);
+    Object.assign(event, options);
 
     this.firstChild.dispatchEvent(event);
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
@@ -2,12 +2,11 @@ import { RenderingTestCase, moduleFor, classes, applyMixins, runTask } from 'int
 
 import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { action } from '@ember/object';
-import { assign } from '@ember/polyfills';
 import { set } from '@ember/-internals/metal';
 
 class TextAreaRenderingTest extends RenderingTestCase {
   assertTextArea({ attrs, value } = {}) {
-    let mergedAttrs = assign({ class: classes('ember-view ember-text-area') }, attrs);
+    let mergedAttrs = Object.assign({ class: classes('ember-view ember-text-area') }, attrs);
     this.assertComponentElement(this.firstChild, {
       tagName: 'textarea',
       attrs: mergedAttrs,
@@ -21,7 +20,7 @@ class TextAreaRenderingTest extends RenderingTestCase {
   triggerEvent(type, options = {}) {
     let event = document.createEvent('Events');
     event.initEvent(type, true, true);
-    assign(event, options);
+    Object.assign(event, options);
 
     this.firstChild.dispatchEvent(event);
   }

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -2,7 +2,6 @@
 
 import { RenderingTestCase, applyMixins, runTask } from 'internal-test-helpers';
 
-import { assign } from '@ember/polyfills';
 import { htmlSafe } from '@ember/-internals/glimmer';
 import { get, set } from '@ember/-internals/metal';
 import {
@@ -115,7 +114,7 @@ export class FalsyGenerator extends AbstractGenerator {
 
 export class StableTruthyGenerator extends TruthyGenerator {
   generate(value, idx) {
-    return assign(super.generate(value, idx), {
+    return Object.assign(super.generate(value, idx), {
       [`@test it maintains DOM stability when condition changes from ${value} to another truthy value and back [${idx}]`]() {
         this.renderValues(value);
 
@@ -141,7 +140,7 @@ export class StableTruthyGenerator extends TruthyGenerator {
 
 export class StableFalsyGenerator extends FalsyGenerator {
   generate(value, idx) {
-    return assign(super.generate(value), {
+    return Object.assign(super.generate(value), {
       [`@test it maintains DOM stability when condition changes from ${value} to another falsy value and back [${idx}]`]() {
         this.renderValues(value);
 
@@ -651,7 +650,7 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
     }
 
     let wrappedTemplate = this.wrapperFor(templates);
-    this.render(wrappedTemplate, assign({ t: 'T', f: 'F' }, context));
+    this.render(wrappedTemplate, Object.assign({ t: 'T', f: 'F' }, context));
   }
 
   ['@test it does not update when the unbound helper is used']() {

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -15,7 +15,6 @@ import {
 import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { assert, deprecate } from '@ember/debug';
 import { ALIAS_METHOD } from '@ember/deprecated-features';
-import { assign } from '@ember/polyfills';
 import { DEBUG } from '@glimmer/env';
 import { _WeakSet } from '@glimmer/util';
 import {
@@ -204,7 +203,7 @@ function applyMergedProperties(
     return value;
   }
 
-  let newBase = assign({}, baseValue);
+  let newBase = Object.assign({}, baseValue);
   let hasFunction = false;
 
   let props = Object.keys(value);

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -4,7 +4,6 @@ import { symbol } from '@ember/-internals/utils';
 import { EMBER_ROUTING_ROUTER_SERVICE_REFRESH } from '@ember/canary-features';
 import { assert } from '@ember/debug';
 import { readOnly } from '@ember/object/computed';
-import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { consumeTag, tagFor } from '@glimmer/validator';
 import Route from '../system/route';
@@ -313,7 +312,7 @@ export default class RouterService extends Service {
     let hasQueryParams = Object.keys(queryParams).length > 0;
 
     if (hasQueryParams) {
-      queryParams = assign({}, queryParams);
+      queryParams = Object.assign({}, queryParams);
       this._router._prepareQueryParams(
         // UNSAFE: casting `routeName as string` here encodes the existing
         // assumption but may be wrong: `extractRouteArgs` correctly returns it

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -5,7 +5,6 @@
 import { getOwner, Owner } from '@ember/-internals/owner';
 import { symbol } from '@ember/-internals/utils';
 import { readOnly } from '@ember/object/computed';
-import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import EmberRouter, { QueryParam } from '../system/router';
 import RouterState from '../system/router_state';
@@ -55,7 +54,7 @@ export default class RoutingService extends Service {
   _generateURL(routeName: string, models: {}[], queryParams: {}) {
     let visibleQueryParams = {};
     if (queryParams) {
-      assign(visibleQueryParams, queryParams);
+      Object.assign(visibleQueryParams, queryParams);
       this.normalizeQueryParams(routeName, models, visibleQueryParams as QueryParam);
     }
 

--- a/packages/@ember/-internals/routing/lib/system/dsl.ts
+++ b/packages/@ember/-internals/routing/lib/system/dsl.ts
@@ -1,6 +1,5 @@
 import { Factory } from '@ember/-internals/owner';
 import { assert } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { Option } from '@glimmer/interfaces';
 import { MatchCallback } from 'route-recognizer';
 import { EngineInfo, EngineRouteInfo } from './engines';
@@ -136,7 +135,7 @@ export default class DSLImpl implements DSL {
 
     if (this.options.engineInfo) {
       let localFullName = name.slice(this.options.engineInfo.fullName.length + 1);
-      let routeInfo: EngineRouteInfo = assign({ localFullName }, this.options.engineInfo);
+      let routeInfo: EngineRouteInfo = Object.assign({ localFullName }, this.options.engineInfo);
 
       if (serialize) {
         routeInfo.serializeMethod = serialize;
@@ -206,7 +205,7 @@ export default class DSLImpl implements DSL {
         this.options.engineInfo = engineInfo;
       }
 
-      let optionsForChild = assign({ engineInfo }, this.options);
+      let optionsForChild = Object.assign({ engineInfo }, this.options);
       let childDSL = new DSLImpl(fullName, optionsForChild);
 
       createRoute(childDSL, 'loading');
@@ -222,14 +221,14 @@ export default class DSLImpl implements DSL {
     }
 
     let localFullName = 'application';
-    let routeInfo = assign({ localFullName }, engineInfo);
+    let routeInfo = Object.assign({ localFullName }, engineInfo);
 
     if (this.enableLoadingSubstates) {
       // These values are important to register the loading routes under their
       // proper names for the Router and within the Engine's registry.
       let substateName = `${name}_loading`;
       let localFullName = `application_loading`;
-      let routeInfo = assign({ localFullName }, engineInfo);
+      let routeInfo = Object.assign({ localFullName }, engineInfo);
       createRoute(this, substateName, {
         resetNamespace: options.resetNamespace,
       });
@@ -237,7 +236,7 @@ export default class DSLImpl implements DSL {
 
       substateName = `${name}_error`;
       localFullName = `application_error`;
-      routeInfo = assign({ localFullName }, engineInfo);
+      routeInfo = Object.assign({ localFullName }, engineInfo);
       createRoute(this, substateName, {
         resetNamespace: options.resetNamespace,
         path: dummyErrorRoute,

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -25,7 +25,6 @@ import Controller from '@ember/controller';
 import { assert, deprecate, info, isTesting } from '@ember/debug';
 import { ROUTER_EVENTS } from '@ember/deprecated-features';
 import { dependentKeyCompat } from '@ember/object/compat';
-import { assign } from '@ember/polyfills';
 import { once } from '@ember/runloop';
 import { classify } from '@ember/string';
 import { DEBUG } from '@glimmer/env';
@@ -435,7 +434,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     let state = transition ? transition[STATE_SYMBOL] : this._router._routerMicrolib.state;
 
     let fullName = route.fullRouteName;
-    let params = assign({}, state!.params[fullName!]);
+    let params = Object.assign({}, state!.params[fullName!]);
     let queryParams = getQueryParamsFor(route, state!);
 
     return Object.keys(queryParams).reduce((params, key) => {
@@ -2403,7 +2402,7 @@ export function getFullQueryParams(router: EmberRouter, state: TransitionState<R
   }
 
   state['fullQueryParams'] = {};
-  assign(state['fullQueryParams'], state.queryParams);
+  Object.assign(state['fullQueryParams'], state.queryParams);
 
   router._deserializeQueryParams(state.routeInfos, state['fullQueryParams'] as QueryParam);
   return state['fullQueryParams'];
@@ -2465,7 +2464,7 @@ function mergeEachQueryParams(controllerQP: {}, routeQP: {}) {
     }
 
     let newControllerParameterConfiguration = {};
-    assign(newControllerParameterConfiguration, controllerQP[cqpName], routeQP[cqpName]);
+    Object.assign(newControllerParameterConfiguration, controllerQP[cqpName], routeQP[cqpName]);
 
     qps[cqpName] = newControllerParameterConfiguration;
 
@@ -2484,7 +2483,7 @@ function mergeEachQueryParams(controllerQP: {}, routeQP: {}) {
     }
 
     let newRouteParameterConfiguration = {};
-    assign(newRouteParameterConfiguration, routeQP[rqpName], controllerQP[rqpName]);
+    Object.assign(newRouteParameterConfiguration, routeQP[rqpName], controllerQP[rqpName]);
     qps[rqpName] = newRouteParameterConfiguration;
   }
 

--- a/packages/@ember/-internals/routing/lib/system/router_state.ts
+++ b/packages/@ember/-internals/routing/lib/system/router_state.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import Router, { TransitionState } from 'router_js';
 import { shallowEqual } from '../utils';
 import Route from './route';
@@ -25,7 +24,7 @@ export default class RouterState {
     }
 
     if (queryParams !== undefined && Object.keys(queryParams).length > 0) {
-      let visibleQueryParams = assign({}, queryParams);
+      let visibleQueryParams = Object.assign({}, queryParams);
 
       this.emberRouter._prepareQueryParams(routeName, models, visibleQueryParams);
       return shallowEqual(visibleQueryParams, state.queryParams);

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -2,7 +2,6 @@ import { get } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
 import { deprecate } from '@ember/debug';
 import EmberError from '@ember/error';
-import { assign } from '@ember/polyfills';
 import Router, { STATE_SYMBOL } from 'router_js';
 import Route from './system/route';
 import EmberRouter, { PrivateRouteInfo, QueryParam } from './system/router';
@@ -182,7 +181,7 @@ function accumulateQueryParamDescriptors(_desc: QueryParam, accum: {}) {
     }
 
     tmp = accum[key] || { as: null, scope: 'model' };
-    assign(tmp, singleDesc);
+    Object.assign(tmp, singleDesc);
 
     accum[key] = tmp;
   }

--- a/packages/@ember/-internals/routing/tests/location/auto_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/auto_location_test.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { window } from '@ember/-internals/browser-environment';
 import { run } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
@@ -11,7 +10,7 @@ import NoneLocation from '../../lib/location/none_location';
 import { buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function mockBrowserLocation(overrides, assert) {
-  return assign(
+  return Object.assign(
     {
       href: 'http://test.com/',
       pathname: '/',
@@ -26,7 +25,7 @@ function mockBrowserLocation(overrides, assert) {
 }
 
 function mockBrowserHistory(overrides, assert) {
-  return assign(
+  return Object.assign(
     {
       pushState() {
         assert.ok(false, 'history.pushState should not be called during testing');

--- a/packages/@ember/-internals/routing/tests/location/util_test.js
+++ b/packages/@ember/-internals/routing/tests/location/util_test.js
@@ -1,10 +1,9 @@
-import { assign } from '@ember/polyfills';
 import { replacePath, getPath, getQuery, getFullPath } from '../../lib/location/util';
 import { supportsHistory, supportsHashChange } from '../../lib/location/util';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function mockBrowserLocation(overrides, assert) {
-  return assign(
+  return Object.assign(
     {
       href: 'http://test.com/',
       pathname: '/',

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -4,7 +4,6 @@
 
 import { getFactoryFor, setFactoryFor, INIT_FACTORY } from '@ember/-internals/container';
 import { getOwner, LEGACY_OWNER } from '@ember/-internals/owner';
-import { assign } from '@ember/polyfills';
 import {
   guidFor,
   lookupDescriptor,
@@ -122,7 +121,7 @@ function initialize(obj, properties) {
 
         if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
           let baseValue = obj[keyName];
-          value = assign({}, baseValue, value);
+          value = Object.assign({}, baseValue, value);
         }
       }
 
@@ -1130,7 +1129,7 @@ function flattenProps(...props) {
       if (hasMergedProps && mergedProperties.indexOf(keyName) > -1) {
         let baseValue = initProperties[keyName];
 
-        value = assign({}, baseValue, value);
+        value = Object.assign({}, baseValue, value);
       }
 
       initProperties[keyName] = value;

--- a/packages/@ember/-internals/views/lib/system/event_dispatcher.js
+++ b/packages/@ember/-internals/views/lib/system/event_dispatcher.js
@@ -1,5 +1,4 @@
 import { getOwner } from '@ember/-internals/owner';
-import { assign } from '@ember/polyfills';
 import { assert } from '@ember/debug';
 import { get, set } from '@ember/-internals/metal';
 import { Object as EmberObject } from '@ember/-internals/runtime';
@@ -67,7 +66,7 @@ export default EmberObject.extend({
     @type Object
     @private
   */
-  events: assign(
+  events: Object.assign(
     {
       touchstart: 'touchStart',
       touchmove: 'touchMove',
@@ -151,9 +150,9 @@ export default EmberObject.extend({
       })()
     );
 
-    let events = (this.finalEventNameMapping = assign({}, get(this, 'events'), addedEvents));
+    let events = (this.finalEventNameMapping = Object.assign({}, get(this, 'events'), addedEvents));
     this._reverseEventNameMapping = Object.keys(events).reduce(
-      (result, key) => assign(result, { [events[key]]: key }),
+      (result, key) => Object.assign(result, { [events[key]]: key }),
       {}
     );
     let lazyEvents = this.lazyEvents;

--- a/packages/@ember/-internals/views/lib/views/states/destroying.js
+++ b/packages/@ember/-internals/views/lib/views/states/destroying.js
@@ -1,8 +1,7 @@
-import { assign } from '@ember/polyfills';
 import EmberError from '@ember/error';
 import _default from './default';
 
-const destroying = assign({}, _default, {
+const destroying = Object.assign({}, _default, {
   appendChild() {
     throw new EmberError("You can't call appendChild on a view being destroyed");
   },

--- a/packages/@ember/-internals/views/lib/views/states/has_element.js
+++ b/packages/@ember/-internals/views/lib/views/states/has_element.js
@@ -1,9 +1,8 @@
-import { assign } from '@ember/polyfills';
 import _default from './default';
 import { join } from '@ember/runloop';
 import { flaggedInstrument } from '@ember/instrumentation';
 
-const hasElement = assign({}, _default, {
+const hasElement = Object.assign({}, _default, {
   rerender(view) {
     view.renderer.rerender(view);
   },

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.js
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.js
@@ -1,10 +1,9 @@
 import { teardownMandatorySetter } from '@ember/-internals/utils';
-import { assign } from '@ember/polyfills';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
 import hasElement from './has_element';
 
-const inDOM = assign({}, hasElement, {
+const inDOM = Object.assign({}, hasElement, {
   enter(view) {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.

--- a/packages/@ember/-internals/views/lib/views/states/pre_render.js
+++ b/packages/@ember/-internals/views/lib/views/states/pre_render.js
@@ -1,6 +1,5 @@
 import _default from './default';
-import { assign } from '@ember/polyfills';
 
-const preRender = assign({}, _default);
+const preRender = Object.assign({}, _default);
 
 export default Object.freeze(preRender);

--- a/packages/@ember/application/instance.js
+++ b/packages/@ember/application/instance.js
@@ -2,7 +2,6 @@
 @module @ember/application
 */
 
-import { assign } from '@ember/polyfills';
 import { get, set, computed } from '@ember/-internals/metal';
 import * as environment from '@ember/-internals/browser-environment';
 import { jQuery } from '@ember/-internals/views';
@@ -202,7 +201,7 @@ const ApplicationInstance = EngineInstance.extend({
     let applicationCustomEvents = get(this.application, 'customEvents');
     let instanceCustomEvents = get(this, 'customEvents');
 
-    let customEvents = assign({}, applicationCustomEvents, instanceCustomEvents);
+    let customEvents = Object.assign({}, applicationCustomEvents, instanceCustomEvents);
     dispatcher.setup(customEvents, this.rootElement);
 
     return dispatcher;
@@ -498,7 +497,7 @@ class BootOptions {
 
   toEnvironment() {
     // Do we really want to assign all of this!?
-    let env = assign({}, environment);
+    let env = Object.assign({}, environment);
     // For compatibility with existing code
     env.hasDOM = this.isBrowser;
     env.isInteractive = this.isInteractive;

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -10,7 +10,6 @@ import { _loaded } from '@ember/application';
 import Controller from '@ember/controller';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { setTemplates } from '@ember/-internals/glimmer';
-import { assign } from '@ember/polyfills';
 import {
   moduleFor,
   ApplicationTestCase,
@@ -37,7 +36,7 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         rootElement: '#one',
         router: null,
         autoboot: true,
@@ -45,7 +44,7 @@ moduleFor(
     }
 
     createSecondApplication(options) {
-      let myOptions = assign(this.applicationOptions, options);
+      let myOptions = Object.assign(this.applicationOptions, options);
       return (this.secondApp = Application.create(myOptions));
     }
 
@@ -187,7 +186,7 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         autoboot: true,
       });
     }

--- a/packages/@ember/application/tests/bootstrap-test.js
+++ b/packages/@ember/application/tests/bootstrap-test.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { moduleFor, DefaultResolverApplicationTestCase, runTask } from 'internal-test-helpers';
 
 moduleFor(
@@ -14,7 +13,7 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         autoboot: true,
         rootElement: '#app',
       });

--- a/packages/@ember/application/tests/dependency_injection/custom_resolver_test.js
+++ b/packages/@ember/application/tests/dependency_injection/custom_resolver_test.js
@@ -1,5 +1,4 @@
 import DefaultResolver from '@ember/application/globals-resolver';
-import { assign } from '@ember/polyfills';
 import { moduleFor, DefaultResolverApplicationTestCase, runTask } from 'internal-test-helpers';
 
 moduleFor(
@@ -18,7 +17,7 @@ moduleFor(
         },
       });
 
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         Resolver,
         autoboot: true,
       });

--- a/packages/@ember/application/tests/initializers_test.js
+++ b/packages/@ember/application/tests/initializers_test.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 import Application from '..';
 
@@ -12,13 +11,13 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         rootElement: '#one',
       });
     }
 
     createSecondApplication(options, MyApplication = Application) {
-      let myOptions = assign(
+      let myOptions = Object.assign(
         this.applicationOptions,
         {
           rootElement: '#two',

--- a/packages/@ember/application/tests/instance_initializers_test.js
+++ b/packages/@ember/application/tests/instance_initializers_test.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { moduleFor, AutobootApplicationTestCase, runTask } from 'internal-test-helpers';
 import ApplicationInstance from '@ember/application/instance';
 import Application from '@ember/application';
@@ -13,13 +12,13 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         rootElement: '#one',
       });
     }
 
     createSecondApplication(options, MyApplication = Application) {
-      let myOptions = assign(
+      let myOptions = Object.assign(
         this.applicationOptions,
         {
           rootElement: '#two',

--- a/packages/@ember/application/tests/logging_test.js
+++ b/packages/@ember/application/tests/logging_test.js
@@ -4,7 +4,6 @@ import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import { Route } from '@ember/-internals/routing';
-import { assign } from '@ember/polyfills';
 
 class LoggingApplicationTestCase extends ApplicationTestCase {
   constructor() {
@@ -40,7 +39,7 @@ moduleFor(
   'Application with LOG_ACTIVE_GENERATION=true',
   class extends LoggingApplicationTestCase {
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         LOG_ACTIVE_GENERATION: true,
       });
     }
@@ -102,7 +101,7 @@ moduleFor(
   'Application when LOG_ACTIVE_GENERATION=false',
   class extends LoggingApplicationTestCase {
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         LOG_ACTIVE_GENERATION: false,
       });
     }
@@ -119,7 +118,7 @@ moduleFor(
   'Application with LOG_VIEW_LOOKUPS=true',
   class extends LoggingApplicationTestCase {
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         LOG_VIEW_LOOKUPS: true,
       });
     }
@@ -159,7 +158,7 @@ moduleFor(
   'Application with LOG_VIEW_LOOKUPS=false',
   class extends LoggingApplicationTestCase {
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         LOG_VIEW_LOOKUPS: false,
       });
     }

--- a/packages/@ember/canary-features/index.ts
+++ b/packages/@ember/canary-features/index.ts
@@ -1,5 +1,4 @@
 import { ENV } from '@ember/-internals/environment';
-import { assign } from '@ember/polyfills';
 
 /**
   Set `EmberENV.FEATURES` in your application's `config/environment.js` file
@@ -33,7 +32,7 @@ export const DEFAULT_FEATURES = {
   @since 1.1.0
   @public
 */
-export const FEATURES = assign(DEFAULT_FEATURES, ENV.FEATURES);
+export const FEATURES = Object.assign(DEFAULT_FEATURES, ENV.FEATURES);
 
 /**
   Determine whether the specified `feature` is enabled. Used by Ember's

--- a/packages/@ember/object/index.js
+++ b/packages/@ember/object/index.js
@@ -1,6 +1,5 @@
 import { DEBUG } from '@glimmer/env';
 import { assert, deprecate } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { isElementDescriptor, setClassicDecorator } from '@ember/-internals/metal';
 
 export { Object as default } from '@ember/-internals/runtime';
@@ -276,7 +275,7 @@ function setupAction(target, key, actionFn) {
   if (!Object.prototype.hasOwnProperty.call(target, 'actions')) {
     let parentActions = target.actions;
     // we need to assign because of the way mixins copy actions down when inheriting
-    target.actions = parentActions ? assign({}, parentActions) : {};
+    target.actions = parentActions ? Object.assign({}, parentActions) : {};
   }
 
   target.actions[key] = actionFn;

--- a/packages/@ember/runloop/tests/later_test.js
+++ b/packages/@ember/runloop/tests/later_test.js
@@ -1,5 +1,4 @@
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
-import { assign } from '@ember/polyfills';
 import { run, later, _backburner, _hasScheduledTimers, _getCurrentRunLoop } from '..';
 
 const originalSetTimeout = window.setTimeout;
@@ -226,7 +225,7 @@ moduleFor(
       // happens when an expired timer callback takes a while to run,
       // which is what we simulate here.
       let newSetTimeoutUsed;
-      _backburner._platform = assign({}, originalPlatform, {
+      _backburner._platform = Object.assign({}, originalPlatform, {
         setTimeout() {
           let wait = arguments[arguments.length - 1];
           newSetTimeoutUsed = true;

--- a/packages/ember-template-compiler/lib/system/compile-options.ts
+++ b/packages/ember-template-compiler/lib/system/compile-options.ts
@@ -1,6 +1,5 @@
 import { EMBER_STRICT_MODE } from '@ember/canary-features';
 import { assert, deprecate } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import { AST, ASTPlugin, ASTPluginEnvironment, Syntax } from '@glimmer/syntax';
 import { RESOLUTION_MODE_TRANSFORMS, STRICT_MODE_TRANSFORMS } from '../plugins/index';
 import { EmberPrecompileOptions, PluginFunc } from '../types';
@@ -14,7 +13,7 @@ function malformedComponentLookup(string: string) {
 
 export function buildCompileOptions(_options: EmberPrecompileOptions): EmberPrecompileOptions {
   let moduleName = _options.moduleName;
-  let options: EmberPrecompileOptions = assign(
+  let options: EmberPrecompileOptions = Object.assign(
     { meta: {}, isProduction: false, plugins: { ast: [] } },
     _options,
     {

--- a/packages/ember-testing/lib/events.js
+++ b/packages/ember-testing/lib/events.js
@@ -1,5 +1,4 @@
 import { run } from '@ember/runloop';
-import { assign } from '@ember/polyfills';
 import isFormControl from './helpers/-is-form-control';
 
 const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
@@ -62,7 +61,7 @@ export function fireEvent(element, type, options = {}) {
       clientX: x,
       clientY: y,
     };
-    event = buildMouseEvent(type, assign(simulatedCoordinates, options));
+    event = buildMouseEvent(type, Object.assign(simulatedCoordinates, options));
   } else {
     event = buildBasicEvent(type, options);
   }
@@ -80,7 +79,7 @@ function buildBasicEvent(type, options = {}) {
   delete options.cancelable;
 
   event.initEvent(type, bubbles, cancelable);
-  assign(event, options);
+  Object.assign(event, options);
   return event;
 }
 
@@ -88,7 +87,7 @@ function buildMouseEvent(type, options = {}) {
   let event;
   try {
     event = document.createEvent('MouseEvents');
-    let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
+    let eventOpts = Object.assign({}, DEFAULT_EVENT_OPTIONS, options);
     event.initMouseEvent(
       type,
       eventOpts.canBubble,
@@ -116,7 +115,7 @@ function buildKeyboardEvent(type, options = {}) {
   let event;
   try {
     event = document.createEvent('KeyEvents');
-    let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
+    let eventOpts = Object.assign({}, DEFAULT_EVENT_OPTIONS, options);
     event.initKeyEvent(
       type,
       eventOpts.canBubble,

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -2,7 +2,6 @@ import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 import Application from '@ember/application';
 import { Component } from '@ember/-internals/glimmer';
 import { getOwner } from '@ember/-internals/owner';
-import { assign } from '@ember/polyfills';
 import { resolve } from 'rsvp';
 
 moduleFor(
@@ -20,7 +19,7 @@ moduleFor(
     }
 
     get applicationOptions() {
-      return assign(super.applicationOptions, {
+      return Object.assign(super.applicationOptions, {
         rootElement: '#one',
         router: null,
       });
@@ -29,7 +28,7 @@ moduleFor(
     createSecondApplication(options) {
       let { applicationOptions } = this;
       let secondApplicationOptions = { rootElement: '#two' };
-      let myOptions = assign(applicationOptions, secondApplicationOptions, options);
+      let myOptions = Object.assign(applicationOptions, secondApplicationOptions, options);
       this.secondApp = Application.create(myOptions);
       this.secondResolver = this.secondApp.__registry__.resolver;
       return this.secondApp;

--- a/packages/internal-test-helpers/lib/apply-mixins.js
+++ b/packages/internal-test-helpers/lib/apply-mixins.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import getAllPropertyNames from './get-all-property-names';
 
 function isGenerator(mixin) {
@@ -14,10 +13,10 @@ export default function applyMixins(TestClass, ...mixins) {
       mixin = {};
 
       generator.cases.forEach((value, idx) => {
-        assign(mixin, generator.generate(value, idx));
+        Object.assign(mixin, generator.generate(value, idx));
       });
 
-      assign(TestClass.prototype, mixin);
+      Object.assign(TestClass.prototype, mixin);
     } else if (typeof mixinOrGenerator === 'function') {
       let properties = getAllPropertyNames(mixinOrGenerator);
       mixin = new mixinOrGenerator();
@@ -29,7 +28,7 @@ export default function applyMixins(TestClass, ...mixins) {
       });
     } else {
       mixin = mixinOrGenerator;
-      assign(TestClass.prototype, mixin);
+      Object.assign(TestClass.prototype, mixin);
     }
   });
 

--- a/packages/internal-test-helpers/lib/system/synthetic-events.js
+++ b/packages/internal-test-helpers/lib/system/synthetic-events.js
@@ -1,8 +1,6 @@
 import { run } from '@ember/runloop';
 /* globals Element */
 
-import { assign } from '@ember/polyfills';
-
 const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
 const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
 const MOUSE_EVENT_TYPES = [
@@ -112,7 +110,7 @@ export function fireEvent(element, type, options = {}) {
       clientX: x,
       clientY: y,
     };
-    event = buildMouseEvent(type, assign(simulatedCoordinates, options));
+    event = buildMouseEvent(type, Object.assign(simulatedCoordinates, options));
   } else {
     event = buildBasicEvent(type, options);
   }
@@ -124,7 +122,7 @@ export function fireEvent(element, type, options = {}) {
 function buildBasicEvent(type, options = {}) {
   let event = document.createEvent('Events');
   event.initEvent(type, true, true);
-  assign(event, options);
+  Object.assign(event, options);
   return event;
 }
 
@@ -132,7 +130,7 @@ function buildMouseEvent(type, options = {}) {
   let event;
   try {
     event = document.createEvent('MouseEvents');
-    let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
+    let eventOpts = Object.assign({}, DEFAULT_EVENT_OPTIONS, options);
 
     event.initMouseEvent(
       type,
@@ -161,7 +159,7 @@ function buildKeyboardEvent(type, options = {}) {
   let event;
   try {
     event = document.createEvent('KeyEvents');
-    let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
+    let eventOpts = Object.assign({}, DEFAULT_EVENT_OPTIONS, options);
     event.initKeyEvent(
       type,
       eventOpts.canBubble,

--- a/packages/internal-test-helpers/lib/test-cases/abstract.js
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.js
@@ -1,7 +1,5 @@
 /* global Element */
 
-import { assign } from '@ember/polyfills';
-
 import NodeQuery from '../node-query';
 import equalInnerHTML from '../equal-inner-html';
 import equalTokens from '../equal-tokens';
@@ -162,7 +160,11 @@ export default class AbstractTestCase {
     node,
     { ElementType = HTMLElement, tagName = 'div', attrs = null, content = null }
   ) {
-    attrs = assign({}, { id: regex(/^ember\d*$/), class: classes('ember-view') }, attrs || {});
+    attrs = Object.assign(
+      {},
+      { id: regex(/^ember\d*$/), class: classes('ember-view') },
+      attrs || {}
+    );
     this.assertElement(node, { ElementType, tagName, attrs, content });
   }
 

--- a/packages/internal-test-helpers/lib/test-cases/application.js
+++ b/packages/internal-test-helpers/lib/test-cases/application.js
@@ -1,7 +1,6 @@
 import TestResolverApplicationTestCase from './test-resolver-application';
 import Application from '@ember/application';
 import { Router } from '@ember/-internals/routing';
-import { assign } from '@ember/polyfills';
 
 import { runTask, runLoopSettled } from '../run';
 
@@ -24,7 +23,7 @@ export default class ApplicationTestCase extends TestResolverApplicationTestCase
   }
 
   get applicationOptions() {
-    return assign(super.applicationOptions, {
+    return Object.assign(super.applicationOptions, {
       autoboot: false,
     });
   }

--- a/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/autoboot-application.js
@@ -1,11 +1,10 @@
 import TestResolverApplicationTestCase from './test-resolver-application';
 import Application from '@ember/application';
-import { assign } from '@ember/polyfills';
 import { Router } from '@ember/-internals/routing';
 
 export default class AutobootApplicationTestCase extends TestResolverApplicationTestCase {
   createApplication(options, MyApplication = Application) {
-    let myOptions = assign(this.applicationOptions, options);
+    let myOptions = Object.assign(this.applicationOptions, options);
     let application = (this.application = MyApplication.create(myOptions));
     this.resolver = application.__registry__.resolver;
 

--- a/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/default-resolver-application.js
@@ -2,7 +2,6 @@ import AbstractApplicationTestCase from './abstract-application';
 import DefaultResolver from '@ember/application/globals-resolver';
 import Application from '@ember/application';
 import { setTemplates, setTemplate } from '@ember/-internals/glimmer';
-import { assign } from '@ember/polyfills';
 import { Router } from '@ember/-internals/routing';
 
 import { runTask } from '../run';
@@ -26,7 +25,7 @@ export default class DefaultResolverApplicationTestCase extends AbstractApplicat
   }
 
   get applicationOptions() {
-    return assign(super.applicationOptions, {
+    return Object.assign(super.applicationOptions, {
       name: 'TestApp',
       autoboot: false,
       Resolver: DefaultResolver,

--- a/packages/internal-test-helpers/lib/test-cases/rendering.js
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { compile } from 'ember-template-compiler';
 import { EventDispatcher } from '@ember/-internals/views';
 import { helper, Helper, Component, _resetRenderers } from '@ember/-internals/glimmer';
@@ -122,7 +121,7 @@ export default class RenderingTestCase extends AbstractTestCase {
       })
     );
 
-    let attrs = assign({}, context, {
+    let attrs = Object.assign({}, context, {
       tagName: '',
       layoutName: '-top-level',
     });

--- a/packages/internal-test-helpers/lib/test-cases/router-non-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/router-non-application.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { compile } from 'ember-template-compiler';
 import { EventDispatcher } from '@ember/-internals/views';
 import { Component, _resetRenderers } from '@ember/-internals/glimmer';
@@ -105,7 +104,7 @@ export default class RouterNonApplicationTestCase extends AbstractTestCase {
       })
     );
 
-    let attrs = assign({}, context, {
+    let attrs = Object.assign({}, context, {
       tagName: '',
       layoutName: '-top-level',
     });

--- a/packages/internal-test-helpers/lib/test-cases/test-resolver-application.js
+++ b/packages/internal-test-helpers/lib/test-cases/test-resolver-application.js
@@ -1,11 +1,10 @@
 import AbstractApplicationTestCase from './abstract-application';
 import { ModuleBasedResolver } from '../test-resolver';
 import { Component } from '@ember/-internals/glimmer';
-import { assign } from '@ember/polyfills';
 
 export default class TestResolverApplicationTestCase extends AbstractApplicationTestCase {
   get applicationOptions() {
-    return assign(super.applicationOptions, {
+    return Object.assign(super.applicationOptions, {
       Resolver: ModuleBasedResolver,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,8 +955,6 @@
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz#07640f28867ed16f9511c99c888291f560921cfa"
   integrity sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-for-of@^7.9.0":
   version "7.9.0"
@@ -1109,13 +1107,6 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz#60cc2ae66d85c95ab540eb34babb6434d4c70c43"
   integrity sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.3"
-
-"@babel/plugin-transform-object-assign@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.8.3.tgz#dc3b8dd50ef03837868a37b7df791f64f288538e"
-  integrity sha512-i3LuN8tPDqUCRFu3dkzF2r1Nx0jp4scxtm7JxtIqI9he9Vk20YD+/zshdzR9JLsoBMlJlNR82a62vQExNEVx/Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -5258,9 +5249,6 @@ find-babel-config@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
   integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
 
 find-index@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
**Note: This is intended to land in a version of Ember that does not support IE11.**

There is no need to use the `assign` polyfill internally post-IE11 support. This PR:

* removes `Ember.assign` usage
* removes `@babel/plugin-transform-object-assign`

Edit: Oddly, the same test fails locally on `master`. In this branch the tests all pass in the browser, with the failure only occurring when run in the console