### PR TITLE
[BUGFIX lts] Ensure legacy LinkTo query params work with `hash`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -11,6 +11,8 @@ import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { assert, deprecate, runInDebug, warn } from '@ember/debug';
 import { EngineInstance, getEngineParent } from '@ember/engine';
 import { flaggedInstrument } from '@ember/instrumentation';
+import { dependentKeyCompat } from '@ember/object/compat';
+import { assign } from '@ember/polyfills';
 import { inject as injectService } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import EmberComponent from '../component';
@@ -543,14 +545,16 @@ const LinkComponent = EmberComponent.extend({
     }
   }),
 
-  _query: computed('query', function computeLinkToComponentQuery(this: any) {
-    let { query } = this;
+  _query: dependentKeyCompat({
+    get(this: any) {
+      let { query } = this;
 
-    if (query === UNDEFINED) {
-      return EMPTY_QUERY_PARAMS;
-    } else {
-      return Object.assign({}, query);
-    }
+      if (query === UNDEFINED) {
+        return EMPTY_QUERY_PARAMS;
+      } else {
+        return assign({}, query);
+      }
+    },
   }),
 
   /**

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -350,6 +350,30 @@ moduleFor(
       assert.equal(theLink.attr('href'), '/?foo=ASL');
     }
 
+    async ['@test supplied QP properties can be bound in legacy components'](assert) {
+      expectDeprecation(/Passing the `@tagName` argument to/);
+
+      this.addTemplate(
+        'index',
+        `
+          <LinkTo @tagName="a" id="the-link" @query={{hash foo=this.boundThing}}>
+            Index
+          </LinkTo>
+        `
+      );
+
+      await this.visit('/');
+
+      let indexController = this.getController('index');
+      let theLink = this.$('#the-link');
+
+      assert.equal(theLink.attr('href'), '/?foo=OMG');
+
+      runTask(() => indexController.set('boundThing', 'ASL'));
+
+      assert.equal(theLink.attr('href'), '/?foo=ASL');
+    }
+
     async ['@test supplied QP properties can be bound (booleans)'](assert) {
       this.addTemplate(
         'index',


### PR DESCRIPTION
Fixes legacy LinkTo's query params that rely on `hash`. Now that `hash` never changes/updates directly, we need to use autotracking since we read all of the keys on the hash. The alternative would be to add observers to each key.