### PR TITLE
[CLEANUP] Cleanup IE11 leftovers

### DIFF
--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -1,5 +1,5 @@
 import { Factory, LookupOptions, Owner, setOwner } from '@ember/-internals/owner';
-import { dictionary, HAS_NATIVE_PROXY, symbol } from '@ember/-internals/utils';
+import { dictionary, symbol } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import Registry, { DebugRegistry, Injection } from './registry';
@@ -234,30 +234,26 @@ if (DEBUG) {
  * set on the manager.
  */
 function wrapManagerInDeprecationProxy<T, C>(manager: FactoryManager<T, C>): FactoryManager<T, C> {
-  if (HAS_NATIVE_PROXY) {
-    let validator = {
-      set(_obj: T, prop: keyof T) {
-        throw new Error(
-          `You attempted to set "${prop}" on a factory manager created by container#factoryFor. A factory manager is a read-only construct.`
-        );
-      },
-    };
+  let validator = {
+    set(_obj: T, prop: keyof T) {
+      throw new Error(
+        `You attempted to set "${prop}" on a factory manager created by container#factoryFor. A factory manager is a read-only construct.`
+      );
+    },
+  };
 
-    // Note:
-    // We have to proxy access to the manager here so that private property
-    // access doesn't cause the above errors to occur.
-    let m = manager;
-    let proxiedManager = {
-      class: m.class,
-      create(props?: { [prop: string]: any }) {
-        return m.create(props);
-      },
-    };
+  // Note:
+  // We have to proxy access to the manager here so that private property
+  // access doesn't cause the above errors to occur.
+  let m = manager;
+  let proxiedManager = {
+    class: m.class,
+    create(props?: { [prop: string]: any }) {
+      return m.create(props);
+    },
+  };
 
-    return new Proxy(proxiedManager, validator as any) as any;
-  }
-
-  return manager;
+  return new Proxy(proxiedManager, validator as any) as any;
 }
 
 function isSingleton(container: Container, fullName: string) {

--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -1,5 +1,5 @@
 import { Factory, LookupOptions, Owner, setOwner } from '@ember/-internals/owner';
-import { dictionary, HAS_NATIVE_PROXY, HAS_NATIVE_SYMBOL, symbol } from '@ember/-internals/utils';
+import { dictionary, HAS_NATIVE_PROXY, symbol } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import Registry, { DebugRegistry, Injection } from './registry';
@@ -551,7 +551,7 @@ class FactoryManager<T, C> {
     this.injections = undefined;
     setFactoryFor(this, this);
 
-    if (factory && (HAS_NATIVE_SYMBOL || INIT_FACTORY in factory)) {
+    if (factory) {
       setFactoryFor(factory, this);
     }
   }

--- a/packages/@ember/-internals/extension-support/lib/data_adapter.js
+++ b/packages/@ember/-internals/extension-support/lib/data_adapter.js
@@ -2,12 +2,11 @@ import { getOwner } from '@ember/-internals/owner';
 import { _backburner } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
 import { dasherize } from '@ember/string';
-import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
 import { Namespace, Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
 import { consumeTag, createCache, getValue, tagFor, untrack } from '@glimmer/validator';
 
 function iterate(arr, fn) {
-  if (HAS_NATIVE_SYMBOL && Symbol.iterator in arr) {
+  if (Symbol.iterator in arr) {
     for (let item of arr) {
       fn(item);
     }

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -29,9 +29,7 @@ import {
 } from './component-managers/curly';
 
 // Keep track of which component classes have already been processed for lazy event setup.
-// Using a WeakSet would be more appropriate here, but this can only be used when IE11 support is dropped.
-// Thus the workaround using a WeakMap<object, true>
-let lazyEventsProcessed = new WeakMap<EventDispatcher, WeakMap<object, true>>();
+let lazyEventsProcessed = new WeakMap<EventDispatcher, WeakSet<object>>();
 
 /**
 @module @ember/component
@@ -671,7 +669,7 @@ const Component = CoreView.extend(
       if (eventDispatcher) {
         let lazyEventsProcessedForComponentClass = lazyEventsProcessed.get(eventDispatcher);
         if (!lazyEventsProcessedForComponentClass) {
-          lazyEventsProcessedForComponentClass = new WeakMap<object, true>();
+          lazyEventsProcessedForComponentClass = new WeakSet<object>();
           lazyEventsProcessed.set(eventDispatcher, lazyEventsProcessedForComponentClass);
         }
 
@@ -685,7 +683,7 @@ const Component = CoreView.extend(
             }
           });
 
-          lazyEventsProcessedForComponentClass.set(proto, true);
+          lazyEventsProcessedForComponentClass.add(proto);
         }
       }
 

--- a/packages/@ember/-internals/glimmer/lib/components/abstract-input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/abstract-input.ts
@@ -15,8 +15,6 @@ import InternalComponent, {
   handleDeprecatedEventArguments,
   InternalComponentConstructor,
   jQueryEventShim,
-  ObjectEntries,
-  ObjectValues,
 } from './internal';
 
 const UNINITIALIZED: unknown = Object.freeze({});
@@ -304,7 +302,7 @@ export function handleDeprecatedFeatures(
 
     handleDeprecatedAttributeArguments(target, attributeBindings);
 
-    handleDeprecatedEventArguments(target, ObjectEntries(virtualEvents));
+    handleDeprecatedEventArguments(target, Object.entries(virtualEvents));
 
     {
       let superIsVirtualEventListener = prototype['isVirtualEventListener'];
@@ -318,7 +316,7 @@ export function handleDeprecatedFeatures(
           listener: Function
         ): listener is VirtualEventListener {
           return (
-            ObjectValues(virtualEvents).indexOf(name) !== -1 ||
+            Object.values(virtualEvents).indexOf(name) !== -1 ||
             superIsVirtualEventListener.call(this, name, listener)
           );
         },

--- a/packages/@ember/-internals/glimmer/lib/components/internal.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/internal.ts
@@ -28,24 +28,6 @@ import InternalModifier, { InternalModifierManager } from '../modifiers/internal
 
 function NOOP(): void {}
 
-// TODO: remove me when IE11 support is EOL
-export let ObjectEntries = ((): typeof Object['entries'] => {
-  if (typeof Object.entries === 'function') {
-    return Object.entries;
-  } else {
-    return (obj: {}) => Object.keys(obj).map((key) => [key, obj[key]] as [string, unknown]);
-  }
-})();
-
-// TODO: remove me when IE11 support is EOL
-export let ObjectValues = ((): typeof Object['values'] => {
-  if (typeof Object.values === 'function') {
-    return Object.values;
-  } else {
-    return (obj: {}) => Object.keys(obj).map((key) => obj[key]);
-  }
-})();
-
 export type EventListener = (event: Event) => void;
 
 export default class InternalComponent {
@@ -444,7 +426,7 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
         name: string
       ): boolean {
         let events = [
-          ...ObjectValues(getEventsMap(this.owner)),
+          ...Object.values(getEventsMap(this.owner)),
           'focus-in',
           'focus-out',
           'key-press',
@@ -470,7 +452,7 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
         let { element, component, listenerFor, listeners } = this;
 
         let entries: [event: string, argument: string][] = [
-          ...ObjectEntries(getEventsMap(this.owner)),
+          ...Object.entries(getEventsMap(this.owner)),
           ...extraEvents,
         ];
 
@@ -489,7 +471,7 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
       remove(): void {
         let { element, listeners } = this;
 
-        for (let [event, listener] of ObjectEntries(listeners)) {
+        for (let [event, listener] of Object.entries(listeners)) {
           element.removeEventListener(event, listener);
         }
 

--- a/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
@@ -1,6 +1,5 @@
 import { objectAt } from '@ember/-internals/metal';
-import { _contentFor } from '@ember/-internals/runtime';
-import { EmberArray, HAS_NATIVE_SYMBOL, isEmberArray, isObject } from '@ember/-internals/utils';
+import { EmberArray, isEmberArray, isObject } from '@ember/-internals/utils';
 import { Option } from '@glimmer/interfaces';
 import { IteratorDelegate } from '@glimmer/reference';
 import { consumeTag, isTracking, tagFor } from '@glimmer/validator';
@@ -21,7 +20,7 @@ function toEachInIterator(iterable: unknown) {
 
   if (Array.isArray(iterable) || isEmberArray(iterable)) {
     return ObjectIterator.fromIndexable(iterable);
-  } else if (HAS_NATIVE_SYMBOL && isNativeIterable<[unknown, unknown]>(iterable)) {
+  } else if (isNativeIterable<[unknown, unknown]>(iterable)) {
     return MapLikeNativeIterator.from(iterable);
   } else if (hasForEach(iterable)) {
     return ObjectIterator.fromForEachable(iterable);
@@ -39,7 +38,7 @@ function toEachIterator(iterable: unknown) {
     return ArrayIterator.from(iterable);
   } else if (isEmberArray(iterable)) {
     return EmberArrayIterator.from(iterable);
-  } else if (HAS_NATIVE_SYMBOL && isNativeIterable(iterable)) {
+  } else if (isNativeIterable(iterable)) {
     return ArrayLikeNativeIterator.from(iterable);
   } else if (hasForEach(iterable)) {
     return ArrayIterator.fromForEachable(iterable);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
@@ -1,8 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
-import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
-
 import { setComponentTemplate, getComponentTemplate } from '@glimmer/manager';
 import { Component, compile } from '../../utils/helpers';
 
@@ -68,11 +66,9 @@ moduleFor(
         setComponentTemplate(compile('foo'), 'foo');
       }, /Cannot call `setComponentTemplate` on `foo`/);
 
-      if (HAS_NATIVE_SYMBOL) {
-        assert.throws(() => {
-          setComponentTemplate(compile('foo'), Symbol('foo'));
-        }, /Cannot call `setComponentTemplate` on `Symbol\(foo\)`/);
-      }
+      assert.throws(() => {
+        setComponentTemplate(compile('foo'), Symbol('foo'));
+      }, /Cannot call `setComponentTemplate` on `Symbol\(foo\)`/);
     }
 
     '@test calling it twice on the same object asserts'(assert) {

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -6,7 +6,6 @@ import { set, computed } from '@ember/-internals/metal';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 import { readOnly } from '@ember/object/computed';
 import { Object as EmberObject, ObjectProxy } from '@ember/-internals/runtime';
-import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
 import { constructStyleDeprecationMessage } from '@ember/-internals/views';
 import { Component, SafeString, htmlSafe } from '../utils/helpers';
 
@@ -768,11 +767,8 @@ const SharedContentTestCases = new DynamicContentTestGenerator([
 
 let GlimmerContentTestCases = new DynamicContentTestGenerator([
   [Object.create(null), EMPTY, 'an object with no toString'],
+  [Symbol('debug'), 'Symbol(debug)', 'a symbol'],
 ]);
-
-if (HAS_NATIVE_SYMBOL) {
-  GlimmerContentTestCases.cases.push([Symbol('debug'), 'Symbol(debug)', 'a symbol']);
-}
 
 applyMixins(DynamicContentTest, SharedContentTestCases, GlimmerContentTestCases);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -8,7 +8,6 @@ import {
 } from '@ember/instrumentation';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
 import { jQueryDisabled, jQuery } from '@ember/-internals/views';
-import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
 import { DEBUG } from '@glimmer/env';
 
 let canDataTransfer = Boolean(document.createEvent('HTMLEvents').dataTransfer);
@@ -749,9 +748,7 @@ if (jQueryDisabled) {
         assert.ok(receivedEvent instanceof jQuery.Event, 'event is a jQuery.Event');
       }
 
-      [`@${HAS_NATIVE_PROXY ? 'test' : 'skip'} accessing jQuery.Event#originalEvent is deprecated`](
-        assert
-      ) {
+      ['@test accessing jQuery.Event#originalEvent is deprecated'](assert) {
         let receivedEvent;
 
         this.registerComponent('x-foo', {
@@ -823,7 +820,7 @@ if (jQueryDisabled) {
       }
 
       [`@${
-        HAS_NATIVE_PROXY && DEBUG ? 'test' : 'skip'
+        DEBUG ? 'test' : 'skip'
       } accessing jQuery.Event#__originalEvent does not trigger deprecations to support ember-jquery-legacy`](
         assert
       ) {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -1,5 +1,4 @@
 import { set } from '@ember/-internals/metal';
-import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
 import { DEBUG } from '@glimmer/env';
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { Component } from '../../utils/helpers';
@@ -121,7 +120,7 @@ moduleFor(
     }
 
     '@test there is no `this` context within the callback'(assert) {
-      if (DEBUG && HAS_NATIVE_PROXY) {
+      if (DEBUG) {
         assert.expect(0);
         return;
       }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -3,7 +3,6 @@ import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { Component } from '../../utils/helpers';
 
 import { set, computed } from '@ember/-internals/metal';
-import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
 
 moduleFor(
   'Helpers test: {{hash}}',
@@ -240,13 +239,9 @@ moduleFor(
       this.assertText('Chad ');
 
       runTask(() => {
-        if (HAS_NATIVE_PROXY) {
-          expectDeprecation(() => {
-            set(fooBarInstance.hash, 'lastName', 'Hietala');
-          }, /You set the '.*' property on a {{hash}} object/);
-        } else {
+        expectDeprecation(() => {
           set(fooBarInstance.hash, 'lastName', 'Hietala');
-        }
+        }, /You set the '.*' property on a {{hash}} object/);
       });
 
       this.assertText('Chad Hietala');

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -1,13 +1,12 @@
-import { moduleFor, RenderingTestCase, strip, applyMixins, runTask } from 'internal-test-helpers';
+import { applyMixins, moduleFor, RenderingTestCase, runTask, strip } from 'internal-test-helpers';
 
 import { get, set } from '@ember/-internals/metal';
 import { Object as EmberObject, ObjectProxy } from '@ember/-internals/runtime';
-import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
 
 import {
+  FalsyGenerator,
   TogglingSyntaxConditionalsTest,
   TruthyGenerator,
-  FalsyGenerator,
 } from '../../utils/shared-conditional-tests';
 
 function EmptyFunction() {}
@@ -677,31 +676,29 @@ moduleFor(
   }
 );
 
-if (HAS_NATIVE_SYMBOL) {
-  moduleFor(
-    'Syntax test: {{#each-in}} with custom iterables',
-    class extends EachInTest {
-      createHash(pojo) {
-        let ary = Object.keys(pojo).reduce((accum, key) => {
-          return accum.concat([[key, pojo[key]]]);
-        }, []);
-        let iterable = {
-          [Symbol.iterator]: () => makeIterator(ary),
-        };
-        return {
-          hash: iterable,
-          delegate: {
-            updateNestedValue(context, key, innerKey, value) {
-              let ary = Array.from(context.hash);
-              let target = ary.find(([k]) => k === key)[1];
-              set(target, innerKey, value);
-            },
+moduleFor(
+  'Syntax test: {{#each-in}} with custom iterables',
+  class extends EachInTest {
+    createHash(pojo) {
+      let ary = Object.keys(pojo).reduce((accum, key) => {
+        return accum.concat([[key, pojo[key]]]);
+      }, []);
+      let iterable = {
+        [Symbol.iterator]: () => makeIterator(ary),
+      };
+      return {
+        hash: iterable,
+        delegate: {
+          updateNestedValue(context, key, innerKey, value) {
+            let ary = Array.from(context.hash);
+            let target = ary.find(([k]) => k === key)[1];
+            set(target, innerKey, value);
           },
-        };
-      }
+        },
+      };
     }
-  );
-}
+  }
+);
 
 // Utils
 function makeIterator(ary) {

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -2,7 +2,6 @@ import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'inter
 
 import { get, set, notifyPropertyChange, computed, on } from '@ember/-internals/metal';
 import { A as emberA, ArrayProxy, RSVP } from '@ember/-internals/runtime';
-import { HAS_NATIVE_SYMBOL } from '@ember/-internals/utils';
 
 import { Component, htmlSafe } from '../../utils/helpers';
 import {
@@ -136,13 +135,11 @@ class ForEachable extends ArrayDelegate {
 
 let ArrayIterable;
 
-if (HAS_NATIVE_SYMBOL) {
-  ArrayIterable = class extends ArrayDelegate {
-    [Symbol.iterator]() {
-      return this._array[Symbol.iterator]();
-    }
-  };
-}
+ArrayIterable = class extends ArrayDelegate {
+  [Symbol.iterator]() {
+    return this._array[Symbol.iterator]();
+  }
+};
 
 class TogglingEachTest extends TogglingSyntaxConditionalsTest {
   get truthyValue() {
@@ -162,6 +159,7 @@ const TRUTHY_CASES = [
   new ForEachable(['hello']),
   ArrayProxy.create({ content: ['hello'] }),
   ArrayProxy.create({ content: emberA(['hello']) }),
+  new ArrayIterable(['hello']),
 ];
 
 const FALSY_CASES = [
@@ -176,12 +174,8 @@ const FALSY_CASES = [
   new ForEachable([]),
   ArrayProxy.create({ content: [] }),
   ArrayProxy.create({ content: emberA([]) }),
+  new ArrayIterable([]),
 ];
-
-if (HAS_NATIVE_SYMBOL) {
-  TRUTHY_CASES.push(new ArrayIterable(['hello']));
-  FALSY_CASES.push(new ArrayIterable([]));
-}
 
 applyMixins(
   BasicEachTest,
@@ -1079,17 +1073,15 @@ moduleFor(
   }
 );
 
-if (HAS_NATIVE_SYMBOL) {
-  moduleFor(
-    'Syntax test: {{#each}} with array-like objects implementing Symbol.iterator',
-    class extends EachTest {
-      createList(items) {
-        let iterable = new ArrayIterable(items);
-        return { list: iterable, delegate: iterable };
-      }
+moduleFor(
+  'Syntax test: {{#each}} with array-like objects implementing Symbol.iterator',
+  class extends EachTest {
+    createList(items) {
+      let iterable = new ArrayIterable(items);
+      return { list: iterable, delegate: iterable };
     }
-  );
-}
+  }
+);
 
 moduleFor(
   'Syntax test: {{#each}} with array proxies, modifying itself',

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -1,7 +1,7 @@
 /**
 @module @ember/object
 */
-import { HAS_NATIVE_PROXY, isEmberArray, setProxy, symbol } from '@ember/-internals/utils';
+import { isEmberArray, setProxy, symbol } from '@ember/-internals/utils';
 import { assert, deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import {
@@ -17,7 +17,7 @@ export const PROXY_CONTENT = symbol('PROXY_CONTENT');
 
 export let getPossibleMandatoryProxyValue: (obj: object, keyName: string) => any;
 
-if (DEBUG && HAS_NATIVE_PROXY) {
+if (DEBUG) {
   getPossibleMandatoryProxyValue = function getPossibleMandatoryProxyValue(obj, keyName): any {
     let content = obj[PROXY_CONTENT];
     if (content === undefined) {
@@ -106,7 +106,7 @@ export function _getProp(obj: object, keyName: string) {
   let value: unknown;
 
   if (isObjectLike) {
-    if (DEBUG && HAS_NATIVE_PROXY) {
+    if (DEBUG) {
       value = getPossibleMandatoryProxyValue(obj, keyName);
     } else {
       value = obj[keyName];

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -1,9 +1,4 @@
-import {
-  HAS_NATIVE_PROXY,
-  lookupDescriptor,
-  setWithMandatorySetter,
-  toString,
-} from '@ember/-internals/utils';
+import { lookupDescriptor, setWithMandatorySetter, toString } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
@@ -80,7 +75,7 @@ export function _setProp(obj: object, keyName: string, value: any) {
   }
 
   let currentValue: any;
-  if (DEBUG && HAS_NATIVE_PROXY) {
+  if (DEBUG) {
     currentValue = getPossibleMandatoryProxyValue(obj, keyName);
   } else {
     currentValue = obj[keyName];

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -10,7 +10,7 @@ import Route from '../system/route';
 import EmberRouter, { QueryParam } from '../system/router';
 import { extractRouteArgs, resemblesURL, shallowEqual } from '../utils';
 
-const ROUTER = symbol('ROUTER') as string;
+const ROUTER = (symbol('ROUTER') as unknown) as string;
 
 function cleanURL(url: string, rootURL: string) {
   if (rootURL === '/') {

--- a/packages/@ember/-internals/routing/lib/services/routing.ts
+++ b/packages/@ember/-internals/routing/lib/services/routing.ts
@@ -9,7 +9,7 @@ import Service from '@ember/service';
 import EmberRouter, { QueryParam } from '../system/router';
 import RouterState from '../system/router_state';
 
-const ROUTER = symbol('ROUTER') as string;
+const ROUTER = (symbol('ROUTER') as unknown) as string;
 
 /**
   The Routing service is used by LinkComponent, and provides facilities for

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -48,7 +48,7 @@ import generateController from './generate_controller';
 import EmberRouter, { QueryParam } from './router';
 
 export const ROUTE_CONNECTIONS = new WeakMap();
-const RENDER = symbol('render') as string;
+const RENDER = (symbol('render') as unknown) as string;
 
 export function defaultSerialize(
   model: {},

--- a/packages/@ember/-internals/runtime/lib/mixins/array.js
+++ b/packages/@ember/-internals/runtime/lib/mixins/array.js
@@ -3,7 +3,7 @@
 */
 import { DEBUG } from '@glimmer/env';
 import { PROXY_CONTENT } from '@ember/-internals/metal';
-import { setEmberArray, HAS_NATIVE_PROXY } from '@ember/-internals/utils';
+import { setEmberArray } from '@ember/-internals/utils';
 import {
   get,
   set,
@@ -138,7 +138,7 @@ function insertAt(array, index, item) {
 */
 export function isArray(_obj) {
   let obj = _obj;
-  if (DEBUG && HAS_NATIVE_PROXY && typeof _obj === 'object' && _obj !== null) {
+  if (DEBUG && typeof _obj === 'object' && _obj !== null) {
     let possibleProxyContent = _obj[PROXY_CONTENT];
     if (possibleProxyContent !== undefined) {
       obj = possibleProxyContent;

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -2,7 +2,7 @@
   @module @ember/object
 */
 
-import { getFactoryFor, setFactoryFor, INIT_FACTORY } from '@ember/-internals/container';
+import { getFactoryFor, setFactoryFor } from '@ember/-internals/container';
 import { getOwner, LEGACY_OWNER } from '@ember/-internals/owner';
 import {
   guidFor,
@@ -10,7 +10,6 @@ import {
   inspect,
   makeArray,
   HAS_NATIVE_PROXY,
-  HAS_NATIVE_SYMBOL,
   isInternalSymbol,
 } from '@ember/-internals/utils';
 import { meta } from '@ember/-internals/meta';
@@ -1190,44 +1189,6 @@ if (DEBUG) {
 
     return injections;
   };
-}
-
-if (!HAS_NATIVE_SYMBOL) {
-  // Allows OWNER and INIT_FACTORY to be non-enumerable in IE11
-  let instanceOwner = new WeakMap();
-  let instanceFactory = new WeakMap();
-
-  Object.defineProperty(CoreObject.prototype, OWNER, {
-    get() {
-      return instanceOwner.get(this);
-    },
-
-    set(value) {
-      instanceOwner.set(this, value);
-    },
-  });
-
-  Object.defineProperty(CoreObject.prototype, INIT_FACTORY, {
-    get() {
-      return instanceFactory.get(this);
-    },
-
-    set(value) {
-      instanceFactory.set(this, value);
-    },
-  });
-
-  Object.defineProperty(CoreObject, INIT_FACTORY, {
-    get() {
-      return instanceFactory.get(this);
-    },
-
-    set(value) {
-      instanceFactory.set(this, value);
-    },
-
-    enumerable: false,
-  });
 }
 
 function implicitInjectionDeprecation(keyName, msg = null) {

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -9,7 +9,6 @@ import {
   lookupDescriptor,
   inspect,
   makeArray,
-  HAS_NATIVE_PROXY,
   isInternalSymbol,
 } from '@ember/-internals/utils';
 import { meta } from '@ember/-internals/meta';
@@ -317,7 +316,7 @@ class CoreObject {
 
     let self = this;
 
-    if (DEBUG && HAS_NATIVE_PROXY && typeof self.unknownProperty === 'function') {
+    if (DEBUG && typeof self.unknownProperty === 'function') {
       let messageFor = (obj, property) => {
         return (
           `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -1,6 +1,5 @@
 import { DEBUG } from '@glimmer/env';
 import { addObserver, observer, computed, get, set, removeObserver } from '@ember/-internals/metal';
-import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
 import ObjectProxy from '../../lib/system/object_proxy';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
 
@@ -101,7 +100,7 @@ moduleFor(
     }
 
     ['@test calling a function on the proxy avoids the assertion'](assert) {
-      if (DEBUG && HAS_NATIVE_PROXY) {
+      if (DEBUG) {
         let proxy = ObjectProxy.extend({
           init() {
             if (!this.foobar) {
@@ -153,7 +152,7 @@ moduleFor(
     }
 
     ['@test getting proxied properties with [] should be an error'](assert) {
-      if (DEBUG && HAS_NATIVE_PROXY) {
+      if (DEBUG) {
         let proxy = ObjectProxy.create({
           content: {
             foo: 'FOO',

--- a/packages/@ember/-internals/utils/index.ts
+++ b/packages/@ember/-internals/utils/index.ts
@@ -28,7 +28,6 @@ export { default as makeArray } from './lib/make-array';
 export { getName, setName } from './lib/name';
 export { default as toString } from './lib/to-string';
 export { isObject } from './lib/spec';
-export { HAS_NATIVE_PROXY } from './lib/proxy-utils';
 export { isProxy, setProxy } from './lib/is_proxy';
 export { default as Cache } from './lib/cache';
 export { EmberArray, setEmberArray, isEmberArray } from './lib/ember-array';

--- a/packages/@ember/-internals/utils/index.ts
+++ b/packages/@ember/-internals/utils/index.ts
@@ -28,7 +28,6 @@ export { default as makeArray } from './lib/make-array';
 export { getName, setName } from './lib/name';
 export { default as toString } from './lib/to-string';
 export { isObject } from './lib/spec';
-export { HAS_NATIVE_SYMBOL } from './lib/symbol-utils';
 export { HAS_NATIVE_PROXY } from './lib/proxy-utils';
 export { isProxy, setProxy } from './lib/is_proxy';
 export { default as Cache } from './lib/cache';

--- a/packages/@ember/-internals/utils/lib/proxy-utils.ts
+++ b/packages/@ember/-internals/utils/lib/proxy-utils.ts
@@ -1,1 +1,0 @@
-export const HAS_NATIVE_PROXY = typeof Proxy === 'function';

--- a/packages/@ember/-internals/utils/lib/symbol-utils.ts
+++ b/packages/@ember/-internals/utils/lib/symbol-utils.ts
@@ -1,7 +1,0 @@
-export const HAS_NATIVE_SYMBOL = (function () {
-  if (typeof Symbol !== 'function') {
-    return false;
-  }
-
-  return typeof Symbol() === 'symbol';
-})();

--- a/packages/@ember/-internals/utils/lib/symbol.ts
+++ b/packages/@ember/-internals/utils/lib/symbol.ts
@@ -1,7 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import { GUID_KEY } from './guid';
 import intern from './intern';
-import { HAS_NATIVE_SYMBOL } from './symbol-utils';
 
 const GENERATED_SYMBOLS: string[] = [];
 
@@ -26,4 +25,4 @@ export function enumerableSymbol(debugName: string): string {
   return symbol;
 }
 
-export const symbol = HAS_NATIVE_SYMBOL ? Symbol : enumerableSymbol;
+export const symbol = Symbol;

--- a/packages/@ember/-internals/utils/tests/guid_for_test.js
+++ b/packages/@ember/-internals/utils/tests/guid_for_test.js
@@ -1,5 +1,5 @@
-import { guidFor, HAS_NATIVE_SYMBOL } from '..';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import { guidFor } from '..';
+import { AbstractTestCase as TestCase, moduleFor } from 'internal-test-helpers';
 
 function sameGuid(assert, a, b, message) {
   assert.equal(guidFor(a), guidFor(b), message);
@@ -49,11 +49,6 @@ moduleFor(
     }
 
     ['@test symbols'](assert) {
-      if (HAS_NATIVE_SYMBOL) {
-        assert.ok(true, 'symbols are not supported on this browser');
-        return;
-      }
-
       let a = Symbol('a');
       let b = Symbol('b');
 

--- a/packages/@ember/-internals/utils/tests/inspect_test.js
+++ b/packages/@ember/-internals/utils/tests/inspect_test.js
@@ -1,5 +1,5 @@
-import { HAS_NATIVE_SYMBOL, inspect } from '..';
-import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
+import { inspect } from '..';
+import { AbstractTestCase as TestCase, moduleFor } from 'internal-test-helpers';
 
 moduleFor(
   'Ember.inspect',
@@ -130,12 +130,8 @@ How are you?`]: 1,
     }
 
     ['@test inspect outputs the toString() representation of Symbols'](assert) {
-      if (HAS_NATIVE_SYMBOL) {
-        let symbol = Symbol('test');
-        assert.equal(inspect(symbol), 'Symbol(test)');
-      } else {
-        assert.expect(0);
-      }
+      let symbol = Symbol('test');
+      assert.equal(inspect(symbol), 'Symbol(test)');
     }
   }
 );

--- a/packages/@ember/-internals/views/lib/system/jquery_event_deprecation.js
+++ b/packages/@ember/-internals/views/lib/system/jquery_event_deprecation.js
@@ -1,12 +1,11 @@
 /* global Proxy */
 import { deprecate } from '@ember/debug';
 import { global } from '@ember/-internals/environment';
-import { HAS_NATIVE_PROXY } from '@ember/-internals/utils';
 import { DEBUG } from '@glimmer/env';
 import { JQUERY_INTEGRATION } from '@ember/deprecated-features';
 
 export default function addJQueryEventDeprecation(jqEvent) {
-  if (DEBUG && JQUERY_INTEGRATION && HAS_NATIVE_PROXY) {
+  if (DEBUG && JQUERY_INTEGRATION) {
     let boundFunctions = new Map();
 
     // wrap the jQuery event in a Proxy to add the deprecation message for originalEvent, according to RFC#294

--- a/tests/index.html
+++ b/tests/index.html
@@ -67,13 +67,7 @@
           EmberENV.ENABLE_OPTIONAL_FEATURES = true;
         }
 
-        var isIE = Boolean(window.MSInputMethodContext) && Boolean(document.documentMode);
-
-        // ignore deprecations for IE11 specifically (due to browser support
-        // policy deprecation, which happens before we can `expectDeprecation`)
-        if (!isIE) {
-          EmberENV['RAISE_ON_DEPRECATION'] = true;
-        }
+        EmberENV['RAISE_ON_DEPRECATION'] = true;
 
         if (QUnit.urlParams.debugrendertree) {
           EmberENV['_DEBUG_RENDER_TREE'] = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,8 @@
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz#07640f28867ed16f9511c99c888291f560921cfa"
   integrity sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-for-of@^7.9.0":
   version "7.9.0"
@@ -5249,6 +5251,9 @@ find-babel-config@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
   integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-index@^1.1.0:
   version "1.1.0"
@@ -6607,11 +6612,6 @@ json-stringify-safe@~5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus= sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 json5@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Further cleanup after dropping IE11 support: (best reviewed commit after commit)
* Use WeakSet for lazy events
* Remove Object.entries/.values polyfills
* Remove HAS_NATIVE_SYMBOL and HAS_NATIVE_PROXY flags (as all supported browser support these)
