### PR TITLE
[BUGFIX lts] Ensure hash objects correctly entangle as dependencies

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -350,6 +350,30 @@ moduleFor(
       assert.equal(theLink.attr('href'), '/?foo=ASL');
     }
 
+    async ['@test supplied QP properties can be bound in legacy components'](assert) {
+      expectDeprecation(/Passing the `@tagName` argument to/);
+
+      this.addTemplate(
+        'index',
+        `
+          <LinkTo @tagName="a" id="the-link" @query={{hash foo=this.boundThing}}>
+            Index
+          </LinkTo>
+        `
+      );
+
+      await this.visit('/');
+
+      let indexController = this.getController('index');
+      let theLink = this.$('#the-link');
+
+      assert.equal(theLink.attr('href'), '/?foo=OMG');
+
+      runTask(() => indexController.set('boundThing', 'ASL'));
+
+      assert.equal(theLink.attr('href'), '/?foo=ASL');
+    }
+
     async ['@test supplied QP properties can be bound (booleans)'](assert) {
       this.addTemplate(
         'index',

--- a/packages/@ember/-internals/meta/index.ts
+++ b/packages/@ember/-internals/meta/index.ts
@@ -1,1 +1,1 @@
-export { counters, Meta, meta, MetaCounters, peekMeta, setMeta, UNDEFINED } from './lib/meta';
+export { counters, Meta, meta, MetaCounters, peekMeta, setMeta, Descriptor } from './lib/meta';

--- a/packages/@ember/-internals/metal/index.ts
+++ b/packages/@ember/-internals/metal/index.ts
@@ -14,6 +14,7 @@ export {
 export { arrayContentWillChange, arrayContentDidChange } from './lib/array_events';
 export { eachProxyArrayWillChange, eachProxyArrayDidChange } from './lib/each_proxy_events';
 export { addListener, hasListeners, on, removeListener, sendEvent } from './lib/events';
+export { HashCompatDescriptor } from './lib/hash-compat';
 
 export { default as isNone } from './lib/is_none';
 export { default as isEmpty } from './lib/is_empty';

--- a/packages/@ember/-internals/metal/lib/decorator.ts
+++ b/packages/@ember/-internals/metal/lib/decorator.ts
@@ -1,4 +1,4 @@
-import { Meta, meta as metaFor, peekMeta } from '@ember/-internals/meta';
+import { Descriptor, Meta, meta as metaFor, peekMeta } from '@ember/-internals/meta';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { _WeakSet as WeakSet } from '@glimmer/util';
@@ -48,7 +48,7 @@ export function nativeDescDecorator(propertyDesc: PropertyDescriptor) {
   @class Descriptor
   @private
 */
-export abstract class ComputedDescriptor {
+export abstract class ComputedDescriptor implements Descriptor {
   enumerable = true;
   configurable = true;
   _dependentKeys?: string[] = undefined;

--- a/packages/@ember/-internals/metal/lib/hash-compat.ts
+++ b/packages/@ember/-internals/metal/lib/hash-compat.ts
@@ -1,0 +1,25 @@
+import { Descriptor } from '@ember/-internals/meta';
+import { CHAIN_PASS_THROUGH } from './chain-tags';
+import { notifyPropertyChange } from './property_events';
+
+export class HashCompatDescriptor implements Descriptor {
+  constructor() {
+    CHAIN_PASS_THROUGH.add(this);
+  }
+
+  get(obj: object, key: string): unknown {
+    return obj[key];
+  }
+
+  set(obj: object, key: string, value: unknown): void {
+    let currentValue = obj[key];
+
+    obj[key] = value;
+
+    if (currentValue !== value) {
+      notifyPropertyChange(obj, key);
+    }
+  }
+
+  teardown(): void {}
+}

--- a/packages/@ember/-internals/metal/lib/properties.ts
+++ b/packages/@ember/-internals/metal/lib/properties.ts
@@ -68,7 +68,7 @@ export function defineProperty(
   let wasDescriptor = previousDesc !== undefined;
 
   if (wasDescriptor) {
-    previousDesc.teardown(obj, keyName, meta);
+    previousDesc!.teardown(obj, keyName, meta);
   }
 
   if (isClassicDecorator(desc)) {

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -1,3 +1,4 @@
+import { meta as metaFor } from '@ember/-internals/meta';
 import {
   HAS_NATIVE_PROXY,
   lookupDescriptor,
@@ -7,7 +8,9 @@ import {
 import { assert } from '@ember/debug';
 import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
+import { isHashProxy } from '@glimmer/runtime';
 import { COMPUTED_SETTERS } from './decorator';
+import { HashCompatDescriptor } from './hash-compat';
 import { isPath } from './path_cache';
 import { notifyPropertyChange } from './property_events';
 import { _getPath as getPath, getPossibleMandatoryProxyValue } from './property_get';
@@ -95,7 +98,11 @@ export function _setProp(obj: object, keyName: string, value: any) {
     /* unknown property */
     (obj as ExtendedObject).setUnknownProperty!(keyName, value);
   } else {
-    if (DEBUG) {
+    if (isHashProxy(value)) {
+      let meta = metaFor(obj);
+      meta.writeDescriptors(keyName, new HashCompatDescriptor());
+      obj[keyName] = value;
+    } else if (DEBUG) {
       setWithMandatorySetter!(obj, keyName, value);
     } else {
       obj[keyName] = value;

--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -1,4 +1,4 @@
-import { meta as metaFor } from '@ember/-internals/meta';
+import { Descriptor, Meta, meta as metaFor } from '@ember/-internals/meta';
 import { isEmberArray } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
@@ -191,7 +191,7 @@ function descriptorForField([target, key, desc]: [
   return newDesc;
 }
 
-export class TrackedDescriptor {
+export class TrackedDescriptor implements Descriptor {
   constructor(private _get: () => unknown, private _set: (value: unknown) => void) {
     CHAIN_PASS_THROUGH.add(this);
   }
@@ -203,4 +203,6 @@ export class TrackedDescriptor {
   set(obj: object, _key: string, value: unknown): void {
     this._set.call(obj, value);
   }
+
+  teardown(): void {}
 }


### PR DESCRIPTION
The previous bugfixes to `{{hash}}` caused a change to the semantics of
computed properties that depend on a hash. Specifically, because
`{{hash}}` objects are now proxies, they are _constant_, never updating
again after they are initially created. This is fine if you depend on
an individual key in a hash, but breaks if you depend directly on the
hash itself:

```js
computed('hash.foo', function() {}) // this works

computed('hash', function() {}) // this will no longer rerun
```

This is used occasionally when you wish to depend on the dynamic keys
of a dictionary, like so:

```js
computed('hash', function() {
  let values = [];

  for (let key in this.hash) {
    values.push(hash[key]);
  }

  return values;
})
```

Notably, this is not a problem with autotracking, because autotracking
will entangle the usage of these keys dynamically. So this is only a
problem with legacy systems such as `computed` and `observer` which
cannot dynamically add dependencies based on the function's runtime.

To fix this, we need to determine if a dependency is a hash when a
computed or an observer depends upon it, and then entangle all of its
keys if it is. Unfortunately, we cannot do this by just checking what
the value is, because we do not load the value of leaf dependencies
(the last segment of a dependency) as a perf optimization.

This tries to instead create a new type of "ComputedProperty" that gets
installed whenever a value is set to be a HashProxy. This gives us a
way to load the value of a property _only_ when it is a hash, or when it
was set to a hash at least once.