### PR TITLE
[DOC] Add missing `Helper` class methods

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -78,6 +78,7 @@ export interface SimpleHelper<T = unknown> {
   Additionally, class helpers can call `recompute` to force a new computation.
 
   @class Helper
+  @extends CoreObject
   @public
   @since 1.13.0
 */


### PR DESCRIPTION
This adds the public `CoreObject` methods to the API docs of the `Helper` class which looks like this:

![Screenshot from 2021-06-03 18-30-04](https://user-images.githubusercontent.com/3533236/120681810-0ef7df80-c49c-11eb-9c13-9d2b71c7898b.png)

I assumed these are public API since the other classes that extend `CoreObject` (or its derivatives) also have them listed. If this isn't the case I think that `willDestroy` should still be documented since that is used in at least 1 already merged RFC.

Closes #19585