### PR TITLE
Fix Changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,16 @@
 
 - [#19472](https://github.com/emberjs/ember.js/pull/19472) [BUGFIX] Prevent transformation of block params called `attrs`
 
-## v3.27.5 (June 10, 2021)
+### v3.27.5 (June 10, 2021)
 
 - [#19597](https://github.com/emberjs/ember.js/pull/19597) [BIGFIX] Fix `<LinkTo>` with nested children
 
-## v3.27.4 (June 9, 2021)
+### v3.27.4 (June 9, 2021)
 
 - [#19594](https://github.com/emberjs/ember.js/pull/19594) [BUGFIX] Revert lazy hash changes
 - [#19596](https://github.com/emberjs/ember.js/pull/19596) [DOC] Fix "Dormant" addon warning typo
 
-## v3.27.3 (June 3, 2021)
+### v3.27.3 (June 3, 2021)
 
 - [#19565](https://github.com/emberjs/ember.js/pull/19565) [BUGFIX] Ensures that `computed` can depend on dynamic `(hash` keys
 - [#19571](https://github.com/emberjs/ember.js/pull/19571) [BUGFIX] Extend `Route.prototype.transitionTo` deprecation until 5.0.0


### PR DESCRIPTION
The different heading levels are causing issues for services that are trying to read and filter the changelog

/cc @rwjblue 