### PR TITLE
Remove deprecated isVisible

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -2,7 +2,6 @@ import { Factory, getOwner, Owner, setOwner } from '@ember/-internals/owner';
 import { enumerableSymbol, guidFor, symbol } from '@ember/-internals/utils';
 import { addChildView, setElementView, setViewElement } from '@ember/-internals/views';
 import { assert, debugFreeze } from '@ember/debug';
-import { EMBER_COMPONENT_IS_VISIBLE } from '@ember/deprecated-features';
 import { _instrumentStart } from '@ember/instrumentation';
 import { DEBUG } from '@glimmer/env';
 import {
@@ -47,7 +46,6 @@ import {
   createClassNameBindingRef,
   createSimpleClassNameBindingRef,
   installAttributeBinding,
-  installIsVisibleBinding,
   parseAttributeBinding,
 } from '../utils/bindings';
 
@@ -102,14 +100,6 @@ function applyAttributeBindings(
   if (seen.indexOf('id') === -1) {
     let id = component.elementId ? component.elementId : guidFor(component);
     operations.setAttribute('id', createPrimitiveRef(id), false, null);
-  }
-
-  if (
-    EMBER_COMPONENT_IS_VISIBLE &&
-    installIsVisibleBinding !== undefined &&
-    seen.indexOf('style') === -1
-  ) {
-    installIsVisibleBinding(rootRef, operations);
   }
 }
 
@@ -390,9 +380,6 @@ export default class CurlyComponentManager
     } else {
       let id = component.elementId ? component.elementId : guidFor(component);
       operations.setAttribute('id', createPrimitiveRef(id), false, null);
-      if (EMBER_COMPONENT_IS_VISIBLE) {
-        installIsVisibleBinding!(rootRef, operations);
-      }
     }
 
     if (classRef) {

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1091,16 +1091,6 @@ const Component = CoreView.extend(
       @type String
       @public
     */
-
-    /**
-     If `false`, the view will appear hidden in DOM.
-
-     @property isVisible
-     @type Boolean
-     @default null
-     @deprecated Use `<div hidden={{this.isHidden}}>` or `{{#if this.showComponent}} <MyComponent /> {{/if}}`
-     @public
-     */
   }
 );
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -5,7 +5,6 @@ import {
   classes,
   equalTokens,
   equalsElement,
-  styles,
   runTask,
   runLoopSettled,
 } from 'internal-test-helpers';
@@ -18,7 +17,7 @@ import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
 import { jQueryDisabled } from '@ember/-internals/views';
 
 import { Component, compile, htmlSafe } from '../../utils/helpers';
-import { backtrackingMessageFor, debugStackMessageFor } from '../../utils/debug-stack';
+import { backtrackingMessageFor } from '../../utils/debug-stack';
 
 moduleFor(
   'Components test: curly components',
@@ -3148,149 +3147,6 @@ moduleFor(
       expectAssertion(() => {
         this.render('{{foo-bar}}');
       }, /You must call `super.init\(...arguments\);` or `this._super\(...arguments\)` when overriding `init` on a framework object. Please update .*/);
-    }
-
-    ['@test should toggle visibility with isVisible'](assert) {
-      let assertStyle = (expected) => {
-        let matcher = styles(expected);
-        let actual = this.firstChild.getAttribute('style');
-
-        assert.pushResult({
-          result: matcher.match(actual),
-          message: matcher.message(),
-          actual,
-          expected,
-        });
-      };
-
-      this.registerComponent('foo-bar', {
-        template: `<p>foo</p>`,
-      });
-
-      expectDeprecation(() => {
-        this.render(`{{foo-bar id="foo-bar" isVisible=this.visible}}`, {
-          visible: false,
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      assertStyle('display: none;');
-
-      this.assertStableRerender();
-
-      expectDeprecation(() => {
-        runTask(() => {
-          set(this.context, 'visible', true);
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      assertStyle('');
-
-      expectDeprecation(() => {
-        runTask(() => {
-          set(this.context, 'visible', false);
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      assertStyle('display: none;');
-    }
-
-    ['@test isVisible does not overwrite component style']() {
-      this.registerComponent('foo-bar', {
-        ComponentClass: Component.extend({
-          attributeBindings: ['style'],
-          style: htmlSafe('color: blue;'),
-        }),
-
-        template: `<p>foo</p>`,
-      });
-
-      expectDeprecation(() => {
-        this.render(`{{foo-bar id="foo-bar" isVisible=this.visible}}`, {
-          visible: false,
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'div',
-        attrs: { id: 'foo-bar', style: styles('color: blue; display: none;') },
-      });
-
-      this.assertStableRerender();
-
-      expectDeprecation(() => {
-        runTask(() => {
-          set(this.context, 'visible', true);
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'div',
-        attrs: { id: 'foo-bar', style: styles('color: blue;') },
-      });
-
-      expectDeprecation(() => {
-        runTask(() => {
-          set(this.context, 'visible', false);
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      this.assertComponentElement(this.firstChild, {
-        tagName: 'div',
-        attrs: { id: 'foo-bar', style: styles('color: blue; display: none;') },
-      });
-    }
-
-    ['@test adds isVisible binding when style binding is missing and other bindings exist'](
-      assert
-    ) {
-      let assertStyle = (expected) => {
-        let matcher = styles(expected);
-        let actual = this.firstChild.getAttribute('style');
-
-        assert.pushResult({
-          result: matcher.match(actual),
-          message: matcher.message(),
-          actual,
-          expected,
-        });
-      };
-
-      this.registerComponent('foo-bar', {
-        ComponentClass: Component.extend({
-          attributeBindings: ['foo'],
-          foo: 'bar',
-        }),
-        template: `<p>foo</p>`,
-      });
-
-      expectDeprecation(() => {
-        this.render(`{{foo-bar id="foo-bar" foo=this.foo isVisible=this.visible}}`, {
-          visible: false,
-          foo: 'baz',
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      assertStyle('display: none;');
-
-      this.assertStableRerender();
-
-      expectDeprecation(() => {
-        runTask(() => {
-          set(this.context, 'visible', true);
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      assertStyle('');
-
-      expectDeprecation(() => {
-        runTask(() => {
-          set(this.context, 'visible', false);
-          set(this.context, 'foo', 'woo');
-        });
-      }, debugStackMessageFor('The `isVisible` property on classic component classes is deprecated. Was accessed:', { renderTree: ['foo-bar'] }));
-
-      assertStyle('display: none;');
-      assert.equal(this.firstChild.getAttribute('foo'), 'woo');
     }
 
     ['@test it can use readDOMAttr to read input value']() {

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -13,6 +13,5 @@ export const ALIAS_METHOD = !!'3.9.0';
 export const APP_CTRL_ROUTER_PROPS = !!'3.10.0-beta.1';
 export const FUNCTION_PROTOTYPE_EXTENSIONS = !!'3.11.0-beta.1';
 export const MOUSE_ENTER_LEAVE_MOVE_EVENTS = !!'3.13.0-beta.1';
-export const EMBER_COMPONENT_IS_VISIBLE = !!'3.15.0-beta.1';
 export const PARTIALS = !!'3.15.0-beta.1';
 export const GLOBALS_RESOLVER = !!'3.16.0-beta.1';

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -332,7 +332,6 @@ module.exports = {
     'isPresent',
     'isRejected',
     'isSettled',
-    'isVisible',
     'join',
     'jQuery',
     'keyDown',


### PR DESCRIPTION
Part of #19617

[Deprecation guide](https://deprecations.emberjs.com/v3.x/#toc_ember-component-is-visible).

`TEST_SUITE=all yarn test` passes locally