### PR TITLE
Remove deprecated application controller router properties

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -388,7 +388,6 @@ export { DOMChanges, NodeDOMTreeConstruction, DOMTreeConstruction } from './lib/
 // TODO just test these through public API
 // a lot of these are testing how a problem was solved
 // rather than the problem was solved
-export { INVOKE } from './lib/helpers/action';
 export { default as OutletView } from './lib/views/outlet';
 export { OutletState } from './lib/utils/outlet';
 export {

--- a/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
@@ -16,7 +16,6 @@ import { setInternalModifierManager } from '@glimmer/manager';
 import { isInvokableRef, updateRef, valueForRef } from '@glimmer/reference';
 import { createUpdatableTag, UpdatableTag } from '@glimmer/validator';
 import { SimpleElement } from '@simple-dom/interface';
-import { INVOKE } from '../helpers/action';
 
 const MODIFIERS = ['alt', 'shift', 'meta', 'ctrl'];
 const POINTER_EVENT_TYPE_REGEX = /^click|mouse|touch/;
@@ -148,27 +147,6 @@ export class ActionState {
         target,
         name: null,
       };
-      if (typeof actionName[INVOKE] === 'function') {
-        deprecate(
-          `Usage of the private INVOKE API to make an object callable via action or fn is no longer supported. Please update to pass in a callback function instead. Received: ${String(
-            actionName
-          )}`,
-          false,
-          {
-            until: '3.25.0',
-            id: 'actions.custom-invoke-invokable',
-            for: 'ember-source',
-            since: {
-              enabled: '3.23.0-beta.1',
-            },
-          }
-        );
-
-        flaggedInstrument('interaction.ember-action', payload, () => {
-          actionName[INVOKE].apply(actionName, args);
-        });
-        return;
-      }
       if (isInvokableRef(actionName)) {
         flaggedInstrument('interaction.ember-action', payload, () => {
           updateRef(actionName, args[0]);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -8,7 +8,7 @@ import { _getCurrentRunLoop } from '@ember/runloop';
 import { set, computed } from '@ember/-internals/metal';
 import { EMBER_IMPROVED_INSTRUMENTATION } from '@ember/canary-features';
 
-import { Component, INVOKE } from '../../utils/helpers';
+import { Component } from '../../utils/helpers';
 
 if (EMBER_IMPROVED_INSTRUMENTATION) {
   moduleFor(
@@ -1041,56 +1041,6 @@ moduleFor(
       });
 
       this.assert.ok(capturedRunLoop, 'action is called within a run loop');
-    }
-
-    // TODO: This is for intimate APIs, specifically ember-concurrency
-    ['@test objects that define INVOKE can be casted to actions']() {
-      expectDeprecation(() => {
-        let innerComponent;
-        let actionArgs;
-        let invokableArgs;
-
-        let InnerComponent = Component.extend({
-          init() {
-            this._super(...arguments);
-            innerComponent = this;
-          },
-          fireAction() {
-            actionArgs = this.attrs.submit(4, 5, 6);
-          },
-        });
-
-        let OuterComponent = Component.extend({
-          foo: 123,
-          submitTask: computed(function () {
-            return {
-              [INVOKE]: (...args) => {
-                invokableArgs = args;
-                return this.foo;
-              },
-            };
-          }),
-        });
-
-        this.registerComponent('inner-component', {
-          ComponentClass: InnerComponent,
-          template: 'inner',
-        });
-
-        this.registerComponent('outer-component', {
-          ComponentClass: OuterComponent,
-          template: `{{inner-component submit=(action this.submitTask 1 2 3)}}`,
-        });
-
-        this.render('{{outer-component}}');
-
-        runTask(() => {
-          innerComponent.fireAction();
-        });
-
-        this.assert.equal(actionArgs, 123);
-        this.assert.deepEqual(invokableArgs, [1, 2, 3, 4, 5, 6]);
-      }, /Usage of the private INVOKE API to make an object callable/);
     }
 
     ['@test closure action with `(mut undefinedThing)` works properly [GH#13959]']() {

--- a/packages/@ember/-internals/glimmer/tests/utils/helpers.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/helpers.js
@@ -2,7 +2,6 @@ export { precompile } from 'ember-template-compiler';
 export { compile } from 'internal-test-helpers';
 
 export {
-  INVOKE,
   Helper,
   helper,
   Component,


### PR DESCRIPTION
Part of #19617

[Deprecation guide](https://deprecations.emberjs.com/v3.x#toc_application-controller-router-properties).

`TEST_SUITE=all yarn test` passes locally