### PR TITLE
Add deprecation warning to Ember.assign

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -9,7 +9,6 @@ import Controller from '@ember/controller';
 import { assert, deprecate, info } from '@ember/debug';
 import { APP_CTRL_ROUTER_PROPS, ROUTER_EVENTS } from '@ember/deprecated-features';
 import EmberError from '@ember/error';
-import { assign } from '@ember/polyfills';
 import { cancel, once, run, scheduleOnce } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import EmberLocation, { EmberLocation as IEmberLocation } from '../location/api';
@@ -1018,7 +1017,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
 
     this._processActiveTransitionQueryParams(targetRouteName, models, queryParams, _queryParams);
 
-    assign(queryParams, _queryParams);
+    Object.assign(queryParams, _queryParams);
     this._prepareQueryParams(
       targetRouteName,
       models,
@@ -1059,7 +1058,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     // from the active transition.
     this._fullyScopeQueryParams(targetRouteName, models, _queryParams);
     this._fullyScopeQueryParams(targetRouteName, models, unchangedQPs);
-    assign(queryParams, unchangedQPs);
+    Object.assign(queryParams, unchangedQPs);
   }
 
   /**
@@ -1156,7 +1155,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
         qps.push(qp);
       }
 
-      assign(map, qpMeta.map);
+      Object.assign(map, qpMeta.map);
     }
 
     let finalQPMeta = { qps, map };

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -16,3 +16,4 @@ export const MOUSE_ENTER_LEAVE_MOVE_EVENTS = !!'3.13.0-beta.1';
 export const EMBER_COMPONENT_IS_VISIBLE = !!'3.15.0-beta.1';
 export const PARTIALS = !!'3.15.0-beta.1';
 export const GLOBALS_RESOLVER = !!'3.16.0-beta.1';
+export const ASSIGN = !!'4.0.0';

--- a/packages/@ember/polyfills/index.ts
+++ b/packages/@ember/polyfills/index.ts
@@ -1,10 +1,12 @@
-import { MERGE } from '@ember/deprecated-features';
+import { MERGE, ASSIGN } from '@ember/deprecated-features';
 import { default as deprecatedMerge } from './lib/merge';
+import { default as deprecatedAssign, assign as assignPolyfill } from './lib/assign';
 
 let merge = MERGE ? deprecatedMerge : undefined;
+let assign = ASSIGN ? deprecatedAssign : undefined;
 
 // Export `assignPolyfill` for testing
-export { default as assign, assign as assignPolyfill } from './lib/assign';
+export { assign, assignPolyfill };
 export { merge };
 
 export const hasPropertyAccessors = true;

--- a/packages/@ember/polyfills/index.ts
+++ b/packages/@ember/polyfills/index.ts
@@ -1,6 +1,6 @@
-import { MERGE, ASSIGN } from '@ember/deprecated-features';
+import { ASSIGN, MERGE } from '@ember/deprecated-features';
+import { assign as assignPolyfill, default as deprecatedAssign } from './lib/assign';
 import { default as deprecatedMerge } from './lib/merge';
-import { default as deprecatedAssign, assign as assignPolyfill } from './lib/assign';
 
 let merge = MERGE ? deprecatedMerge : undefined;
 let assign = ASSIGN ? deprecatedAssign : undefined;

--- a/packages/@ember/polyfills/lib/assign.ts
+++ b/packages/@ember/polyfills/lib/assign.ts
@@ -1,3 +1,5 @@
+import { deprecate } from '@ember/debug';
+
 /**
  @module @ember/polyfills
 */
@@ -28,6 +30,20 @@ export function assign(target: object, ...sources: any[]): any;
   @static
 */
 export function assign(target: object) {
+  deprecate(
+    'Use of `assign` has been deprecated. Please use `Object.assign` or the spread operator instead.',
+    false,
+    {
+      id: 'ember-polyfills.deprecate-assign',
+      until: '5.0.0',
+      url: 'https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign',
+      for: 'ember-source',
+      since: {
+        enabled: '4.0.0',
+      },
+    }
+  );
+
   for (let i = 1; i < arguments.length; i++) {
     let arg = arguments[i];
     if (!arg) {

--- a/packages/@ember/polyfills/tests/assign_test.js
+++ b/packages/@ember/polyfills/tests/assign_test.js
@@ -49,7 +49,9 @@ moduleFor(
   'Ember.assign (polyfill)',
   class extends AssignTests {
     assign() {
-      return assignPolyfill(...arguments);
+      return expectDeprecation(() => {
+        assignPolyfill(...arguments);
+      }, 'Use of `assign` has been deprecated. Please use `Object.assign` or the spread operator instead.');
     }
   }
 );


### PR DESCRIPTION
[Ember RFC #750 ](https://github.com/emberjs/rfcs/pull/750)was approved; this implements it.

The `url` for the deprecation is optimistic (in that that page does not yet exist), let me know if I should handle that differently.