### PR TITLE
Remove LEGACY_OWNER

### DIFF
--- a/packages/@ember/-internals/container/tests/owner_test.js
+++ b/packages/@ember/-internals/container/tests/owner_test.js
@@ -14,26 +14,5 @@ moduleFor(
 
       assert.strictEqual(getOwner(obj), owner, 'owner has been set');
     }
-
-    ['@test getOwner deprecates using LEGACY_OWNER'](assert) {
-      let owner = {};
-      let obj = {};
-
-      setOwner(obj, owner);
-
-      let legacyOwner;
-
-      // This is not something we expect to happen a lot, but does exist currently
-      // in the wild: https://github.com/hjdivad/ember-m3/pull/822
-      for (let key in obj) {
-        legacyOwner = key;
-      }
-
-      let newObj = { [legacyOwner]: owner };
-
-      expectDeprecation(() => {
-        assert.strictEqual(getOwner(newObj), owner, 'owner has been set');
-      }, /You accessed the owner using `getOwner` on an object/);
-    }
   }
 );

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -38,11 +38,6 @@ export interface Owner {
   routable?: boolean;
 }
 
-import { enumerableSymbol } from '@ember/-internals/utils';
-import { deprecate } from '@ember/debug';
-
-export const LEGACY_OWNER: unique symbol = enumerableSymbol('LEGACY_OWNER') as any;
-
 /**
   Framework objects in an Ember application (components, services, routes, etc.)
   are created via a factory and dependency injection system. Each of these
@@ -88,26 +83,7 @@ export const LEGACY_OWNER: unique symbol = enumerableSymbol('LEGACY_OWNER') as a
   @public
 */
 export function getOwner(object: any): Owner {
-  let owner = glimmerGetOwner(object) as Owner;
-
-  if (owner === undefined) {
-    owner = object[LEGACY_OWNER];
-
-    deprecate(
-      `You accessed the owner using \`getOwner\` on an object, but it was not set on that object with \`setOwner\`. You must use \`setOwner\` to set the owner on all objects. You cannot use Object.assign().`,
-      owner === undefined,
-      {
-        id: 'owner.legacy-owner-injection',
-        until: '3.25.0',
-        for: 'ember-source',
-        since: {
-          enabled: '3.22.0',
-        },
-      }
-    );
-  }
-
-  return owner;
+  return glimmerGetOwner(object) as Owner;
 }
 
 /**
@@ -124,5 +100,4 @@ export function getOwner(object: any): Owner {
 */
 export function setOwner(object: any, owner: Owner): void {
   glimmerSetOwner(object, owner);
-  object[LEGACY_OWNER] = owner;
 }

--- a/packages/@ember/-internals/runtime/lib/system/core_object.js
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.js
@@ -3,7 +3,7 @@
 */
 
 import { getFactoryFor, setFactoryFor } from '@ember/-internals/container';
-import { getOwner, LEGACY_OWNER } from '@ember/-internals/owner';
+import { getOwner } from '@ember/-internals/owner';
 import {
   guidFor,
   lookupDescriptor,
@@ -306,9 +306,6 @@ function defineSelfDestructingImplicitInjectionGetter(obj, keyName, value, messa
 */
 class CoreObject {
   constructor(owner) {
-    // setOwner has to set both OWNER and LEGACY_OWNER for backwards compatibility, and
-    // LEGACY_OWNER is enumerable, so setting it would add an enumerable property to the object,
-    // so we just set `OWNER` directly here.
     this[OWNER] = owner;
 
     // prepare prototype...
@@ -378,10 +375,6 @@ class CoreObject {
       return self;
     }
   }
-
-  // Empty setter for absorbing setting the LEGACY_OWNER, which should _not_
-  // become an enumerable property, and should not be used in general.
-  set [LEGACY_OWNER](value) {}
 
   reopen(...args) {
     applyMixin(this, args);


### PR DESCRIPTION
Per https://github.com/emberjs/ember.js/issues/19617 remove `LEGACY_OWNER` usage for setting an owner without `setOwner`.