### PR TITLE
Remove @ember/string methods from native prototype

### DIFF
--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -16,7 +16,7 @@ export const ENV = {
   ENABLE_OPTIONAL_FEATURES: false,
 
   /**
-    Determines whether Ember should add to `Array` and `String`
+    Determines whether Ember should add to `Array`
     native object prototypes, a few extra methods in order to provide a more
     friendly API.
 
@@ -36,7 +36,6 @@ export const ENV = {
   */
   EXTEND_PROTOTYPES: {
     Array: true,
-    String: true,
   },
 
   /**
@@ -217,12 +216,9 @@ export const ENV = {
   let { EXTEND_PROTOTYPES } = EmberENV;
   if (EXTEND_PROTOTYPES !== undefined) {
     if (typeof EXTEND_PROTOTYPES === 'object' && EXTEND_PROTOTYPES !== null) {
-      ENV.EXTEND_PROTOTYPES.String = EXTEND_PROTOTYPES.String !== false;
       ENV.EXTEND_PROTOTYPES.Array = EXTEND_PROTOTYPES.Array !== false;
     } else {
-      let isEnabled = EXTEND_PROTOTYPES !== false;
-      ENV.EXTEND_PROTOTYPES.String = isEnabled;
-      ENV.EXTEND_PROTOTYPES.Array = isEnabled;
+      ENV.EXTEND_PROTOTYPES.Array = EXTEND_PROTOTYPES !== false;
     }
   }
 

--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -16,7 +16,7 @@ export const ENV = {
   ENABLE_OPTIONAL_FEATURES: false,
 
   /**
-    Determines whether Ember should add to `Array`, `Function`, and `String`
+    Determines whether Ember should add to `Array` and `String`
     native object prototypes, a few extra methods in order to provide a more
     friendly API.
 
@@ -36,7 +36,6 @@ export const ENV = {
   */
   EXTEND_PROTOTYPES: {
     Array: true,
-    Function: true,
     String: true,
   },
 

--- a/packages/@ember/-internals/glimmer/tests/utils/string-test.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/string-test.js
@@ -1,5 +1,4 @@
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
-import { ENV } from '@ember/-internals/environment';
 
 import { SafeString, htmlSafe, isHTMLSafe } from './helpers';
 
@@ -10,19 +9,6 @@ moduleFor(
       let safeString = htmlSafe('you need to be more <b>bold</b>');
 
       this.assert.ok(safeString instanceof SafeString, 'should be a SafeString');
-    }
-
-    ['@test [deprecated] htmlSafe via string prototype should return an instance of SafeString']() {
-      if (ENV.EXTEND_PROTOTYPES.String) {
-        let safeString;
-        expectDeprecation(() => {
-          safeString = 'you need to be more <b>bold</b>'.htmlSafe();
-        }, /String prototype extensions are deprecated/);
-
-        this.assert.ok(safeString instanceof SafeString, 'should be a SafeString');
-      } else {
-        this.assert.expect(0);
-      }
     }
 
     ['@test htmlSafe should return an empty string for null']() {
@@ -37,32 +23,6 @@ moduleFor(
 
       this.assert.equal(safeString instanceof SafeString, true, 'should be a SafeString');
       this.assert.equal(safeString.toString(), '', 'should return an empty string');
-    }
-
-    ['@test [deprecated] htmlSafe via string prototype should return an instance of SafeString for an empty string']() {
-      if (ENV.EXTEND_PROTOTYPES.String) {
-        let safeString;
-        expectDeprecation(() => {
-          safeString = ''.htmlSafe();
-        }, /String prototype extensions are deprecated/);
-
-        this.assert.ok(safeString instanceof SafeString, 'should be a SafeString');
-      } else {
-        this.assert.expect(0);
-      }
-    }
-
-    ['@test [deprecated] String.prototype.htmlSafe is not modified without EXTEND_PROTOTYPES'](
-      assert
-    ) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.htmlSafe,
-          'String.prototype helper disabled'
-        );
-      } else {
-        this.assert.expect(0);
-      }
     }
   }
 );

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -4,7 +4,6 @@
 
 export { getStrings as _getStrings, setStrings as _setStrings } from './lib/string_registry';
 
-import { ENV } from '@ember/-internals/environment';
 import { Cache } from '@ember/-internals/utils';
 import { deprecate } from '@ember/debug';
 
@@ -73,8 +72,6 @@ const DECAMELIZE_CACHE = new Cache<string, string>(1000, (str) =>
 
 /**
   Defines string helper methods including string formatting and localization.
-  Unless `EmberENV.EXTEND_PROTOTYPES.String` is `false` these methods will also be
-  added to the `String.prototype` as well.
 
   @class String
   @public
@@ -82,8 +79,7 @@ const DECAMELIZE_CACHE = new Cache<string, string>(1000, (str) =>
 
 /**
   Splits a string into separate units separated by spaces, eliminating any
-  empty strings in the process. This is a convenience method for split that
-  is mostly useful when applied to the `String.prototype`.
+  empty strings in the process.
 
   ```javascript
   import { w } from '@ember/string';
@@ -266,140 +262,4 @@ export function isHTMLSafe(str: any | null | undefined): str is SafeString {
   deprecateImportFromString('isHTMLSafe');
 
   return internalIsHtmlSafe(str);
-}
-
-if (ENV.EXTEND_PROTOTYPES.String) {
-  let deprecateEmberStringPrototypeExtension = function (
-    name: string,
-    fn: (utility: string, ...options: any) => string | string[],
-    message = `String prototype extensions are deprecated. Please import ${name} from '@ember/string' instead.`
-  ) {
-    return function (this: string) {
-      deprecate(message, false, {
-        id: 'ember-string.prototype-extensions',
-        for: 'ember-source',
-        since: {
-          enabled: '3.24',
-        },
-        until: '4.0.0',
-        url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions',
-      });
-
-      return fn(this, ...arguments);
-    };
-  };
-
-  Object.defineProperties(String.prototype, {
-    /**
-      See [String.w](/ember/release/classes/String/methods/w?anchor=w).
-
-      @method w
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    w: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('w', w),
-    },
-
-    /**
-      See [String.camelize](/ember/release/classes/String/methods/camelize?anchor=camelize).
-
-      @method camelize
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    camelize: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('camelize', camelize),
-    },
-
-    /**
-      See [String.decamelize](/ember/release/classes/String/methods/decamelize?anchor=decamelize).
-
-      @method decamelize
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    decamelize: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('decamelize', decamelize),
-    },
-
-    /**
-      See [String.dasherize](/ember/release/classes/String/methods/dasherize?anchor=dasherize).
-
-      @method dasherize
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    dasherize: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('dasherize', dasherize),
-    },
-
-    /**
-      See [String.underscore](/ember/release/classes/String/methods/underscore?anchor=underscore).
-
-      @method underscore
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    underscore: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('underscore', underscore),
-    },
-
-    /**
-      See [String.classify](/ember/release/classes/String/methods/classify?anchor=classify).
-
-      @method classify
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    classify: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('classify', classify),
-    },
-
-    /**
-      See [String.capitalize](/ember/release/classes/String/methods/capitalize?anchor=capitalize).
-
-      @method capitalize
-      @for @ember/string
-      @static
-      @private
-      @deprecated
-    */
-    capitalize: {
-      configurable: true,
-      enumerable: false,
-      writeable: true,
-      value: deprecateEmberStringPrototypeExtension('capitalize', capitalize),
-    },
-  });
 }

--- a/packages/@ember/string/tests/camelize_test.js
+++ b/packages/@ember/string/tests/camelize_test.js
@@ -1,30 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { camelize } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(camelize(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.camelize(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.camelize',
   class extends AbstractTestCase {
-    ['@test String.prototype.camelize is not modified without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.camelize,
-          'String.prototype helper disabled'
-        );
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String camelize tests'](assert) {
       test(assert, 'my favorite items', 'myFavoriteItems', 'camelize normal string');
       test(assert, 'I Love Ramen', 'iLoveRamen', 'camelize capitalized string');

--- a/packages/@ember/string/tests/capitalize_test.js
+++ b/packages/@ember/string/tests/capitalize_test.js
@@ -1,30 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { capitalize } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(capitalize(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.capitalize(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.capitalize',
   class extends AbstractTestCase {
-    ['@test String.prototype.capitalize is not modified without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.capitalize,
-          'String.prototype helper disabled'
-        );
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String capitalize tests'](assert) {
       test(assert, 'my favorite items', 'My favorite items', 'capitalize normal string');
       test(assert, 'css-class-name', 'Css-class-name', 'capitalize dasherized string');

--- a/packages/@ember/string/tests/classify_test.js
+++ b/packages/@ember/string/tests/classify_test.js
@@ -1,30 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { classify } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(classify(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.classify(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.classify',
   class extends AbstractTestCase {
-    ['@test String.prototype.classify is not modified without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.classify,
-          'String.prototype helper disabled'
-        );
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String classify tests'](assert) {
       test(assert, 'my favorite items', 'MyFavoriteItems', 'classify normal string');
       test(assert, 'css-class-name', 'CssClassName', 'classify dasherized string');

--- a/packages/@ember/string/tests/dasherize_test.js
+++ b/packages/@ember/string/tests/dasherize_test.js
@@ -1,30 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { dasherize } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(dasherize(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.dasherize(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.dasherize',
   class extends AbstractTestCase {
-    ['@test String.prototype.dasherize is not modified without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.dasherize,
-          'String.prototype helper disabled'
-        );
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String dasherize tests'](assert) {
       test(assert, 'my favorite items', 'my-favorite-items', 'dasherize normal string');
       test(assert, 'css-class-name', 'css-class-name', 'does nothing with dasherized string');

--- a/packages/@ember/string/tests/decamelize_test.js
+++ b/packages/@ember/string/tests/decamelize_test.js
@@ -1,30 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { decamelize } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(decamelize(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.decamelize(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.decamelize',
   class extends AbstractTestCase {
-    ['@test String.prototype.decamelize is not modified without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.decamelize,
-          'String.prototype helper disabled'
-        );
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String decamelize tests'](assert) {
       test(assert, 'my favorite items', 'my favorite items', 'does nothing with normal string');
       test(assert, 'css-class-name', 'css-class-name', 'does nothing with dasherized string');

--- a/packages/@ember/string/tests/underscore_test.js
+++ b/packages/@ember/string/tests/underscore_test.js
@@ -1,30 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { underscore } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(underscore(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.underscore(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.underscore',
   class extends AbstractTestCase {
-    ['@test String.prototype.underscore is not available without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok(
-          'undefined' === typeof String.prototype.underscore,
-          'String.prototype helper disabled'
-        );
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String underscore tests'](assert) {
       test(assert, 'my favorite items', 'my_favorite_items', 'with normal string');
       test(assert, 'css-class-name', 'css_class_name', 'with dasherized string');

--- a/packages/@ember/string/tests/w_test.js
+++ b/packages/@ember/string/tests/w_test.js
@@ -1,27 +1,13 @@
-import { ENV } from '@ember/-internals/environment';
 import { w } from '@ember/string';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 function test(assert, given, expected, description) {
   assert.deepEqual(w(given), expected, description);
-  if (ENV.EXTEND_PROTOTYPES.String) {
-    expectDeprecation(() => {
-      assert.deepEqual(given.w(), expected, description);
-    }, /String prototype extensions are deprecated/);
-  }
 }
 
 moduleFor(
   'EmberStringUtils.w',
   class extends AbstractTestCase {
-    ['@test String.prototype.w is not available without EXTEND_PROTOTYPES'](assert) {
-      if (!ENV.EXTEND_PROTOTYPES.String) {
-        assert.ok('undefined' === typeof String.prototype.w, 'String.prototype helper disabled');
-      } else {
-        assert.expect(0);
-      }
-    }
-
     ['@test String w tests'](assert) {
       test(
         assert,

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -1,6 +1,6 @@
 import require, { has } from 'require';
 
-import { getENV, getLookup, setLookup, ENV } from '@ember/-internals/environment';
+import { getENV, getLookup, setLookup } from '@ember/-internals/environment';
 import * as utils from '@ember/-internals/utils';
 import { Registry, Container } from '@ember/-internals/container';
 import * as instrumentation from '@ember/instrumentation';
@@ -491,24 +491,6 @@ if (EMBER_GLIMMER_INVOKE_HELPER) {
 }
 Ember._captureRenderTree = captureRenderTree;
 
-if (ENV.EXTEND_PROTOTYPES.String) {
-  String.prototype.htmlSafe = function () {
-    deprecate(
-      `String prototype extensions are deprecated. Please import htmlSafe from '@ember/template' instead.`,
-      false,
-      {
-        id: 'ember-string.prototype-extensions',
-        for: 'ember-source',
-        since: {
-          enabled: '3.27.6',
-        },
-        until: '4.0.0',
-        url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
-      }
-    );
-    return htmlSafe(this);
-  };
-}
 const deprecateImportFromString = function (
   name,
   message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`


### PR DESCRIPTION
Deprecated API removal per https://github.com/emberjs/ember.js/issues/19617

~This patch does *not* removed the setting of `String.prototype.htmlSafe`, as installed at https://github.com/emberjs/ember.js/blob/a884ee5db7a69899f2689e2da2324bb85114c805/packages/ember/index.js#L548-L552. I don't believe that was ever deprecated. Maybe we just missed it?~

~As such, this also does not completely remove `ENV.EXTEND_PROTOTYPES.String`~

_edit: The above caveat was discussed and you can read the comments here for the details._