### PR TITLE
Remove LinkTo's tagName

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -201,27 +201,6 @@ import layout from '../templates/-link-to';
   When transitioning into the linked route, the `model` hook will
   be triggered with parameters including this passed identifier.
 
-  ### Supplying a `tagName`
-
-  By default `<LinkTo>` renders an `<a>` element. This can be overridden for a single use of
-  `<LinkTo>` by supplying a `tagName` argument:
-
-  ```handlebars
-  <LinkTo @route='photoGallery' @tagName='li'>
-    Great Hamster Photos
-  </LinkTo>
-  ```
-
-  This produces:
-
-  ```html
-  <li>
-    Great Hamster Photos
-  </li>
-  ```
-
-  In general, this is not recommended.
-
   ### Supplying query parameters
 
   If you need to add optional key-value pairs that appear to the right of the ? in a URL,
@@ -791,9 +770,6 @@ const LinkComponent = EmberComponent.extend({
     Sets the element's `href` attribute to the url for
     the `LinkComponent`'s targeted route.
 
-    If the `LinkComponent`'s `tagName` is changed to a value other
-    than `a`, this property will be ignored.
-
     @property href
     @private
   */
@@ -802,14 +778,9 @@ const LinkComponent = EmberComponent.extend({
     '_route',
     '_models',
     '_query',
-    'tagName',
     'loading',
     'loadingHref',
     function computeLinkToComponentHref(this: any) {
-      if (this.tagName !== 'a') {
-        return;
-      }
-
       if (this.loading) {
         return this.loadingHref;
       }
@@ -869,7 +840,6 @@ const LinkComponent = EmberComponent.extend({
 
   /**
     The default href value to use while a link-to is loading.
-    Only applies when tagName is 'a'
 
     @property loadingHref
     @type String

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -418,40 +418,6 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
     });
   }
 
-  // @tagName
-  {
-    let superOnUnsupportedArgument = prototype['onUnsupportedArgument'];
-
-    Object.defineProperty(prototype, 'onUnsupportedArgument', {
-      configurable: true,
-      enumerable: false,
-      value: function onUnsupportedArgument(this: LinkTo, name: string): void {
-        if (name === 'tagName') {
-          let tagName = this.named('tagName');
-
-          deprecate(
-            `Passing the \`@tagName\` argument to <LinkTo> is deprecated. Using a <${tagName}> ` +
-              'element for navigation is not recommended as it creates issues with assistive ' +
-              'technologies. Remove this argument to use the default <a> element. In the rare ' +
-              'cases that calls for using a different element, refactor to use the router ' +
-              'service inside a custom event handler instead.',
-            false,
-            {
-              id: 'ember.link-to.tag-name',
-              for: 'ember-source',
-              since: {},
-              until: '4.0.0',
-            }
-          );
-
-          this.modernized = false;
-        } else {
-          superOnUnsupportedArgument.call(this, name);
-        }
-      },
-    });
-  }
-
   // @bubbles & @preventDefault
   {
     let superIsSupportedArgument = prototype['isSupportedArgument'];

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -80,6 +80,11 @@ class LinkTo extends InternalComponent implements DeprecatingInternalComponent {
       !('model' in this.args.named && 'models' in this.args.named)
     );
 
+    assert(
+      'Passing the `@tagName` argument to <LinkTo> is not supported.',
+      !('tagName' in this.args.named)
+    );
+
     super.validateArguments();
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -351,12 +351,10 @@ moduleFor(
     }
 
     async ['@test supplied QP properties can be bound in legacy components'](assert) {
-      expectDeprecation(/Passing the `@tagName` argument to/);
-
       this.addTemplate(
         'index',
         `
-          <LinkTo @tagName="a" id="the-link" @query={{hash foo=this.boundThing}}>
+          <LinkTo id="the-link" @query={{hash foo=this.boundThing}}>
             Index
           </LinkTo>
         `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -171,6 +171,12 @@ moduleFor(
         content: 'Go to Index',
       });
     }
+
+    ['@test it should throw an error if `tagName` is passed in']() {
+      expectAssertion(() => {
+        this.render(`<LinkTo @route='index' @tagName='button'>Go to Index</LinkTo>`);
+      }, /Passing the `@tagName` argument to <LinkTo> is not supported./);
+    }
   }
 );
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
@@ -192,5 +192,11 @@ moduleFor(
 
       this.assertText('Go to Index');
     }
+
+    ['@test it should throw an error if `tagName` is passed in']() {
+      expectAssertion(() => {
+        this.render(`{{#link-to route='index' tagName='button'}}Go to Index{{/link-to}}`);
+      }, /Passing the `@tagName` argument to <LinkTo> is not supported./);
+    }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -133,20 +133,6 @@ moduleFor(
       );
     }
 
-    async [`@test [DEPRECATED] it doesn't add an href when the tagName isn't 'a'`](assert) {
-      this.addTemplate(
-        'index',
-        `<LinkTo @route='about' id='about-link' @tagName='div'>About</LinkTo>`
-      );
-
-      await expectDeprecationAsync(
-        () => this.visit('/'),
-        /Passing the `@tagName` argument to <LinkTo> is deprecated\./,
-        EMBER_MODERNIZED_BUILT_IN_COMPONENTS
-      );
-      assert.strictEqual(this.$('#about-link').attr('href'), null, 'there is no href attribute');
-    }
-
     async [`@test it applies a 'disabled' class when disabled`](assert) {
       this.addTemplate(
         'index',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -133,25 +133,6 @@ moduleFor(
       );
     }
 
-    async [`@test [DEPRECATED] it doesn't add an href when the tagName isn't 'a'`](assert) {
-      this.addTemplate(
-        'index',
-        `<div id='about-link'>{{#link-to route='about' tagName='div'}}About{{/link-to}}</div>`
-      );
-
-      await expectDeprecationAsync(
-        () => this.visit('/'),
-        /Passing the `@tagName` argument to <LinkTo> is deprecated\./,
-        EMBER_MODERNIZED_BUILT_IN_COMPONENTS
-      );
-
-      assert.strictEqual(
-        this.$('#about-link > div').attr('href'),
-        null,
-        'there is no href attribute'
-      );
-    }
-
     async [`@test it applies a 'disabled' class when disabled`](assert) {
       this.addTemplate(
         'index',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-angle-test.js
@@ -1,6 +1,5 @@
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 
 function assertHasClass(assert, selector, label) {
@@ -190,13 +189,13 @@ moduleFor(
         'application',
         `
         {{outlet}}
-        <LinkTo @tagName='li' @route='index'>
+        <LinkTo @route='index'>
           <LinkTo id='index-link' @route='index'>Index</LinkTo>
         </LinkTo>
-        <LinkTo @tagName='li' @route='parent-route.about'>
+        <LinkTo @route='parent-route.about'>
           <LinkTo id='about-link' @route='parent-route.about'>About</LinkTo>
         </LinkTo>
-        <LinkTo @tagName='li' @route='parent-route.other'>
+        <LinkTo @route='parent-route.other'>
           <LinkTo id='other-link' @route='parent-route.other'>Other</LinkTo>
         </LinkTo>
         `
@@ -204,11 +203,7 @@ moduleFor(
     }
 
     async beforeEach() {
-      return expectDeprecationAsync(
-        () => this.visit('/'),
-        /Passing the `@tagName` argument to <LinkTo> is deprecated\./,
-        EMBER_MODERNIZED_BUILT_IN_COMPONENTS
-      );
+      return this.visit('/');
     }
 
     resolveAbout() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-curly-test.js
@@ -1,6 +1,5 @@
 import { RSVP } from '@ember/-internals/runtime';
 import { Route } from '@ember/-internals/routing';
-import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 
 function assertHasClass(assert, selector, label) {
@@ -190,13 +189,13 @@ moduleFor(
         'application',
         `
         {{outlet}}
-        {{#link-to route='index' tagName='li'}}
+        {{#link-to route='index'}}
           <div id='index-link'>{{#link-to route='index'}}Index{{/link-to}}</div>
         {{/link-to}}
-        {{#link-to route='parent-route.about' tagName='li'}}
+        {{#link-to route='parent-route.about'}}
           <div id='about-link'>{{#link-to route='parent-route.about'}}About{{/link-to}}</div>
         {{/link-to}}
-        {{#link-to route='parent-route.other' tagName='li'}}
+        {{#link-to route='parent-route.other'}}
           <div id='other-link'>{{#link-to route='parent-route.other'}}Other{{/link-to}}</div>
         {{/link-to}}
         `
@@ -204,11 +203,7 @@ moduleFor(
     }
 
     async beforeEach() {
-      return expectDeprecationAsync(
-        () => this.visit('/'),
-        /Passing the `@tagName` argument to <LinkTo> is deprecated\./,
-        EMBER_MODERNIZED_BUILT_IN_COMPONENTS
-      );
+      return this.visit('/');
     }
 
     resolveAbout() {


### PR DESCRIPTION
Part of #19617

[Deprecation Guide](https://github.com/emberjs/ember.js/issues/19617)

Tests pass locally