### PR TITLE
Remove .volatile()

### DIFF
--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -135,7 +135,6 @@ function giveDecoratorSuper(
     ]);
 
     newProperty._readOnly = property._readOnly;
-    newProperty._volatile = property._volatile;
     newProperty._meta = property._meta;
     newProperty.enumerable = property.enumerable;
 

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -586,7 +586,6 @@ module.exports = {
     'validationCache',
     'value',
     'visit',
-    'volatile',
     'w',
     'wait',
     'waitForDOMReady',


### PR DESCRIPTION
Part of #19617

[Deprecation guide](https://deprecations.emberjs.com/v3.x#toc_computed-property-volatile)

Tests pass locally