### PR TITLE
Remove computed deep each

### DIFF
--- a/packages/@ember/-internals/metal/lib/chain-tags.ts
+++ b/packages/@ember/-internals/metal/lib/chain-tags.ts
@@ -1,6 +1,6 @@
 import { Meta, meta as metaFor, peekMeta } from '@ember/-internals/meta';
 import { isObject } from '@ember/-internals/utils';
-import { assert, deprecate } from '@ember/debug';
+import { assert } from '@ember/debug';
 import { _WeakSet } from '@glimmer/util';
 import {
   combine,
@@ -88,33 +88,6 @@ function getChainTags(
     if (segment === '@each' && segmentEnd !== pathLength) {
       lastSegmentEnd = segmentEnd + 1;
       segmentEnd = path.indexOf('.', lastSegmentEnd);
-
-      // There should be exactly one segment after an `@each` (i.e. `@each.foo`, not `@each.foo.bar`)
-      deprecate(
-        `When using @each in a dependent-key or an observer, ` +
-          `you can only chain one property level deep after ` +
-          `the @each. That is, \`${path.slice(0, segmentEnd)}\` ` +
-          `is allowed but \`${path}\` (which is what you passed) ` +
-          `is not.\n\n` +
-          `This was never supported. Currently, the extra segments ` +
-          `are silently ignored, i.e. \`${path}\` behaves exactly ` +
-          `the same as \`${path.slice(0, segmentEnd)}\`. ` +
-          `In the future, this will throw an error.\n\n` +
-          `If the current behavior is acceptable for your use case, ` +
-          `please remove the extraneous segments by changing your ` +
-          `key to \`${path.slice(0, segmentEnd)}\`. ` +
-          `Otherwise, please create an intermediary computed property ` +
-          `or switch to using tracked properties.`,
-        segmentEnd === -1,
-        {
-          until: '3.17.0',
-          id: 'ember-metal.computed-deep-each',
-          for: 'ember-source',
-          since: {
-            enabled: '3.13.0-beta.3',
-          },
-        }
-      );
 
       let arrLength = current.length;
 

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -1,6 +1,6 @@
 import { Meta, meta as metaFor } from '@ember/-internals/meta';
 import { inspect, toString } from '@ember/-internals/utils';
-import { assert, warn } from '@ember/debug';
+import { assert } from '@ember/debug';
 import EmberError from '@ember/error';
 import { isDestroyed } from '@glimmer/destroyable';
 import { DEBUG } from '@glimmer/env';
@@ -351,13 +351,14 @@ export class ComputedProperty extends ComputedDescriptor {
     let args: string[] = [];
 
     function addArg(property: string): void {
-      warn(
+      assert(
         `Dependent keys containing @each only work one level deep. ` +
           `You used the key "${property}" which is invalid. ` +
-          `Please create an intermediary computed property.`,
-        DEEP_EACH_REGEX.test(property) === false,
-        { id: 'ember-metal.computed-deep-each' }
+          `Please create an intermediary computed property or ` +
+          `switch to using tracked properties.`,
+        DEEP_EACH_REGEX.test(property) === false
       );
+
       args.push(property);
     }
 

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -166,7 +166,7 @@ moduleFor(
     //   assert.deepEqual(cp._dependentKeys, ['qux', 'zoopa.[]']);
     // }
 
-    ['@test defining a computed property with a dependent key more than one level deep beyond @each is not supported']() {
+    ['@test defining a computed property with a dependent key more than one level deep beyond @each throws an assertion']() {
       expectNoWarning(() => {
         obj = {};
         defineProperty(
@@ -185,50 +185,24 @@ moduleFor(
         );
       });
 
-      expectWarning(() => {
+      let expected = /Dependent keys containing @each only work one level deep./;
+
+      expectAssertion(() => {
         obj = {};
         defineProperty(
           obj,
           'someProp',
           computed('todos.@each.owner.name', () => {})
         );
-      }, /You used the key "todos\.@each\.owner\.name" which is invalid\. /);
+      }, expected);
 
-      expectWarning(() => {
+      expectAssertion(() => {
         obj = {};
         defineProperty(
           obj,
           'someProp',
           computed('todos.@each.owner.@each.name', () => {})
         );
-      }, /You used the key "todos\.@each\.owner\.@each\.name" which is invalid\. /);
-
-      let expected = new RegExp(
-        'When using @each in a dependent-key or an observer, ' +
-          'you can only chain one property level deep after the @each\\. ' +
-          'That is, `todos\\.@each\\.owner` is allowed but ' +
-          '`todos\\.@each\\.owner\\.name` \\(which is what you passed\\) is not\\.\n\n' +
-          'This was never supported\\. Currently, the extra segments ' +
-          'are silently ignored, i\\.e\\. `todos\\.@each\\.owner\\.name` ' +
-          'behaves exactly the same as `todos\\.@each\\.owner`\\. ' +
-          'In the future, this will throw an error\\.\n\n' +
-          'If the current behavior is acceptable for your use case, ' +
-          'please remove the extraneous segments by changing your key to ' +
-          '`todos\\.@each\\.owner`\\. Otherwise, please create an ' +
-          'intermediary computed property or switch to using tracked properties\\.'
-      );
-
-      expectDeprecation(() => {
-        obj = {
-          todos: [],
-        };
-        defineProperty(
-          obj,
-          'someProp',
-          computed('todos.@each.owner.name', () => {})
-        );
-
-        get(obj, 'someProp');
       }, expected);
     }
   }


### PR DESCRIPTION
Part of #19662
`ember-metal.computed-deep-each`
Tests pass locally

The code in `getChainTags` was deleted because it seems that that condition won't be reached since setting a deep dependent key will throw an error before it can be `get`ed.