### PR TITLE
[CLEANUP beta] Remove jQuery from build

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -61,12 +61,6 @@ function generateTestsFor(packageName) {
   testFunctions.push(() => run('package=' + packageName + '&edition=classic'));
   testFunctions.push(() => run('package=' + packageName + '&prebuilt=true'));
   testFunctions.push(() => run('package=' + packageName + '&enableoptionalfeatures=true'));
-
-  // TODO: this should ultimately be deleted (when all packages can run with and
-  // without jQuery)
-  if (packageName !== 'ember') {
-    testFunctions.push(() => run('package=' + packageName + '&jquery=none'));
-  }
 }
 
 function generateEachPackageTests() {

--- a/broccoli/packages.js
+++ b/broccoli/packages.js
@@ -34,14 +34,6 @@ module.exports.routerES = function _routerES() {
   });
 };
 
-module.exports.jquery = function _jquery() {
-  return new Funnel(findLib('jquery'), {
-    files: ['jquery.js'],
-    destDir: 'jquery',
-    annotation: 'jquery',
-  });
-};
-
 module.exports.loader = function _loader() {
   return new Funnel('packages/loader/lib', {
     files: ['index.js'],

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,7 +14,6 @@ Error.stackTraceLimit = Infinity;
 
 const {
   routerES,
-  jquery,
   loader,
   qunit,
   handlebarsES,
@@ -249,14 +248,7 @@ function templateCompilerBundle(emberPackages, transpileTree) {
 }
 
 function testHarness() {
-  return new MergeTrees([
-    emptyTestem(),
-    testPolyfills(),
-    testIndexHTML(),
-    loader(),
-    qunit(),
-    jquery(),
-  ]);
+  return new MergeTrees([emptyTestem(), testPolyfills(), testIndexHTML(), loader(), qunit()]);
 }
 
 function emptyTestem() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 const MergeTrees = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const path = require('path');
-const resolve = require('resolve');
 const concatBundle = require('./concat-bundle');
 const buildDebugMacroPlugin = require('./build-debug-macro-plugin');
 const buildStripClassCallcheckPlugin = require('./build-strip-class-callcheck-plugin');
@@ -33,7 +32,6 @@ function add(paths, name, path) {
 add(paths, 'prod', 'vendor/ember/ember.js');
 add(paths, 'debug', 'vendor/ember/ember.js');
 add(paths, 'testing', 'vendor/ember/ember-testing.js');
-add(paths, 'jquery', 'vendor/ember/jquery/jquery.js');
 
 add(
   absolutePaths,
@@ -97,25 +95,6 @@ module.exports = {
 
       if (
         optionalFeaturesMissing ||
-        typeof optionalFeatures.isFeatureExplicitlySet !== 'function'
-      ) {
-        message.push(
-          '* Unable to detect if jquery-integration is explicitly set to a value, please update `@ember/optional-features` to the latest version'
-        );
-      }
-
-      if (
-        optionalFeaturesMissing ||
-        (typeof optionalFeatures.isFeatureExplicitlySet === 'function' &&
-          !optionalFeatures.isFeatureExplicitlySet('jquery-integration'))
-      ) {
-        message.push(
-          `* The jquery-integration optional feature should be explicitly set to a value under Octane, run \`ember feature:disable jquery-integration\` to disable it, or \`ember feature:enable jquery-integration\` to explicitly enable it`
-        );
-      }
-
-      if (
-        optionalFeaturesMissing ||
         optionalFeatures.isFeatureEnabled('application-template-wrapper')
       ) {
         message.push(
@@ -165,11 +144,12 @@ module.exports = {
     }
 
     this._jqueryIntegrationEnabled =
-      optionalFeaturesMissing || optionalFeatures.isFeatureEnabled('jquery-integration');
+      !optionalFeaturesMissing && optionalFeatures.isFeatureEnabled('jquery-integration');
 
     if (this._jqueryIntegrationEnabled) {
-      this.ui.writeWarnLine(
-        'Setting the `jquery-integration` optional feature flag to `true`, or not providing a setting at all, has been deprecated. You must add the `@ember/optional-features` addon and set this feature to `false`. This warning will become an error in Ember 4.0.0.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-jquery-integration'
+      const SilentError = require('silent-error');
+      throw new SilentError(
+        'Setting the `jquery-integration` optional feature flag to `true` was deprecated in Ember 3.x and removed in Ember 4.0.0. You must add the `@ember/optional-features` addon and set this feature to `false`.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-jquery-integration'
       );
     }
   },
@@ -237,10 +217,7 @@ module.exports = {
       false
     );
 
-    let exclude = [
-      isProduction ? 'ember-testing/**' : null,
-      !this._jqueryIntegrationEnabled ? 'jquery' : null,
-    ].filter((value) => value !== null);
+    let exclude = isProduction ? ['ember-testing/**'] : [];
 
     let emberFiles = new MergeTrees([new Funnel(packages, { exclude }), dependencies, headerFiles]);
 
@@ -270,21 +247,6 @@ module.exports = {
   },
 
   treeForVendor(tree) {
-    let jqueryPath;
-
-    try {
-      jqueryPath = path.dirname(
-        resolve.sync('jquery/package.json', { basedir: this.project.root })
-      );
-    } catch (error) {
-      jqueryPath = path.dirname(require.resolve('jquery/package.json'));
-    }
-
-    let jquery = new Funnel(jqueryPath + '/dist', {
-      destDir: 'ember/jquery',
-      files: ['jquery.js'],
-    });
-
     let templateCompiler = new Funnel(tree, {
       destDir: 'ember',
       include: ['ember-template-compiler.js', 'ember-template-compiler.map'],
@@ -319,6 +281,6 @@ module.exports = {
       });
     }
 
-    return debugTree(new MergeTrees([ember, templateCompiler, jquery]), 'vendor:final');
+    return debugTree(new MergeTrees([ember, templateCompiler]), 'vendor:final');
   },
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,6 @@ module.exports = {
   name: 'ember-source',
   paths,
   absolutePaths,
-  _jqueryIntegrationEnabled: true,
   _overrideTree: undefined,
 
   included() {
@@ -143,10 +142,12 @@ module.exports = {
       }
     }
 
-    this._jqueryIntegrationEnabled =
-      !optionalFeaturesMissing && optionalFeatures.isFeatureEnabled('jquery-integration');
-
-    if (this._jqueryIntegrationEnabled) {
+    if (
+      !optionalFeaturesMissing &&
+      optionalFeatures.isFeatureEnabled('jquery-integration') &&
+      typeof optionalFeatures.isFeatureExplicitlySet === 'function' &&
+      optionalFeatures.isFeatureExplicitlySet('jquery-integration')
+    ) {
       const SilentError = require('silent-error');
       throw new SilentError(
         'Setting the `jquery-integration` optional feature flag to `true` was deprecated in Ember 3.x and removed in Ember 4.0.0. You must add the `@ember/optional-features` addon and set this feature to `false`.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-jquery-integration'

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "ember-source",
   "version": "4.1.0-alpha.2",
   "description": "A JavaScript framework for creating ambitious web applications",
-  "keywords": [
-    "ember-addon"
-  ],
+  "keywords": ["ember-addon"],
   "homepage": "https://emberjs.com/",
   "bugs": {
     "url": "https://github.com/emberjs/ember.js/issues"
@@ -69,7 +67,6 @@
     "ember-cli-version-checker": "^5.1.1",
     "ember-router-generator": "^2.0.0",
     "inflection": "^1.13.1",
-    "jquery": "^3.5.1",
     "resolve": "^1.17.0",
     "semver": "^7.3.4",
     "silent-error": "^1.1.1"

--- a/packages/jquery/index.js
+++ b/packages/jquery/index.js
@@ -1,3 +1,0 @@
-import { jQuery } from '@ember/-internals/views';
-
-export default jQuery;

--- a/tests/index.html
+++ b/tests/index.html
@@ -29,14 +29,6 @@
       // Close the script tag to make sure document.write happens
     </script>
 
-    <script type="text/javascript">
-      // Fallback to default jQuery
-      if (jQueryVersion !== 'none' && !window.jQuery) {
-        loadScript('./jquery/jquery.js');
-      }
-      // Close the script tag to make sure document.write happens
-    </script>
-
     <script>
       (function() {
         window.EmberENV = window.EmberENV || {};

--- a/tests/index.html
+++ b/tests/index.html
@@ -126,7 +126,7 @@
           testsTotal = testsPassed = testsFailed = 0;
 
           if (QUnit.urlParams.hideskipped) {
-            $('#qunit-tests').addClass('hideskipped');
+            document.getElementById('qunit-tests').classList.add('hideskipped');
           }
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7812,11 +7812,6 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc= sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
 
-jquery@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
 js-reporters@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.3.tgz#8febcab370539df62e09b95da133da04b11f6168"


### PR DESCRIPTION
Removes jQuery from dependencies, the build process and test runs.

Should be passing once the other open jQuery related PRs have landed (#19666, #19675, #19676)   

