### PR TITLE
[DOC] Clarify invokeHelper example

### DIFF
--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -252,14 +252,18 @@
   The `invokeHelper` function can be used to create a helper instance in
   JavaScript.
 
+  To access a helper's value you have to use `getValue` from
+  `@glimmer/tracking/primitives/cache`.
+
   ```js
   // app/components/data-loader.js
   import Component from '@glimmer/component';
+  import { getValue } from '@glimmer/tracking/primitives/cache';
   import Helper from '@ember/component/helper';
   import { invokeHelper } from '@ember/helper';
 
   class PlusOne extends Helper {
-    compute([num]) {
+    compute([number]) {
       return number + 1;
     }
   }
@@ -270,10 +274,14 @@
         positional: [this.args.number],
       };
     });
+
+    get value() {
+      return getValue(this.plusOne);
+    }
   }
   ```
   ```hbs
-  {{this.plusOne.value}}
+  {{this.value}}
   ```
 
   It receives three arguments:


### PR DESCRIPTION
The `invokeHelper`-docs don't explain that one has to create a getter that accesses the helper's value via `getValue` from `@glimmer/tracking/primitives/cache`.

I only realised this was by design after looking at the tests here - https://github.com/emberjs/ember.js/blob/21bd70c773dcc4bfe4883d7943e8a68d203b5bad/packages/%40ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js#L34

The current docs state that it was possible to access an invoked helper's value by accessing it via `.value` which does not work in current Ember.