### PR TITLE
[router.ts] Convert this._super to super

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -802,7 +802,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
       this._toplevelView = null;
     }
 
-    this._super(...arguments);
+    super.willDestroy();
 
     this.reset();
 


### PR DESCRIPTION
The router class has already been converted to a native JS class, so it should be using `super.willDestroy` in its `willDestroy` hook instead of `this._super`.