### PR TITLE
Fix assign polyfill

### DIFF
--- a/packages/@ember/polyfills/lib/assign.ts
+++ b/packages/@ember/polyfills/lib/assign.ts
@@ -29,7 +29,7 @@ export function assign(target: object, ...sources: object[]): object;
   @public
   @static
 */
-export function assign(target: object): object {
+export function assign(target: object, ...rest: object[]): object {
   deprecate(
     'Use of `assign` has been deprecated. Please use `Object.assign` or the spread operator instead.',
     false,
@@ -44,5 +44,5 @@ export function assign(target: object): object {
     }
   );
 
-  return Object.assign(target, ...arguments);
+  return Object.assign(target, ...rest);
 }


### PR DESCRIPTION
In https://github.com/emberjs/ember.js/pull/19649 `assign` was re-written to just pass through to `Object.assign`. However, the implementation is not ideal - it assigns all the arguments, which includes the `target` itself. This can lead to problems, e.g. in ember-test-helpers when you have an implementation like this: `assign(event, options)`, it will end up as `Object.assign(event, event, options)`, and complain that we try to set read-only attributes on `event`.

See: https://github.com/emberjs/ember-test-helpers/issues/1077