### PR TITLE
Add `HAS_NATIVE_PROXY` guard to test 

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -309,10 +309,15 @@ moduleFor(
       this.assertText('Chad Hietala');
 
       runTask(() => {
-        expectDeprecation(() => {
+        if (HAS_NATIVE_PROXY) {
+          expectDeprecation(() => {
+            set(fooBarInstance.hash, 'firstName', 'Godfrey');
+            set(fooBarInstance.hash, 'lastName', 'Chan');
+          }, /You set the '.*' property on a {{hash}} object/);
+        } else {
           set(fooBarInstance.hash, 'firstName', 'Godfrey');
           set(fooBarInstance.hash, 'lastName', 'Chan');
-        }, /You set the '.*' property on a {{hash}} object/);
+        }
       });
 
       this.assertText('Godfrey Chan');


### PR DESCRIPTION
After backporting https://github.com/emberjs/ember.js/pull/19681 to beta, CI fails in IE https://github.com/emberjs/ember.js/runs/3223442589?check_suite_focus=true#step:7:185 on this test https://github.com/emberjs/ember.js/blob/0825f8a92daf2420d16a8edca34c5f5c01ce5d06/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js#L279

@pzuraq suggested this guard was missing.

I still don't understand exactly why this test would not have failed in IE before the backport as well, since the backported code did not touch the test. 