### PR TITLE
[DOC] fix component's closing tag

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -125,7 +125,7 @@
       <p class="error">{{validationError}}</p>
     {{/if}}
     First name:
-  {{/labeled-textfield}}
+  </LabeledTextfield>
   ```
 
   ```app/components/labeled-textfield.hbs


### PR DESCRIPTION
Looks like https://github.com/emberjs/ember.js/pull/18337 forgot to update the closing tag of a component.

On a side note, the file paths `app/components/labeled-textfield.hbs` are not correctly displayed in the code blocks, while they are correctly written in the documentation.

![ember-doc](https://user-images.githubusercontent.com/47531779/128211882-2694a46e-4e97-4d89-aacb-7882e5221d04.png)
