### PR TITLE
[BUGFIX lts] ensure `deserializeQueryParam` is called for lazy routes

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -2082,11 +2082,21 @@ export function getFullQueryParams(router: EmberRouter, state: TransitionState<R
     return state['fullQueryParams'];
   }
 
-  state['fullQueryParams'] = {};
-  Object.assign(state['fullQueryParams'], state.queryParams);
+  let fullQueryParamsState = {};
+  let haveAllRouteInfosResolved = state.routeInfos.every((routeInfo) => routeInfo.route);
 
-  router._deserializeQueryParams(state.routeInfos, state['fullQueryParams'] as QueryParam);
-  return state['fullQueryParams'];
+  Object.assign(fullQueryParamsState, state.queryParams);
+
+  router._deserializeQueryParams(state.routeInfos, fullQueryParamsState as QueryParam);
+
+  // only cache query params state if all routeinfos have resolved; it's possible
+  // for lazy routes to not have resolved when `getFullQueryParams` is called, so
+  // we wait until all routes have resolved prior to caching query params state
+  if (haveAllRouteInfosResolved) {
+    state['fullQueryParams'] = fullQueryParamsState;
+  }
+
+  return fullQueryParamsState;
 }
 
 function getQueryParamsFor(route: Route, state: TransitionState<Route>) {


### PR DESCRIPTION
Currently it's possible for `deserializeQueryParam` to not be called on lazy routes, which can break deserialization of query params. As soon as `getFullQueryParams` is called it caches query params state regardless of whether all routes have resolved; this PR updates to only cache state if all routes have resolved, however we still process query params in both of these cases. I've also added a test-case here to prevent this from regressing in the future.