### PR TITLE
[BUGFIX beta] Update Node.js CI tests and package.json engines to match support policy

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/cache@v2
         with:
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -292,7 +292,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": ">= 12.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"


### PR DESCRIPTION
ember-cli dropped support for Node 10.x in Ember 3.28 https://github.com/ember-cli/ember-cli/pull/9530