### PR TITLE
[CLEANUP beta] Remove manager-capabilities deprecations

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/managers.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/managers.ts
@@ -1,6 +1,4 @@
 import { Owner } from '@ember/-internals/owner';
-import { deprecate } from '@ember/debug';
-import { DEBUG } from '@glimmer/env';
 import { ComponentManager } from '@glimmer/interfaces';
 import {
   componentCapabilities as glimmerComponentCapabilities,
@@ -17,41 +15,3 @@ export function setComponentManager(
 
 export let componentCapabilities = glimmerComponentCapabilities;
 export let modifierCapabilities = glimmerModifierCapabilities;
-
-if (DEBUG) {
-  componentCapabilities = (version, options) => {
-    deprecate(
-      'Versions of component manager capabilities prior to 3.13 have been deprecated. You must update to the 3.13 capabilities.',
-      version === '3.13',
-      {
-        id: 'manager-capabilities.components-3-4',
-        url: 'https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-components-3-4',
-        until: '4.0.0',
-        for: 'ember-source',
-        since: {
-          enabled: '3.26.0',
-        },
-      }
-    );
-
-    return glimmerComponentCapabilities(version, options);
-  };
-
-  modifierCapabilities = (version, options) => {
-    deprecate(
-      'Versions of modifier manager capabilities prior to 3.22 have been deprecated. You must update to the 3.22 capabilities.',
-      version === '3.22',
-      {
-        id: 'manager-capabilities.modifiers-3-13',
-        url: 'https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-modifiers-3-13',
-        until: '4.0.0',
-        for: 'ember-source',
-        since: {
-          enabled: '3.26.0',
-        },
-      }
-    );
-
-    return glimmerModifierCapabilities(version, options);
-  };
-}

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -7,7 +7,7 @@ import { set, setProperties, computed, tracked } from '@ember/-internals/metal';
 import { setComponentManager } from '@ember/-internals/glimmer';
 
 const BasicComponentManager = EmberObject.extend({
-  capabilities: componentCapabilities('3.4'),
+  capabilities: componentCapabilities('3.13'),
 
   createComponent(factory, args) {
     return factory.create({ args });
@@ -39,7 +39,7 @@ class ComponentManagerTest extends RenderingTestCase {
     super(...arguments);
 
     InstrumentedComponentManager = EmberObject.extend({
-      capabilities: componentCapabilities('3.4', {
+      capabilities: componentCapabilities('3.13', {
         destructor: true,
         asyncLifecycleCallbacks: true,
       }),
@@ -119,7 +119,7 @@ moduleFor(
     ['@test it can have no template context']() {
       let ComponentClass = setComponentManager(() => {
         return EmberObject.create({
-          capabilities: componentCapabilities('3.4'),
+          capabilities: componentCapabilities('3.13'),
 
           createComponent() {
             return null;
@@ -147,7 +147,7 @@ moduleFor(
       class Base {}
       setComponentManager(() => {
         return EmberObject.create({
-          capabilities: componentCapabilities('3.4'),
+          capabilities: componentCapabilities('3.13'),
 
           createComponent(Factory, args) {
             return new Factory(args);
@@ -206,7 +206,7 @@ moduleFor(
       let ComponentClass = setComponentManager(
         () => {
           return EmberObject.create({
-            capabilities: componentCapabilities('3.4'),
+            capabilities: componentCapabilities('3.13'),
 
             createComponent(factory) {
               return factory.create();
@@ -411,7 +411,7 @@ moduleFor(
       let ComponentClass = setComponentManager(
         () => {
           return EmberObject.create({
-            capabilities: componentCapabilities('3.4', {
+            capabilities: componentCapabilities('3.13', {
               destructor: true,
             }),
 
@@ -461,7 +461,7 @@ moduleFor(
       let ComponentClass = setComponentManager(
         () => {
           return EmberObject.create({
-            capabilities: componentCapabilities('3.4', {
+            capabilities: componentCapabilities('3.13', {
               asyncLifecycleCallbacks: true,
             }),
 
@@ -570,7 +570,7 @@ moduleFor(
 
       assert.throws(() => {
         this.render('{{foo-bar name=this.name}}', { name: 'world' });
-      }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.4' \| '3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
+      }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
 
       assert.verifySteps([]);
     }
@@ -665,7 +665,7 @@ moduleFor(
 
     ['@test updating attributes triggers updateComponent and didUpdateComponent'](assert) {
       let TestManager = EmberObject.extend({
-        capabilities: componentCapabilities('3.4', {
+        capabilities: componentCapabilities('3.13', {
           destructor: true,
           asyncLifecycleCallbacks: true,
         }),
@@ -883,7 +883,7 @@ moduleFor(
 
       assert.throws(() => {
         this.render('<FooBar @name={{this.name}} />', { name: 'world' });
-      }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.4' \| '3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
+      }, /Custom component managers must have a `capabilities` property that is the result of calling the `capabilities\('3.13'\)` \(imported via `import \{ capabilities \} from '@ember\/component';`\). /);
 
       assert.verifySteps([]);
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -360,95 +360,11 @@ class ModifierManagerTest extends RenderingTestCase {
 
     assert.throws(() => {
       this.render('<h1 {{foo-bar}}>hello world</h1>');
-    }, /Custom modifier managers must have a `capabilities` property that is the result of calling the `capabilities\('3.13' \| '3.22'\)` \(imported via `import \{ capabilities \} from '@ember\/modifier';`\). /);
+    }, /Custom modifier managers must have a `capabilities` property that is the result of calling the `capabilities\('3.22'\)` \(imported via `import \{ capabilities \} from '@ember\/modifier';`\). /);
 
     assert.verifySteps([]);
   }
 }
-
-moduleFor(
-  'Basic Custom Modifier Manager: 3.13',
-  class extends ModifierManagerTest {
-    CustomModifierManager = class CustomModifierManager {
-      capabilities = modifierCapabilities('3.13');
-
-      constructor(owner) {
-        this.owner = owner;
-      }
-
-      createModifier(factory, args) {
-        // factory is the owner.factoryFor result
-        return factory.create(args);
-      }
-
-      installModifier(instance, element, args) {
-        instance.element = element;
-        let { positional, named } = args;
-        instance.didInsertElement(positional, named);
-      }
-
-      updateModifier(instance, args) {
-        let { positional, named } = args;
-        instance.didUpdate(positional, named);
-      }
-
-      destroyModifier(instance) {
-        instance.willDestroyElement();
-      }
-    };
-
-    '@test modifers consume all arguments'(assert) {
-      let insertCount = 0;
-      let updateCount = 0;
-
-      let ModifierClass = setModifierManager(
-        (owner) => {
-          return new this.CustomModifierManager(owner);
-        },
-        EmberObject.extend({
-          didInsertElement() {},
-          didUpdate() {},
-          willDestroyElement() {},
-        })
-      );
-
-      this.registerModifier(
-        'foo-bar',
-        ModifierClass.extend({
-          didInsertElement(_positional, named) {
-            insertCount++;
-
-            // consume qux
-            named.qux;
-          },
-
-          didUpdate(_positiona, named) {
-            updateCount++;
-
-            // consume qux
-            named.qux;
-          },
-        })
-      );
-
-      this.render('<h1 {{foo-bar bar=this.bar qux=this.qux}}>hello world</h1>', {
-        bar: 'bar',
-        qux: 'quz',
-      });
-
-      this.assertHTML(`<h1>hello world</h1>`);
-
-      assert.equal(insertCount, 1);
-      assert.equal(updateCount, 0);
-
-      runTask(() => set(this.context, 'bar', 'other bar'));
-      assert.equal(updateCount, 1);
-
-      runTask(() => set(this.context, 'qux', 'quuuuxxxxxx'));
-      assert.equal(updateCount, 2);
-    }
-  }
-);
 
 moduleFor(
   'Basic Custom Modifier Manager: 3.22',
@@ -672,60 +588,6 @@ moduleFor(
   class extends RenderingTestCase {
     getBootOptions() {
       return { isInteractive: false };
-    }
-
-    [`@test doesn't trigger lifecycle hooks when non-interactive: modifierCapabilities('3.13')`](
-      assert
-    ) {
-      class CustomModifierManager {
-        capabilities = modifierCapabilities('3.13');
-
-        constructor(owner) {
-          this.owner = owner;
-        }
-
-        createModifier(factory, args) {
-          return factory.create(args);
-        }
-
-        installModifier(instance, element, args) {
-          instance.element = element;
-          let { positional, named } = args;
-          instance.didInsertElement(positional, named);
-        }
-
-        updateModifier(instance, args) {
-          let { positional, named } = args;
-          instance.didUpdate(positional, named);
-        }
-
-        destroyModifier(instance) {
-          instance.willDestroyElement();
-        }
-      }
-      let ModifierClass = setModifierManager(
-        (owner) => {
-          return new CustomModifierManager(owner);
-        },
-        EmberObject.extend({
-          didInsertElement() {
-            assert.ok(false);
-          },
-          didUpdate() {
-            assert.ok(false);
-          },
-          willDestroyElement() {
-            assert.ok(false);
-          },
-        })
-      );
-
-      this.registerModifier('foo-bar', ModifierClass);
-
-      this.render('<h1 {{foo-bar this.baz}}>hello world</h1>');
-      runTask(() => this.context.set('baz', 'Hello'));
-
-      this.assertHTML('<h1>hello world</h1>');
     }
 
     [`@test doesn't trigger lifecycle hooks when non-interactive: modifierCapabilities('3.22')`](


### PR DESCRIPTION
Part of #19617

**NOTE**: `glimmer-vm` will need to be published and updated in this PR (to pull in [these commits](https://github.com/glimmerjs/glimmer-vm/commits?author=nlfurniss)) before it's ready to merge