### PR TITLE
[cleanup]: Remove mutation after consumption id:autotracking.mutation-after-consumption

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -99,14 +99,6 @@ const VM_DEPRECATION_OVERRIDES: (DeprecationOptions & {
   message?: string;
 })[] = [
   {
-    id: 'autotracking.mutation-after-consumption',
-    until: '4.0.0',
-    for: 'ember-source',
-    since: {
-      enabled: '3.21.0',
-    },
-  },
-  {
     id: 'this-property-fallback',
     disabled: ENV._DISABLE_PROPERTY_FALLBACK_DEPRECATION,
     url: 'https://deprecations.emberjs.com/v3.x#toc_this-property-fallback',

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -3,7 +3,7 @@ import { moduleFor, RenderingTestCase, runTask, strip } from 'internal-test-help
 
 import { componentCapabilities } from '@glimmer/manager';
 import { Object as EmberObject } from '@ember/-internals/runtime';
-import { set, setProperties, computed, tracked } from '@ember/-internals/metal';
+import { set, setProperties, computed } from '@ember/-internals/metal';
 import { setComponentManager } from '@ember/-internals/glimmer';
 
 const BasicComponentManager = EmberObject.extend({

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -887,35 +887,5 @@ moduleFor(
 
       assert.verifySteps([]);
     }
-
-    '@test tracked property mutation in constructor issues a deprecation'() {
-      let ComponentClass = setComponentManager(
-        createBasicManager,
-        class extends EmberObject {
-          @tracked itemCount = 0;
-
-          init() {
-            super.init(...arguments);
-
-            // first read the tracked property
-            let { itemCount } = this;
-
-            // then attempt to update the tracked property
-            this.itemCount = itemCount + 1;
-          }
-        }
-      );
-
-      this.registerComponent('foo-bar', {
-        template: `{{this.itemCount}}`,
-        ComponentClass,
-      });
-
-      expectDeprecation(() => {
-        this.render('<FooBar />');
-      }, /You attempted to update `itemCount` on `<.*>`, but it had already been used previously in the same computation/);
-
-      this.assertHTML(`1`);
-    }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -241,50 +241,6 @@ class ModifierManagerTest extends RenderingTestCase {
     assert.equal(updateCount, 2);
   }
 
-  '@test provides a helpful deprecation when mutating a tracked value that was consumed already within constructor'(
-    assert
-  ) {
-    let ModifierClass = setModifierManager(
-      (owner) => {
-        return new this.CustomModifierManager(owner);
-      },
-      class {
-        static create() {
-          return new this();
-        }
-
-        @tracked foo = 123;
-
-        constructor() {
-          // first read the tracked property
-          this.foo;
-
-          // then attempt to update the tracked property
-          this.foo = 456;
-        }
-
-        didInsertElement() {}
-        didUpdate() {}
-        willDestroyElement() {}
-      }
-    );
-
-    this.registerModifier(
-      'foo-bar',
-      class extends ModifierClass {
-        didInsertElement() {
-          assert.ok(true, 'modifiers didInsertElement was called');
-        }
-      }
-    );
-
-    let expectedMessage = backtrackingMessageFor('foo');
-
-    expectDeprecation(() => {
-      this.render('<h1 {{foo-bar}}>hello world</h1>');
-    }, expectedMessage);
-  }
-
   '@test provides a helpful assertion when mutating a value that was consumed already'() {
     class Person {
       @tracked name = 'bob';

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -731,55 +731,6 @@ moduleFor(
       this.assertText('huzza!');
     }
 
-    ['@test class-based helper gives helpful warning when mutating a value that was tracked already']() {
-      this.add(
-        'helper:hello-world',
-        class extends Helper {
-          compute() {
-            this.get('value');
-            this.set('value', 123);
-          }
-        }
-      );
-
-      let expectedMessage = backtrackingMessageFor('value', '<.+?>', {
-        renderTree: ['\\(result of a `<\\(unknown\\).*?>` helper\\)'],
-      });
-
-      expectDeprecation(() => {
-        // TODO: this must be a bug??
-        expectDeprecation(
-          backtrackingMessageFor('undefined', undefined, {
-            renderTree: ['\\(result of a `<\\(unknown\\).*?>` helper\\)'],
-          })
-        );
-
-        this.render('{{hello-world}}');
-      }, expectedMessage);
-    }
-
-    ['@test class-based helper gives helpful deprecation when mutating a tracked property that was tracked already']() {
-      this.add(
-        'helper:hello-world',
-        class HelloWorld extends Helper {
-          @tracked value;
-
-          compute() {
-            this.value;
-            this.value = 123;
-          }
-        }
-      );
-
-      let expectedMessage = backtrackingMessageFor('value', '<HelloWorld.+?>', {
-        renderTree: ['\\(result of a `<HelloWorld.*?>` helper\\)'],
-      });
-
-      expectDeprecation(() => {
-        this.render('{{hello-world}}');
-      }, expectedMessage);
-    }
-
     '@feature(EMBER_DYNAMIC_HELPERS_AND_MODIFIERS) Can resolve a helper'() {
       this.registerHelper('hello-world', ([text]) => text ?? 'Hello, world!');
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -8,8 +8,7 @@ import {
   defineSimpleHelper,
 } from 'internal-test-helpers';
 import { Helper, Component } from '@ember/-internals/glimmer';
-import { set, tracked } from '@ember/-internals/metal';
-import { backtrackingMessageFor } from '../../utils/debug-stack';
+import { set } from '@ember/-internals/metal';
 
 moduleFor(
   'Helpers test: custom helpers',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -406,46 +406,5 @@ moduleFor(
 
       this.assertText('12');
     }
-
-    '@test simple helper gives helpful warning when mutating a value that was tracked already'() {
-      this.registerHelper('hello-world', function helloWorld([person]) {
-        get(person, 'name');
-        set(person, 'name', 'sam');
-      });
-
-      let expectedMessage = backtrackingMessageFor('name', '\\(unknown object\\)', {
-        renderTree: ['\\(result of a `.*` helper\\)'],
-      });
-
-      expectDeprecation(() => {
-        // TODO: this must be a bug??
-        expectDeprecation(
-          backtrackingMessageFor('undefined', undefined, {
-            renderTree: ['\\(result of a `.*` helper\\)'],
-          })
-        );
-
-        this.render('{{hello-world this.model}}', { model: {} });
-      }, expectedMessage);
-    }
-
-    '@test simple helper gives helpful deprecation when mutating a tracked property that was tracked already'() {
-      class Person {
-        @tracked name = 'bob';
-      }
-
-      this.registerHelper('hello-world', ([person]) => {
-        person.name;
-        person.name = 'sam';
-      });
-
-      let expectedMessage = backtrackingMessageFor('name', 'Person', {
-        renderTree: ['\\(result of a `\\(unknown function\\)` helper\\)'],
-      });
-
-      expectDeprecation(() => {
-        this.render('{{hello-world this.model}}', { model: new Person() });
-      }, expectedMessage);
-    }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -1,7 +1,5 @@
 import { Object as EmberObject, A, MutableArray } from '@ember/-internals/runtime';
 import {
-  get,
-  set,
   tracked,
   nativeDescDecorator as descriptor,
   notifyPropertyChange,
@@ -9,7 +7,6 @@ import {
 import Service, { inject } from '@ember/service';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
-import { backtrackingMessageFor } from '../../utils/debug-stack';
 import { Component } from '../../utils/helpers';
 
 moduleFor(

--- a/packages/@ember/-internals/metal/tests/tracked/validation_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/validation_test.js
@@ -378,25 +378,6 @@ moduleFor(
       }, /You attempted to update `value` on `EmberObject`, but it had already been used previously in the same computation/);
     }
 
-    ['@test gives helpful deprecation when a tracked property is mutated after access within unknownProperty within an autotracking transaction']() {
-      class EmberObject {
-        @tracked foo;
-
-        unknownProperty() {
-          this.foo;
-          this.foo = 123;
-        }
-      }
-
-      let obj = new EmberObject();
-
-      expectDeprecation(() => {
-        track(() => {
-          get(obj, 'bar');
-        });
-      }, /You attempted to update `foo` on `EmberObject`, but it had already been used previously in the same computation/);
-    }
-
     ['@test get() does not entangle in the autotracking stack until after retrieving the value'](
       assert
     ) {


### PR DESCRIPTION
ref Ember.js issue - https://github.com/emberjs/ember.js/issues/19617

Ref Glimmer PR - https://github.com/glimmerjs/glimmer-vm/pull/1330

We can add a few more "assertion" tests once the glimmer VM `VM_DEPRECATION_OVERRIDES` is updated here.  There is one assertion test in `validation_test.js`.