### PR TITLE
[DOC beta] Deprecation link for Ember.Component.reopen

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1083,8 +1083,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.component.reopen',
             for: 'ember-source',
-            since: {},
-            until: '4.0.0',
+            since: {
+              enabled: '4.0.0',
+            },
+            url: 'https://deprecations.emberjs.com/v4.x#toc_ember-component-reopen',
+            until: '5.0.0',
           }
         );
 
@@ -1109,8 +1112,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.component.reopen',
             for: 'ember-source',
-            since: {},
-            until: '4.0.0',
+            url: 'https://deprecations.emberjs.com/v4.x#toc_ember-component-reopen',
+            since: {
+              enabled: '4.0.0',
+            },
+            until: '5.0.0',
           }
         );
 


### PR DESCRIPTION
Should wait for https://github.com/ember-learn/deprecation-app/pull/948