### PR TITLE
[DOC] Mark `replaceWith` and `replaceRoute` as deprecated

### DIFF
--- a/packages/@ember/-internals/routing/lib/ext/controller.ts
+++ b/packages/@ember/-internals/routing/lib/ext/controller.ts
@@ -231,6 +231,7 @@ ControllerMixin.reopen({
     @method replaceRoute
     @return {Transition} the transition object associated with this
       attempted transition
+    @deprecated Use replaceWith from the Router service instead.
     @public
   */
   replaceRoute(...args: string[]) {

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1074,6 +1074,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     @return {Transition} the transition object associated with this
       attempted transition
     @since 1.0.0
+    @deprecated Use replaceWith from the Router service instead.
     @public
   */
   replaceWith(...args: any[]) {


### PR DESCRIPTION
Related to https://github.com/emberjs/rfcs/pull/674.