### PR TITLE
Provide `service` export from `@ember/service` in favour of `inject`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/-link-to.ts
@@ -11,7 +11,7 @@ import { EMBER_MODERNIZED_BUILT_IN_COMPONENTS } from '@ember/canary-features';
 import { assert, deprecate, runInDebug, warn } from '@ember/debug';
 import { EngineInstance, getEngineParent } from '@ember/engine';
 import { flaggedInstrument } from '@ember/instrumentation';
-import { inject as injectService } from '@ember/service';
+import { service } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import EmberComponent from '../component';
 import { HAS_BLOCK } from '../component-managers/curly';
@@ -506,7 +506,7 @@ const LinkComponent = EmberComponent.extend({
     this.on(eventName, this, this._invoke);
   },
 
-  _routing: injectService('-routing'),
+  _routing: service('-routing'),
   _currentRoute: alias('_routing.currentRouteName'),
   _currentRouterState: alias('_routing.currentState'),
   _targetRouterState: alias('_routing.targetState'),

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -8,7 +8,7 @@ import { assert, debugFreeze, deprecate, warn } from '@ember/debug';
 import { EngineInstance, getEngineParent } from '@ember/engine';
 import { flaggedInstrument } from '@ember/instrumentation';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import { Maybe, Option } from '@glimmer/interfaces';
 import { consumeTag, createCache, getValue, tagFor, untrack } from '@glimmer/validator';

--- a/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-component-docs.ts
@@ -296,7 +296,7 @@
 
   ```javascript
   import Component from '@glimmer/component';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
 
   export default class SomeComponent extends Component {
     @service myAnimations;
@@ -319,7 +319,7 @@
 
   ```javascript
   import Component from '@glimmer/component';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
 
   export default class SomeComponent extends Component {
     @service myAnimations;

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -97,7 +97,7 @@ let Helper = FrameworkObject.extend({
 
     ```app/helpers/current-user-email.js
     import Helper from '@ember/component/helper'
-    import { inject as service } from '@ember/service'
+    import { service } from '@ember/service'
     import { observer } from '@ember/object'
 
     export default Helper.extend({

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -271,7 +271,7 @@ export const ACTIONS = new _WeakSet();
 
   ```app/controllers/application.js
   import Controller from '@ember/controller';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
 
   export default class extends Controller {
     @service someService;

--- a/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import Controller from '@ember/controller';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { Helper, helper } from '@ember/-internals/glimmer';
 
 moduleFor(
@@ -92,7 +92,7 @@ moduleFor(
       this.add(
         'helper:full-name',
         Helper.extend({
-          nameBuilder: injectService('name-builder'),
+          nameBuilder: service('name-builder'),
           compute() {
             this.get('nameBuilder').build();
           },

--- a/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, ApplicationTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { ENV } from '@ember/-internals/environment';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { Component, Helper } from '@ember/-internals/glimmer';
 import { expect } from '@glimmer/util';
 
@@ -59,7 +59,7 @@ moduleFor(
       this.add(
         'helper:hot-reload',
         Helper.extend({
-          reloader: injectService(),
+          reloader: service(),
 
           init() {
             this._super(...arguments);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -12,7 +12,7 @@ import {
 import { run } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import { alias, set, get, observer, on, computed, tracked } from '@ember/-internals/metal';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { Object as EmberObject, A as emberA } from '@ember/-internals/runtime';
 
 import { Component, compile, htmlSafe } from '../../utils/helpers';
@@ -2855,13 +2855,13 @@ moduleFor(
     }
 
     ['@test services can be injected into components']() {
-      let service;
+      let serviceInstance;
       this.registerService(
         'name',
         Service.extend({
           init() {
             this._super(...arguments);
-            service = this;
+            serviceInstance = this;
           },
           last: 'Jackson',
         })
@@ -2869,7 +2869,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: Component.extend({
-          name: injectService(),
+          name: service(),
         }),
         template: '{{this.name.last}}',
       });
@@ -2883,13 +2883,13 @@ moduleFor(
       this.assertText('Jackson');
 
       runTask(() => {
-        service.set('last', 'McGuffey');
+        serviceInstance.set('last', 'McGuffey');
       });
 
       this.assertText('McGuffey');
 
       runTask(() => {
-        service.set('last', 'Jackson');
+        serviceInstance.set('last', 'Jackson');
       });
 
       this.assertText('Jackson');
@@ -2898,7 +2898,7 @@ moduleFor(
     ['@test injecting an unknown service raises an exception']() {
       this.registerComponent('foo-bar', {
         ComponentClass: Component.extend({
-          missingService: injectService(),
+          missingService: service(),
         }),
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
@@ -4,7 +4,7 @@ import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { tracked, set } from '@ember/-internals/metal';
 import { setOwner } from '@ember/-internals/owner';
 import { EMBER_GLIMMER_HELPER_MANAGER } from '@ember/canary-features';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { registerDestructor } from '@glimmer/destroyable';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js
@@ -4,7 +4,7 @@ import { Helper, helper, Component as EmberComponent } from '@ember/-internals/g
 import { tracked, set } from '@ember/-internals/metal';
 import { getOwner } from '@ember/-internals/owner';
 import { EMBER_GLIMMER_INVOKE_HELPER, EMBER_GLIMMER_HELPER_MANAGER } from '@ember/canary-features';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import { getValue } from '@glimmer/validator';
 import { destroy, isDestroyed, registerDestructor } from '@glimmer/destroyable';

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -6,7 +6,7 @@ import {
   nativeDescDecorator as descriptor,
   notifyPropertyChange,
 } from '@ember/-internals/metal';
-import Service, { inject } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { backtrackingMessageFor } from '../../utils/debug-stack';
@@ -293,7 +293,7 @@ moduleFor(
 
       this.registerComponent('person', {
         ComponentClass: Component.extend({
-          currentUser: inject('current-user'),
+          currentUser: service('current-user'),
         }),
 
         template: strip`

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -33,7 +33,7 @@ function cleanURL(url: string, rootURL: string) {
    ```app/components/example.js
    import Component from '@glimmer/component';
    import { action } from '@ember/object';
-   import { inject as service } from '@ember/service';
+   import { service } from '@ember/service';
 
    export default class ExampleComponent extends Component {
      @service router;
@@ -85,7 +85,7 @@ export default class RouterService extends Service {
      ```app/components/example.js
      import Component from '@glimmer/component';
      import { action } from '@ember/object';
-     import { inject as service } from '@ember/service';
+     import { service } from '@ember/service';
 
      export default class extends Component {
        @service router;
@@ -184,7 +184,7 @@ export default class RouterService extends Service {
 
     ```app/components/copy-link.js
     import Component from '@glimmer/component';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
     import { action } from '@ember/object';
 
     export default class CopyLinkComponent extends Component {
@@ -211,7 +211,7 @@ export default class RouterService extends Service {
 
     ```app/components/copy-link.js
     import Component from '@glimmer/component';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
     import { action } from '@ember/object';
 
     export default class CopyLinkComponent extends Component {
@@ -254,7 +254,7 @@ export default class RouterService extends Service {
 
      ```app/components/posts.js
      import Component from '@glimmer/component';
-     import { inject as service } from '@ember/service';
+     import { service } from '@ember/service';
 
      export default class extends Component {
        @service router;
@@ -270,7 +270,7 @@ export default class RouterService extends Service {
 
      ```app/components/posts.js
      import Component from '@glimmer/component';
-     import { inject as service } from '@ember/service';
+     import { service } from '@ember/service';
 
      export default class extends Component {
        @service router;
@@ -354,7 +354,7 @@ export default class RouterService extends Service {
 
      ```
      import Component from '@ember/component';
-     import { inject as service } from '@ember/service';
+     import { service } from '@ember/service';
 
      export default class extends Component {
        @service router;
@@ -414,7 +414,7 @@ export default class RouterService extends Service {
 
     ```app/routes/contact-form.js
     import Route from '@ember/routing';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
 
     export default class extends Route {
       @service router;
@@ -448,7 +448,7 @@ export default class RouterService extends Service {
 
     ```app/routes/contact-form.js
     import Route from '@ember/routing';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
 
     export default class extends Route {
       @service router;
@@ -656,7 +656,7 @@ RouterService.reopen(Evented, {
     Usage example:
     ```app/components/header.js
       import Component from '@glimmer/component';
-      import { inject as service } from '@ember/service';
+      import { service } from '@ember/service';
       import { notEmpty } from '@ember/object/computed';
 
       export default class extends Component {

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1680,7 +1680,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
 
     ```app/routes/application.js
     import Route from '@ember/routing/route';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
 
     export default class ApplicationRoute extends Route {
       @service router

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -1387,7 +1387,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     ```javascript
     import config from './config/environment';
     import EmberRouter from '@ember/routing/router';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
 
     let Router = EmberRouter.extend({
       location: config.locationType,

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -1,6 +1,6 @@
 import { setOwner } from '@ember/-internals/owner';
 import { runDestroy, buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import EmberRoute from '../../lib/system/route';
 import { defineProperty } from '../../../metal';
@@ -321,7 +321,7 @@ moduleFor(
       owner.register(
         'route:application',
         EmberRoute.extend({
-          authService: injectService('auth'),
+          authService: service('auth'),
         })
       );
 

--- a/packages/@ember/-internals/runtime/tests/system/object/create_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/create_test.js
@@ -1,7 +1,7 @@
 import { getFactoryFor, Registry } from '@ember/-internals/container';
 import { getOwner, setOwner } from '@ember/-internals/owner';
 import { computed, Mixin, observer, addObserver, alias } from '@ember/-internals/metal';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import EmberObject from '../../../lib/system/object';
 import { buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -1039,7 +1039,7 @@ const Application = Engine.extend({
 
     ```app/routes/post.js
     import Route from '@ember/routing/route';
-    import { inject as service } from '@ember/service';
+    import { service } from '@ember/service';
 
     // An example of how the (hypothetical) service is used in routes.
 

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -4,7 +4,7 @@ import {
   ApplicationTestCase,
   runTask,
 } from 'internal-test-helpers';
-import { inject as injectService } from '@ember/service';
+import { service } from '@ember/service';
 import { Object as EmberObject, RSVP, onerrorDefault } from '@ember/-internals/runtime';
 import { later } from '@ember/runloop';
 import Application from '@ember/application';
@@ -683,8 +683,8 @@ moduleFor(
         Component.extend({
           tagName: 'x-foo',
 
-          isolatedCounter: injectService(),
-          sharedCounter: injectService(),
+          isolatedCounter: service(),
+          sharedCounter: service(),
 
           init() {
             this._super();
@@ -713,7 +713,7 @@ moduleFor(
       this.add(
         'component:x-bar',
         Component.extend({
-          counter: injectService('sharedCounter'),
+          counter: service('sharedCounter'),
 
           actions: {
             incrementCounter() {

--- a/packages/@ember/controller/tests/controller_test.js
+++ b/packages/@ember/controller/tests/controller_test.js
@@ -1,5 +1,5 @@
 import Controller, { inject as injectController } from '@ember/controller';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { Mixin, get } from '@ember/-internals/metal';
 import { setOwner } from '@ember/-internals/owner';
@@ -265,7 +265,7 @@ moduleFor(
       owner.register(
         'controller:application',
         Controller.extend({
-          authService: injectService('auth'),
+          authService: service('auth'),
         })
       );
 

--- a/packages/@ember/service/index.d.ts
+++ b/packages/@ember/service/index.d.ts
@@ -1,3 +1,4 @@
 export function inject(name?: string): any;
+export function service(name?: string): any;
 declare let Service: any;
 export default Service;

--- a/packages/@ember/service/index.js
+++ b/packages/@ember/service/index.js
@@ -7,6 +7,20 @@ import { inject as metalInject } from '@ember/-internals/metal';
  */
 
 /**
+  @method inject
+  @static
+  @since 1.10.0
+  @for @ember/service
+  @param {String} name (optional) name of the service to inject, defaults to
+         the property's name
+  @return {ComputedDecorator} injection decorator instance
+  @public
+*/
+export function inject() {
+  return metalInject('service', ...arguments);
+}
+
+/**
   Creates a property that lazily looks up a service in the container. There are
   no restrictions as to what objects a service can be injected into.
 
@@ -14,7 +28,7 @@ import { inject as metalInject } from '@ember/-internals/metal';
 
   ```app/routes/application.js
   import Route from '@ember/routing/route';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
 
   export default class ApplicationRoute extends Route {
     @service('auth') authManager;
@@ -29,7 +43,7 @@ import { inject as metalInject } from '@ember/-internals/metal';
 
   ```app/routes/application.js
   import Route from '@ember/routing/route';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
 
   export default Route.extend({
     authManager: service('auth'),
@@ -44,16 +58,16 @@ import { inject as metalInject } from '@ember/-internals/metal';
   that looks up the `auth` service in the container, making it easily accessible
   in the `model` hook.
 
-  @method inject
+  @method service
   @static
-  @since 1.10.0
+  @since 4.1.0
   @for @ember/service
   @param {String} name (optional) name of the service to inject, defaults to
          the property's name
   @return {ComputedDecorator} injection decorator instance
   @public
 */
-export function inject() {
+export function service() {
   return metalInject('service', ...arguments);
 }
 

--- a/packages/@ember/service/tests/service_test.js
+++ b/packages/@ember/service/tests/service_test.js
@@ -1,4 +1,4 @@
-import Service, { inject as injectService } from '@ember/service';
+import Service, { inject, service } from '@ember/service';
 import { Object as EmberObject } from '@ember/-internals/runtime';
 import { buildOwner } from 'internal-test-helpers';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -12,7 +12,7 @@ moduleFor(
       class MainService extends Service {}
 
       class Foo extends EmberObject {
-        @injectService('main') main;
+        @inject('main') main;
       }
 
       owner.register('service:main', MainService);
@@ -29,7 +29,46 @@ moduleFor(
       class MainService extends Service {}
 
       class Foo extends EmberObject {
-        @injectService main;
+        @inject main;
+      }
+
+      owner.register('service:main', MainService);
+      owner.register('foo:main', Foo);
+
+      let foo = owner.lookup('foo:main');
+
+      assert.ok(foo.main instanceof Service, 'service injected correctly');
+    }
+  }
+);
+
+moduleFor(
+  'service - decorator',
+  class extends AbstractTestCase {
+    ['@test works with native decorators'](assert) {
+      let owner = buildOwner();
+
+      class MainService extends Service {}
+
+      class Foo extends EmberObject {
+        @service('main') main;
+      }
+
+      owner.register('service:main', MainService);
+      owner.register('foo:main', Foo);
+
+      let foo = owner.lookup('foo:main');
+
+      assert.ok(foo.main instanceof Service, 'service injected correctly');
+    }
+
+    ['@test uses the decorated property key if not provided'](assert) {
+      let owner = buildOwner();
+
+      class MainService extends Service {}
+
+      class Foo extends EmberObject {
+        @service main;
       }
 
       owner.register('service:main', MainService);

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -30,7 +30,7 @@ import {
   underscore,
   w,
 } from '@ember/string';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 import { action, computed } from '@ember/object';
 import { dependentKeyCompat } from '@ember/object/compat';
@@ -340,7 +340,7 @@ Ember.inject = function inject() {
       .join(' or ')}'`
   );
 };
-Ember.inject.service = injectService;
+Ember.inject.service = service;
 Ember.inject.controller = injectController;
 
 Ember.Array = EmberArray;

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -310,7 +310,7 @@ let allExports = [
 
   // @ember/service
   ['Service', '@ember/service', 'default'],
-  ['inject.service', '@ember/service', 'inject'],
+  ['inject.service', '@ember/service', 'service'],
 
   // @ember/string
   ['String.camelize', '@ember/string', 'camelize'],

--- a/packages/ember/tests/routing/query_params_test/shared_state_test.js
+++ b/packages/ember/tests/routing/query_params_test/shared_state_test.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { run } from '@ember/runloop';
 import { QueryParamTestCase, moduleFor } from 'internal-test-helpers';
 
@@ -27,14 +27,14 @@ moduleFor(
       this.add(
         'controller:home',
         Controller.extend({
-          filters: injectService(),
+          filters: service(),
         })
       );
 
       this.add(
         'controller:dashboard',
         Controller.extend({
-          filters: injectService(),
+          filters: service(),
           queryParams: [{ 'filters.shared': 'shared' }],
         })
       );

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -1,7 +1,7 @@
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import { set } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { inject as injectService } from '@ember/service';
+import { service } from '@ember/service';
 
 moduleFor(
   'Router Service - main',
@@ -156,7 +156,7 @@ moduleFor(
       assert.expect(1);
 
       this.router.reopen({
-        routerService: injectService('router'),
+        routerService: service('router'),
         init() {
           this.routerService.one('routeDidChange', () => {
             assert.ok(true, 'routeDidChange event listener called');

--- a/packages/ember/tests/routing/router_service_test/build_routeinfo_metadata_test.js
+++ b/packages/ember/tests/routing/router_service_test/build_routeinfo_metadata_test.js
@@ -1,5 +1,5 @@
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Route } from '@ember/-internals/routing';
 
 moduleFor(

--- a/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
+++ b/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
@@ -1,4 +1,4 @@
-import { inject as injectService } from '@ember/service';
+import { service } from '@ember/service';
 import { readOnly } from '@ember/object/computed';
 import { Component } from '@ember/-internals/glimmer';
 import { Route } from '@ember/-internals/routing';
@@ -10,7 +10,7 @@ let results = [];
 let ROUTE_NAMES = ['index', 'child', 'sister', 'brother', 'loading'];
 
 let InstrumentedRoute = Route.extend({
-  routerService: injectService('router'),
+  routerService: service('router'),
 
   init() {
     this._super(...arguments);
@@ -122,7 +122,7 @@ moduleFor(
       });
 
       let CurrenURLComponent = Component.extend({
-        routerService: injectService('router'),
+        routerService: service('router'),
         currentURL: readOnly('routerService.currentURL'),
         currentRouteName: readOnly('routerService.currentRouteName'),
         currentRoute: readOnly('routerService.currentRoute'),

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -1,5 +1,5 @@
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Route } from '@ember/-internals/routing';
 import { later } from '@ember/runloop';
 

--- a/packages/ember/tests/routing/router_service_test/isActive_test.js
+++ b/packages/ember/tests/routing/router_service_test/isActive_test.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 moduleFor(
   'Router Service - isActive',

--- a/packages/ember/tests/routing/router_service_test/non_application_test_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test_test.js
@@ -1,4 +1,4 @@
-import { inject as injectService } from '@ember/service';
+import { service } from '@ember/service';
 import { Router, NoneLocation } from '@ember/-internals/routing';
 import { get } from '@ember/-internals/metal';
 import { run } from '@ember/runloop';
@@ -83,7 +83,7 @@ moduleFor(
 
       this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
-          routerService: injectService('router'),
+          routerService: service('router'),
           init() {
             this._super(...arguments);
             componentInstance = this;

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -1,4 +1,4 @@
-import { inject as injectService } from '@ember/service';
+import { service } from '@ember/service';
 import { Component } from '@ember/-internals/glimmer';
 import { Route, NoneLocation } from '@ember/-internals/routing';
 import Controller from '@ember/controller';
@@ -6,7 +6,6 @@ import { run } from '@ember/runloop';
 import { get } from '@ember/-internals/metal';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
 import { InternalTransition as Transition } from 'router_js';
-import { inject as service } from '@ember/service';
 
 moduleFor(
   'Router Service - transitionTo',
@@ -103,7 +102,7 @@ moduleFor(
 
       this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
-          routerService: injectService('router'),
+          routerService: service('router'),
           init() {
             this._super();
             componentInstance = this;
@@ -135,7 +134,7 @@ moduleFor(
 
       this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
-          routerService: injectService('router'),
+          routerService: service('router'),
           init() {
             this._super();
             componentInstance = this;
@@ -169,7 +168,7 @@ moduleFor(
 
       this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
-          routerService: injectService('router'),
+          routerService: service('router'),
           init() {
             this._super();
             componentInstance = this;
@@ -214,7 +213,7 @@ moduleFor(
 
       this.addComponent('foo-bar', {
         ComponentClass: Component.extend({
-          routerService: injectService('router'),
+          routerService: service('router'),
           init() {
             this._super();
             componentInstance = this;

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -1,6 +1,6 @@
 import { getOwner } from '@ember/-internals/owner';
 import Controller from '@ember/controller';
-import Service, { inject as injectService } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { _ProxyMixin } from '@ember/-internals/runtime';
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
 import { computed } from '@ember/-internals/metal';
@@ -12,7 +12,7 @@ moduleFor(
       this.add(
         'controller:application',
         Controller.extend({
-          myService: injectService('my-service'),
+          myService: service('my-service'),
         })
       );
       let MyService = Service.extend();
@@ -31,7 +31,7 @@ moduleFor(
       this.add(
         'controller:application',
         Controller.extend({
-          myService: injectService('my-service'),
+          myService: service('my-service'),
         })
       );
       let MyService = Service.extend(_ProxyMixin, {
@@ -60,7 +60,7 @@ moduleFor(
       this.add(
         'controller:application',
         Controller.extend({
-          myService: injectService('my-service'),
+          myService: service('my-service'),
         })
       );
       let MyService = Service.extend({

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -489,6 +489,7 @@ module.exports = {
     'serialize',
     'serializeQueryParam',
     'serializeQueryParamKey',
+    'service',
     'set',
     'setClassicDecorator',
     'setDiff',


### PR DESCRIPTION
Implements https://github.com/emberjs/rfcs/pull/752.