### PR TITLE
Call _routerMicrolib.clean() to cleanup properties on Router

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -795,6 +795,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     this._initialTransitionStarted = false;
     if (this._routerMicrolib) {
       this._routerMicrolib.reset();
+      this._routerMicrolib.cleanup();
     }
   }
 


### PR DESCRIPTION
Fix for https://github.com/emberjs/ember.js/issues/19773

Note: This may not be the best fix, although I have not found the correct place to clean up all Router constructors. See issue for more info.

TODO:

- [ ] Use latest version of router.js which exposes cleanup()