### PR TITLE
Fix failing alpha release publishing

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -55,4 +55,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       - name: push branch + tag
-        run: git push origin HEAD --follow-tags
+        run: git push https://${GITHUB_ACTOR}:${{ secrets.PERSONAL_TOKEN }}@github.com/${GITHUB_REPOSITORY} HEAD --follow-tags

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "4.1.0-alpha.1",
+  "version": "4.1.0-alpha.2",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Alpha release CI jobs are failing because the version it is attempting to publish has already been published. 

The root cause of this is the original failure to push the commit that updated the version https://github.com/emberjs/ember.js/runs/3365200021?check_suite_focus=true#step:10:2

This corrects the version in package.json to the latest that was published and has potential fix for the failure to push.