### PR TITLE
Promote `*engineParent` methods for public API

### DIFF
--- a/packages/@ember/engine/lib/engine-parent.js
+++ b/packages/@ember/engine/lib/engine-parent.js
@@ -13,7 +13,7 @@ const ENGINE_PARENT = symbol('ENGINE_PARENT');
   @return {EngineInstance} The parent engine instance.
   @for @ember/engine
   @static
-  @private
+  @public
 */
 export function getEngineParent(engine) {
   return engine[ENGINE_PARENT];
@@ -25,7 +25,8 @@ export function getEngineParent(engine) {
   @method setEngineParent
   @param {EngineInstance} engine An engine instance.
   @param {EngineInstance} parent The parent engine instance.
-  @private
+  @for @ember/engine
+  @public
 */
 export function setEngineParent(engine, parent) {
   engine[ENGINE_PARENT] = parent;


### PR DESCRIPTION
this API was introduced before by https://github.com/emberjs/ember.js/pull/13518 to enable developers and ember internal tracking the parents of engine instances. Sometimes we want to use **getEngineParent** as an immediate parent (which usually will be the host app, but maybe another engine) to get the desirable parent to do something since getting the **rootApplication** or access the parent context across **engines**.

A great example, using `glimmer-apollo` I can for example share the Apollo Client across engines (nested or not )

On `ember-source: 3.28.1` I already can access these methods using `import { getEngineParent, setEngineParent } from '@ember/engine';` now we just need to make it public in the docs


cc: @rwjblue @dgeb 