### PR TITLE
Switch from QUnit `assert.equal()` to `assert.strictEqual()`

### DIFF
--- a/node-tests/fixtures/component-test/unit.js
+++ b/node-tests/fixtures/component-test/unit.js
@@ -7,7 +7,7 @@ moduleForComponent('x-foo', 'Unit | Component | x-foo', {
 });
 
 test('it renders', function(assert) {
-  
+
   // Creates the component instance
   /*let component =*/ this.subject();
   // Renders the component to the page

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.1",
-    "eslint-plugin-qunit": "^6.2.0",
+    "eslint-plugin-qunit": "^7.0.0",
     "execa": "^5.1.1",
     "expect-type": "^0.12.0",
     "express": "^4.17.1",

--- a/packages/@ember/-internals/container/tests/container_test.js
+++ b/packages/@ember/-internals/container/tests/container_test.js
@@ -23,7 +23,7 @@ moduleFor(
       });
       let postController4 = container.lookup('controller:post');
 
-      assert.equal(
+      assert.strictEqual(
         postController1.toString(),
         postController4.toString(),
         'Singleton factories looked up normally return the same value'
@@ -220,7 +220,7 @@ moduleFor(
         'The lookup is an instance of the factory'
       );
 
-      assert.equal(postController, container.lookup('controller:post'));
+      assert.strictEqual(postController, container.lookup('controller:post'));
     }
 
     ['@test A non-singleton instance is never cached'](assert) {
@@ -242,14 +242,14 @@ moduleFor(
 
       let template = function () {};
       registry.register('template:foo', template, { instantiate: false });
-      assert.equal(container.lookup('template:foo'), template);
+      assert.strictEqual(container.lookup('template:foo'), template);
     }
 
     ['@test A failed lookup returns undefined'](assert) {
       let registry = new Registry();
       let container = registry.container();
 
-      assert.equal(container.lookup('doesnot:exist'), undefined);
+      assert.strictEqual(container.lookup('doesnot:exist'), undefined);
     }
 
     ['@test An invalid factory throws an error']() {
@@ -480,7 +480,7 @@ moduleFor(
 
       let result = container.ownerInjection();
 
-      assert.equal(getOwner(result), owner, 'owner is properly included');
+      assert.strictEqual(getOwner(result), owner, 'owner is properly included');
     }
 
     ['@test ownerInjection should be usable to create a service for testing'](assert) {
@@ -538,7 +538,7 @@ moduleFor(
       let factoryManager2 = container.factoryFor('component:foo-bar');
       let factoryManager3 = container.factoryFor('component:baz-bar');
 
-      assert.equal(factoryManager1, factoryManager2, 'cache hit');
+      assert.strictEqual(factoryManager1, factoryManager2, 'cache hit');
       assert.notEqual(factoryManager1, factoryManager3, 'cache miss');
     }
 
@@ -581,8 +581,8 @@ moduleFor(
       let instance1 = container.lookup('component:foo-bar');
       let instance2 = container.lookup('component:foo-bar');
 
-      assert.equal(instance1, instance2);
-      assert.equal(factory1, factory2);
+      assert.strictEqual(instance1, instance2);
+      assert.strictEqual(factory1, factory2);
 
       container.reset();
 

--- a/packages/@ember/-internals/container/tests/registry_test.js
+++ b/packages/@ember/-internals/container/tests/registry_test.js
@@ -67,12 +67,12 @@ moduleFor(
 
       registry.register('controller:post', PostController);
 
-      assert.equal(
+      assert.strictEqual(
         registry.has('controller:post'),
         true,
         'The `has` method returned true for registered factories'
       );
-      assert.equal(
+      assert.strictEqual(
         registry.has('controller:posts'),
         false,
         'The `has` method returned false for unregistered factories'
@@ -136,7 +136,7 @@ moduleFor(
       registry.register('controller:post', PostController);
       let isPresent = registry.has('controller:normalized');
 
-      assert.equal(
+      assert.strictEqual(
         isPresent,
         true,
         'Normalizes the name when checking if the factory or instance is present'
@@ -200,7 +200,7 @@ moduleFor(
         },
       };
 
-      assert.equal(registry.resolve('models:bar'), Bar);
+      assert.strictEqual(registry.resolve('models:bar'), Bar);
     }
 
     ['@test factory resolves are cached'](assert) {
@@ -294,7 +294,7 @@ moduleFor(
 
       let registry = new Registry({ fallback, resolver });
 
-      assert.equal(
+      assert.strictEqual(
         registry.describe('controller:post'),
         'controller:post-resolver',
         '`describe` handled by the resolver first.'
@@ -302,7 +302,7 @@ moduleFor(
 
       registry.resolver = null;
 
-      assert.equal(
+      assert.strictEqual(
         registry.describe('controller:post'),
         'controller:post-fallback',
         '`describe` handled by fallback registry next.'
@@ -310,7 +310,7 @@ moduleFor(
 
       registry.fallback = null;
 
-      assert.equal(
+      assert.strictEqual(
         registry.describe('controller:post'),
         'controller:post',
         '`describe` by default returns argument.'
@@ -334,7 +334,7 @@ moduleFor(
 
       let registry = new Registry({ fallback, resolver });
 
-      assert.equal(
+      assert.strictEqual(
         registry.normalizeFullName('controller:post'),
         'controller:post-resolver',
         '`normalizeFullName` handled by the resolver first.'
@@ -342,7 +342,7 @@ moduleFor(
 
       registry.resolver = null;
 
-      assert.equal(
+      assert.strictEqual(
         registry.normalizeFullName('controller:post'),
         'controller:post-fallback',
         '`normalizeFullName` handled by fallback registry next.'
@@ -350,7 +350,7 @@ moduleFor(
 
       registry.fallback = null;
 
-      assert.equal(
+      assert.strictEqual(
         registry.normalizeFullName('controller:post'),
         'controller:post',
         '`normalizeFullName` by default returns argument.'
@@ -374,7 +374,7 @@ moduleFor(
 
       let registry = new Registry({ fallback, resolver });
 
-      assert.equal(
+      assert.strictEqual(
         registry.makeToString('controller:post'),
         'controller:post-resolver',
         '`makeToString` handled by the resolver first.'
@@ -382,7 +382,7 @@ moduleFor(
 
       registry.resolver = null;
 
-      assert.equal(
+      assert.strictEqual(
         registry.makeToString('controller:post'),
         'controller:post-fallback',
         '`makeToString` handled by fallback registry next.'
@@ -390,7 +390,7 @@ moduleFor(
 
       registry.fallback = null;
 
-      assert.equal(
+      assert.strictEqual(
         registry.makeToString('controller:post'),
         'controller:post',
         '`makeToString` by default returns argument.'
@@ -422,7 +422,7 @@ moduleFor(
 
       fallback.register('controller:post', PostController);
 
-      assert.equal(
+      assert.strictEqual(
         registry.has('controller:post'),
         true,
         'Fallback registry is checked for registration'
@@ -466,7 +466,7 @@ moduleFor(
       let resolver = {
         knownForType(type) {
           assert.ok(true, 'knownForType called on the resolver');
-          assert.equal(type, 'foo', 'the type was passed through');
+          assert.strictEqual(type, 'foo', 'the type was passed through');
 
           return { 'foo:yorp': true };
         },
@@ -495,8 +495,8 @@ moduleFor(
       let matched = privatized.match(/^([^:]+):([^:]+)-(\d+)$/);
 
       assert.ok(matched, 'privatized format was recognized');
-      assert.equal(matched[1], 'secret');
-      assert.equal(matched[2], 'factory');
+      assert.strictEqual(matched[1], 'secret');
+      assert.strictEqual(matched[2], 'factory');
       assert.ok(/^\d+$/.test(matched[3]));
     }
   }

--- a/packages/@ember/-internals/extension-support/tests/container_debug_adapter_test.js
+++ b/packages/@ember/-internals/extension-support/tests/container_debug_adapter_test.js
@@ -31,12 +31,12 @@ moduleFor(
     }
 
     ['@test default ContainerDebugAdapter cannot catalog certain entries by type'](assert) {
-      assert.equal(
+      assert.strictEqual(
         this.adapter.canCatalogEntriesByType('model'),
         false,
         'canCatalogEntriesByType should return false for model'
       );
-      assert.equal(
+      assert.strictEqual(
         this.adapter.canCatalogEntriesByType('template'),
         false,
         'canCatalogEntriesByType should return false for template'
@@ -44,17 +44,17 @@ moduleFor(
     }
 
     ['@test default ContainerDebugAdapter can catalog typical entries by type'](assert) {
-      assert.equal(
+      assert.strictEqual(
         this.adapter.canCatalogEntriesByType('controller'),
         true,
         'canCatalogEntriesByType should return true for controller'
       );
-      assert.equal(
+      assert.strictEqual(
         this.adapter.canCatalogEntriesByType('route'),
         true,
         'canCatalogEntriesByType should return true for route'
       );
-      assert.equal(
+      assert.strictEqual(
         this.adapter.canCatalogEntriesByType('view'),
         true,
         'canCatalogEntriesByType should return true for view'
@@ -65,8 +65,8 @@ moduleFor(
       this.application.PostController = EmberController.extend();
       let controllerClasses = this.adapter.catalogEntriesByType('controller');
 
-      assert.equal(controllerClasses.length, 1, 'found 1 class');
-      assert.equal(controllerClasses[0], 'post', 'found the right class');
+      assert.strictEqual(controllerClasses.length, 1, 'found 1 class');
+      assert.strictEqual(controllerClasses[0], 'post', 'found the right class');
     }
   }
 );

--- a/packages/@ember/-internals/extension-support/tests/data_adapter_test.js
+++ b/packages/@ember/-internals/extension-support/tests/data_adapter_test.js
@@ -52,10 +52,10 @@ moduleFor(
         let adapter = this.applicationInstance.lookup('data-adapter:main');
 
         function modelTypesAdded(types) {
-          assert.equal(types.length, 1);
+          assert.strictEqual(types.length, 1);
           let postType = types[0];
-          assert.equal(postType.name, 'post', 'Correctly sets the name');
-          assert.equal(postType.count, 3, 'Correctly sets the record count');
+          assert.strictEqual(postType.name, 'post', 'Correctly sets the name');
+          assert.strictEqual(postType.count, 3, 'Correctly sets the record count');
           assert.strictEqual(postType.object, PostClass, 'Correctly sets the object');
           assert.deepEqual(
             postType.columns,
@@ -73,7 +73,7 @@ moduleFor(
         'data-adapter:main',
         DataAdapter.extend({
           getRecords(klass, name) {
-            assert.equal(name, 'post');
+            assert.strictEqual(name, 'post');
             return emberA();
           },
         })
@@ -113,10 +113,10 @@ moduleFor(
         let adapter = this.applicationInstance.lookup('data-adapter:main');
 
         function modelTypesAdded(types) {
-          assert.equal(types.length, 1);
+          assert.strictEqual(types.length, 1);
           let postType = types[0];
-          assert.equal(postType.name, 'post', 'Correctly sets the name');
-          assert.equal(postType.count, 3, 'Correctly sets the record count');
+          assert.strictEqual(postType.name, 'post', 'Correctly sets the name');
+          assert.strictEqual(postType.count, 3, 'Correctly sets the record count');
           assert.strictEqual(postType.object, PostClass, 'Correctly sets the object');
           assert.deepEqual(
             postType.columns,
@@ -152,7 +152,7 @@ moduleFor(
 
         function modelTypesUpdated(types) {
           let postType = types[0];
-          assert.equal(postType.count, 4, 'Correctly updates the count');
+          assert.strictEqual(postType.count, 4, 'Correctly updates the count');
         }
 
         adapter.watchModelTypes(modelTypesAdded, modelTypesUpdated);
@@ -188,7 +188,7 @@ moduleFor(
 
         function recordsAdded(records) {
           let record = records[0];
-          assert.equal(record.color, 'blue', 'Sets the color correctly');
+          assert.strictEqual(record.color, 'blue', 'Sets the color correctly');
           assert.deepEqual(
             record.columnValues,
             { title: 'Post ' + countAdded },
@@ -234,12 +234,12 @@ moduleFor(
           adapter = this.applicationInstance.lookup('data-adapter:main');
 
           function recordsAdded(records) {
-            assert.equal(records[0].columnValues.title, 'Post', 'Post added correctly');
+            assert.strictEqual(records[0].columnValues.title, 'Post', 'Post added correctly');
           }
 
           function recordsUpdated(records) {
             updatesCalled++;
-            assert.equal(records[0].columnValues.title, 'Post Modified');
+            assert.strictEqual(records[0].columnValues.title, 'Post Modified');
           }
 
           release = adapter.watchRecords('post', recordsAdded, recordsUpdated);
@@ -254,7 +254,7 @@ moduleFor(
         .then(() => {
           release();
           set(post, 'title', 'New Title');
-          assert.equal(updatesCalled, 1, 'Release function removes observers');
+          assert.strictEqual(updatesCalled, 1, 'Release function removes observers');
         });
     }
 
@@ -266,7 +266,7 @@ moduleFor(
 
         let klass = adapter._nameToClass('foo');
 
-        assert.equal(klass, undefined, 'returns undefined');
+        assert.strictEqual(klass, undefined, 'returns undefined');
       });
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -821,7 +821,7 @@ moduleFor(
           return this.visit('/blog');
         })
         .catch((error) => {
-          assert.equal(error.message, 'Whoops! Something went wrong...');
+          assert.strictEqual(error.message, 'Whoops! Something went wrong...');
         });
     }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/helper-registration-test.js
@@ -13,7 +13,7 @@ moduleFor(
       this.application.register('helper:x-borf', myHelper);
 
       return this.visit('/').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.$('#wrapper').text(),
           'BORF YES',
           'The helper was invoked from the container'
@@ -42,7 +42,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.$('#wrapper').text(),
           '-- xela',
           'The bound helper was invoked from the container'
@@ -67,7 +67,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.$('#wrapper').text(),
           'OMG|boo|ya',
           'The helper was invoked from the container'

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -170,7 +170,7 @@ moduleFor(
 
       await this.visit('/red');
 
-      assert.equal(this.currentURL, '/red');
+      assert.strictEqual(this.currentURL, '/red');
 
       this.assertInnerHTML(strip`
         [@model: red]
@@ -180,7 +180,7 @@ moduleFor(
 
       await this.visit('/yellow');
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: yellow]
@@ -193,7 +193,7 @@ moduleFor(
         set(model, 'color', 'blue');
       });
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: blue]
@@ -239,7 +239,7 @@ moduleFor(
 
       await this.visit('/red');
 
-      assert.equal(this.currentURL, '/red');
+      assert.strictEqual(this.currentURL, '/red');
 
       this.assertInnerHTML(strip`
         [@model: red]
@@ -249,7 +249,7 @@ moduleFor(
 
       await this.visit('/yellow');
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: yellow]
@@ -261,7 +261,7 @@ moduleFor(
         this.controllerFor('color').model.color = 'blue';
       });
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: blue]
@@ -299,7 +299,7 @@ moduleFor(
 
       await this.visit('/red');
 
-      assert.equal(this.currentURL, '/red');
+      assert.strictEqual(this.currentURL, '/red');
 
       this.assertInnerHTML(strip`
         [@model: red]
@@ -309,7 +309,7 @@ moduleFor(
 
       await this.visit('/yellow');
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: yellow]
@@ -322,7 +322,7 @@ moduleFor(
         set(controller, 'model', 'blue');
       });
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: yellow]
@@ -367,7 +367,7 @@ moduleFor(
 
       await this.visit('/red');
 
-      assert.equal(this.currentURL, '/red');
+      assert.strictEqual(this.currentURL, '/red');
 
       this.assertInnerHTML(strip`
         [@model: red]
@@ -377,7 +377,7 @@ moduleFor(
 
       await this.visit('/yellow');
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: yellow]
@@ -389,7 +389,7 @@ moduleFor(
         this.controllerFor('color').model = 'blue';
       });
 
-      assert.equal(this.currentURL, '/yellow');
+      assert.strictEqual(this.currentURL, '/yellow');
 
       this.assertInnerHTML(strip`
         [@model: yellow]

--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -397,8 +397,8 @@ moduleFor(
       this.render('<FooBar />');
       this.assertText('foo-bar foo-bar-baz');
 
-      assert.equal(fooBarInstance.parentView, this.component);
-      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+      assert.strictEqual(fooBarInstance.parentView, this.component);
+      assert.strictEqual(fooBarBazInstance.parentView, fooBarInstance);
 
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
@@ -406,8 +406,8 @@ moduleFor(
       runTask(() => this.rerender());
       this.assertText('foo-bar foo-bar-baz');
 
-      assert.equal(fooBarInstance.parentView, this.component);
-      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+      assert.strictEqual(fooBarInstance.parentView, this.component);
+      assert.strictEqual(fooBarBazInstance.parentView, fooBarInstance);
 
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
@@ -1295,7 +1295,7 @@ moduleFor(
       this.render('<TheFoo {{bar "something" foo="else"}}/>', {});
       assert.deepEqual(modifierParams, ['something'], 'positional arguments');
       this.assertNamedArgs(modifierNamedArgs, { foo: 'else' }, 'named arguments');
-      assert.equal(
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'
@@ -1359,7 +1359,7 @@ moduleFor(
       });
       assert.deepEqual(modifierParams, ['something']);
       this.assertNamedArgs(modifierNamedArgs, { foo: 'else' });
-      assert.equal(
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'
@@ -1367,7 +1367,7 @@ moduleFor(
       runTask(() => setProperties(this.context, { something: 'another', foo: 'thingy' }));
       assert.deepEqual(modifierParams, ['another']);
       this.assertNamedArgs(modifierNamedArgs, { foo: 'thingy' });
-      assert.equal(
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'
@@ -1402,17 +1402,17 @@ moduleFor(
         })
       );
       this.render('<TheFoo {{bar "name" this foo=this}}/>', context);
-      assert.equal(modifierParams[1].id, 1);
-      assert.equal(modifierNamedArgs.foo.id, 1);
-      assert.equal(
+      assert.strictEqual(modifierParams[1].id, 1);
+      assert.strictEqual(modifierNamedArgs.foo.id, 1);
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'
       );
       runTask(() => setProperties(this.context, context2));
-      assert.equal(modifierParams[1].id, 2);
-      assert.equal(modifierNamedArgs.foo.id, 2);
-      assert.equal(
+      assert.strictEqual(modifierParams[1].id, 2);
+      assert.strictEqual(modifierNamedArgs.foo.id, 2);
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'
@@ -1453,7 +1453,7 @@ moduleFor(
       );
       assert.deepEqual(modifierParams, ['bar']);
       this.assertNamedArgs(modifierNamedArgs, { foo: 'bar' });
-      assert.equal(
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'
@@ -1461,7 +1461,7 @@ moduleFor(
       runTask(() => setProperties(this.context, { foo: 'qux' }));
       assert.deepEqual(modifierParams, ['qux']);
       this.assertNamedArgs(modifierNamedArgs, { foo: 'qux' });
-      assert.equal(
+      assert.strictEqual(
         modifiedElement && modifiedElement.getAttribute('id'),
         'inner-div',
         'Modifier is called on the element receiving the splattributes'

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -322,7 +322,7 @@ class AbstractAppendTest extends RenderingTestCase {
       content: '[parent: zomg][child: zomg][yielded: zomg]',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement.parentElement,
       this.element,
       'It should be attached to the target'
@@ -334,7 +334,7 @@ class AbstractAppendTest extends RenderingTestCase {
       content: '[parent: zomg][child: zomg][yielded: zomg]',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement.parentElement,
       this.element,
       'It should be attached to the target'
@@ -346,7 +346,7 @@ class AbstractAppendTest extends RenderingTestCase {
       content: '[parent: wow][child: wow][yielded: wow]',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement.parentElement,
       this.element,
       'It should be attached to the target'
@@ -358,7 +358,7 @@ class AbstractAppendTest extends RenderingTestCase {
       content: '[parent: zomg][child: zomg][yielded: zomg]',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement.parentElement,
       this.element,
       'It should be attached to the target'
@@ -369,7 +369,7 @@ class AbstractAppendTest extends RenderingTestCase {
     assert.ok(!this.component.element, 'It should not have an element');
     assert.ok(!componentElement.parentElement, 'The component element should be detached');
 
-    this.assert.equal(willDestroyCalled, 1);
+    this.assert.strictEqual(willDestroyCalled, 1);
   }
 
   ['@test releasing a root component after it has been destroy'](assert) {
@@ -382,11 +382,11 @@ class AbstractAppendTest extends RenderingTestCase {
     this.component = this.owner.factoryFor('component:x-component').create();
     this.append(this.component);
 
-    assert.equal(renderer._roots.length, 1, 'added a root component');
+    assert.strictEqual(renderer._roots.length, 1, 'added a root component');
 
     runTask(() => this.component.destroy());
 
-    assert.equal(renderer._roots.length, 0, 'released the root component');
+    assert.strictEqual(renderer._roots.length, 0, 'released the root component');
   }
 
   ['@test appending, updating and destroying multiple components'](assert) {
@@ -440,12 +440,12 @@ class AbstractAppendTest extends RenderingTestCase {
       content: 'x-second bar!',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement1.parentElement,
       wrapper1,
       'The first component should be attached to the target'
     );
-    assert.equal(
+    assert.strictEqual(
       componentElement2.parentElement,
       wrapper2,
       'The second component should be attached to the target'
@@ -458,12 +458,12 @@ class AbstractAppendTest extends RenderingTestCase {
       content: 'x-second bar!',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement1.parentElement,
       wrapper1,
       'The first component should be attached to the target'
     );
-    assert.equal(
+    assert.strictEqual(
       componentElement2.parentElement,
       wrapper2,
       'The second component should be attached to the target'
@@ -476,12 +476,12 @@ class AbstractAppendTest extends RenderingTestCase {
       content: 'x-second BAR!',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement1.parentElement,
       wrapper1,
       'The first component should be attached to the target'
     );
-    assert.equal(
+    assert.strictEqual(
       componentElement2.parentElement,
       wrapper2,
       'The second component should be attached to the target'
@@ -497,12 +497,12 @@ class AbstractAppendTest extends RenderingTestCase {
       content: 'x-second bar!',
     });
 
-    assert.equal(
+    assert.strictEqual(
       componentElement1.parentElement,
       wrapper1,
       'The first component should be attached to the target'
     );
-    assert.equal(
+    assert.strictEqual(
       componentElement2.parentElement,
       wrapper2,
       'The second component should be attached to the target'
@@ -519,7 +519,7 @@ class AbstractAppendTest extends RenderingTestCase {
     assert.ok(!componentElement1.parentElement, 'The first component element should be detached');
     assert.ok(!componentElement2.parentElement, 'The second component element should be detached');
 
-    this.assert.equal(willDestroyCalled, 2);
+    this.assert.strictEqual(willDestroyCalled, 2);
   }
 
   ['@test can appendTo while rendering']() {
@@ -657,14 +657,14 @@ class AbstractAppendTest extends RenderingTestCase {
 
     this.assertComponentElement(element1, {});
     this.assertComponentElement(element2, { content: 'fake-thing: 0' });
-    assert.equal(instantiatedRoots, 1);
+    assert.strictEqual(instantiatedRoots, 1);
 
     this.assertStableRerender();
 
     runTask(() => set(this.context, 'showFooBar', false));
 
-    assert.equal(instantiatedRoots, 2);
-    assert.equal(destroyedRoots, 1);
+    assert.strictEqual(instantiatedRoots, 2);
+    assert.strictEqual(destroyedRoots, 1);
 
     this.assertComponentElement(element3, {});
     this.assertComponentElement(element4, { content: 'fake-thing: 1' });
@@ -674,8 +674,8 @@ class AbstractAppendTest extends RenderingTestCase {
       component2.destroy();
     });
 
-    assert.equal(instantiatedRoots, 2);
-    assert.equal(destroyedRoots, 2);
+    assert.strictEqual(instantiatedRoots, 2);
+    assert.strictEqual(destroyedRoots, 2);
   }
 }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attribute-bindings-test.js
@@ -329,7 +329,7 @@ moduleFor(
         foo: '0 0 100 100',
       });
 
-      this.assert.equal(
+      this.assert.strictEqual(
         this.firstChild.getAttribute('viewBox'),
         '0 0 100 100',
         'viewBox attribute'
@@ -343,7 +343,7 @@ moduleFor(
 
       runTask(() => set(this.context, 'foo', '0 0 100 200'));
 
-      this.assert.equal(
+      this.assert.strictEqual(
         this.firstChild.getAttribute('viewBox'),
         '0 0 100 200',
         'viewBox attribute'

--- a/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/attrs-lookup-test.js
@@ -47,15 +47,15 @@ moduleFor(
         firstAttr: 'first attr',
       });
 
-      assert.equal(instance.get('first'), 'first attr');
+      assert.strictEqual(instance.get('first'), 'first attr');
 
       runTask(() => this.rerender());
 
-      assert.equal(instance.get('first'), 'first attr');
+      assert.strictEqual(instance.get('first'), 'first attr');
 
       runTask(() => set(this.context, 'firstAttr', 'second attr'));
 
-      assert.equal(instance.get('first'), 'second attr');
+      assert.strictEqual(instance.get('first'), 'second attr');
 
       runTask(() => set(this.context, 'firstAttr', 'first attr'));
 
@@ -81,12 +81,12 @@ moduleFor(
 
       this.render(`{{foo-bar first="first attr"}}`);
 
-      assert.equal(instance.get('first'), 'FIRST ATTR', 'component lookup uses local state');
+      assert.strictEqual(instance.get('first'), 'FIRST ATTR', 'component lookup uses local state');
       this.assertText('FIRST ATTR');
 
       runTask(() => this.rerender());
 
-      assert.equal(
+      assert.strictEqual(
         instance.get('first'),
         'FIRST ATTR',
         'component lookup uses local state during rerender'
@@ -108,7 +108,7 @@ moduleFor(
         },
 
         didReceiveAttrs() {
-          assert.equal(this.get('woot'), wootVal, 'found attr in didReceiveAttrs');
+          assert.strictEqual(this.get('woot'), wootVal, 'found attr in didReceiveAttrs');
         },
       });
       this.registerComponent('foo-bar', { ComponentClass: FooBarComponent });
@@ -117,25 +117,25 @@ moduleFor(
         woot: wootVal,
       });
 
-      assert.equal(instance.get('woot'), 'yes', 'component found attr');
+      assert.strictEqual(instance.get('woot'), 'yes', 'component found attr');
 
       runTask(() => this.rerender());
 
-      assert.equal(instance.get('woot'), 'yes', 'component found attr after rerender');
+      assert.strictEqual(instance.get('woot'), 'yes', 'component found attr after rerender');
 
       runTask(() => {
         wootVal = 'nope';
         set(this.context, 'woot', wootVal);
       });
 
-      assert.equal(instance.get('woot'), 'nope', 'component found attr after attr change');
+      assert.strictEqual(instance.get('woot'), 'nope', 'component found attr after attr change');
 
       runTask(() => {
         wootVal = 'yes';
         set(this.context, 'woot', wootVal);
       });
 
-      assert.equal(instance.get('woot'), 'yes', 'component found attr after reset');
+      assert.strictEqual(instance.get('woot'), 'yes', 'component found attr after reset');
     }
 
     ['@test getAttr() should return the same value as get()'](assert) {
@@ -156,13 +156,13 @@ moduleFor(
           let attrFirst = this.getAttr('first');
           let attrSecond = this.getAttr('second');
 
-          assert.equal(
+          assert.strictEqual(
             rootFirstPositional,
             attrFirstPositional,
             'root property matches attrs value'
           );
-          assert.equal(rootFirst, attrFirst, 'root property matches attrs value');
-          assert.equal(rootSecond, attrSecond, 'root property matches attrs value');
+          assert.strictEqual(rootFirst, attrFirst, 'root property matches attrs value');
+          assert.strictEqual(rootSecond, attrSecond, 'root property matches attrs value');
         },
       });
 
@@ -178,39 +178,39 @@ moduleFor(
         second: 'second',
       });
 
-      assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
-      assert.equal(instance.get('first'), 'first', 'matches known value');
-      assert.equal(instance.get('second'), 'second', 'matches known value');
+      assert.strictEqual(instance.get('firstPositional'), 'firstPositional', 'matches known value');
+      assert.strictEqual(instance.get('first'), 'first', 'matches known value');
+      assert.strictEqual(instance.get('second'), 'second', 'matches known value');
 
       runTask(() => this.rerender());
 
-      assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
-      assert.equal(instance.get('first'), 'first', 'matches known value');
-      assert.equal(instance.get('second'), 'second', 'matches known value');
+      assert.strictEqual(instance.get('firstPositional'), 'firstPositional', 'matches known value');
+      assert.strictEqual(instance.get('first'), 'first', 'matches known value');
+      assert.strictEqual(instance.get('second'), 'second', 'matches known value');
 
       runTask(() => {
         set(this.context, 'first', 'third');
       });
 
-      assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
-      assert.equal(instance.get('first'), 'third', 'matches known value');
-      assert.equal(instance.get('second'), 'second', 'matches known value');
+      assert.strictEqual(instance.get('firstPositional'), 'firstPositional', 'matches known value');
+      assert.strictEqual(instance.get('first'), 'third', 'matches known value');
+      assert.strictEqual(instance.get('second'), 'second', 'matches known value');
 
       runTask(() => {
         set(this.context, 'second', 'fourth');
       });
 
-      assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
-      assert.equal(instance.get('first'), 'third', 'matches known value');
-      assert.equal(instance.get('second'), 'fourth', 'matches known value');
+      assert.strictEqual(instance.get('firstPositional'), 'firstPositional', 'matches known value');
+      assert.strictEqual(instance.get('first'), 'third', 'matches known value');
+      assert.strictEqual(instance.get('second'), 'fourth', 'matches known value');
 
       runTask(() => {
         set(this.context, 'firstPositional', 'fifth');
       });
 
-      assert.equal(instance.get('firstPositional'), 'fifth', 'matches known value');
-      assert.equal(instance.get('first'), 'third', 'matches known value');
-      assert.equal(instance.get('second'), 'fourth', 'matches known value');
+      assert.strictEqual(instance.get('firstPositional'), 'fifth', 'matches known value');
+      assert.strictEqual(instance.get('first'), 'third', 'matches known value');
+      assert.strictEqual(instance.get('second'), 'fourth', 'matches known value');
 
       runTask(() => {
         set(this.context, 'firstPositional', 'firstPositional');
@@ -218,9 +218,9 @@ moduleFor(
         set(this.context, 'second', 'second');
       });
 
-      assert.equal(instance.get('firstPositional'), 'firstPositional', 'matches known value');
-      assert.equal(instance.get('first'), 'first', 'matches known value');
-      assert.equal(instance.get('second'), 'second', 'matches known value');
+      assert.strictEqual(instance.get('firstPositional'), 'firstPositional', 'matches known value');
+      assert.strictEqual(instance.get('first'), 'first', 'matches known value');
+      assert.strictEqual(instance.get('second'), 'second', 'matches known value');
     }
 
     ['@test bound computed properties can be overridden in extensions, set during init, and passed in as attrs']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -753,7 +753,7 @@ moduleFor(
         { first: 'first' }
       );
 
-      assert.equal(value, 'first', 'value is the expected parameter');
+      assert.strictEqual(value, 'first', 'value is the expected parameter');
     }
 
     ['@test renders with dot path and updates attributes'](assert) {
@@ -793,23 +793,23 @@ moduleFor(
         },
       });
 
-      assert.equal(this.$('#nested-prop').text(), '1');
+      assert.strictEqual(this.$('#nested-prop').text(), '1');
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$('#nested-prop').text(), '1');
+      assert.strictEqual(this.$('#nested-prop').text(), '1');
 
       runTask(() => this.$('button').click());
 
-      assert.equal(this.$('#nested-prop').text(), '2');
+      assert.strictEqual(this.$('#nested-prop').text(), '2');
 
       runTask(() => this.$('button').click());
 
-      assert.equal(this.$('#nested-prop').text(), '3');
+      assert.strictEqual(this.$('#nested-prop').text(), '3');
 
       runTask(() => this.context.set('model', { myProp: 1 }));
 
-      assert.equal(this.$('#nested-prop').text(), '1');
+      assert.strictEqual(this.$('#nested-prop').text(), '1');
     }
 
     ["@test adding parameters to a contextual component's instance does not add it to other instances"]() {
@@ -861,19 +861,19 @@ moduleFor(
         }
       );
 
-      assert.equal(this.$('.value').text(), '8');
+      assert.strictEqual(this.$('.value').text(), '8');
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$('.value').text(), '8');
+      assert.strictEqual(this.$('.value').text(), '8');
 
       runTask(() => this.$('.my-button').click());
 
-      assert.equal(this.$('.value').text(), '10');
+      assert.strictEqual(this.$('.value').text(), '10');
 
       runTask(() => this.context.set('model', { val2: 8 }));
 
-      assert.equal(this.$('.value').text(), '8');
+      assert.strictEqual(this.$('.value').text(), '8');
     }
 
     ['@test tagless blockless components render'](assert) {
@@ -885,7 +885,7 @@ moduleFor(
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$().text(), '');
+      assert.strictEqual(this.$().text(), '');
     }
 
     ['@test GH#13494 tagless blockless component with property binding'](assert) {
@@ -911,19 +911,19 @@ moduleFor(
 
       this.render(`{{outer-component}}`);
 
-      assert.equal(this.$().text(), 'message: hello');
+      assert.strictEqual(this.$().text(), 'message: hello');
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$().text(), 'message: hello');
+      assert.strictEqual(this.$().text(), 'message: hello');
 
       runTask(() => this.$('button').click());
 
-      assert.equal(this.$().text(), 'message: goodbye');
+      assert.strictEqual(this.$().text(), 'message: goodbye');
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$().text(), 'message: goodbye');
+      assert.strictEqual(this.$().text(), 'message: goodbye');
     }
 
     ['@test GH#13982 contextual component ref is stable even when bound params change'](assert) {
@@ -955,37 +955,37 @@ moduleFor(
       );
 
       assert.ok(!isEmpty(instance), 'a instance was created');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'open', 'the components text is "open"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'open', 'the components text is "open"');
 
       runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'open', 'the components text is "open"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'open', 'the components text is "open"');
 
       runTask(() => this.context.set('isOpen', false));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'closed', 'the component text is "closed"');
 
       runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'closed', 'the component text is "closed"');
 
       runTask(() => this.context.set('isOpen', true));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'open', 'the components text is "open"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'open', 'the components text is "open"');
     }
 
     ['@test GH#13982 contextual component ref is stable even when bound params change (bound name param)'](
@@ -1020,37 +1020,37 @@ moduleFor(
       );
 
       assert.ok(!isEmpty(instance), 'a instance was created');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'open', 'the components text is "open"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'open', 'the components text is "open"');
 
       runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'open', 'the components text is "open"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'open', 'the components text is "open"');
 
       runTask(() => this.context.set('isOpen', false));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'closed', 'the component text is "closed"');
 
       runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'closed', 'the component text is "closed"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'closed', 'the component text is "closed"');
 
       runTask(() => this.context.set('isOpen', true));
 
       assert.ok(!isEmpty(instance), 'the component instance exists');
-      assert.equal(previousInstance, undefined, 'no previous component exists');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'open', 'the components text is "open"');
+      assert.strictEqual(previousInstance, undefined, 'no previous component exists');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'open', 'the components text is "open"');
     }
 
     ['@test GH#13982 contextual component ref is recomputed when component name param changes'](
@@ -1098,16 +1098,20 @@ moduleFor(
       );
 
       assert.ok(!isEmpty(instance), 'a instance was created');
-      assert.equal(previousInstance, undefined, 'there is no previous instance');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'my-comp: open');
+      assert.strictEqual(previousInstance, undefined, 'there is no previous instance');
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'my-comp: open');
 
       runTask(() => this.rerender());
 
       assert.ok(!isEmpty(instance), 'a instance exists after rerender');
-      assert.equal(previousInstance, undefined, 'there is no previous instance after rerender');
-      assert.equal(initCount, 1, 'the component was constructed exactly 1 time');
-      assert.equal(this.$().text(), 'my-comp: open');
+      assert.strictEqual(
+        previousInstance,
+        undefined,
+        'there is no previous instance after rerender'
+      );
+      assert.strictEqual(initCount, 1, 'the component was constructed exactly 1 time');
+      assert.strictEqual(this.$().text(), 'my-comp: open');
 
       runTask(() => this.context.set('compName', 'your-comp'));
 
@@ -1118,8 +1122,8 @@ moduleFor(
         previousInstance,
         'the instance and previous instance are not the same object'
       );
-      assert.equal(initCount, 2, 'the component was constructed exactly 2 times');
-      assert.equal(this.$().text(), 'your-comp: open');
+      assert.strictEqual(initCount, 2, 'the component was constructed exactly 2 times');
+      assert.strictEqual(this.$().text(), 'your-comp: open');
 
       runTask(() => this.rerender());
 
@@ -1133,8 +1137,8 @@ moduleFor(
         previousInstance,
         'the instance and previous instance are not the same object (rerender)'
       );
-      assert.equal(initCount, 2, 'the component was constructed exactly 2 times (rerender)');
-      assert.equal(this.$().text(), 'your-comp: open');
+      assert.strictEqual(initCount, 2, 'the component was constructed exactly 2 times (rerender)');
+      assert.strictEqual(this.$().text(), 'your-comp: open');
 
       runTask(() => this.context.set('compName', 'my-comp'));
 
@@ -1145,8 +1149,8 @@ moduleFor(
         previousInstance,
         'the instance and previous instance are not the same object'
       );
-      assert.equal(initCount, 3, 'the component was constructed exactly 3 times (rerender)');
-      assert.equal(this.$().text(), 'my-comp: open');
+      assert.strictEqual(initCount, 3, 'the component was constructed exactly 3 times (rerender)');
+      assert.strictEqual(this.$().text(), 'my-comp: open');
     }
 
     ['@test GH#14508 rest positional params are received when passed as named parameter']() {
@@ -1454,19 +1458,19 @@ class MutableParamTestGenerator {
 
         setup.call(this, assert);
 
-        assert.equal(this.$('.value').text(), '8');
+        assert.strictEqual(this.$('.value').text(), '8');
 
         runTask(() => this.rerender());
 
-        assert.equal(this.$('.value').text(), '8');
+        assert.strictEqual(this.$('.value').text(), '8');
 
         runTask(() => this.$('.my-button').click());
 
-        assert.equal(this.$('.value').text(), '10');
+        assert.strictEqual(this.$('.value').text(), '10');
 
         runTask(() => this.context.set('model', { val2: 8 }));
 
-        assert.equal(this.$('.value').text(), '8');
+        assert.strictEqual(this.$('.value').text(), '8');
       },
     };
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -204,7 +204,7 @@ moduleFor(
         'Has a reasonable id attribute (found id=' + newFoundId + ').'
       );
 
-      assert.equal(foundId, newFoundId);
+      assert.strictEqual(foundId, newFoundId);
     }
 
     ['@test id is an alias for elementId'](assert) {
@@ -220,14 +220,14 @@ moduleFor(
       this.render('{{foo-bar id="custom-id"}}');
 
       let foundId = this.$('h1').attr('id');
-      assert.equal(foundId, 'custom-id');
+      assert.strictEqual(foundId, 'custom-id');
 
       runTask(() => this.rerender());
 
       let newFoundId = this.$('h1').attr('id');
-      assert.equal(newFoundId, 'custom-id');
+      assert.strictEqual(newFoundId, 'custom-id');
 
-      assert.equal(foundId, newFoundId);
+      assert.strictEqual(foundId, newFoundId);
     }
 
     ['@test cannot pass both id and elementId at the same time']() {
@@ -341,7 +341,7 @@ moduleFor(
 
       this.render('{{foo-bar class="foo-bar"}}');
 
-      assert.equal(componentClass, 'foo-bar ember-view');
+      assert.strictEqual(componentClass, 'foo-bar ember-view');
     }
 
     ['@test it can have custom classNames']() {
@@ -660,8 +660,8 @@ moduleFor(
       this.render('{{foo-bar}}');
       this.assertText('foo-bar foo-bar-baz');
 
-      assert.equal(fooBarInstance.parentView, this.component);
-      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+      assert.strictEqual(fooBarInstance.parentView, this.component);
+      assert.strictEqual(fooBarBazInstance.parentView, fooBarInstance);
 
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
@@ -669,8 +669,8 @@ moduleFor(
       runTask(() => this.rerender());
       this.assertText('foo-bar foo-bar-baz');
 
-      assert.equal(fooBarInstance.parentView, this.component);
-      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+      assert.strictEqual(fooBarInstance.parentView, this.component);
+      assert.strictEqual(fooBarBazInstance.parentView, fooBarInstance);
 
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
@@ -1174,8 +1174,8 @@ moduleFor(
       );
 
       let [t1, t2, t3, t4] = templateIds;
-      assert.equal(t1, t3);
-      assert.equal(t2, t4);
+      assert.strictEqual(t1, t3);
+      assert.strictEqual(t2, t4);
     }
 
     ['@test can use isStream property without conflict (#13271)']() {
@@ -1442,12 +1442,12 @@ moduleFor(
             click() {
               let currentCounter = this.get('counter');
 
-              assert.equal(currentCounter, 0, 'the current `counter` value is correct');
+              assert.strictEqual(currentCounter, 0, 'the current `counter` value is correct');
 
               let newCounter = currentCounter + 1;
               this.set('counter', newCounter);
 
-              assert.equal(
+              assert.strictEqual(
                 this.get('counter'),
                 newCounter,
                 "getting the newly set `counter` property works; it's equal to the value we just set and not `undefined`"
@@ -1466,7 +1466,7 @@ moduleFor(
 
       runTask(() => this.$('button').click());
 
-      assert.equal(
+      assert.strictEqual(
         componentInstance.get('counter'),
         1,
         '`counter` incremented on click on the component and is not `undefined`'
@@ -1647,13 +1647,13 @@ moduleFor(
       {{sample-component "Foo" 4 "Bar" elementId="args-3"}}
       {{sample-component "Foo" 4 "Bar" 5 "Baz" elementId="args-5"}}`);
 
-      assert.equal(this.$('#args-3').text(), 'Foo4Bar');
-      assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
+      assert.strictEqual(this.$('#args-3').text(), 'Foo4Bar');
+      assert.strictEqual(this.$('#args-5').text(), 'Foo4Bar5Baz');
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$('#args-3').text(), 'Foo4Bar');
-      assert.equal(this.$('#args-5').text(), 'Foo4Bar5Baz');
+      assert.strictEqual(this.$('#args-3').text(), 'Foo4Bar');
+      assert.strictEqual(this.$('#args-5').text(), 'Foo4Bar5Baz');
     }
 
     ['@test arbitrary positional parameter conflict with hash parameter is reported']() {
@@ -1726,15 +1726,15 @@ moduleFor(
       {{sample-component "one" second="two" elementId="one-positional"}}
       {{sample-component first="one" second="two" elementId="no-positional"}}`);
 
-      assert.equal(this.$('#two-positional').text(), 'one - two');
-      assert.equal(this.$('#one-positional').text(), 'one - two');
-      assert.equal(this.$('#no-positional').text(), 'one - two');
+      assert.strictEqual(this.$('#two-positional').text(), 'one - two');
+      assert.strictEqual(this.$('#one-positional').text(), 'one - two');
+      assert.strictEqual(this.$('#no-positional').text(), 'one - two');
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$('#two-positional').text(), 'one - two');
-      assert.equal(this.$('#one-positional').text(), 'one - two');
-      assert.equal(this.$('#no-positional').text(), 'one - two');
+      assert.strictEqual(this.$('#two-positional').text(), 'one - two');
+      assert.strictEqual(this.$('#one-positional').text(), 'one - two');
+      assert.strictEqual(this.$('#no-positional').text(), 'one - two');
     }
 
     ['@test dynamic arbitrary number of positional parameters']() {
@@ -2327,17 +2327,17 @@ moduleFor(
 
       this.render('{{#x-outer}}{{x-inner-in-template}}{{/x-outer}}');
 
-      assert.equal(
+      assert.strictEqual(
         innerTemplate.parentView,
         outer,
         'receives the wrapping component as its parentView in template blocks'
       );
-      assert.equal(
+      assert.strictEqual(
         innerLayout.parentView,
         outer,
         'receives the wrapping component as its parentView in layout'
       );
-      assert.equal(
+      assert.strictEqual(
         outer.parentView,
         this.context,
         'x-outer receives the ambient scope as its parentView'
@@ -2345,17 +2345,17 @@ moduleFor(
 
       runTask(() => this.rerender());
 
-      assert.equal(
+      assert.strictEqual(
         innerTemplate.parentView,
         outer,
         'receives the wrapping component as its parentView in template blocks'
       );
-      assert.equal(
+      assert.strictEqual(
         innerLayout.parentView,
         outer,
         'receives the wrapping component as its parentView in layout'
       );
-      assert.equal(
+      assert.strictEqual(
         outer.parentView,
         this.context,
         'x-outer receives the ambient scope as its parentView'
@@ -2395,7 +2395,7 @@ moduleFor(
         }
       );
 
-      assert.equal(
+      assert.strictEqual(
         outer.parentView,
         this.context,
         'x-outer receives the ambient scope as its parentView'
@@ -2403,7 +2403,7 @@ moduleFor(
 
       runTask(() => this.rerender());
 
-      assert.equal(
+      assert.strictEqual(
         outer.parentView,
         this.context,
         'x-outer receives the ambient scope as its parentView (after rerender)'
@@ -2411,12 +2411,12 @@ moduleFor(
 
       runTask(() => this.context.set('showInner', true));
 
-      assert.equal(
+      assert.strictEqual(
         outer.parentView,
         this.context,
         'x-outer receives the ambient scope as its parentView'
       );
-      assert.equal(
+      assert.strictEqual(
         inner.parentView,
         outer,
         'receives the wrapping component as its parentView in template blocks'
@@ -2424,7 +2424,7 @@ moduleFor(
 
       runTask(() => this.context.set('showInner', false));
 
-      assert.equal(
+      assert.strictEqual(
         outer.parentView,
         this.context,
         'x-outer receives the ambient scope as its parentView'
@@ -2823,8 +2823,8 @@ moduleFor(
 
       this.render('{{parent}}');
 
-      this.assert.equal(parent.string, 'Hello|World', 'precond - parent value');
-      this.assert.equal(
+      this.assert.strictEqual(parent.string, 'Hello|World', 'precond - parent value');
+      this.assert.strictEqual(
         this.element.querySelector('[data-test-parent-value]').textContent.trim(),
         'Hello|World',
         'precond - parent rendered value'
@@ -2834,9 +2834,9 @@ moduleFor(
         child.set('a', 'Foo');
       });
 
-      this.assert.equal(parent.string, 'Foo|World', 'parent value updated');
+      this.assert.strictEqual(parent.string, 'Foo|World', 'parent value updated');
 
-      this.assert.equal(
+      this.assert.strictEqual(
         this.element.querySelector('[data-test-parent-value]').textContent.trim(),
         'Foo|World',
         'parent updated value rendered'
@@ -2846,8 +2846,8 @@ moduleFor(
         child.set('a', 'Hello');
       });
 
-      this.assert.equal(parent.string, 'Hello|World', 'parent value reset');
-      this.assert.equal(
+      this.assert.strictEqual(parent.string, 'Hello|World', 'parent value reset');
+      this.assert.strictEqual(
         this.element.querySelector('[data-test-parent-value]').textContent.trim(),
         'Hello|World',
         'parent template reset'
@@ -2924,8 +2924,8 @@ moduleFor(
       let assertElement = (expectedValue) => {
         // value is a property, not an attribute
         this.assertHTML(`<input class="ember-view" id="${component.elementId}">`);
-        this.assert.equal(this.firstChild.value, expectedValue, 'value property is correct');
-        this.assert.equal(
+        this.assert.strictEqual(this.firstChild.value, expectedValue, 'value property is correct');
+        this.assert.strictEqual(
           get(component, 'value'),
           expectedValue,
           'component.get("value") is correct'
@@ -3117,7 +3117,7 @@ moduleFor(
       this.registerComponent('foo-bar', {
         ComponentClass: Component.extend({
           didReceiveAttrs() {
-            assert.equal(1, this.get('foo'), 'expected attrs to have correct value');
+            assert.strictEqual(1, this.get('foo'), 'expected attrs to have correct value');
           },
         }),
 
@@ -3131,7 +3131,7 @@ moduleFor(
       this.registerComponent('foo-bar', {
         ComponentClass: Component.extend({
           didUpdateAttrs() {
-            assert.equal(5, this.get('foo'), 'expected newAttrs to have new value');
+            assert.strictEqual(5, this.get('foo'), 'expected newAttrs to have new value');
           },
         }),
 
@@ -3189,7 +3189,7 @@ moduleFor(
       this.render(`{{display-toggle target=this}}`, {
         send(actionName) {
           assert.ok(true, 'send should be called when action is "subscribed" to');
-          assert.equal(actionName, 'show');
+          assert.strictEqual(actionName, 'show');
         },
       });
 
@@ -3423,7 +3423,7 @@ moduleFor(
         }
 
         didReceiveAttrs() {
-          assert.equal(this.foo, 'bar', 'received default attrs correctly');
+          assert.strictEqual(this.foo, 'bar', 'received default attrs correctly');
         }
       }
 
@@ -3500,7 +3500,11 @@ moduleFor(
           constructor(owner) {
             super(owner);
 
-            assert.equal(owner, testContext.owner, 'owner was passed as a constructor argument');
+            assert.strictEqual(
+              owner,
+              testContext.owner,
+              'owner was passed as a constructor argument'
+            );
           }
         },
         template: 'hello',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -133,8 +133,8 @@ moduleFor(
       this.render('{{component "foo-bar"}}');
       this.assertText('foo-bar foo-bar-baz');
 
-      assert.equal(fooBarInstance.parentView, this.component);
-      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+      assert.strictEqual(fooBarInstance.parentView, this.component);
+      assert.strictEqual(fooBarBazInstance.parentView, fooBarInstance);
 
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
@@ -142,8 +142,8 @@ moduleFor(
       runTask(() => this.rerender());
       this.assertText('foo-bar foo-bar-baz');
 
-      assert.equal(fooBarInstance.parentView, this.component);
-      assert.equal(fooBarBazInstance.parentView, fooBarInstance);
+      assert.strictEqual(fooBarInstance.parentView, this.component);
+      assert.strictEqual(fooBarBazInstance.parentView, fooBarInstance);
 
       assert.deepEqual(this.component.childViews, [fooBarInstance]);
       assert.deepEqual(fooBarInstance.childViews, [fooBarBazInstance]);
@@ -333,7 +333,7 @@ moduleFor(
         template: 'hello from foo-bar',
         ComponentClass: Component.extend({
           willDestroyElement() {
-            assert.equal(
+            assert.strictEqual(
               testContext.$(`#${this.elementId}`).length,
               1,
               'element is still attached to the document'
@@ -466,13 +466,13 @@ moduleFor(
 
       this.render('{{outer-component}}');
 
-      assert.equal(actionTriggered, 0, 'action was not triggered');
+      assert.strictEqual(actionTriggered, 0, 'action was not triggered');
 
       runTask(() => {
         this.$('.inner-component').click();
       });
 
-      assert.equal(actionTriggered, 1, 'action was triggered');
+      assert.strictEqual(actionTriggered, 1, 'action was triggered');
     }
 
     ['@test nested component helpers']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -33,7 +33,7 @@ moduleFor(
         });
       }, /silly mistake in init/);
 
-      assert.equal(
+      assert.strictEqual(
         this.renderer._inRenderTransaction,
         false,
         'should not be in a transaction even though an error was thrown'
@@ -86,7 +86,7 @@ moduleFor(
         runTask(() => set(this.context, 'switch', true));
       }, /silly mistake in init/);
 
-      assert.equal(
+      assert.strictEqual(
         this.renderer._inRenderTransaction,
         false,
         'should not be in a transaction even though an error was thrown'
@@ -130,7 +130,7 @@ moduleFor(
         });
       }, /silly mistake/);
 
-      assert.equal(
+      assert.strictEqual(
         this.renderer._inRenderTransaction,
         false,
         'should not be in a transaction even though an error was thrown'

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -26,31 +26,31 @@ class InputRenderingTest extends RenderingTestCase {
   }
 
   assertInputId(expectedId) {
-    this.assert.equal(this.inputID(), expectedId, 'the input id should be `expectedId`');
+    this.assert.strictEqual(this.inputID(), expectedId, 'the input id should be `expectedId`');
   }
 
   assertSingleInput() {
-    this.assert.equal(this.$('input').length, 1, 'A single text field was inserted');
+    this.assert.strictEqual(this.$('input').length, 1, 'A single text field was inserted');
   }
 
   assertSingleCheckbox() {
-    this.assert.equal(this.$('input[type=checkbox]').length, 1, 'A single checkbox is added');
+    this.assert.strictEqual(this.$('input[type=checkbox]').length, 1, 'A single checkbox is added');
   }
 
   assertCheckboxIsChecked() {
-    this.assert.equal(this.$input().prop('checked'), true, 'the checkbox is checked');
+    this.assert.strictEqual(this.$input().prop('checked'), true, 'the checkbox is checked');
   }
 
   assertCheckboxIsNotChecked() {
-    this.assert.equal(this.$input().prop('checked'), false, 'the checkbox is not checked');
+    this.assert.strictEqual(this.$input().prop('checked'), false, 'the checkbox is not checked');
   }
 
   assertValue(expected) {
-    this.assert.equal(this.$input().val(), expected, `the input value should be ${expected}`);
+    this.assert.strictEqual(this.$input().val(), expected, `the input value should be ${expected}`);
   }
 
   assertAttr(name, expected) {
-    this.assert.equal(
+    this.assert.strictEqual(
       this.$input().attr(name),
       expected,
       `the input ${name} attribute has the value '${expected}'`
@@ -63,8 +63,12 @@ class InputRenderingTest extends RenderingTestCase {
 
   assertSelectionRange(start, end) {
     let input = this.$input()[0];
-    this.assert.equal(input.selectionStart, start, `the cursor start position should be ${start}`);
-    this.assert.equal(input.selectionEnd, end, `the cursor end position should be ${end}`);
+    this.assert.strictEqual(
+      input.selectionStart,
+      start,
+      `the cursor start position should be ${start}`
+    );
+    this.assert.strictEqual(input.selectionEnd, end, `the cursor end position should be ${end}`);
   }
 
   triggerEvent(type, options, selector) {
@@ -157,7 +161,7 @@ class InputRenderingTest extends RenderingTestCase {
     let $standard = this.$('#standard');
     let $custom = this.$('#custom');
 
-    this.assert.equal($standard.type, $custom.type);
+    this.assert.strictEqual($standard.type, $custom.type);
 
     Object.keys(events).forEach((event) => {
       // triggerEvent does not seem to work with focusin and focusout events
@@ -596,7 +600,7 @@ moduleFor(
 
       this.triggerEvent('keypress', { key: 'A' });
 
-      assert.equal(triggered, 1, 'The action was triggered exactly once');
+      assert.strictEqual(triggered, 1, 'The action was triggered exactly once');
     }
 
     ['@test sends an action to the parent level when `bubbles=true` is provided'](assert) {
@@ -705,7 +709,7 @@ moduleFor(
 
       this.triggerEvent('keydown', { key: 'A' });
 
-      assert.equal(triggered, 1, 'The action was triggered exactly once');
+      assert.strictEqual(triggered, 1, 'The action was triggered exactly once');
     }
 
     ['@test [DEPRECATED] sends an action with `<Input @key-up={{action "foo"}} />` when a key is pressed'](
@@ -731,14 +735,14 @@ moduleFor(
 
       this.triggerEvent('keyup', { key: 'A' });
 
-      assert.equal(triggered, 1, 'The action was triggered exactly once');
+      assert.strictEqual(triggered, 1, 'The action was triggered exactly once');
     }
 
     ['@test GH#14727 can render a file input after having had render an input of other type']() {
       this.render(`<Input @type="text" /><Input @type="file" />`);
 
-      this.assert.equal(this.$input()[0].type, 'text');
-      this.assert.equal(this.$input()[1].type, 'file');
+      this.assert.strictEqual(this.$input()[0].type, 'text');
+      this.assert.strictEqual(this.$input()[1].type, 'file');
     }
 
     ['@test sends an action with `<Input EVENT={{action "foo"}} />` for native DOM events']() {
@@ -820,9 +824,9 @@ moduleFor(
       );
 
       let inputs = this.element.querySelectorAll('input');
-      this.assert.equal(inputs.length, 2, 'there are two inputs');
-      this.assert.equal(inputs[0].getAttribute('type'), 'password');
-      this.assert.equal(inputs[1].getAttribute('type'), 'email');
+      this.assert.strictEqual(inputs.length, 2, 'there are two inputs');
+      this.assert.strictEqual(inputs[0].getAttribute('type'), 'password');
+      this.assert.strictEqual(inputs[1].getAttribute('type'), 'email');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -24,31 +24,31 @@ class InputRenderingTest extends RenderingTestCase {
   }
 
   assertInputId(expectedId) {
-    this.assert.equal(this.inputID(), expectedId, 'the input id should be `expectedId`');
+    this.assert.strictEqual(this.inputID(), expectedId, 'the input id should be `expectedId`');
   }
 
   assertSingleInput() {
-    this.assert.equal(this.$('input').length, 1, 'A single text field was inserted');
+    this.assert.strictEqual(this.$('input').length, 1, 'A single text field was inserted');
   }
 
   assertSingleCheckbox() {
-    this.assert.equal(this.$('input[type=checkbox]').length, 1, 'A single checkbox is added');
+    this.assert.strictEqual(this.$('input[type=checkbox]').length, 1, 'A single checkbox is added');
   }
 
   assertCheckboxIsChecked() {
-    this.assert.equal(this.$input().prop('checked'), true, 'the checkbox is checked');
+    this.assert.strictEqual(this.$input().prop('checked'), true, 'the checkbox is checked');
   }
 
   assertCheckboxIsNotChecked() {
-    this.assert.equal(this.$input().prop('checked'), false, 'the checkbox is not checked');
+    this.assert.strictEqual(this.$input().prop('checked'), false, 'the checkbox is not checked');
   }
 
   assertValue(expected) {
-    this.assert.equal(this.$input().val(), expected, `the input value should be ${expected}`);
+    this.assert.strictEqual(this.$input().val(), expected, `the input value should be ${expected}`);
   }
 
   assertAttr(name, expected) {
-    this.assert.equal(
+    this.assert.strictEqual(
       this.$input().attr(name),
       expected,
       `the input ${name} attribute has the value '${expected}'`
@@ -61,8 +61,12 @@ class InputRenderingTest extends RenderingTestCase {
 
   assertSelectionRange(start, end) {
     let input = this.$input()[0];
-    this.assert.equal(input.selectionStart, start, `the cursor start position should be ${start}`);
-    this.assert.equal(input.selectionEnd, end, `the cursor end position should be ${end}`);
+    this.assert.strictEqual(
+      input.selectionStart,
+      start,
+      `the cursor start position should be ${start}`
+    );
+    this.assert.strictEqual(input.selectionEnd, end, `the cursor end position should be ${end}`);
   }
 
   triggerEvent(type, options) {
@@ -426,7 +430,7 @@ moduleFor(
 
       this.triggerEvent('keypress', { key: 'A' });
 
-      assert.equal(triggered, 1, 'The action was triggered exactly once');
+      assert.strictEqual(triggered, 1, 'The action was triggered exactly once');
     }
 
     ['@test sends an action to the parent level when `bubbles=true` is provided'](assert) {
@@ -535,7 +539,7 @@ moduleFor(
 
       this.triggerEvent('keydown', { key: 'A' });
 
-      assert.equal(triggered, 1, 'The action was triggered exactly once');
+      assert.strictEqual(triggered, 1, 'The action was triggered exactly once');
     }
 
     ['@test sends an action with `{{input key-up=(action "foo")}}` when a key is pressed'](assert) {
@@ -560,8 +564,8 @@ moduleFor(
     ['@test GH#14727 can render a file input after having had render an input of other type']() {
       this.render(`{{input type="text"}}{{input type="file"}}`);
 
-      this.assert.equal(this.$input()[0].type, 'text');
-      this.assert.equal(this.$input()[1].type, 'file');
+      this.assert.strictEqual(this.$input()[0].type, 'text');
+      this.assert.strictEqual(this.$input()[1].type, 'file');
     }
 
     ['@test [DEPRECATED] sends an action with `{{input EVENT=(action "foo")}}` for native DOM events']() {
@@ -640,9 +644,9 @@ moduleFor(
       });
 
       let inputs = this.element.querySelectorAll('input');
-      this.assert.equal(inputs.length, 2, 'there are two inputs');
-      this.assert.equal(inputs[0].getAttribute('type'), 'password');
-      this.assert.equal(inputs[1].getAttribute('type'), 'email');
+      this.assert.strictEqual(inputs.length, 2, 'there are two inputs');
+      this.assert.strictEqual(inputs[0].getAttribute('type'), 'password');
+      this.assert.strictEqual(inputs[1].getAttribute('type'), 'email');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-compile-test.js
@@ -94,7 +94,7 @@ moduleFor(
     }
 
     _assertEvents(label, actual, expected) {
-      this.assert.equal(
+      this.assert.strictEqual(
         actual.length,
         expected.length,
         `${label}: expected ${expected.length} and got ${actual.length}`
@@ -104,7 +104,7 @@ moduleFor(
     }
 
     assertPayload(payload, component) {
-      this.assert.equal(payload.object, component._debugContainerKey, 'payload.object');
+      this.assert.strictEqual(payload.object, component._debugContainerKey, 'payload.object');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/instrumentation-test.js
@@ -139,7 +139,7 @@ moduleFor(
     }
 
     _assertEvents(label, actual, expected, initialRender) {
-      this.assert.equal(
+      this.assert.strictEqual(
         actual.length,
         expected.length,
         `${label}: expected ${expected.length} and got ${actual.length}`
@@ -149,10 +149,14 @@ moduleFor(
     }
 
     assertPayload(payload, component, initialRender) {
-      this.assert.equal(payload.object, component.toString(), 'payload.object');
+      this.assert.strictEqual(payload.object, component.toString(), 'payload.object');
       this.assert.ok(payload.containerKey, 'the container key should be present');
-      this.assert.equal(payload.containerKey, component._debugContainerKey, 'payload.containerKey');
-      this.assert.equal(payload.view, component, 'payload.view');
+      this.assert.strictEqual(
+        payload.containerKey,
+        component._debugContainerKey,
+        'payload.containerKey'
+      );
+      this.assert.strictEqual(payload.view, component, 'payload.view');
       this.assert.strictEqual(payload.initialRender, initialRender, 'payload.initialRender');
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/life-cycle-test.js
@@ -116,7 +116,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
           instance.element,
           `this.element should be present on ${instance} during ${hookName}`
         );
-        this.assert.equal(
+        this.assert.strictEqual(
           document.body.contains(instance.element),
           inDOM,
           `element for ${instance} ${
@@ -153,7 +153,7 @@ class LifeCycleHooksTest extends RenderingTestCase {
     };
 
     let assertState = (hookName, expectedState, instance) => {
-      this.assert.equal(
+      this.assert.strictEqual(
         instance._state,
         expectedState,
         `within ${hookName} the expected _state is ${expectedState}`
@@ -1139,14 +1139,14 @@ class LifeCycleHooksTest extends RenderingTestCase {
 
     // TODO: Is this correct? Should childViews be populated in non-interactive mode?
     if (this.isInteractive) {
-      this.assert.equal(this.component.childViews.length, 5, 'childViews precond');
+      this.assert.strictEqual(this.component.childViews.length, 5, 'childViews precond');
     }
 
     runTask(() => set(this.context, 'items', []));
 
     // TODO: Is this correct? Should childViews be populated in non-interactive mode?
     if (this.isInteractive) {
-      this.assert.equal(this.component.childViews.length, 1, 'childViews updated');
+      this.assert.strictEqual(this.component.childViews.length, 1, 'childViews updated');
     }
 
     this.assertText('Nothing to see here');
@@ -1581,18 +1581,30 @@ moduleFor(
       // Make sure we get the finalized component prototype
       let prototype = Component.proto();
 
-      assert.equal(typeof prototype.didDestroyElement, 'function', 'didDestroyElement exists');
-      assert.equal(typeof prototype.didInsertElement, 'function', 'didInsertElement exists');
-      assert.equal(typeof prototype.didReceiveAttrs, 'function', 'didReceiveAttrs exists');
-      assert.equal(typeof prototype.didRender, 'function', 'didRender exists');
-      assert.equal(typeof prototype.didUpdate, 'function', 'didUpdate exists');
-      assert.equal(typeof prototype.didUpdateAttrs, 'function', 'didUpdateAttrs exists');
-      assert.equal(typeof prototype.willClearRender, 'function', 'willClearRender exists');
-      assert.equal(typeof prototype.willDestroy, 'function', 'willDestroy exists');
-      assert.equal(typeof prototype.willDestroyElement, 'function', 'willDestroyElement exists');
-      assert.equal(typeof prototype.willInsertElement, 'function', 'willInsertElement exists');
-      assert.equal(typeof prototype.willRender, 'function', 'willRender exists');
-      assert.equal(typeof prototype.willUpdate, 'function', 'willUpdate exists');
+      assert.strictEqual(
+        typeof prototype.didDestroyElement,
+        'function',
+        'didDestroyElement exists'
+      );
+      assert.strictEqual(typeof prototype.didInsertElement, 'function', 'didInsertElement exists');
+      assert.strictEqual(typeof prototype.didReceiveAttrs, 'function', 'didReceiveAttrs exists');
+      assert.strictEqual(typeof prototype.didRender, 'function', 'didRender exists');
+      assert.strictEqual(typeof prototype.didUpdate, 'function', 'didUpdate exists');
+      assert.strictEqual(typeof prototype.didUpdateAttrs, 'function', 'didUpdateAttrs exists');
+      assert.strictEqual(typeof prototype.willClearRender, 'function', 'willClearRender exists');
+      assert.strictEqual(typeof prototype.willDestroy, 'function', 'willDestroy exists');
+      assert.strictEqual(
+        typeof prototype.willDestroyElement,
+        'function',
+        'willDestroyElement exists'
+      );
+      assert.strictEqual(
+        typeof prototype.willInsertElement,
+        'function',
+        'willInsertElement exists'
+      );
+      assert.strictEqual(typeof prototype.willRender, 'function', 'willRender exists');
+      assert.strictEqual(typeof prototype.willUpdate, 'function', 'willUpdate exists');
     }
   }
 );
@@ -1600,10 +1612,14 @@ moduleFor(
 function assertDestroyHooks(assert, _actual, _expected) {
   _expected.forEach((expected, i) => {
     let name = expected.name;
-    assert.equal(expected.id, _actual[i].id, `${name} id is the same`);
-    assert.equal(expected.hasParent, _actual[i].hasParent, `${name} has parent node`);
-    assert.equal(expected.nextSibling, _actual[i].nextSibling, `${name} has next sibling node`);
-    assert.equal(
+    assert.strictEqual(expected.id, _actual[i].id, `${name} id is the same`);
+    assert.strictEqual(expected.hasParent, _actual[i].hasParent, `${name} has parent node`);
+    assert.strictEqual(
+      expected.nextSibling,
+      _actual[i].nextSibling,
+      `${name} has next sibling node`
+    );
+    assert.strictEqual(
       expected.previousSibling,
       _actual[i].previousSibling,
       `${name} has previous sibling node`

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -114,7 +114,7 @@ moduleFor(
 
     checkActive(assert, selector, active) {
       let classList = this.$(selector)[0].className;
-      assert.equal(
+      assert.strictEqual(
         classList.indexOf('active') > -1,
         active,
         selector + ' active should be ' + active.toString()
@@ -246,7 +246,7 @@ moduleFor(
 
       let theLink = this.$('#the-link');
 
-      assert.equal(theLink.attr('href'), '/about?baz=lol');
+      assert.strictEqual(theLink.attr('href'), '/about?baz=lol');
 
       runTask(() => this.click('#the-link'));
 
@@ -301,22 +301,22 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#good-link').length, 1, 'good-link should be in the DOM');
-      assert.equal(this.$('#bad-link').length, 1, 'bad-link should be in the DOM');
+      assert.strictEqual(this.$('#good-link').length, 1, 'good-link should be in the DOM');
+      assert.strictEqual(this.$('#bad-link').length, 1, 'bad-link should be in the DOM');
 
       let goodLink = this.$('#good-link');
-      assert.equal(goodLink.attr('href'), '/?baz=lol');
+      assert.strictEqual(goodLink.attr('href'), '/?baz=lol');
 
       await this.visit('/bad');
 
-      assert.equal(this.$('#good-link').length, 1, 'good-link should be in the DOM');
-      assert.equal(this.$('#bad-link').length, 1, 'bad-link should be in the DOM');
+      assert.strictEqual(this.$('#good-link').length, 1, 'good-link should be in the DOM');
+      assert.strictEqual(this.$('#bad-link').length, 1, 'bad-link should be in the DOM');
 
       goodLink = this.$('#good-link');
       // should still be / because we never entered /bad (it errored before being fully entered)
       // and error states do not get represented in the URL, so we are _effectively_ still
       // on /
-      assert.equal(goodLink.attr('href'), '/?baz=lol');
+      assert.strictEqual(goodLink.attr('href'), '/?baz=lol');
 
       runTask(() => this.click('#good-link'));
 
@@ -343,11 +343,11 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link');
 
-      assert.equal(theLink.attr('href'), '/?foo=OMG');
+      assert.strictEqual(theLink.attr('href'), '/?foo=OMG');
 
       runTask(() => indexController.set('boundThing', 'ASL'));
 
-      assert.equal(theLink.attr('href'), '/?foo=ASL');
+      assert.strictEqual(theLink.attr('href'), '/?foo=ASL');
     }
 
     async ['@test supplied QP properties can be bound in legacy components'](assert) {
@@ -367,11 +367,11 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link');
 
-      assert.equal(theLink.attr('href'), '/?foo=OMG');
+      assert.strictEqual(theLink.attr('href'), '/?foo=OMG');
 
       runTask(() => indexController.set('boundThing', 'ASL'));
 
-      assert.equal(theLink.attr('href'), '/?foo=ASL');
+      assert.strictEqual(theLink.attr('href'), '/?foo=ASL');
     }
 
     async ['@test supplied QP properties can be bound (booleans)'](assert) {
@@ -389,11 +389,11 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link');
 
-      assert.equal(theLink.attr('href'), '/?abool=OMG');
+      assert.strictEqual(theLink.attr('href'), '/?abool=OMG');
 
       runTask(() => indexController.set('boundThing', false));
 
-      assert.equal(theLink.attr('href'), '/?abool=false');
+      assert.strictEqual(theLink.attr('href'), '/?abool=false');
 
       await this.click('#the-link');
 
@@ -419,17 +419,17 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link');
 
-      assert.equal(theLink.attr('href'), '/?foo=lol');
+      assert.strictEqual(theLink.attr('href'), '/?foo=lol');
 
       runTask(() => indexController.set('bar', 'BORF'));
       await runLoopSettled();
 
-      assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
+      assert.strictEqual(theLink.attr('href'), '/?bar=BORF&foo=lol');
 
       runTask(() => indexController.set('foo', 'YEAH'));
       await runLoopSettled();
 
-      assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
+      assert.strictEqual(theLink.attr('href'), '/?bar=BORF&foo=lol');
     }
 
     async ['@test [GH#12033] with only query params, it always transitions to the current route with the query params applied'](
@@ -468,19 +468,19 @@ moduleFor(
       let router = this.appRouter;
       let carsController = this.getController('cars');
 
-      assert.equal(router.currentRouteName, 'cars.create');
+      assert.strictEqual(router.currentRouteName, 'cars.create');
 
       runTask(() => this.click('#close-link'));
 
-      assert.equal(router.currentRouteName, 'cars.index');
-      assert.equal(router.get('url'), '/cars');
-      assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
+      assert.strictEqual(router.currentRouteName, 'cars.index');
+      assert.strictEqual(router.get('url'), '/cars');
+      assert.strictEqual(carsController.get('page'), 1, 'The page query-param is 1');
 
       runTask(() => this.click('#page2-link'));
 
-      assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
-      assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
-      assert.equal(carsController.get('page'), 2, 'The query params have been updated');
+      assert.strictEqual(router.currentRouteName, 'cars.index', 'The active route is still cars');
+      assert.strictEqual(router.get('url'), '/cars?page=2', 'The url has been updated');
+      assert.strictEqual(carsController.get('page'), 2, 'The query params have been updated');
     }
 
     async ['@test it applies activeClass when query params are not changed'](assert) {
@@ -733,7 +733,7 @@ moduleFor(
 
       appLink = this.$('#app-link');
 
-      assert.equal(appLink.attr('href'), '/parent');
+      assert.strictEqual(appLink.attr('href'), '/parent');
       this.shouldNotBeActive(assert, '#app-link');
 
       await this.visit('/parent?page=2');
@@ -741,25 +741,25 @@ moduleFor(
       appLink = this.$('#app-link');
       let router = this.appRouter;
 
-      assert.equal(appLink.attr('href'), '/parent');
+      assert.strictEqual(appLink.attr('href'), '/parent');
       this.shouldBeActive(assert, '#app-link');
-      assert.equal(this.$('#parent-link').attr('href'), '/parent');
+      assert.strictEqual(this.$('#parent-link').attr('href'), '/parent');
       this.shouldBeActive(assert, '#parent-link');
 
       let parentController = this.getController('parent');
 
-      assert.equal(parentController.get('page'), 2);
+      assert.strictEqual(parentController.get('page'), 2);
 
       runTask(() => parentController.set('page', 3));
       await runLoopSettled();
 
-      assert.equal(router.get('location.path'), '/parent?page=3');
+      assert.strictEqual(router.get('location.path'), '/parent?page=3');
       this.shouldBeActive(assert, '#app-link');
       this.shouldBeActive(assert, '#parent-link');
 
       await this.click('#app-link');
 
-      assert.equal(router.get('location.path'), '/parent');
+      assert.strictEqual(router.get('location.path'), '/parent');
     }
 
     async ['@test it defaults query params while in active transition regression test'](assert) {
@@ -821,10 +821,10 @@ moduleFor(
       let barsLink = this.$('#bars-link');
       let bazLink = this.$('#baz-foos-link');
 
-      assert.equal(foosLink.attr('href'), '/foos');
-      assert.equal(bazLink.attr('href'), '/foos?baz=true');
-      assert.equal(barsLink.attr('href'), '/bars?quux=true');
-      assert.equal(router.get('location.path'), '/');
+      assert.strictEqual(foosLink.attr('href'), '/foos');
+      assert.strictEqual(bazLink.attr('href'), '/foos?baz=true');
+      assert.strictEqual(barsLink.attr('href'), '/bars?quux=true');
+      assert.strictEqual(router.get('location.path'), '/');
       this.shouldNotBeActive(assert, '#foos-link');
       this.shouldNotBeActive(assert, '#baz-foos-link');
       this.shouldNotBeActive(assert, '#bars-link');
@@ -837,7 +837,7 @@ moduleFor(
 
       runTask(() => foos.resolve());
 
-      assert.equal(router.get('location.path'), '/foos');
+      assert.strictEqual(router.get('location.path'), '/foos');
       this.shouldBeActive(assert, '#foos-link');
     }
 
@@ -921,7 +921,7 @@ moduleFor(
       await this.visit('/foo/bar/baz?qux=abc');
 
       let bazLink = this.$('#baz-link');
-      assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
+      assert.strictEqual(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -146,7 +146,7 @@ moduleFor(
 
     checkActive(assert, selector, active) {
       let classList = this.$(selector)[0].className;
-      assert.equal(
+      assert.strictEqual(
         classList.indexOf('active') > -1,
         active,
         selector + ' active should be ' + active.toString()
@@ -290,7 +290,7 @@ moduleFor(
 
       let theLink = this.$('#the-link > a');
 
-      assert.equal(theLink.attr('href'), '/about?baz=lol');
+      assert.strictEqual(theLink.attr('href'), '/about?baz=lol');
 
       runTask(() => this.click('#the-link > a'));
 
@@ -314,11 +314,11 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link > a');
 
-      assert.equal(theLink.attr('href'), '/?foo=OMG');
+      assert.strictEqual(theLink.attr('href'), '/?foo=OMG');
 
       runTask(() => indexController.set('boundThing', 'ASL'));
 
-      assert.equal(theLink.attr('href'), '/?foo=ASL');
+      assert.strictEqual(theLink.attr('href'), '/?foo=ASL');
     }
 
     async ['@test supplied QP properties can be bound (booleans)'](assert) {
@@ -338,11 +338,11 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link > a');
 
-      assert.equal(theLink.attr('href'), '/?abool=OMG');
+      assert.strictEqual(theLink.attr('href'), '/?abool=OMG');
 
       runTask(() => indexController.set('boundThing', false));
 
-      assert.equal(theLink.attr('href'), '/?abool=false');
+      assert.strictEqual(theLink.attr('href'), '/?abool=false');
 
       await this.click('#the-link > a');
 
@@ -368,17 +368,17 @@ moduleFor(
       let indexController = this.getController('index');
       let theLink = this.$('#the-link > a');
 
-      assert.equal(theLink.attr('href'), '/?foo=lol');
+      assert.strictEqual(theLink.attr('href'), '/?foo=lol');
 
       runTask(() => indexController.set('bar', 'BORF'));
       await runLoopSettled();
 
-      assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
+      assert.strictEqual(theLink.attr('href'), '/?bar=BORF&foo=lol');
 
       runTask(() => indexController.set('foo', 'YEAH'));
       await runLoopSettled();
 
-      assert.equal(theLink.attr('href'), '/?bar=BORF&foo=lol');
+      assert.strictEqual(theLink.attr('href'), '/?bar=BORF&foo=lol');
     }
 
     async ['@test [GH#12033] with only query params, it always transitions to the current route with the query params applied'](
@@ -417,19 +417,19 @@ moduleFor(
       let router = this.appRouter;
       let carsController = this.getController('cars');
 
-      assert.equal(router.currentRouteName, 'cars.create');
+      assert.strictEqual(router.currentRouteName, 'cars.create');
 
       runTask(() => this.click('#close-link > a'));
 
-      assert.equal(router.currentRouteName, 'cars.index');
-      assert.equal(router.get('url'), '/cars');
-      assert.equal(carsController.get('page'), 1, 'The page query-param is 1');
+      assert.strictEqual(router.currentRouteName, 'cars.index');
+      assert.strictEqual(router.get('url'), '/cars');
+      assert.strictEqual(carsController.get('page'), 1, 'The page query-param is 1');
 
       runTask(() => this.click('#page2-link > a'));
 
-      assert.equal(router.currentRouteName, 'cars.index', 'The active route is still cars');
-      assert.equal(router.get('url'), '/cars?page=2', 'The url has been updated');
-      assert.equal(carsController.get('page'), 2, 'The query params have been updated');
+      assert.strictEqual(router.currentRouteName, 'cars.index', 'The active route is still cars');
+      assert.strictEqual(router.get('url'), '/cars?page=2', 'The url has been updated');
+      assert.strictEqual(carsController.get('page'), 2, 'The query params have been updated');
     }
 
     async ['@test it applies activeClass when query params are not changed'](assert) {
@@ -688,7 +688,7 @@ moduleFor(
 
       appLink = this.$('#app-link > a');
 
-      assert.equal(appLink.attr('href'), '/parent');
+      assert.strictEqual(appLink.attr('href'), '/parent');
       this.shouldNotBeActive(assert, '#app-link > a');
 
       await this.visit('/parent?page=2');
@@ -696,25 +696,25 @@ moduleFor(
       appLink = this.$('#app-link > a');
       let router = this.appRouter;
 
-      assert.equal(appLink.attr('href'), '/parent');
+      assert.strictEqual(appLink.attr('href'), '/parent');
       this.shouldBeActive(assert, '#app-link > a');
-      assert.equal(this.$('#parent-link > a').attr('href'), '/parent');
+      assert.strictEqual(this.$('#parent-link > a').attr('href'), '/parent');
       this.shouldBeActive(assert, '#parent-link > a');
 
       let parentController = this.getController('parent');
 
-      assert.equal(parentController.get('page'), 2);
+      assert.strictEqual(parentController.get('page'), 2);
 
       runTask(() => parentController.set('page', 3));
       await runLoopSettled();
 
-      assert.equal(router.get('location.path'), '/parent?page=3');
+      assert.strictEqual(router.get('location.path'), '/parent?page=3');
       this.shouldBeActive(assert, '#app-link > a');
       this.shouldBeActive(assert, '#parent-link > a');
 
       await this.click('#app-link > a');
 
-      assert.equal(router.get('location.path'), '/parent');
+      assert.strictEqual(router.get('location.path'), '/parent');
     }
 
     async ['@test it defaults query params while in active transition regression test'](assert) {
@@ -776,10 +776,10 @@ moduleFor(
       let barsLink = this.$('#bars-link > a');
       let bazLink = this.$('#baz-foos-link > a');
 
-      assert.equal(foosLink.attr('href'), '/foos');
-      assert.equal(bazLink.attr('href'), '/foos?baz=true');
-      assert.equal(barsLink.attr('href'), '/bars?quux=true');
-      assert.equal(router.get('location.path'), '/');
+      assert.strictEqual(foosLink.attr('href'), '/foos');
+      assert.strictEqual(bazLink.attr('href'), '/foos?baz=true');
+      assert.strictEqual(barsLink.attr('href'), '/bars?quux=true');
+      assert.strictEqual(router.get('location.path'), '/');
       this.shouldNotBeActive(assert, '#foos-link > a');
       this.shouldNotBeActive(assert, '#baz-foos-link > a');
       this.shouldNotBeActive(assert, '#bars-link > a');
@@ -792,7 +792,7 @@ moduleFor(
 
       runTask(() => foos.resolve());
 
-      assert.equal(router.get('location.path'), '/foos');
+      assert.strictEqual(router.get('location.path'), '/foos');
       this.shouldBeActive(assert, '#foos-link > a');
     }
 
@@ -913,7 +913,7 @@ moduleFor(
       await this.visit('/foo/bar/baz?qux=abc');
 
       let bazLink = this.$('#baz-link > a');
-      assert.equal(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
+      assert.strictEqual(bazLink.attr('href'), '/foo/bar/baz?qux=abc');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -93,11 +93,11 @@ moduleFor(
 
       await this.visit('/bar');
 
-      assert.equal(this.firstChild.classList.contains('active'), false);
+      assert.strictEqual(this.firstChild.classList.contains('active'), false);
 
       runTask(() => set(controller, 'routeName', 'bar'));
 
-      assert.equal(this.firstChild.classList.contains('active'), true);
+      assert.strictEqual(this.firstChild.classList.contains('active'), true);
     }
 
     async ['@test able to safely extend the built-in component and use the normal path']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-curly-test.js
@@ -86,11 +86,11 @@ moduleFor(
 
       await this.visit('/bar');
 
-      assert.equal(this.firstChild.classList.contains('active'), false);
+      assert.strictEqual(this.firstChild.classList.contains('active'), false);
 
       runTask(() => set(controller, 'routeName', 'bar'));
 
-      assert.equal(this.firstChild.classList.contains('active'), true);
+      assert.strictEqual(this.firstChild.classList.contains('active'), true);
     }
 
     async ['@test [DEPRECATED] escaped inline form (double curlies) escapes link title']() {
@@ -127,7 +127,7 @@ moduleFor(
       await this.visit('/');
 
       this.assertText('blah');
-      assert.equal(this.$('b').length, 1);
+      assert.strictEqual(this.$('b').length, 1);
     }
 
     async ['@test able to safely extend the built-in component and use the normal path']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -31,7 +31,11 @@ function shouldBeActive(assert, element) {
 
 function checkActive(assert, element, active) {
   let classList = element.attr('class');
-  assert.equal(classList.indexOf('active') > -1, active, `${element} active should be ${active}`);
+  assert.strictEqual(
+    classList.indexOf('active') > -1,
+    active,
+    `${element} active should be ${active}`
+  );
 }
 
 moduleFor(
@@ -65,13 +69,13 @@ moduleFor(
     async ['@test it navigates into the named route'](assert) {
       await this.visit('/');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -79,13 +83,13 @@ moduleFor(
 
       await this.click('#about-link');
 
-      assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.about').length, 1, 'The about template was rendered');
+      assert.strictEqual(
         this.$('#self-link.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -106,13 +110,13 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.about').length, 1, 'The about template was rendered');
+      assert.strictEqual(
         this.$('#self-link.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -120,13 +124,13 @@ moduleFor(
 
       await this.click('#inside');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -176,12 +180,12 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static.disabled').length,
         1,
         'The static link is disabled when its disabledWhen is true'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-dynamic.disabled').length,
         1,
         'The dynamic link is disabled when its disabledWhen is true'
@@ -193,7 +197,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static.disabled').length,
         1,
         'The static link is disabled when its disabledWhen is true'
@@ -230,12 +234,12 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static.disabled').length,
         1,
         'The static link is disabled when its disabled is true'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-dynamic.disabled').length,
         1,
         'The dynamic link is disabled when its disabled is true'
@@ -243,7 +247,7 @@ moduleFor(
 
       runTask(() => controller.set('dynamicDisabled', false));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static.disabled').length,
         1,
         'The static link is disabled when its disabled is true'
@@ -291,7 +295,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static.do-not-want').length,
         1,
         'The static link is disabled when its disabled is true'
@@ -314,7 +318,7 @@ moduleFor(
 
       runTask(() => controller.set('dynamicDisabled', false));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static.do-not-want').length,
         1,
         'The static link is disabled when its disabled is true'
@@ -358,7 +362,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link.do-not-want').length,
         1,
         'The link can apply a custom disabled class via bound param'
@@ -371,7 +375,7 @@ moduleFor(
 
       runTask(() => controller.set('disabledClass', 'can-not-use'));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link.can-not-use').length,
         1,
         'The link can apply a custom disabled class via bound param'
@@ -448,7 +452,7 @@ moduleFor(
 
       await this.click('#about-link');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('h3.about').length,
         1,
         'Transitioning did occur when disabledWhen became false'
@@ -467,13 +471,13 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link.zomg-active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link:not(.zomg-active)').length,
         1,
         'The other link was rendered without active class'
@@ -516,13 +520,13 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link.zomg-active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link:not(.zomg-active)').length,
         1,
         'The other link was rendered without active class'
@@ -540,12 +544,12 @@ moduleFor(
 
       runTask(() => controller.set('activeClass', 'wow-active'));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#self-link.wow-active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link:not(.wow-active)').length,
         1,
         'The other link was rendered without active class'
@@ -666,14 +670,30 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+      assert.strictEqual(
+        this.$('#application-link.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.strictEqual(
+        this.$('#engine-link:not(.active)').length,
+        1,
+        'The engine link is not active'
+      );
 
-      assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
-      assert.equal(this.$('#self-link.active').length, 1, 'The application index link is active');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The application index page is rendered');
+      assert.strictEqual(
+        this.$('#self-link.active').length,
+        1,
+        'The application index link is active'
+      );
+      assert.strictEqual(
         this.$('#about-link:not(.active)').length,
         1,
         'The application about link is not active'
@@ -681,14 +701,30 @@ moduleFor(
 
       await this.click('#about-link');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+      assert.strictEqual(
+        this.$('#application-link.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.strictEqual(
+        this.$('#engine-link:not(.active)').length,
+        1,
+        'The engine link is not active'
+      );
 
-      assert.equal(this.$('h3.about').length, 1, 'The application about page is rendered');
-      assert.equal(this.$('#self-link.active').length, 1, 'The application about link is active');
-      assert.equal(
+      assert.strictEqual(this.$('h3.about').length, 1, 'The application about page is rendered');
+      assert.strictEqual(
+        this.$('#self-link.active').length,
+        1,
+        'The application about link is active'
+      );
+      assert.strictEqual(
         this.$('#home-link:not(.active)').length,
         1,
         'The application home link is not active'
@@ -696,19 +732,31 @@ moduleFor(
 
       await this.click('#engine-link');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
-      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
-      assert.equal(
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
+      assert.strictEqual(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.strictEqual(
+        this.$('#application-link.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.strictEqual(this.$('#engine-link.active').length, 1, 'The engine link is active');
+      assert.strictEqual(
         this.$('#engine-application-link.active').length,
         1,
         'The engine application link is active'
       );
 
-      assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
-      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine index link is active');
-      assert.equal(
+      assert.strictEqual(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
+      assert.strictEqual(
+        this.$('#engine-self-link.active').length,
+        1,
+        'The engine index link is active'
+      );
+      assert.strictEqual(
         this.$('#engine-about-link:not(.active)').length,
         1,
         'The engine about link is not active'
@@ -716,19 +764,31 @@ moduleFor(
 
       await this.click('#engine-about-link');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
-      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
-      assert.equal(
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
+      assert.strictEqual(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.strictEqual(
+        this.$('#application-link.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.strictEqual(this.$('#engine-link.active').length, 1, 'The engine link is active');
+      assert.strictEqual(
         this.$('#engine-application-link.active').length,
         1,
         'The engine application link is active'
       );
 
-      assert.equal(this.$('h3.engine-about').length, 1, 'The engine about page is rendered');
-      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine about link is active');
-      assert.equal(
+      assert.strictEqual(this.$('h3.engine-about').length, 1, 'The engine about page is rendered');
+      assert.strictEqual(
+        this.$('#engine-self-link.active').length,
+        1,
+        'The engine about link is active'
+      );
+      assert.strictEqual(
         this.$('#engine-home-link:not(.active)').length,
         1,
         'The engine home link is not active'
@@ -736,19 +796,31 @@ moduleFor(
 
       await this.click('#engine-application-link');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
-      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link.active').length, 1, 'The engine link is active');
-      assert.equal(
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
+      assert.strictEqual(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.strictEqual(
+        this.$('#application-link.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.strictEqual(this.$('#engine-link.active').length, 1, 'The engine link is active');
+      assert.strictEqual(
         this.$('#engine-application-link.active').length,
         1,
         'The engine application link is active'
       );
 
-      assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
-      assert.equal(this.$('#engine-self-link.active').length, 1, 'The engine index link is active');
-      assert.equal(
+      assert.strictEqual(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
+      assert.strictEqual(
+        this.$('#engine-self-link.active').length,
+        1,
+        'The engine index link is active'
+      );
+      assert.strictEqual(
         this.$('#engine-about-link:not(.active)').length,
         1,
         'The engine about link is not active'
@@ -756,14 +828,30 @@ moduleFor(
 
       await this.click('#application-link');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(this.$('#application-link.active').length, 1, 'The application link is active');
-      assert.equal(this.$('#engine-link:not(.active)').length, 1, 'The engine link is not active');
+      assert.strictEqual(
+        this.$('#application-link.active').length,
+        1,
+        'The application link is active'
+      );
+      assert.strictEqual(
+        this.$('#engine-link:not(.active)').length,
+        1,
+        'The engine link is not active'
+      );
 
-      assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
-      assert.equal(this.$('#self-link.active').length, 1, 'The application index link is active');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The application index page is rendered');
+      assert.strictEqual(
+        this.$('#self-link.active').length,
+        1,
+        'The application index link is active'
+      );
+      assert.strictEqual(
         this.$('#about-link:not(.active)').length,
         1,
         'The application about link is not active'
@@ -988,12 +1076,20 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
         subscribe('interaction.link-to', {
           before(name, timestamp, { routeName }) {
             before++;
-            assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
+            assert.strictEqual(
+              routeName,
+              'about',
+              'instrumentation subscriber was passed route name'
+            );
           },
           after(name, timestamp, { routeName, transition }) {
             after++;
-            assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
-            assert.equal(
+            assert.strictEqual(
+              routeName,
+              'about',
+              'instrumentation subscriber was passed route name'
+            );
+            assert.strictEqual(
               transition.targetName,
               'about',
               'instrumentation subscriber was passed transition object in the after hook'
@@ -1029,7 +1125,7 @@ moduleFor(
 
       await this.visit('/about/item');
 
-      assert.equal(normalizeUrl(this.$('#item a').attr('href')), '/about');
+      assert.strictEqual(normalizeUrl(this.$('#item a').attr('href')), '/about');
     }
 
     async [`@test it supports custom, nested, current-when`](assert) {
@@ -1049,7 +1145,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#other-link.active').length,
         1,
         'The link is active since current-when is a parent route'
@@ -1077,7 +1173,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#other-link.active').length,
         1,
         'The link is active when current-when is given for explicitly for a route'
@@ -1110,7 +1206,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#other-link.active').length,
         1,
         'The link is active when current-when is given for explicitly for a route'
@@ -1142,7 +1238,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#link1.active').length,
         1,
         'The link is active since current-when contains the parent route'
@@ -1150,7 +1246,7 @@ moduleFor(
 
       await this.visit('/item');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#link2.active').length,
         1,
         'The link is active since you are on the active route'
@@ -1158,7 +1254,7 @@ moduleFor(
 
       await this.visit('/foo');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#link3.active').length,
         0,
         'The link is not active since current-when does not contain the active route'
@@ -1248,9 +1344,9 @@ moduleFor(
 
       await this.click('#about-contact');
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
 
-      assert.equal(hidden, 1, 'The link bubbles');
+      assert.strictEqual(hidden, 1, 'The link bubbles');
     }
 
     async [`@test [DEPRECATED] it supports bubbles=false`](assert) {
@@ -1311,7 +1407,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
 
       assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
@@ -1376,7 +1472,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
       assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
 
@@ -1422,9 +1518,9 @@ moduleFor(
 
       await this.click('#about-contact');
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
 
-      assert.equal(hidden, 0, "The link didn't bubble");
+      assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
 
     async [`@test it moves into the named route with context`](assert) {
@@ -1482,8 +1578,8 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(this.$('h3.list').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.list').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         normalizeUrl(this.$('#home-link').attr('href')),
         '/',
         'The home link points back at /'
@@ -1491,21 +1587,21 @@ moduleFor(
 
       await this.click('#yehuda');
 
-      assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
-      assert.equal(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
+      assert.strictEqual(this.$('h3.item').length, 1, 'The item template was rendered');
+      assert.strictEqual(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
 
       await this.click('#home-link');
 
       await this.click('#about-link');
 
-      assert.equal(normalizeUrl(this.$('li a#yehuda').attr('href')), '/item/yehuda');
-      assert.equal(normalizeUrl(this.$('li a#tom').attr('href')), '/item/tom');
-      assert.equal(normalizeUrl(this.$('li a#erik').attr('href')), '/item/erik');
+      assert.strictEqual(normalizeUrl(this.$('li a#yehuda').attr('href')), '/item/yehuda');
+      assert.strictEqual(normalizeUrl(this.$('li a#tom').attr('href')), '/item/tom');
+      assert.strictEqual(normalizeUrl(this.$('li a#erik').attr('href')), '/item/erik');
 
       await this.click('#erik');
 
-      assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
-      assert.equal(this.$('p').text(), 'Erik Brynroflsson', 'The name is correct');
+      assert.strictEqual(this.$('h3.item').length, 1, 'The item template was rendered');
+      assert.strictEqual(this.$('p').text(), 'Erik Brynroflsson', 'The name is correct');
     }
 
     async [`@test it binds some anchor html tag common attributes`](assert) {
@@ -1522,9 +1618,13 @@ moduleFor(
       await this.visit('/');
 
       let link = this.$('#self-link');
-      assert.equal(link.attr('title'), 'title-attr', 'The self-link contains title attribute');
-      assert.equal(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
-      assert.equal(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
+      assert.strictEqual(
+        link.attr('title'),
+        'title-attr',
+        'The self-link contains title attribute'
+      );
+      assert.strictEqual(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
+      assert.strictEqual(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
     }
 
     async [`@test it supports 'target' attribute`](assert) {
@@ -1539,7 +1639,11 @@ moduleFor(
       await this.visit('/');
 
       let link = this.$('#self-link');
-      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
+      assert.strictEqual(
+        link.attr('target'),
+        '_blank',
+        'The self-link contains `target` attribute'
+      );
     }
 
     async [`@test it supports 'target' attribute specified as a bound param`](assert) {
@@ -1568,11 +1672,15 @@ moduleFor(
       await this.visit('/');
 
       let link = this.$('#self-link');
-      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
+      assert.strictEqual(
+        link.attr('target'),
+        '_blank',
+        'The self-link contains `target` attribute'
+      );
 
       runTask(() => controller.set('boundLinkTarget', '_self'));
 
-      assert.equal(link.attr('target'), '_self', 'The self-link contains `target` attribute');
+      assert.strictEqual(link.attr('target'), '_self', 'The self-link contains `target` attribute');
     }
 
     async [`@test it calls preventDefault`](assert) {
@@ -1763,11 +1871,14 @@ moduleFor(
 
       await this.visit('/filters/popular');
 
-      assert.equal(normalizeUrl(this.$('#link').attr('href')), '/filters/unpopular');
-      assert.equal(normalizeUrl(this.$('#path-link').attr('href')), '/filters/unpopular');
-      assert.equal(normalizeUrl(this.$('#post-path-link').attr('href')), '/post/123');
-      assert.equal(normalizeUrl(this.$('#post-number-link').attr('href')), '/post/123');
-      assert.equal(normalizeUrl(this.$('#repo-object-link').attr('href')), '/repo/ember/ember.js');
+      assert.strictEqual(normalizeUrl(this.$('#link').attr('href')), '/filters/unpopular');
+      assert.strictEqual(normalizeUrl(this.$('#path-link').attr('href')), '/filters/unpopular');
+      assert.strictEqual(normalizeUrl(this.$('#post-path-link').attr('href')), '/post/123');
+      assert.strictEqual(normalizeUrl(this.$('#post-number-link').attr('href')), '/post/123');
+      assert.strictEqual(
+        normalizeUrl(this.$('#repo-object-link').attr('href')),
+        '/repo/ember/ember.js'
+      );
     }
 
     async [`@test [GH#4201] Shorthand for route.index shouldn't throw errors about context arguments`](
@@ -1784,7 +1895,7 @@ moduleFor(
         'route:lobby.index',
         class extends Route {
           model(params) {
-            assert.equal(params.lobby_id, 'foobar');
+            assert.strictEqual(params.lobby_id, 'foobar');
             return params.lobby_id;
           }
         }
@@ -1835,8 +1946,8 @@ moduleFor(
       );
 
       let assertEquality = (href) => {
-        assert.equal(normalizeUrl(this.$('#string-link').attr('href')), '/');
-        assert.equal(normalizeUrl(this.$('#path-link').attr('href')), href);
+        assert.strictEqual(normalizeUrl(this.$('#string-link').attr('href')), '/');
+        assert.strictEqual(normalizeUrl(this.$('#path-link').attr('href')), href);
       };
 
       await this.visit('/');
@@ -1877,7 +1988,7 @@ moduleFor(
 
       runTask(() => controller.set('post', post));
 
-      assert.equal(
+      assert.strictEqual(
         normalizeUrl(this.$('#post').attr('href')),
         '/posts/1',
         'precond - Link has rendered href attr properly'
@@ -1885,7 +1996,7 @@ moduleFor(
 
       runTask(() => controller.set('post', secondPost));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#post').attr('href'),
         '/posts/2',
         'href attr was updated after one of the params had been changed'
@@ -1893,7 +2004,7 @@ moduleFor(
 
       runTask(() => controller.set('post', null));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#post').attr('href'),
         '#',
         'href attr becomes # when one of the arguments in nullified'
@@ -1920,13 +2031,13 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
-      assert.equal(this.$('#item-link.active').length, 0, 'The item route link is inactive');
+      assert.strictEqual(this.$('#about-link.active').length, 1, 'The about route link is active');
+      assert.strictEqual(this.$('#item-link.active').length, 0, 'The item route link is inactive');
 
       await this.visit('/about/item');
 
-      assert.equal(this.$('#about-link.active').length, 1, 'The about route link is active');
-      assert.equal(this.$('#item-link.active').length, 1, 'The item route link is active');
+      assert.strictEqual(this.$('#about-link.active').length, 1, 'The about route link is active');
+      assert.strictEqual(this.$('#item-link.active').length, 1, 'The item route link is active');
     }
 
     async [`@test it works in an #each'd array of string route names`](assert) {
@@ -1967,13 +2078,13 @@ moduleFor(
       );
 
       let linksEqual = (links, expected) => {
-        assert.equal(links.length, expected.length, 'Has correct number of links');
+        assert.strictEqual(links.length, expected.length, 'Has correct number of links');
 
         let idx;
         for (idx = 0; idx < links.length; idx++) {
           let href = this.$(links[idx]).attr('href');
           // Old IE includes the whole hostname as well
-          assert.equal(
+          assert.strictEqual(
             href.slice(-expected[idx].length),
             expected[idx],
             `Expected link to be '${expected[idx]}', but was '${href}'`
@@ -2105,7 +2216,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
+      assert.strictEqual(this.$('#the-link').attr('href'), '/', 'link has right href');
     }
 
     async [`@test it populates href with default query param values with empty query-params object`](
@@ -2126,7 +2237,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
+      assert.strictEqual(this.$('#the-link').attr('href'), '/', 'link has right href');
     }
 
     async [`@test it updates when route changes with only query-params and a block`](assert) {
@@ -2150,11 +2261,15 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#the-link').attr('href'), '/?bar=NAW&foo=456', 'link has right href');
+      assert.strictEqual(
+        this.$('#the-link').attr('href'),
+        '/?bar=NAW&foo=456',
+        'link has right href'
+      );
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#the-link').attr('href'),
         '/about?bar=NAW&foo=456',
         'link has right href'
@@ -2232,14 +2347,14 @@ moduleFor(
 
       let link = this.$('#dynamic-link');
 
-      assert.equal(link.attr('href'), '/foo/one/two');
+      assert.strictEqual(link.attr('href'), '/foo/one/two');
 
       expectDeprecation(
         () => runTask(() => controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three'])),
         /Invoking the `<LinkTo>` component with positional arguments is deprecated/
       );
 
-      assert.equal(link.attr('href'), '/bar/one/two/three');
+      assert.strictEqual(link.attr('href'), '/bar/one/two/three');
     }
 
     async [`@test [GH#13256]: <LinkTo /> to a parent root model hook which performs a 'transitionTo' has correct active class`](
@@ -2328,10 +2443,14 @@ moduleFor(
 
       function assertLinkStatus(link, url) {
         if (url) {
-          assert.equal(normalizeUrl(link.attr('href')), url, 'loaded link-to has expected href');
+          assert.strictEqual(
+            normalizeUrl(link.attr('href')),
+            url,
+            'loaded link-to has expected href'
+          );
           assert.ok(!link.hasClass('i-am-loading'), 'loaded linkComponent has no loadingClass');
         } else {
-          assert.equal(normalizeUrl(link.attr('href')), '#', "unloaded link-to has href='#'");
+          assert.strictEqual(normalizeUrl(link.attr('href')), '#', "unloaded link-to has href='#'");
           assert.ok(link.hasClass('i-am-loading'), 'loading linkComponent has loadingClass');
         }
       }
@@ -2374,7 +2493,7 @@ moduleFor(
       // Click the now-active link
       await this.click(staticLink[0]);
 
-      assert.equal(activate, 1, 'About route was entered');
+      assert.strictEqual(activate, 1, 'About route was entered');
     }
   }
 );
@@ -2383,7 +2502,7 @@ function assertNav(options, callback, assert) {
   let nav = false;
 
   function check(event) {
-    assert.equal(
+    assert.strictEqual(
       event.defaultPrevented,
       options.prevented,
       `expected defaultPrevented=${options.prevented}`

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -31,7 +31,11 @@ function shouldBeActive(assert, element) {
 
 function checkActive(assert, element, active) {
   let classList = element.attr('class');
-  assert.equal(classList.indexOf('active') > -1, active, `${element} active should be ${active}`);
+  assert.strictEqual(
+    classList.indexOf('active') > -1,
+    active,
+    `${element} active should be ${active}`
+  );
 }
 
 moduleFor(
@@ -65,13 +69,13 @@ moduleFor(
     async ['@test it navigates into the named route'](assert) {
       await this.visit('/');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link a.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -79,13 +83,13 @@ moduleFor(
 
       await this.click('#about-link > a');
 
-      assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.about').length, 1, 'The about template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link > a:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -106,13 +110,13 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(this.$('h3.about').length, 1, 'The about template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.about').length, 1, 'The about template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link > a:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -120,13 +124,13 @@ moduleFor(
 
       await this.click('#inside');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -181,12 +185,12 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static > a.disabled').length,
         1,
         'The static link is disabled when its disabledWhen is true'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-dynamic > a.disabled').length,
         1,
         'The dynamic link is disabled when its disabledWhen is true'
@@ -198,7 +202,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static > a.disabled').length,
         1,
         'The static link is disabled when its disabledWhen is true'
@@ -235,12 +239,12 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static > a.disabled').length,
         1,
         'The static link is disabled when its disabled is true'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-dynamic > a.disabled').length,
         1,
         'The dynamic link is disabled when its disabled is true'
@@ -248,7 +252,7 @@ moduleFor(
 
       runTask(() => controller.set('dynamicDisabled', false));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static > a.disabled').length,
         1,
         'The static link is disabled when its disabledWhen is true'
@@ -299,7 +303,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static > a.do-not-want').length,
         1,
         'The static link is disabled when its disabled is true'
@@ -322,7 +326,7 @@ moduleFor(
 
       runTask(() => controller.set('dynamicDisabled', false));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link-static > a.do-not-want').length,
         1,
         'The static link is disabled when its disabled is true'
@@ -366,7 +370,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a.do-not-want').length,
         1,
         'The link can apply a custom disabled class via bound param'
@@ -379,7 +383,7 @@ moduleFor(
 
       runTask(() => controller.set('disabledClass', 'can-not-use'));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a.can-not-use').length,
         1,
         'The link can apply a custom disabled class via bound param'
@@ -460,7 +464,7 @@ moduleFor(
 
       await this.click('#about-link > a');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('h3.about').length,
         1,
         'Transitioning did occur when disabledWhen became false'
@@ -479,13 +483,13 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.zomg-active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.zomg-active)').length,
         1,
         'The other link was rendered without active class'
@@ -528,13 +532,13 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('h3.home').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.zomg-active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.zomg-active)').length,
         1,
         'The other link was rendered without active class'
@@ -552,12 +556,12 @@ moduleFor(
 
       runTask(() => controller.set('activeClass', 'wow-active'));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#self-link > a.wow-active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.wow-active)').length,
         1,
         'The other link was rendered without active class'
@@ -678,26 +682,30 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(
+      assert.strictEqual(
         this.$('#application-link > a.active').length,
         1,
         'The application link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#engine-link > a:not(.active)').length,
         1,
         'The engine link is not active'
       );
 
-      assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The application index page is rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The application index link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.active)').length,
         1,
         'The application about link is not active'
@@ -705,26 +713,30 @@ moduleFor(
 
       await this.click('#about-link > a');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(
+      assert.strictEqual(
         this.$('#application-link > a.active').length,
         1,
         'The application link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#engine-link > a:not(.active)').length,
         1,
         'The engine link is not active'
       );
 
-      assert.equal(this.$('h3.about').length, 1, 'The application about page is rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.about').length, 1, 'The application about page is rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The application about link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link > a:not(.active)').length,
         1,
         'The application home link is not active'
@@ -732,27 +744,31 @@ moduleFor(
 
       await this.click('#engine-link > a');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
-      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
+      assert.strictEqual(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.strictEqual(
         this.$('#application-link > a.active').length,
         1,
         'The application link is active'
       );
-      assert.equal(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
-      assert.equal(
+      assert.strictEqual(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
+      assert.strictEqual(
         this.$('#engine-application-link > a.active').length,
         1,
         'The engine application link is active'
       );
 
-      assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
+      assert.strictEqual(
         this.$('#engine-self-link > a.active').length,
         1,
         'The engine index link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#engine-about-link > a:not(.active)').length,
         1,
         'The engine about link is not active'
@@ -760,27 +776,31 @@ moduleFor(
 
       await this.click('#engine-about-link > a');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
-      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
+      assert.strictEqual(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.strictEqual(
         this.$('#application-link > a.active').length,
         1,
         'The application link is active'
       );
-      assert.equal(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
-      assert.equal(
+      assert.strictEqual(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
+      assert.strictEqual(
         this.$('#engine-application-link > a.active').length,
         1,
         'The engine application link is active'
       );
 
-      assert.equal(this.$('h3.engine-about').length, 1, 'The engine about page is rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.engine-about').length, 1, 'The engine about page is rendered');
+      assert.strictEqual(
         this.$('#engine-self-link > a.active').length,
         1,
         'The engine about link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#engine-home-link > a:not(.active)').length,
         1,
         'The engine home link is not active'
@@ -788,27 +808,31 @@ moduleFor(
 
       await this.click('#engine-application-link > a');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
-      assert.equal(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
-      assert.equal(
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
+      assert.strictEqual(this.$('#engine-layout').length, 1, 'The engine layout was rendered');
+      assert.strictEqual(
         this.$('#application-link > a.active').length,
         1,
         'The application link is active'
       );
-      assert.equal(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
-      assert.equal(
+      assert.strictEqual(this.$('#engine-link > a.active').length, 1, 'The engine link is active');
+      assert.strictEqual(
         this.$('#engine-application-link > a.active').length,
         1,
         'The engine application link is active'
       );
 
-      assert.equal(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.engine-home').length, 1, 'The engine index page is rendered');
+      assert.strictEqual(
         this.$('#engine-self-link > a.active').length,
         1,
         'The engine index link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#engine-about-link > a:not(.active)').length,
         1,
         'The engine about link is not active'
@@ -816,26 +840,30 @@ moduleFor(
 
       await this.click('#application-link > a');
 
-      assert.equal(this.$('#application-layout').length, 1, 'The application layout was rendered');
+      assert.strictEqual(
+        this.$('#application-layout').length,
+        1,
+        'The application layout was rendered'
+      );
       assert.strictEqual(this.$('#engine-layout').length, 0, 'The engine layout was not rendered');
-      assert.equal(
+      assert.strictEqual(
         this.$('#application-link > a.active').length,
         1,
         'The application link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#engine-link > a:not(.active)').length,
         1,
         'The engine link is not active'
       );
 
-      assert.equal(this.$('h3.home').length, 1, 'The application index page is rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The application index page is rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The application index link is active'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#about-link > a:not(.active)').length,
         1,
         'The application about link is not active'
@@ -1060,12 +1088,20 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
         subscribe('interaction.link-to', {
           before(name, timestamp, { routeName }) {
             before++;
-            assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
+            assert.strictEqual(
+              routeName,
+              'about',
+              'instrumentation subscriber was passed route name'
+            );
           },
           after(name, timestamp, { routeName, transition }) {
             after++;
-            assert.equal(routeName, 'about', 'instrumentation subscriber was passed route name');
-            assert.equal(
+            assert.strictEqual(
+              routeName,
+              'about',
+              'instrumentation subscriber was passed route name'
+            );
+            assert.strictEqual(
               transition.targetName,
               'about',
               'instrumentation subscriber was passed transition object in the after hook'
@@ -1104,7 +1140,7 @@ moduleFor(
 
       await this.visit('/about/item');
 
-      assert.equal(normalizeUrl(this.$('#item a').attr('href')), '/about');
+      assert.strictEqual(normalizeUrl(this.$('#item a').attr('href')), '/about');
     }
 
     async [`@test it supports custom, nested, current-when`](assert) {
@@ -1124,7 +1160,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#other-link > a.active').length,
         1,
         'The link is active since current-when is a parent route'
@@ -1152,7 +1188,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#other-link > a.active').length,
         1,
         'The link is active when current-when is given for explicitly for a route'
@@ -1185,7 +1221,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#other-link > a.active').length,
         1,
         'The link is active when current-when is given for explicitly for a route'
@@ -1217,7 +1253,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#link1 > a.active').length,
         1,
         'The link is active since current-when contains the parent route'
@@ -1225,7 +1261,7 @@ moduleFor(
 
       await this.visit('/item');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#link2 > a.active').length,
         1,
         'The link is active since you are on the active route'
@@ -1233,7 +1269,7 @@ moduleFor(
 
       await this.visit('/foo');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#link3 > a.active').length,
         0,
         'The link is not active since current-when does not contain the active route'
@@ -1323,9 +1359,9 @@ moduleFor(
 
       await this.click('#about-contact > a');
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
 
-      assert.equal(hidden, 1, 'The link bubbles');
+      assert.strictEqual(hidden, 1, 'The link bubbles');
     }
 
     async [`@test [DEPRECATED] it supports bubbles=false`](assert) {
@@ -1386,7 +1422,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
 
       assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
@@ -1451,7 +1487,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(this.$('#contact').text(), 'Contact', 'precond - the link worked');
+      assert.strictEqual(this.$('#contact').text(), 'Contact', 'precond - the link worked');
       assert.strictEqual(hidden, 0, "The link didn't bubble");
     }
 
@@ -1510,8 +1546,8 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(this.$('h3.list').length, 1, 'The home template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.list').length, 1, 'The home template was rendered');
+      assert.strictEqual(
         normalizeUrl(this.$('#home-link > a').attr('href')),
         '/',
         'The home link points back at /'
@@ -1519,21 +1555,21 @@ moduleFor(
 
       await this.click('#yehuda > a');
 
-      assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
-      assert.equal(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
+      assert.strictEqual(this.$('h3.item').length, 1, 'The item template was rendered');
+      assert.strictEqual(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
 
       await this.click('#home-link > a');
 
       await this.click('#about-link > a');
 
-      assert.equal(normalizeUrl(this.$('li#yehuda > a').attr('href')), '/item/yehuda');
-      assert.equal(normalizeUrl(this.$('li#tom > a').attr('href')), '/item/tom');
-      assert.equal(normalizeUrl(this.$('li#erik > a').attr('href')), '/item/erik');
+      assert.strictEqual(normalizeUrl(this.$('li#yehuda > a').attr('href')), '/item/yehuda');
+      assert.strictEqual(normalizeUrl(this.$('li#tom > a').attr('href')), '/item/tom');
+      assert.strictEqual(normalizeUrl(this.$('li#erik > a').attr('href')), '/item/erik');
 
       await this.click('#erik > a');
 
-      assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
-      assert.equal(this.$('p').text(), 'Erik Brynroflsson', 'The name is correct');
+      assert.strictEqual(this.$('h3.item').length, 1, 'The item template was rendered');
+      assert.strictEqual(this.$('p').text(), 'Erik Brynroflsson', 'The name is correct');
     }
 
     async [`@test [DEPRECATED] it binds some anchor html tag common attributes`](assert) {
@@ -1557,9 +1593,13 @@ moduleFor(
 
       let link = this.$('#self-link > a');
 
-      assert.equal(link.attr('title'), 'title-attr', 'The self-link contains title attribute');
-      assert.equal(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
-      assert.equal(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
+      assert.strictEqual(
+        link.attr('title'),
+        'title-attr',
+        'The self-link contains title attribute'
+      );
+      assert.strictEqual(link.attr('rel'), 'rel-attr', 'The self-link contains rel attribute');
+      assert.strictEqual(link.attr('tabindex'), '-1', 'The self-link contains tabindex attribute');
     }
 
     async [`@test [DEPRECATED] it supports 'target' attribute`](assert) {
@@ -1578,7 +1618,11 @@ moduleFor(
       );
 
       let link = this.$('#self-link > a');
-      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
+      assert.strictEqual(
+        link.attr('target'),
+        '_blank',
+        'The self-link contains `target` attribute'
+      );
     }
 
     async [`@test [DEPRECATED] it supports 'target' attribute specified as a bound param`](assert) {
@@ -1611,7 +1655,11 @@ moduleFor(
       );
 
       let link = this.$('#self-link > a');
-      assert.equal(link.attr('target'), '_blank', 'The self-link contains `target` attribute');
+      assert.strictEqual(
+        link.attr('target'),
+        '_blank',
+        'The self-link contains `target` attribute'
+      );
 
       expectDeprecation(
         () => runTask(() => controller.set('boundLinkTarget', '_self')),
@@ -1619,7 +1667,7 @@ moduleFor(
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
 
-      assert.equal(link.attr('target'), '_self', 'The self-link contains `target` attribute');
+      assert.strictEqual(link.attr('target'), '_self', 'The self-link contains `target` attribute');
     }
 
     async [`@test it calls preventDefault`](assert) {
@@ -1831,11 +1879,11 @@ moduleFor(
 
       await this.visit('/filters/popular');
 
-      assert.equal(normalizeUrl(this.$('#link > a').attr('href')), '/filters/unpopular');
-      assert.equal(normalizeUrl(this.$('#path-link > a').attr('href')), '/filters/unpopular');
-      assert.equal(normalizeUrl(this.$('#post-path-link > a').attr('href')), '/post/123');
-      assert.equal(normalizeUrl(this.$('#post-number-link > a').attr('href')), '/post/123');
-      assert.equal(
+      assert.strictEqual(normalizeUrl(this.$('#link > a').attr('href')), '/filters/unpopular');
+      assert.strictEqual(normalizeUrl(this.$('#path-link > a').attr('href')), '/filters/unpopular');
+      assert.strictEqual(normalizeUrl(this.$('#post-path-link > a').attr('href')), '/post/123');
+      assert.strictEqual(normalizeUrl(this.$('#post-number-link > a').attr('href')), '/post/123');
+      assert.strictEqual(
         normalizeUrl(this.$('#repo-object-link > a').attr('href')),
         '/repo/ember/ember.js'
       );
@@ -1855,7 +1903,7 @@ moduleFor(
         'route:lobby.index',
         class extends Route {
           model(params) {
-            assert.equal(params.lobby_id, 'foobar');
+            assert.strictEqual(params.lobby_id, 'foobar');
             return params.lobby_id;
           }
         }
@@ -1906,8 +1954,8 @@ moduleFor(
       );
 
       let assertEquality = (href) => {
-        assert.equal(normalizeUrl(this.$('#string-link > a').attr('href')), '/');
-        assert.equal(normalizeUrl(this.$('#path-link > a').attr('href')), href);
+        assert.strictEqual(normalizeUrl(this.$('#string-link > a').attr('href')), '/');
+        assert.strictEqual(normalizeUrl(this.$('#path-link > a').attr('href')), href);
       };
 
       await this.visit('/');
@@ -1948,7 +1996,7 @@ moduleFor(
 
       runTask(() => controller.set('post', post));
 
-      assert.equal(
+      assert.strictEqual(
         normalizeUrl(this.$('#post > a').attr('href')),
         '/posts/1',
         'precond - Link has rendered href attr properly'
@@ -1956,7 +2004,7 @@ moduleFor(
 
       runTask(() => controller.set('post', secondPost));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#post > a').attr('href'),
         '/posts/2',
         'href attr was updated after one of the params had been changed'
@@ -1964,7 +2012,7 @@ moduleFor(
 
       runTask(() => controller.set('post', null));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#post > a').attr('href'),
         '#',
         'href attr becomes # when one of the arguments in nullified'
@@ -1991,13 +2039,29 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(this.$('#about-link > a.active').length, 1, 'The about route link is active');
-      assert.equal(this.$('#item-link > a.active').length, 0, 'The item route link is inactive');
+      assert.strictEqual(
+        this.$('#about-link > a.active').length,
+        1,
+        'The about route link is active'
+      );
+      assert.strictEqual(
+        this.$('#item-link > a.active').length,
+        0,
+        'The item route link is inactive'
+      );
 
       await this.visit('/about/item');
 
-      assert.equal(this.$('#about-link > a.active').length, 1, 'The about route link is active');
-      assert.equal(this.$('#item-link > a.active').length, 1, 'The item route link is active');
+      assert.strictEqual(
+        this.$('#about-link > a.active').length,
+        1,
+        'The about route link is active'
+      );
+      assert.strictEqual(
+        this.$('#item-link > a.active').length,
+        1,
+        'The item route link is active'
+      );
     }
 
     async [`@test it works in an #each'd array of string route names`](assert) {
@@ -2038,13 +2102,13 @@ moduleFor(
       );
 
       let linksEqual = (links, expected) => {
-        assert.equal(links.length, expected.length, 'Has correct number of links');
+        assert.strictEqual(links.length, expected.length, 'Has correct number of links');
 
         let idx;
         for (idx = 0; idx < links.length; idx++) {
           let href = this.$(links[idx]).attr('href');
           // Old IE includes the whole hostname as well
-          assert.equal(
+          assert.strictEqual(
             href.slice(-expected[idx].length),
             expected[idx],
             `Expected link to be '${expected[idx]}', but was '${href}'`
@@ -2098,13 +2162,13 @@ moduleFor(
 
       await this.click('#contact-link > a');
 
-      assert.equal(this.$('h3.contact').length, 1, 'The contact template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.contact').length, 1, 'The contact template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link > a:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -2156,7 +2220,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#contact-link > a').text(),
         'Jane',
         'The link title is correctly resolved'
@@ -2164,7 +2228,7 @@ moduleFor(
 
       runTask(() => controller.set('contactName', 'Joe'));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#contact-link > a').text(),
         'Joe',
         'The link title is correctly updated when the bound property changes'
@@ -2172,7 +2236,7 @@ moduleFor(
 
       runTask(() => controller.set('contactName', 'Robert'));
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#contact-link > a').text(),
         'Robert',
         'The link title is correctly updated when the bound property changes a second time'
@@ -2180,13 +2244,13 @@ moduleFor(
 
       await this.click('#contact-link > a');
 
-      assert.equal(this.$('h3.contact').length, 1, 'The contact template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.contact').length, 1, 'The contact template was rendered');
+      assert.strictEqual(
         this.$('#self-link > a.active').length,
         1,
         'The self-link was rendered with active class'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('#home-link > a:not(.active)').length,
         1,
         'The other link was rendered without active class'
@@ -2194,8 +2258,8 @@ moduleFor(
 
       await this.click('#home-link > a');
 
-      assert.equal(this.$('h3.home').length, 1, 'The index template was rendered');
-      assert.equal(
+      assert.strictEqual(this.$('h3.home').length, 1, 'The index template was rendered');
+      assert.strictEqual(
         this.$('#contact-link > a').text(),
         'Robert',
         'The link title is correctly updated when the route changes'
@@ -2251,14 +2315,14 @@ moduleFor(
 
       await this.click('#yehuda > a');
 
-      assert.equal(this.$('h3.item').length, 1, 'The item template was rendered');
-      assert.equal(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
+      assert.strictEqual(this.$('h3.item').length, 1, 'The item template was rendered');
+      assert.strictEqual(this.$('p').text(), 'Yehuda Katz', 'The name is correct');
 
       await this.click('#home-link > a');
 
-      assert.equal(normalizeUrl(this.$('li#yehuda > a').attr('href')), '/item/yehuda');
-      assert.equal(normalizeUrl(this.$('li#tom > a').attr('href')), '/item/tom');
-      assert.equal(normalizeUrl(this.$('li#erik > a').attr('href')), '/item/erik');
+      assert.strictEqual(normalizeUrl(this.$('li#yehuda > a').attr('href')), '/item/yehuda');
+      assert.strictEqual(normalizeUrl(this.$('li#tom > a').attr('href')), '/item/tom');
+      assert.strictEqual(normalizeUrl(this.$('li#erik > a').attr('href')), '/item/erik');
     }
 
     async [`@test [DEPRECATED] The non-block form {{link-to}} performs property lookup`](assert) {
@@ -2293,8 +2357,8 @@ moduleFor(
       await this.visit('/');
 
       let assertEquality = (href) => {
-        assert.equal(normalizeUrl(this.$('#string-link > a').attr('href')), '/');
-        assert.equal(normalizeUrl(this.$('#path-link > a').attr('href')), href);
+        assert.strictEqual(normalizeUrl(this.$('#string-link > a').attr('href')), '/');
+        assert.strictEqual(normalizeUrl(this.$('#path-link > a').attr('href')), href);
       };
 
       assertEquality('/');
@@ -2325,11 +2389,11 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#link > a').text(), 'blahzorz');
+      assert.strictEqual(this.$('#link > a').text(), 'blahzorz');
 
       runTask(() => controller.set('display', '<b>BLAMMO</b>'));
 
-      assert.equal(this.$('#link > a').text(), '<b>BLAMMO</b>');
+      assert.strictEqual(this.$('#link > a').text(), '<b>BLAMMO</b>');
       assert.strictEqual(this.$('b').length, 0);
     }
 
@@ -2447,7 +2511,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#the-link > a').attr('href'), '/', 'link has right href');
+      assert.strictEqual(this.$('#the-link > a').attr('href'), '/', 'link has right href');
     }
 
     async [`@test it populates href with default query param values with empty query-params object`](
@@ -2468,7 +2532,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#the-link > a').attr('href'), '/', 'link has right href');
+      assert.strictEqual(this.$('#the-link > a').attr('href'), '/', 'link has right href');
     }
 
     async [`@test it updates when route changes with only query-params and a block`](assert) {
@@ -2492,7 +2556,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#the-link > a').attr('href'),
         '/?bar=NAW&foo=456',
         'link has right href'
@@ -2500,7 +2564,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#the-link > a').attr('href'),
         '/about?bar=NAW&foo=456',
         'link has right href'
@@ -2532,7 +2596,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#the-link > a').attr('href'),
         '/?bar=NAW&foo=456',
         'link has right href'
@@ -2540,7 +2604,7 @@ moduleFor(
 
       await this.visit('/about');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#the-link > a').attr('href'),
         '/about?bar=NAW&foo=456',
         'link has right href'
@@ -2618,14 +2682,14 @@ moduleFor(
 
       let link = this.$('#dynamic-link > a');
 
-      assert.equal(link.attr('href'), '/foo/one/two');
+      assert.strictEqual(link.attr('href'), '/foo/one/two');
 
       expectDeprecation(
         () => runTask(() => controller.set('dynamicLinkParams', ['bar', 'one', 'two', 'three'])),
         /Invoking the `<LinkTo>` component with positional arguments is deprecated/
       );
 
-      assert.equal(link.attr('href'), '/bar/one/two/three');
+      assert.strictEqual(link.attr('href'), '/bar/one/two/three');
     }
 
     async [`@test [GH#13256]: {{link-to}} to a parent root model hook which performs a 'transitionTo' has correct active class`](
@@ -2721,10 +2785,14 @@ moduleFor(
 
       function assertLinkStatus(link, url) {
         if (url) {
-          assert.equal(normalizeUrl(link.attr('href')), url, 'loaded link-to has expected href');
+          assert.strictEqual(
+            normalizeUrl(link.attr('href')),
+            url,
+            'loaded link-to has expected href'
+          );
           assert.ok(!link.hasClass('i-am-loading'), 'loaded linkComponent has no loadingClass');
         } else {
-          assert.equal(normalizeUrl(link.attr('href')), '#', "unloaded link-to has href='#'");
+          assert.strictEqual(normalizeUrl(link.attr('href')), '#', "unloaded link-to has href='#'");
           assert.ok(link.hasClass('i-am-loading'), 'loading linkComponent has loadingClass');
         }
       }
@@ -2767,7 +2835,7 @@ moduleFor(
       // Click the now-active link
       await this.click(staticLink[0]);
 
-      assert.equal(activate, 1, 'About route was entered');
+      assert.strictEqual(activate, 1, 'About route was entered');
     }
   }
 );
@@ -2776,7 +2844,7 @@ function assertNav(options, callback, assert) {
   let nav = false;
 
   function check(event) {
-    assert.equal(
+    assert.strictEqual(
       event.defaultPrevented,
       options.prevented,
       `expected defaultPrevented=${options.prevented}`

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-angle-test.js
@@ -6,13 +6,13 @@ import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 function assertHasClass(assert, selector, label) {
   let testLabel = `${selector.attr('id')} should have class ${label}`;
 
-  assert.equal(selector.hasClass(label), true, testLabel);
+  assert.strictEqual(selector.hasClass(label), true, testLabel);
 }
 
 function assertHasNoClass(assert, selector, label) {
   let testLabel = `${selector.attr('id')} should not have class ${label}`;
 
-  assert.equal(selector.hasClass(label), false, testLabel);
+  assert.strictEqual(selector.hasClass(label), false, testLabel);
 }
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/transitioning-classes-curly-test.js
@@ -6,13 +6,13 @@ import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 function assertHasClass(assert, selector, label) {
   let testLabel = `${selector.attr('id')} should have class ${label}`;
 
-  assert.equal(selector.hasClass(label), true, testLabel);
+  assert.strictEqual(selector.hasClass(label), true, testLabel);
 }
 
 function assertHasNoClass(assert, selector, label) {
   let testLabel = `${selector.attr('id')} should not have class ${label}`;
 
-  assert.equal(selector.hasClass(label), false, testLabel);
+  assert.strictEqual(selector.hasClass(label), false, testLabel);
 }
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/strict-mode-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/strict-mode-test.js
@@ -246,7 +246,7 @@ if (EMBER_STRICT_MODE) {
         assert.expect(1);
 
         let handleClick = (value) => {
-          assert.equal(value, 123);
+          assert.strictEqual(value, 123);
         };
 
         let Foo = defineComponent(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -22,7 +22,7 @@ moduleFor(
           },
           actions: {
             foo(message) {
-              assert.equal('bar', message);
+              assert.strictEqual('bar', message);
             },
           },
         }),
@@ -41,8 +41,8 @@ moduleFor(
       let component;
       let target = {
         send: (message, payload) => {
-          this.assert.equal('foo', message);
-          this.assert.equal('baz', payload);
+          this.assert.strictEqual('foo', message);
+          this.assert.strictEqual('baz', payload);
         },
       };
 
@@ -104,7 +104,7 @@ moduleFor(
             assert.ok(true, 'foo');
           },
           bar(msg) {
-            assert.equal(msg, 'HELLO');
+            assert.strictEqual(msg, 'HELLO');
           },
         },
       });
@@ -112,7 +112,7 @@ moduleFor(
       let BarViewMixin = Mixin.create({
         actions: {
           bar(msg) {
-            assert.equal(msg, 'HELLO');
+            assert.strictEqual(msg, 'HELLO');
             this._super(msg);
           },
         },

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -318,7 +318,7 @@ moduleFor(
     ) {
       let ComponentClass = templateOnlyComponent('my-app/components/foo');
 
-      assert.equal(`${ComponentClass}`, 'my-app/components/foo');
+      assert.strictEqual(`${ComponentClass}`, 'my-app/components/foo');
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-angle-test.js
@@ -106,7 +106,7 @@ moduleFor(
     ['@test Should insert a <textarea>'](assert) {
       this.render('<Textarea />');
 
-      assert.equal(this.$('textarea').length, 1);
+      assert.strictEqual(this.$('textarea').length, 1);
 
       this.assertStableRerender();
     }
@@ -117,7 +117,7 @@ moduleFor(
         /Passing the `@elementId` argument to <Textarea> is deprecated\./,
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
-      assert.equal(this.$('textarea').attr('id'), 'test-textarea');
+      assert.strictEqual(this.$('textarea').attr('id'), 'test-textarea');
     }
 
     ['@test Should respect disabled (HTML attribute)'](assert) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/textarea-curly-test.js
@@ -85,7 +85,7 @@ moduleFor(
     ['@test Should insert a textarea'](assert) {
       this.render('{{textarea}}');
 
-      assert.equal(this.$('textarea').length, 1);
+      assert.strictEqual(this.$('textarea').length, 1);
 
       this.assertStableRerender();
     }
@@ -96,7 +96,7 @@ moduleFor(
         /Passing the `@elementId` argument to <Textarea> is deprecated\./,
         EMBER_MODERNIZED_BUILT_IN_COMPONENTS
       );
-      assert.equal(this.$('textarea').attr('id'), 'test-textarea');
+      assert.strictEqual(this.$('textarea').attr('id'), 'test-textarea');
     }
 
     ['@test [DEPRECATED] Should respect disabled'](assert) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -415,13 +415,13 @@ moduleFor(
 
       this.render('<Parent />');
 
-      assert.equal(this.$('#parent').text(), 'Rob Jackson');
-      assert.equal(this.$('#child').text(), 'Rob Jackson');
+      assert.strictEqual(this.$('#parent').text(), 'Rob Jackson');
+      assert.strictEqual(this.$('#child').text(), 'Rob Jackson');
 
       runTask(() => this.$('button').click());
 
-      assert.equal(this.$('#parent').text(), 'Kris Selden');
-      assert.equal(this.$('#child').text(), 'Kris Selden');
+      assert.strictEqual(this.$('#parent').text(), 'Kris Selden');
+      assert.strictEqual(this.$('#child').text(), 'Kris Selden');
     }
 
     '@test yielded getters update correctly'() {
@@ -628,19 +628,19 @@ moduleFor(
 
       this.assertText('0');
 
-      assert.equal(outerRenderCount, 1);
-      assert.equal(innerRenderCount, 1);
+      assert.strictEqual(outerRenderCount, 1);
+      assert.strictEqual(innerRenderCount, 1);
 
       runTask(() => this.$('button').click());
 
       this.assertText('1');
 
-      assert.equal(
+      assert.strictEqual(
         outerRenderCount,
         1,
         'updating inner component does not cause outer component to rerender'
       );
-      assert.equal(
+      assert.strictEqual(
         innerRenderCount,
         2,
         'updating inner component causes inner component to rerender'
@@ -650,8 +650,8 @@ moduleFor(
 
       this.assertText('2');
 
-      assert.equal(outerRenderCount, 2, 'outer component updates based on context');
-      assert.equal(innerRenderCount, 3, 'inner component updates based on outer component');
+      assert.strictEqual(outerRenderCount, 2, 'outer component updates based on context');
+      assert.strictEqual(innerRenderCount, 3, 'inner component updates based on outer component');
     }
 
     '@test computed properties can depend on args'() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -300,17 +300,17 @@ moduleFor(
 
       let { parentElement, firstNode, lastNode } = getViewBounds(component);
 
-      assert.equal(
+      assert.strictEqual(
         parentElement,
         this.element,
         'a regular component should have the right parentElement'
       );
-      assert.equal(
+      assert.strictEqual(
         firstNode,
         component.element,
         'a regular component should have a single node that is its element'
       );
-      assert.equal(
+      assert.strictEqual(
         lastNode,
         component.element,
         'a regular component should have a single node that is its element'
@@ -334,17 +334,17 @@ moduleFor(
 
       let { parentElement, firstNode, lastNode } = getViewBounds(component);
 
-      assert.equal(
+      assert.strictEqual(
         parentElement,
         this.element,
         'a tagless component should have the right parentElement'
       );
-      assert.equal(
+      assert.strictEqual(
         firstNode,
         this.$('#start-node')[0],
         'a tagless component should have a range enclosing all of its nodes'
       );
-      assert.equal(
+      assert.strictEqual(
         lastNode,
         this.$('#before-end-node')[0].nextSibling,
         'a tagless component should have a range enclosing all of its nodes'

--- a/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/will-destroy-element-hook-test.js
@@ -28,13 +28,13 @@ moduleFor(
 
       this.render('{{#if this.switch}}{{foo-bar}}{{/if}}', { switch: true });
 
-      assert.equal(didInsertElementCount, 1, 'didInsertElement was called once');
+      assert.strictEqual(didInsertElementCount, 1, 'didInsertElement was called once');
 
       this.assertComponentElement(this.firstChild, { content: 'hello' });
 
       runTask(() => set(this.context, 'switch', false));
 
-      assert.equal(willDestroyElementCount, 1, 'willDestroyElement was called once');
+      assert.strictEqual(willDestroyElementCount, 1, 'willDestroyElement was called once');
 
       this.assertText('');
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1231,7 +1231,7 @@ moduleFor(
 
       runTask(() => set(this.context, 'fooBar', false));
 
-      assert.equal(this.firstChild.className, '');
+      assert.strictEqual(this.firstChild.className, '');
 
       runTask(() => set(this.context, 'fooBar', true));
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -80,11 +80,11 @@ class ModifierManagerTest extends RenderingTestCase {
       ModifierClass.extend({
         didUpdate([truthy]) {
           assert.ok(true, 'Called didUpdate');
-          assert.equal(truthy, 'true', 'gets updated args');
+          assert.strictEqual(truthy, 'true', 'gets updated args');
         },
         didInsertElement([truthy]) {
           assert.ok(true, 'Called didInsertElement');
-          assert.equal(truthy, true, 'gets initial args');
+          assert.strictEqual(truthy, true, 'gets initial args');
         },
         willDestroyElement() {
           assert.ok(true, 'Called willDestroyElement');
@@ -121,7 +121,7 @@ class ModifierManagerTest extends RenderingTestCase {
       didInsertElement([truthy]) {
         this._super(...arguments);
         assert.ok(true, 'Called didInsertElement');
-        assert.equal(truthy, true, 'gets initial args');
+        assert.strictEqual(truthy, true, 'gets initial args');
       },
     });
 
@@ -131,7 +131,7 @@ class ModifierManagerTest extends RenderingTestCase {
         didInsertElement([truthy]) {
           this._super(...arguments);
           assert.ok(true, 'Called didInsertElement');
-          assert.equal(truthy, true, 'gets initial args');
+          assert.strictEqual(truthy, true, 'gets initial args');
         },
       })
     );
@@ -163,14 +163,14 @@ class ModifierManagerTest extends RenderingTestCase {
           // consume first positional argument (ensures updates run)
           positional[0];
 
-          assert.equal(this.element.tagName, 'H1');
+          assert.strictEqual(this.element.tagName, 'H1');
           this.set('savedElement', this.element);
         },
         didUpdate() {
-          assert.equal(this.element, this.savedElement);
+          assert.strictEqual(this.element, this.savedElement);
         },
         willDestroyElement() {
-          assert.equal(this.element, this.savedElement);
+          assert.strictEqual(this.element, this.savedElement);
         },
       })
     );
@@ -225,20 +225,20 @@ class ModifierManagerTest extends RenderingTestCase {
     this.render('<h1 {{foo-bar this.truthy}}>hello world</h1>');
     this.assertHTML(`<h1>hello world</h1>`);
 
-    assert.equal(insertCount, 1);
-    assert.equal(updateCount, 0);
+    assert.strictEqual(insertCount, 1);
+    assert.strictEqual(updateCount, 0);
 
     runTask(() => trackedTwo.count++);
-    assert.equal(updateCount, 0);
+    assert.strictEqual(updateCount, 0);
 
     runTask(() => trackedOne.count++);
-    assert.equal(updateCount, 1);
+    assert.strictEqual(updateCount, 1);
 
     runTask(() => trackedOne.count++);
-    assert.equal(updateCount, 1);
+    assert.strictEqual(updateCount, 1);
 
     runTask(() => trackedTwo.count++);
-    assert.equal(updateCount, 2);
+    assert.strictEqual(updateCount, 2);
   }
 
   '@test provides a helpful deprecation when mutating a tracked value that was consumed already within constructor'(
@@ -438,14 +438,14 @@ moduleFor(
 
       this.assertHTML(`<h1>hello world</h1>`);
 
-      assert.equal(insertCount, 1);
-      assert.equal(updateCount, 0);
+      assert.strictEqual(insertCount, 1);
+      assert.strictEqual(updateCount, 0);
 
       runTask(() => set(this.context, 'bar', 'other bar'));
-      assert.equal(updateCount, 1);
+      assert.strictEqual(updateCount, 1);
 
       runTask(() => set(this.context, 'qux', 'quuuuxxxxxx'));
-      assert.equal(updateCount, 2);
+      assert.strictEqual(updateCount, 2);
     }
   }
 );
@@ -526,14 +526,14 @@ moduleFor(
 
       this.assertHTML(`<h1>hello world</h1>`);
 
-      assert.equal(insertCount, 1);
-      assert.equal(updateCount, 0);
+      assert.strictEqual(insertCount, 1);
+      assert.strictEqual(updateCount, 0);
 
       runTask(() => set(this.context, 'positionOne', 'no first?'));
-      assert.equal(updateCount, 0);
+      assert.strictEqual(updateCount, 0);
 
       runTask(() => set(this.context, 'positionTwo', 'YASSSSSSS!!!'));
-      assert.equal(updateCount, 1);
+      assert.strictEqual(updateCount, 1);
     }
 
     '@test modifers only track named arguments they consume'(assert) {
@@ -577,14 +577,14 @@ moduleFor(
 
       this.assertHTML(`<h1>hello world</h1>`);
 
-      assert.equal(insertCount, 1);
-      assert.equal(updateCount, 0);
+      assert.strictEqual(insertCount, 1);
+      assert.strictEqual(updateCount, 0);
 
       runTask(() => set(this.context, 'bar', 'other bar'));
-      assert.equal(updateCount, 0);
+      assert.strictEqual(updateCount, 0);
 
       runTask(() => set(this.context, 'qux', 'quuuuxxxxxx'));
-      assert.equal(updateCount, 1);
+      assert.strictEqual(updateCount, 1);
     }
 
     '@feature(EMBER_DYNAMIC_HELPERS_AND_MODIFIERS) Can resolve a modifier'() {

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -311,7 +311,11 @@ moduleFor(
       this.dispatcher.setup({ myevent: 'myEvent' }, '#app');
 
       assert.ok(this.$('#app').hasClass('ember-application'), 'custom rootElement was used');
-      assert.equal(this.dispatcher.rootElement, '#app', 'the dispatchers rootElement was updated');
+      assert.strictEqual(
+        this.dispatcher.rootElement,
+        '#app',
+        'the dispatchers rootElement was updated'
+      );
     }
 
     ['@test default events can be disabled via `customEvents`'](assert) {
@@ -374,17 +378,17 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.$('div').trigger('click');
 
-        assert.equal(clicked, 1, 'precond - the click handler was invoked');
+        assert.strictEqual(clicked, 1, 'precond - the click handler was invoked');
 
         let clickInstrumented = 0;
         instrumentationSubscribe('interaction.click', {
           before() {
             clickInstrumented++;
-            assert.equal(clicked, 1, 'invoked before event is handled');
+            assert.strictEqual(clicked, 1, 'invoked before event is handled');
           },
           after() {
             clickInstrumented++;
-            assert.equal(clicked, 2, 'invoked after event is handled');
+            assert.strictEqual(clicked, 2, 'invoked after event is handled');
           },
         });
 
@@ -400,8 +404,8 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.$('div').trigger('click');
         this.$('div').trigger('change');
-        assert.equal(clicked, 2, 'precond - The click handler was invoked');
-        assert.equal(clickInstrumented, 2, 'The click was instrumented');
+        assert.strictEqual(clicked, 2, 'precond - The click handler was invoked');
+        assert.strictEqual(clickInstrumented, 2, 'The click was instrumented');
         assert.strictEqual(keypressInstrumented, 0, 'The keypress was not instrumented');
       }
     }
@@ -425,7 +429,7 @@ if (canDataTransfer) {
         this.render(`{{x-foo}}`);
 
         fireNativeWithDataTransfer(this.$('div')[0], 'drop', 'success');
-        assert.equal(receivedEvent.dataTransfer, 'success');
+        assert.strictEqual(receivedEvent.dataTransfer, 'success');
       }
     }
   );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -174,7 +174,7 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
           this.$('#instrument-button').trigger('click');
         });
 
-        this.assert.equal(actualReturnedValue, returnedValue, 'action can return to caller');
+        this.assert.strictEqual(actualReturnedValue, returnedValue, 'action can return to caller');
       }
     }
   );
@@ -302,7 +302,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(returnedValue, expectedValue, 'action can return to caller');
+      this.assert.strictEqual(returnedValue, expectedValue, 'action can return to caller');
     }
 
     ['@test action should be called on the correct scope']() {
@@ -347,7 +347,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(actualComponent, outerComponent, 'action has the correct context');
+      this.assert.strictEqual(actualComponent, outerComponent, 'action has the correct context');
       this.assert.ok(actualComponent.isOuterComponent, 'action has the correct context');
     }
 
@@ -558,9 +558,9 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(actualFirst, first, 'action has the correct first arg');
-      this.assert.equal(actualSecond, second, 'action has the correct second arg');
-      this.assert.equal(actualThird, third, 'action has the correct third arg');
+      this.assert.strictEqual(actualFirst, first, 'action has the correct first arg');
+      this.assert.strictEqual(actualSecond, second, 'action has the correct second arg');
+      this.assert.strictEqual(actualThird, third, 'action has the correct third arg');
     }
 
     ['@test mut values can be wrapped in actions, are settable']() {
@@ -603,7 +603,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(outerComponent.get('outerMut'), newValue, 'mut value is set');
+      this.assert.strictEqual(outerComponent.get('outerMut'), newValue, 'mut value is set');
     }
 
     ['@test mut values can be wrapped in actions, are settable with a curry']() {
@@ -646,7 +646,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(outerComponent.get('outerMut'), newValue, 'mut value is set');
+      this.assert.strictEqual(outerComponent.get('outerMut'), newValue, 'mut value is set');
     }
 
     ['@test action can create closures over actions']() {
@@ -696,9 +696,9 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(actualReturnedValue, returnValue, 'return value is present');
-      this.assert.equal(actualFirst, first, 'first argument is correct');
-      this.assert.equal(actualSecond, second, 'second argument is correct');
+      this.assert.strictEqual(actualReturnedValue, returnValue, 'return value is present');
+      this.assert.strictEqual(actualFirst, first, 'first argument is correct');
+      this.assert.strictEqual(actualSecond, second, 'second argument is correct');
     }
 
     ['@test provides a helpful error if an action is not present']() {
@@ -839,7 +839,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(actualValue, newValue, 'value is read');
+      this.assert.strictEqual(actualValue, newValue, 'value is read');
     }
 
     ['@test action will read the value of a first property']() {
@@ -882,7 +882,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(actualValue, newValue, 'property is read');
+      this.assert.strictEqual(actualValue, newValue, 'property is read');
     }
 
     ['@test action will read the value of a curried first argument property']() {
@@ -926,7 +926,7 @@ moduleFor(
         innerComponent.fireAction();
       });
 
-      this.assert.equal(actualValue, newValue, 'property is read');
+      this.assert.strictEqual(actualValue, newValue, 'property is read');
     }
 
     ['@test action closure does not get auto-mut wrapped'](assert) {
@@ -950,7 +950,7 @@ moduleFor(
           let attrsSubmitReturnValue = this.attrs['attrs-submit'](second);
           let submitReturnValue = this.attrs.submit(second);
 
-          assert.equal(
+          assert.strictEqual(
             attrsSubmitReturnValue,
             submitReturnValue,
             'both attrs.foo and foo should behave the same'
@@ -993,9 +993,9 @@ moduleFor(
         actualReturnedValue = innerComponent.fireAction();
       });
 
-      this.assert.equal(actualFirst, first, 'first argument is correct');
-      this.assert.equal(actualSecond, second, 'second argument is correct');
-      this.assert.equal(actualReturnedValue, returnValue, 'return value is present');
+      this.assert.strictEqual(actualFirst, first, 'first argument is correct');
+      this.assert.strictEqual(actualSecond, second, 'second argument is correct');
+      this.assert.strictEqual(actualReturnedValue, returnValue, 'return value is present');
     }
 
     ['@test action should be called within a run loop']() {
@@ -1142,31 +1142,31 @@ moduleFor(
 
       this.assertText('clicked: 0; foo: 1');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() => this.rerender());
 
       this.assertText('clicked: 0; foo: 1');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() => set(this.context, 'foo', 2));
 
       this.assertText('clicked: 0; foo: 2');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() => this.$('#string-action').click());
 
       this.assertText('clicked: 1; foo: 2');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() => this.$('#function-action').click());
 
       this.assertText('clicked: 2; foo: 2');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() =>
         set(outer, 'onClick', function () {
@@ -1176,19 +1176,19 @@ moduleFor(
 
       this.assertText('clicked: 2; foo: 2');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() => this.$('#function-action').click());
 
       this.assertText('clicked: 3; foo: 2');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
 
       runTask(() => this.$('#mut-action').click());
 
       this.assertText('clicked: 4; foo: 2');
 
-      assert.equal(didReceiveAttrsFired, 3);
+      assert.strictEqual(didReceiveAttrsFired, 3);
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -676,7 +676,7 @@ moduleFor(
 
       runDestroy(this.component);
 
-      assert.equal(destroyCount, 1, 'destroy is called after a view is destroyed');
+      assert.strictEqual(destroyCount, 1, 'destroy is called after a view is destroyed');
     }
 
     ['@test simple helper can be invoked manually via `owner.factoryFor(...).create().compute()'](
@@ -689,8 +689,12 @@ moduleFor(
 
       let instance = this.owner.factoryFor('helper:some-helper').create();
 
-      assert.equal(typeof instance.compute, 'function', 'expected instance.compute to be present');
-      assert.equal(instance.compute(), 'lolol', 'can invoke `.compute`');
+      assert.strictEqual(
+        typeof instance.compute,
+        'function',
+        'expected instance.compute to be present'
+      );
+      assert.strictEqual(instance.compute(), 'lolol', 'can invoke `.compute`');
     }
 
     ['@test class-based helper can be invoked manually via `owner.factoryFor(...).create().compute()'](
@@ -705,8 +709,12 @@ moduleFor(
 
       let instance = this.owner.factoryFor('helper:some-helper').create();
 
-      assert.equal(typeof instance.compute, 'function', 'expected instance.compute to be present');
-      assert.equal(instance.compute(), 'lolol', 'can invoke `.compute`');
+      assert.strictEqual(
+        typeof instance.compute,
+        'function',
+        'expected instance.compute to be present'
+      );
+      assert.strictEqual(instance.compute(), 'lolol', 'can invoke `.compute`');
     }
 
     ['@test class-based helper in native ES syntax receives owner'](assert) {
@@ -717,7 +725,11 @@ moduleFor(
           constructor(owner) {
             super(owner);
 
-            assert.equal(owner, testContext.owner, 'owner was passed as a constructor argument');
+            assert.strictEqual(
+              owner,
+              testContext.owner,
+              'owner was passed as a constructor argument'
+            );
           }
 
           compute() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -67,19 +67,27 @@ if (EMBER_IMPROVED_INSTRUMENTATION) {
 
         this.render('{{example-component}}');
 
-        this.assert.equal(subscriberCallCount, 0, 'subscriber has not been called');
+        this.assert.strictEqual(subscriberCallCount, 0, 'subscriber has not been called');
 
         runTask(() => this.rerender());
 
-        this.assert.equal(subscriberCallCount, 0, 'subscriber has not been called');
+        this.assert.strictEqual(subscriberCallCount, 0, 'subscriber has not been called');
 
         runTask(() => {
           this.$('button').click();
         });
 
-        this.assert.equal(subscriberCallCount, 1, 'subscriber has been called 1 time');
-        this.assert.equal(subscriberPayload.name, 'foo', 'subscriber called with correct name');
-        this.assert.equal(subscriberPayload.args[0], 'bar', 'subscriber called with correct args');
+        this.assert.strictEqual(subscriberCallCount, 1, 'subscriber has been called 1 time');
+        this.assert.strictEqual(
+          subscriberPayload.name,
+          'foo',
+          'subscriber called with correct name'
+        );
+        this.assert.strictEqual(
+          subscriberPayload.args[0],
+          'bar',
+          'subscriber called with correct args'
+        );
       }
     }
   );
@@ -106,23 +114,23 @@ moduleFor(
 
       this.render('{{example-component}}');
 
-      this.assert.equal(fooCallCount, 0, 'foo has not been called');
+      this.assert.strictEqual(fooCallCount, 0, 'foo has not been called');
 
       runTask(() => this.rerender());
 
-      this.assert.equal(fooCallCount, 0, 'foo has not been called');
+      this.assert.strictEqual(fooCallCount, 0, 'foo has not been called');
 
       runTask(() => {
         this.$('button').click();
       });
 
-      this.assert.equal(fooCallCount, 1, 'foo has been called 1 time');
+      this.assert.strictEqual(fooCallCount, 1, 'foo has been called 1 time');
 
       runTask(() => {
         this.$('button').click();
       });
 
-      this.assert.equal(fooCallCount, 2, 'foo has been called 2 times');
+      this.assert.strictEqual(fooCallCount, 2, 'foo has been called 2 times');
     }
 
     ['@test it can call an action with parameters']() {
@@ -291,7 +299,7 @@ moduleFor(
         this.$('a').click();
       });
 
-      this.assert.equal(targetWatted, true, 'the specified target was watted');
+      this.assert.strictEqual(targetWatted, true, 'the specified target was watted');
     }
 
     ['@test it should lazily evaluate the target']() {
@@ -330,7 +338,7 @@ moduleFor(
         this.$('a').click();
       });
 
-      this.assert.equal(firstEdit, 1);
+      this.assert.strictEqual(firstEdit, 1);
 
       runTask(() => {
         set(component, 'theTarget', second);
@@ -340,8 +348,8 @@ moduleFor(
         this.$('a').click();
       });
 
-      this.assert.equal(firstEdit, 1);
-      this.assert.equal(secondEdit, 1);
+      this.assert.strictEqual(firstEdit, 1);
+      this.assert.strictEqual(secondEdit, 1);
     }
 
     ['@test it should register an event handler']() {
@@ -371,13 +379,13 @@ moduleFor(
         this.$('a[data-ember-action]').trigger('click', { altKey: true });
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the event handler was called');
 
       runTask(() => {
         this.$('div[data-ember-action]').trigger('click', { ctrlKey: true });
       });
 
-      this.assert.equal(
+      this.assert.strictEqual(
         shortcutHandlerWasCalled,
         true,
         'the "any" shortcut\'s event handler was called'
@@ -413,13 +421,13 @@ moduleFor(
         this.$('a[data-ember-action]').trigger('click', { altKey: true });
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the event handler was called');
 
       runTask(() => {
         this.$('div[data-ember-action]').trigger('click', { ctrlKey: true });
       });
 
-      this.assert.equal(
+      this.assert.strictEqual(
         shortcutHandlerWasCalled,
         true,
         'the "any" shortcut\'s event handler was called'
@@ -454,7 +462,7 @@ moduleFor(
         this.$('a[data-ember-action]').trigger('click', { altKey: true });
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the event handler was called');
 
       editHandlerWasCalled = false;
 
@@ -466,7 +474,7 @@ moduleFor(
         this.$('div[data-ember-action]').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the event handler was not called');
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the event handler was not called');
     }
 
     ['@test should be able to use action more than once for the same event within a view']() {
@@ -505,9 +513,9 @@ moduleFor(
         this.$('#edit').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the edit action was called');
-      this.assert.equal(deleteHandlerWasCalled, false, 'the delete action was not called');
-      this.assert.equal(
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the edit action was called');
+      this.assert.strictEqual(deleteHandlerWasCalled, false, 'the delete action was not called');
+      this.assert.strictEqual(
         originalHandlerWasCalled,
         true,
         'the click handler was called (due to bubbling)'
@@ -519,9 +527,9 @@ moduleFor(
         this.$('#delete').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the edit action was not called');
-      this.assert.equal(deleteHandlerWasCalled, true, 'the delete action was called');
-      this.assert.equal(
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the edit action was not called');
+      this.assert.strictEqual(deleteHandlerWasCalled, true, 'the delete action was called');
+      this.assert.strictEqual(
         originalHandlerWasCalled,
         true,
         'the click handler was called (due to bubbling)'
@@ -533,9 +541,9 @@ moduleFor(
         this.wrap(component.element).click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the edit action was not called');
-      this.assert.equal(deleteHandlerWasCalled, false, 'the delete action was not called');
-      this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the edit action was not called');
+      this.assert.strictEqual(deleteHandlerWasCalled, false, 'the delete action was not called');
+      this.assert.strictEqual(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
     ['@test the event should not bubble if `bubbles=false` is passed']() {
@@ -574,9 +582,9 @@ moduleFor(
         this.$('#edit').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the edit action was called');
-      this.assert.equal(deleteHandlerWasCalled, false, 'the delete action was not called');
-      this.assert.equal(originalHandlerWasCalled, false, 'the click handler was not called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the edit action was called');
+      this.assert.strictEqual(deleteHandlerWasCalled, false, 'the delete action was not called');
+      this.assert.strictEqual(originalHandlerWasCalled, false, 'the click handler was not called');
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
@@ -584,9 +592,9 @@ moduleFor(
         this.$('#delete').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the edit action was not called');
-      this.assert.equal(deleteHandlerWasCalled, true, 'the delete action was called');
-      this.assert.equal(originalHandlerWasCalled, false, 'the click handler was not called');
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the edit action was not called');
+      this.assert.strictEqual(deleteHandlerWasCalled, true, 'the delete action was called');
+      this.assert.strictEqual(originalHandlerWasCalled, false, 'the click handler was not called');
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
@@ -594,9 +602,9 @@ moduleFor(
         this.wrap(component.element).click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the edit action was not called');
-      this.assert.equal(deleteHandlerWasCalled, false, 'the delete action was not called');
-      this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the edit action was not called');
+      this.assert.strictEqual(deleteHandlerWasCalled, false, 'the delete action was not called');
+      this.assert.strictEqual(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
     ['@test the event should not bubble if `bubbles=false` is passed bound']() {
@@ -636,9 +644,9 @@ moduleFor(
         this.$('#edit').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the edit action was called');
-      this.assert.equal(deleteHandlerWasCalled, false, 'the delete action was not called');
-      this.assert.equal(originalHandlerWasCalled, false, 'the click handler was not called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the edit action was called');
+      this.assert.strictEqual(deleteHandlerWasCalled, false, 'the delete action was not called');
+      this.assert.strictEqual(originalHandlerWasCalled, false, 'the click handler was not called');
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
@@ -646,9 +654,9 @@ moduleFor(
         this.$('#delete').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the edit action was not called');
-      this.assert.equal(deleteHandlerWasCalled, true, 'the delete action was called');
-      this.assert.equal(originalHandlerWasCalled, false, 'the click handler was not called');
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the edit action was not called');
+      this.assert.strictEqual(deleteHandlerWasCalled, true, 'the delete action was called');
+      this.assert.strictEqual(originalHandlerWasCalled, false, 'the click handler was not called');
 
       editHandlerWasCalled = deleteHandlerWasCalled = originalHandlerWasCalled = false;
 
@@ -656,9 +664,9 @@ moduleFor(
         this.wrap(component.element).click();
       });
 
-      this.assert.equal(editHandlerWasCalled, false, 'the edit action was not called');
-      this.assert.equal(deleteHandlerWasCalled, false, 'the delete action was not called');
-      this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, false, 'the edit action was not called');
+      this.assert.strictEqual(deleteHandlerWasCalled, false, 'the delete action was not called');
+      this.assert.strictEqual(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
     ['@test the bubbling depends on the bound parameter']() {
@@ -693,8 +701,8 @@ moduleFor(
         this.$('#edit').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the edit action was called');
-      this.assert.equal(originalHandlerWasCalled, false, 'the click handler was not called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the edit action was called');
+      this.assert.strictEqual(originalHandlerWasCalled, false, 'the click handler was not called');
 
       editHandlerWasCalled = originalHandlerWasCalled = false;
 
@@ -706,8 +714,8 @@ moduleFor(
         this.$('#edit').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the edit action was called');
-      this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the edit action was called');
+      this.assert.strictEqual(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
     ['@test multiple actions with bubbles=false for same event are called but prevent bubbling']() {
@@ -773,7 +781,7 @@ moduleFor(
         this.$('a').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the event handler was called');
     }
 
     ['@test it should work properly in a {{#let foo as |bar|}} block']() {
@@ -800,7 +808,7 @@ moduleFor(
         this.$('a').click();
       });
 
-      this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
+      this.assert.strictEqual(editHandlerWasCalled, true, 'the event handler was called');
     }
 
     ['@test it should unregister event handlers when an element action is removed'](assert) {
@@ -819,7 +827,7 @@ moduleFor(
         isActive: true,
       });
 
-      assert.equal(this.$('a[data-ember-action]').length, 1, 'The element is rendered');
+      assert.strictEqual(this.$('a[data-ember-action]').length, 1, 'The element is rendered');
 
       let actionId;
 
@@ -829,7 +837,7 @@ moduleFor(
 
       runTask(() => this.rerender());
 
-      assert.equal(this.$('a[data-ember-action]').length, 1, 'The element is still present');
+      assert.strictEqual(this.$('a[data-ember-action]').length, 1, 'The element is still present');
 
       assert.ok(ActionManager.registeredActions[actionId], 'The action is still registered');
 
@@ -841,7 +849,7 @@ moduleFor(
 
       runTask(() => set(this.context, 'isActive', true));
 
-      assert.equal(this.$('a[data-ember-action]').length, 1, 'The element is rendered');
+      assert.strictEqual(this.$('a[data-ember-action]').length, 1, 'The element is rendered');
 
       actionId = getActionIds(this.$('a[data-ember-action]')[0])[0];
 
@@ -1330,7 +1338,7 @@ moduleFor(
       });
 
       this.assert.ok(submitCalled, 'submit function called');
-      this.assert.equal(incomingArg, arg, 'argument passed');
+      this.assert.strictEqual(incomingArg, arg, 'argument passed');
     }
 
     ['@test a quoteless parameter that does not resolve to a value asserts']() {
@@ -1443,7 +1451,7 @@ moduleFor(
         event = this.$('a').click()[0];
       });
 
-      this.assert.equal(event.defaultPrevented, false, 'should not preventDefault');
+      this.assert.strictEqual(event.defaultPrevented, false, 'should not preventDefault');
     }
 
     ['@test it should respect preventDefault option if provided bound']() {
@@ -1473,14 +1481,14 @@ moduleFor(
         event = this.$('a').trigger(event)[0];
       });
 
-      this.assert.equal(event.defaultPrevented, false, 'should not preventDefault');
+      this.assert.strictEqual(event.defaultPrevented, false, 'should not preventDefault');
 
       runTask(() => {
         component.set('shouldPreventDefault', true);
         event = this.$('a').trigger('click')[0];
       });
 
-      this.assert.equal(event.defaultPrevented, true, 'should preventDefault');
+      this.assert.strictEqual(event.defaultPrevented, true, 'should preventDefault');
     }
 
     ['@test it should target the proper component when `action` is in yielded block [GH #12409]']() {
@@ -1596,7 +1604,7 @@ moduleFor(
         { show: true }
       );
 
-      this.assert.equal(this.$('button').text().trim(), 'Show (true)');
+      this.assert.strictEqual(this.$('button').text().trim(), 'Show (true)');
       // We need to focus in to simulate an actual click.
       runTask(() => {
         document.getElementById('ddButton').focus();
@@ -1628,7 +1636,7 @@ moduleFor(
         this.$('button').click();
       });
 
-      this.assert.equal(actionCount, 1, 'Click action only fired once.');
+      this.assert.strictEqual(actionCount, 1, 'Click action only fired once.');
       this.assert.ok(
         this.$('button').hasClass('selected'),
         "Element with action handler has properly updated it's conditional class"
@@ -1638,7 +1646,7 @@ moduleFor(
         this.$('button').click();
       });
 
-      this.assert.equal(actionCount, 2, 'Second click action only fired once.');
+      this.assert.strictEqual(actionCount, 2, 'Second click action only fired once.');
       this.assert.ok(
         !this.$('button').hasClass('selected'),
         "Element with action handler has properly updated it's conditional class"

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -81,20 +81,20 @@ moduleFor(
         arg2: 'bar',
       });
 
-      assert.equal(this.stashedFn(), 'arg1: foo, arg2: bar');
+      assert.strictEqual(this.stashedFn(), 'arg1: foo, arg2: bar');
 
       runTask(() => set(this.context, 'arg1', 'qux'));
-      assert.equal(this.stashedFn(), 'arg1: qux, arg2: bar');
+      assert.strictEqual(this.stashedFn(), 'arg1: qux, arg2: bar');
 
       runTask(() => set(this.context, 'arg2', 'derp'));
-      assert.equal(this.stashedFn(), 'arg1: qux, arg2: derp');
+      assert.strictEqual(this.stashedFn(), 'arg1: qux, arg2: derp');
 
       runTask(() => {
         set(this.context, 'arg1', 'foo');
         set(this.context, 'arg2', 'bar');
       });
 
-      assert.equal(this.stashedFn(), 'arg1: foo, arg2: bar');
+      assert.strictEqual(this.stashedFn(), 'arg1: foo, arg2: bar');
     }
 
     '@test a stashed fn result invokes the correct function when the bound function changes'(
@@ -110,13 +110,13 @@ moduleFor(
         arg2: 'bar',
       });
 
-      assert.equal(this.stashedFn(), 'arg1: foo, arg2: bar');
+      assert.strictEqual(this.stashedFn(), 'arg1: foo, arg2: bar');
 
       runTask(() => set(this.context, 'myFunc', func2));
-      assert.equal(this.stashedFn(), 'arg2: bar, arg1: foo');
+      assert.strictEqual(this.stashedFn(), 'arg2: bar, arg1: foo');
 
       runTask(() => set(this.context, 'myFunc', func1));
-      assert.equal(this.stashedFn(), 'arg1: foo, arg2: bar');
+      assert.strictEqual(this.stashedFn(), 'arg1: foo, arg2: bar');
     }
 
     '@test there is no `this` context within the callback'(assert) {
@@ -144,7 +144,7 @@ moduleFor(
         arg2: 'bar',
       });
 
-      assert.equal(this.stashedFn(), 'arg1: foo, arg2: bar');
+      assert.strictEqual(this.stashedFn(), 'arg1: foo, arg2: bar');
     }
 
     '@test partially applies each layer when nested [GH#17959]'() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/helper-manager-test.js
@@ -88,17 +88,17 @@ if (EMBER_GLIMMER_HELPER_MANAGER) {
           foo: 123,
         });
 
-        assert.equal(count, 1, 'rendered once');
+        assert.strictEqual(count, 1, 'rendered once');
         this.assertText('123');
 
         runTask(() => this.rerender());
 
-        assert.equal(count, 1, 'rendered once');
+        assert.strictEqual(count, 1, 'rendered once');
         this.assertText('123');
 
         runTask(() => set(this.context, 'foo', 456));
 
-        assert.equal(count, 2, 'rendered twice');
+        assert.strictEqual(count, 2, 'rendered twice');
         this.assertText('456');
       }
 
@@ -119,17 +119,17 @@ if (EMBER_GLIMMER_HELPER_MANAGER) {
           foo: 123,
         });
 
-        assert.equal(count, 1, 'rendered once');
+        assert.strictEqual(count, 1, 'rendered once');
         this.assertText('123');
 
         runTask(() => this.rerender());
 
-        assert.equal(count, 1, 'rendered once');
+        assert.strictEqual(count, 1, 'rendered once');
         this.assertText('123');
 
         runTask(() => set(this.context, 'foo', 456));
 
-        assert.equal(count, 2, 'rendered twice');
+        assert.strictEqual(count, 2, 'rendered twice');
         this.assertText('456');
       }
 
@@ -156,17 +156,17 @@ if (EMBER_GLIMMER_HELPER_MANAGER) {
 
         this.render('{{hello}}');
 
-        assert.equal(count, 1, 'rendered once');
+        assert.strictEqual(count, 1, 'rendered once');
         this.assertText('123');
 
         runTask(() => this.rerender());
 
-        assert.equal(count, 1, 'rendered once');
+        assert.strictEqual(count, 1, 'rendered once');
         this.assertText('123');
 
         runTask(() => (instance.foo = 456));
 
-        assert.equal(count, 2, 'rendered twice');
+        assert.strictEqual(count, 2, 'rendered twice');
         this.assertText('456');
       }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js
@@ -169,7 +169,7 @@ if (EMBER_GLIMMER_INVOKE_HELPER) {
         let instance = new PlusOne(4);
 
         assert.notOk(getOwner(instance), 'no owner exists on the wrapper');
-        assert.equal(instance.value, 5, 'helper works without an owner');
+        assert.strictEqual(instance.value, 5, 'helper works without an owner');
       }
 
       '@test tracking for arguments works for tracked properties'(assert) {
@@ -200,14 +200,14 @@ if (EMBER_GLIMMER_INVOKE_HELPER) {
 
         let instance = new PlusOne(4);
 
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(count, 1, 'helper only called once');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(count, 1, 'helper only called once');
 
         instance.number = 5;
 
-        assert.equal(instance.value, 6, 'helper works');
-        assert.equal(count, 2, 'helper called a second time');
+        assert.strictEqual(instance.value, 6, 'helper works');
+        assert.strictEqual(count, 2, 'helper called a second time');
       }
 
       '@test computeArgs only called when consumed values change'(assert) {
@@ -245,23 +245,23 @@ if (EMBER_GLIMMER_INVOKE_HELPER) {
 
         let instance = new PlusN(4, 1);
 
-        assert.equal(count, 0, 'computeArgs not called yet');
+        assert.strictEqual(count, 0, 'computeArgs not called yet');
 
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(count, 1, 'computeArgs only called once');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(count, 1, 'computeArgs only called once');
 
         instance.number = 5;
 
-        assert.equal(instance.value, 6, 'helper works');
-        assert.equal(instance.value, 6, 'helper works');
-        assert.equal(count, 2, 'computeArgs called a second time');
+        assert.strictEqual(instance.value, 6, 'helper works');
+        assert.strictEqual(instance.value, 6, 'helper works');
+        assert.strictEqual(count, 2, 'computeArgs called a second time');
 
         instance.n = 5;
 
-        assert.equal(instance.value, 10, 'helper works');
-        assert.equal(instance.value, 10, 'helper works');
-        assert.equal(count, 3, 'computeArgs called a third time');
+        assert.strictEqual(instance.value, 10, 'helper works');
+        assert.strictEqual(instance.value, 10, 'helper works');
+        assert.strictEqual(count, 3, 'computeArgs called a third time');
       }
 
       '@test helper updates based on internal state changes'(assert) {
@@ -292,14 +292,14 @@ if (EMBER_GLIMMER_INVOKE_HELPER) {
 
         let instance = new PlusOne();
 
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(count, 1, 'helper only called once');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(count, 1, 'helper only called once');
 
         helper.number = 5;
 
-        assert.equal(instance.value, 6, 'helper works');
-        assert.equal(count, 2, 'helper called a second time');
+        assert.strictEqual(instance.value, 6, 'helper works');
+        assert.strictEqual(count, 2, 'helper called a second time');
       }
 
       '@test helper that with constant args is constant'(assert) {
@@ -330,14 +330,14 @@ if (EMBER_GLIMMER_INVOKE_HELPER) {
 
         let instance = new PlusOne(4);
 
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(count, 1, 'helper only called once');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(count, 1, 'helper only called once');
 
         instance.number = 5;
 
-        assert.equal(instance.value, 5, 'helper works');
-        assert.equal(count, 1, 'helper not called a second time');
+        assert.strictEqual(instance.value, 5, 'helper works');
+        assert.strictEqual(count, 1, 'helper not called a second time');
       }
 
       '@test helper destroys correctly when context object is destroyed'(assert) {
@@ -553,14 +553,14 @@ if (EMBER_GLIMMER_HELPER_MANAGER && EMBER_GLIMMER_INVOKE_HELPER) {
 
         let instance = new PlusOne(4);
 
-        assert.equal(instance.value, 123, 'helper works');
-        assert.equal(instance.value, 123, 'helper works');
-        assert.equal(count, 1, 'helper only called once');
+        assert.strictEqual(instance.value, 123, 'helper works');
+        assert.strictEqual(instance.value, 123, 'helper works');
+        assert.strictEqual(count, 1, 'helper only called once');
 
         instance.number = 5;
 
-        assert.equal(instance.value, 123, 'helper works');
-        assert.equal(count, 1, 'helper not called a second time');
+        assert.strictEqual(instance.value, 123, 'helper works');
+        assert.strictEqual(count, 1, 'helper not called a second time');
       }
 
       '@test helper destroys correctly when context object is destroyed'(assert) {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/mut-test.js
@@ -137,7 +137,7 @@ moduleFor(
 
       this.render('{{middle-mut value="foo"}}');
 
-      this.assert.equal(get(bottom, 'stuff'), 'foo', 'the data propagated');
+      this.assert.strictEqual(get(bottom, 'stuff'), 'foo', 'the data propagated');
       this.assertText('foo');
 
       this.assertStableRerender();
@@ -352,8 +352,8 @@ moduleFor(
 
       runTask(() => inner.attrs.foo.update('bar'));
 
-      this.assert.equal(inner.attrs.foo.value, 'bar');
-      this.assert.equal(get(inner, 'foo'), 'bar');
+      this.assert.strictEqual(inner.attrs.foo.value, 'bar');
+      this.assert.strictEqual(get(inner, 'foo'), 'bar');
       this.assertText('bar');
 
       runTask(() => inner.attrs.foo.update('foo'));
@@ -385,8 +385,8 @@ moduleFor(
 
       runTask(() => inner.attrs.model.update(42));
 
-      this.assert.equal(inner.attrs.model.value, 42);
-      this.assert.equal(get(inner, 'model'), 42);
+      this.assert.strictEqual(inner.attrs.model.value, 42);
+      this.assert.strictEqual(get(inner, 'model'), 42);
       this.assertText('42');
 
       runTask(() => inner.attrs.model.update(undefined));
@@ -421,8 +421,8 @@ moduleFor(
 
       runTask(() => inner.attrs.model.update(42));
 
-      this.assert.equal(inner.attrs.model.value, 42);
-      this.assert.equal(get(inner, 'model'), 42);
+      this.assert.strictEqual(inner.attrs.model.value, 42);
+      this.assert.strictEqual(get(inner, 'model'), 42);
       this.assertText('hello42');
 
       runTask(() => inner.attrs.model.update('foo'));

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -31,7 +31,7 @@ moduleFor(
       this.assert.notOk(component.attrs.value.update);
 
       this.assertText('13', 'local property is updated');
-      this.assert.equal(get(this.context, 'val'), 12, 'upstream attribute is not updated');
+      this.assert.strictEqual(get(this.context, 'val'), 12, 'upstream attribute is not updated');
 
       // No U-R
     }
@@ -65,14 +65,14 @@ moduleFor(
         },
       });
 
-      assert.equal(
+      assert.strictEqual(
         typeof outer.attrs.onClick,
         'function',
         'function itself is present in outer component attrs'
       );
       outer.attrs.onClick();
 
-      assert.equal(
+      assert.strictEqual(
         typeof inner.attrs.onClick,
         'function',
         'function itself is present in inner component attrs'
@@ -213,61 +213,61 @@ moduleFor(
 
       this.assertStableRerender();
 
-      this.assert.equal(get(bottom, 'bar'), 12, "bottom's local bar received the value");
-      this.assert.equal(get(middle, 'foo'), 12, "middle's local foo received the value");
+      this.assert.strictEqual(get(bottom, 'bar'), 12, "bottom's local bar received the value");
+      this.assert.strictEqual(get(middle, 'foo'), 12, "middle's local foo received the value");
 
       // updating the mut-cell directly
       runTask(() => bottom.attrs.bar.update(13));
 
-      this.assert.equal(
+      this.assert.strictEqual(
         get(bottom, 'bar'),
         13,
         "bottom's local bar was updated after set of bottom's bar"
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         get(middle, 'foo'),
         13,
         "middle's local foo was updated after set of bottom's bar"
       );
       this.assertText('13 13');
-      this.assert.equal(get(this.context, 'val'), 12, 'But context val is not updated');
+      this.assert.strictEqual(get(this.context, 'val'), 12, 'But context val is not updated');
 
       runTask(() => set(bottom, 'bar', 14));
 
-      this.assert.equal(
+      this.assert.strictEqual(
         get(bottom, 'bar'),
         14,
         "bottom's local bar was updated after set of bottom's bar"
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         get(middle, 'foo'),
         14,
         "middle's local foo was updated after set of bottom's bar"
       );
       this.assertText('14 14');
-      this.assert.equal(get(this.context, 'val'), 12, 'But context val is not updated');
+      this.assert.strictEqual(get(this.context, 'val'), 12, 'But context val is not updated');
 
       this.assert.notOk(middle.attrs.foo.update, "middle's foo attr is not a mutable cell");
       runTask(() => set(middle, 'foo', 15));
 
       this.assertText('15 15');
-      this.assert.equal(get(middle, 'foo'), 15, "set of middle's foo took effect");
-      this.assert.equal(
+      this.assert.strictEqual(get(middle, 'foo'), 15, "set of middle's foo took effect");
+      this.assert.strictEqual(
         get(bottom, 'bar'),
         15,
         "bottom's local bar was updated after set of middle's foo"
       );
-      this.assert.equal(get(this.context, 'val'), 12, 'Context val remains unchanged');
+      this.assert.strictEqual(get(this.context, 'val'), 12, 'Context val remains unchanged');
 
       runTask(() => set(this.context, 'val', 10));
 
       this.assertText('10 10');
-      this.assert.equal(
+      this.assert.strictEqual(
         get(bottom, 'bar'),
         10,
         "bottom's local bar was updated after set of context's val"
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         get(middle, 'foo'),
         10,
         "middle's local foo was updated after set of context's val"
@@ -277,12 +277,12 @@ moduleFor(
       runTask(() => set(bottom, 'bar', undefined));
 
       this.assertText(' ');
-      this.assert.equal(
+      this.assert.strictEqual(
         get(bottom, 'bar'),
         undefined,
         "bottom's local bar was updated to a falsy value"
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         get(middle, 'foo'),
         undefined,
         "middle's local foo was updated to a falsy value"

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -81,25 +81,25 @@ moduleFor(
 
       this.render(`<input disabled={{this.model.value}}>`, model);
 
-      this.assert.equal(this.$inputElement().prop('disabled'), false);
+      this.assert.strictEqual(this.$inputElement().prop('disabled'), false);
 
       runTask(() => this.rerender());
 
-      this.assert.equal(this.$inputElement().prop('disabled'), false);
+      this.assert.strictEqual(this.$inputElement().prop('disabled'), false);
 
       runTask(() => this.context.set('model.value', true));
 
-      this.assert.equal(this.$inputElement().prop('disabled'), true);
+      this.assert.strictEqual(this.$inputElement().prop('disabled'), true);
       this.assertHTML('<input disabled="">'); // Note the DOM output is <input disabled>
 
       runTask(() => this.context.set('model.value', 'wat'));
 
-      this.assert.equal(this.$inputElement().prop('disabled'), true);
+      this.assert.strictEqual(this.$inputElement().prop('disabled'), true);
       this.assertHTML('<input disabled="">'); // Note the DOM output is <input disabled>
 
       runTask(() => this.context.set('model', { value: false }));
 
-      this.assert.equal(this.$inputElement().prop('disabled'), false);
+      this.assert.strictEqual(this.$inputElement().prop('disabled'), false);
       this.assertHTML('<input>');
     }
 
@@ -256,16 +256,20 @@ moduleFor(
     }
 
     assertAttributeHasValue(attribute, value, message) {
-      this.assert.equal(this.$inputElement().attr(attribute), value, `${attribute} ${message}`);
+      this.assert.strictEqual(
+        this.$inputElement().attr(attribute),
+        value,
+        `${attribute} ${message}`
+      );
     }
 
     assertPropertyHasValue(property, value, message) {
-      this.assert.equal(this.$inputElement().prop(property), value, `${property} ${message}`);
+      this.assert.strictEqual(this.$inputElement().prop(property), value, `${property} ${message}`);
     }
 
     assertSelectionRange(start, end) {
-      this.assert.equal(this.inputElement().selectionStart, start);
-      this.assert.equal(this.inputElement().selectionEnd, end);
+      this.assert.strictEqual(this.inputElement().selectionStart, start);
+      this.assert.strictEqual(this.inputElement().selectionEnd, end);
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -53,17 +53,17 @@ moduleFor(
         },
       });
 
-      assert.equal(count, 0, 'not called on initial render');
+      assert.strictEqual(count, 0, 'not called on initial render');
 
       this.assertStableRerender();
       this.assertCounts({ adds: 1, removes: 0 });
-      assert.equal(count, 0, 'not called on a rerender');
+      assert.strictEqual(count, 0, 'not called on a rerender');
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 1, 'has been called 1 time');
+      assert.strictEqual(count, 1, 'has been called 1 time');
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 2, 'has been called 2 times');
+      assert.strictEqual(count, 2, 'has been called 2 times');
 
       this.assertCounts({ adds: 1, removes: 0 });
     }
@@ -96,18 +96,18 @@ moduleFor(
         callback: firstCallback,
       });
 
-      assert.equal(first, 0, 'precond - first not called on initial render');
-      assert.equal(second, 0, 'precond - second not called on initial render');
+      assert.strictEqual(first, 0, 'precond - first not called on initial render');
+      assert.strictEqual(second, 0, 'precond - second not called on initial render');
 
       runTask(() => this.$('button').click());
-      assert.equal(first, 1, 'first has been called 1 time');
-      assert.equal(second, 0, 'second not called on initial render');
+      assert.strictEqual(first, 1, 'first has been called 1 time');
+      assert.strictEqual(second, 0, 'second not called on initial render');
 
       runTask(() => this.context.set('callback', secondCallback));
       runTask(() => this.$('button').click());
 
-      assert.equal(first, 1, 'first has been called 1 time');
-      assert.equal(second, 1, 'second has been called 1 times');
+      assert.strictEqual(first, 1, 'first has been called 1 time');
+      assert.strictEqual(second, 1, 'second has been called 1 times');
 
       this.assertCounts({ adds: 2, removes: 1 });
     }
@@ -121,16 +121,16 @@ moduleFor(
         },
       });
 
-      assert.equal(count, 0, 'not called on initial render');
+      assert.strictEqual(count, 0, 'not called on initial render');
 
       this.assertStableRerender();
-      assert.equal(count, 0, 'not called on a rerender');
+      assert.strictEqual(count, 0, 'not called on a rerender');
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 1, 'has been called 1 time');
+      assert.strictEqual(count, 1, 'has been called 1 time');
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 1, 'has been called 1 times');
+      assert.strictEqual(count, 1, 'has been called 1 times');
 
       this.assertCounts({ adds: 1, removes: 0 });
     }
@@ -149,17 +149,17 @@ moduleFor(
       });
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 1, 'has been called 1 time');
+      assert.strictEqual(count, 1, 'has been called 1 time');
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 2, 'has been called 2 times');
+      assert.strictEqual(count, 2, 'has been called 2 times');
 
       runTask(() => this.context.set('once', true));
       runTask(() => this.$('button').click());
-      assert.equal(count, 3, 'has been called 3 time');
+      assert.strictEqual(count, 3, 'has been called 3 time');
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 3, 'is not called again');
+      assert.strictEqual(count, 3, 'is not called again');
 
       this.assertCounts({ adds: 2, removes: 1 });
     }
@@ -249,7 +249,7 @@ moduleFor(
       this.assertCounts({ adds: 1, removes: 0 });
 
       runTask(() => this.$('button').click());
-      assert.equal(count, 1, 'has been called 1 time');
+      assert.strictEqual(count, 1, 'has been called 1 time');
 
       runTask(() => this.context.set('showButton', false));
 

--- a/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/svg-test.js
@@ -30,7 +30,7 @@ moduleFor(
 
       runTask(() => set(this.context, 'model.viewBoxString', null));
 
-      assert.equal(this.firstChild.getAttribute('svg'), null);
+      assert.strictEqual(this.firstChild.getAttribute('svg'), null);
 
       runTask(() => set(this.context, 'model', { viewBoxString }));
 
@@ -66,7 +66,7 @@ moduleFor(
 
       runTask(() => set(this.context, 'model.viewBoxString', null));
 
-      assert.equal(this.firstChild.getAttribute('svg'), null);
+      assert.strictEqual(this.firstChild.getAttribute('svg'), null);
 
       runTask(() => set(this.context, 'model', { viewBoxString }));
 

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
@@ -72,7 +72,7 @@ moduleFor(
       runTask(() => set(this.context, 'cond', false));
 
       this.assertText('Nothing Here!');
-      assert.equal(destroyedChildrenCount, 3, 'the children were properly destroyed');
+      assert.strictEqual(destroyedChildrenCount, 3, 'the children were properly destroyed');
 
       runTask(() => set(this.context, 'cond', true));
 

--- a/packages/@ember/-internals/glimmer/tests/unit/outlet-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/outlet-test.js
@@ -13,8 +13,8 @@ moduleFor(
       let renderer = {
         appendOutletView(view, target) {
           didAppendOutletView++;
-          assert.equal(view, outletView);
-          assert.equal(target, expectedOutlet);
+          assert.strictEqual(view, outletView);
+          assert.strictEqual(target, expectedOutlet);
         },
       };
 
@@ -28,27 +28,27 @@ moduleFor(
       );
 
       run(() => {
-        assert.equal(
+        assert.strictEqual(
           didAppendOutletView,
           0,
           'appendOutletView should not yet have been called (before appendTo)'
         );
         outletView.appendTo(expectedOutlet);
-        assert.equal(
+        assert.strictEqual(
           didAppendOutletView,
           0,
           'appendOutletView should not yet have been called (sync after appendTo)'
         );
 
         schedule('actions', () =>
-          assert.equal(
+          assert.strictEqual(
             didAppendOutletView,
             0,
             'appendOutletView should not yet have been called (in actions)'
           )
         );
         schedule('render', () =>
-          assert.equal(didAppendOutletView, 1, 'appendOutletView should be invoked in render')
+          assert.strictEqual(didAppendOutletView, 1, 'appendOutletView should be invoked in render')
         );
       });
     }

--- a/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/template-factory-test.js
@@ -26,8 +26,8 @@ moduleFor(
       let Precompiled = exports['default'];
       let Compiled = compile(templateStr, options);
 
-      assert.equal(typeof Precompiled, 'function', 'precompiled is a factory');
-      assert.equal(typeof Compiled, 'function', 'compiled is a factory');
+      assert.strictEqual(typeof Precompiled, 'function', 'precompiled is a factory');
+      assert.strictEqual(typeof Compiled, 'function', 'compiled is a factory');
 
       this.expectCacheChanges({}, 'no changes');
 

--- a/packages/@ember/-internals/glimmer/tests/utils/string-test.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/string-test.js
@@ -14,15 +14,15 @@ moduleFor(
     ['@test htmlSafe should return an empty string for null']() {
       let safeString = htmlSafe(null);
 
-      this.assert.equal(safeString instanceof SafeString, true, 'should be a SafeString');
-      this.assert.equal(safeString.toString(), '', 'should return an empty string');
+      this.assert.strictEqual(safeString instanceof SafeString, true, 'should be a SafeString');
+      this.assert.strictEqual(safeString.toString(), '', 'should return an empty string');
     }
 
     ['@test htmlSafe should return an instance of SafeString for an empty string']() {
       let safeString = htmlSafe();
 
-      this.assert.equal(safeString instanceof SafeString, true, 'should be a SafeString');
-      this.assert.equal(safeString.toString(), '', 'should return an empty string');
+      this.assert.strictEqual(safeString instanceof SafeString, true, 'should be a SafeString');
+      this.assert.strictEqual(safeString.toString(), '', 'should return an empty string');
     }
   }
 );

--- a/packages/@ember/-internals/meta/tests/listeners_test.js
+++ b/packages/@ember/-internals/meta/tests/listeners_test.js
@@ -10,11 +10,11 @@ moduleFor(
       let m = meta({});
       m.addToListeners('hello', t, 'm', 0);
       let matching = m.matchingListeners('hello');
-      assert.equal(matching.length, 3);
-      assert.equal(matching[0], t);
+      assert.strictEqual(matching.length, 3);
+      assert.strictEqual(matching[0], t);
       m.removeFromListeners('hello', t, 'm');
       matching = m.matchingListeners('hello');
-      assert.equal(matching, undefined);
+      assert.strictEqual(matching, undefined);
     }
 
     ['@test inheritance'](assert) {
@@ -57,7 +57,7 @@ moduleFor(
       m1.removeFromListeners('hello', target, 'm');
 
       matching = m1.matchingListeners('hello');
-      assert.equal(matching, undefined, 'listener removed from child1');
+      assert.strictEqual(matching, undefined, 'listener removed from child1');
 
       matching = m2.matchingListeners('hello');
       assert.deepEqual(matching, [target, 'm', false], 'listener still exists for child2');
@@ -72,8 +72,8 @@ moduleFor(
       m.addToListeners('hello', t, 'm', 0);
       m.addToListeners('hello', t, 'm', 0);
       let matching = m.matchingListeners('hello');
-      assert.equal(matching.length, 3);
-      assert.equal(matching[0], t);
+      assert.strictEqual(matching.length, 3);
+      assert.strictEqual(matching[0], t);
     }
 
     ['@test parent caching'](assert) {
@@ -91,17 +91,17 @@ moduleFor(
 
       let matching = m.matchingListeners('hello');
 
-      assert.equal(matching.length, 3);
+      assert.strictEqual(matching.length, 3);
       if (DEBUG) {
-        assert.equal(counters.flattenedListenersCalls, 2);
-        assert.equal(counters.parentListenersUsed, 1);
+        assert.strictEqual(counters.flattenedListenersCalls, 2);
+        assert.strictEqual(counters.parentListenersUsed, 1);
       }
       matching = m.matchingListeners('hello');
 
-      assert.equal(matching.length, 3);
+      assert.strictEqual(matching.length, 3);
       if (DEBUG) {
-        assert.equal(counters.flattenedListenersCalls, 3);
-        assert.equal(counters.parentListenersUsed, 1);
+        assert.strictEqual(counters.flattenedListenersCalls, 3);
+        assert.strictEqual(counters.parentListenersUsed, 1);
       }
     }
 
@@ -121,22 +121,22 @@ moduleFor(
 
       let matching = m.matchingListeners('hello');
 
-      assert.equal(matching.length, 3);
+      assert.strictEqual(matching.length, 3);
       if (DEBUG) {
-        assert.equal(counters.flattenedListenersCalls, 2);
-        assert.equal(counters.parentListenersUsed, 1);
-        assert.equal(counters.listenersInherited, 0);
+        assert.strictEqual(counters.flattenedListenersCalls, 2);
+        assert.strictEqual(counters.parentListenersUsed, 1);
+        assert.strictEqual(counters.listenersInherited, 0);
       }
 
       m.addToListeners('hello', null, 'm2');
 
       matching = m.matchingListeners('hello');
 
-      assert.equal(matching.length, 6);
+      assert.strictEqual(matching.length, 6);
       if (DEBUG) {
-        assert.equal(counters.flattenedListenersCalls, 4);
-        assert.equal(counters.parentListenersUsed, 1);
-        assert.equal(counters.listenersInherited, 1);
+        assert.strictEqual(counters.flattenedListenersCalls, 4);
+        assert.strictEqual(counters.parentListenersUsed, 1);
+        assert.strictEqual(counters.listenersInherited, 1);
       }
     }
 
@@ -166,35 +166,43 @@ moduleFor(
       m1.matchingListeners('hello');
       m2.matchingListeners('hello');
 
-      assert.equal(counters.reopensAfterFlatten, 0, 'no reopen calls yet');
+      assert.strictEqual(counters.reopensAfterFlatten, 0, 'no reopen calls yet');
 
       m1.addToListeners('world', null, 'm', 0);
       m2.addToListeners('world', null, 'm', 0);
       m1.matchingListeners('world');
       m2.matchingListeners('world');
 
-      assert.equal(counters.reopensAfterFlatten, 1, 'reopen calls after invalidating parent cache');
+      assert.strictEqual(
+        counters.reopensAfterFlatten,
+        1,
+        'reopen calls after invalidating parent cache'
+      );
 
       m1.addToListeners('world', null, 'm', 0);
       m2.addToListeners('world', null, 'm', 0);
       m1.matchingListeners('world');
       m2.matchingListeners('world');
 
-      assert.equal(counters.reopensAfterFlatten, 1, 'no reopen calls after mutating leaf nodes');
+      assert.strictEqual(
+        counters.reopensAfterFlatten,
+        1,
+        'no reopen calls after mutating leaf nodes'
+      );
 
       class1Meta.removeFromListeners('hello', null, 'm');
       class2Meta.removeFromListeners('hello', null, 'm');
       m1.matchingListeners('hello');
       m2.matchingListeners('hello');
 
-      assert.equal(counters.reopensAfterFlatten, 2, 'one reopen call after mutating parents');
+      assert.strictEqual(counters.reopensAfterFlatten, 2, 'one reopen call after mutating parents');
 
       class1Meta.addToListeners('hello', null, 'm', 0);
       m1.matchingListeners('hello');
       class2Meta.addToListeners('hello', null, 'm', 0);
       m2.matchingListeners('hello');
 
-      assert.equal(
+      assert.strictEqual(
         counters.reopensAfterFlatten,
         3,
         'one reopen call after mutating parents and flattening out of order'
@@ -222,7 +230,7 @@ moduleFor(
       m1.removeFromListeners('functionListener', null, listenerFunc, 0);
       m1.removeFromListeners('stringListener', null, 'm', 0);
 
-      assert.equal(
+      assert.strictEqual(
         m1.flattenedListeners().length,
         1,
         'instance listeners correctly removed, inherited listeners remain'

--- a/packages/@ember/-internals/meta/tests/meta_test.js
+++ b/packages/@ember/-internals/meta/tests/meta_test.js
@@ -9,7 +9,11 @@ moduleFor(
 
       meta(obj).foo = 'bar';
 
-      assert.equal(meta(obj).foo, 'bar', 'returns same hash with multiple calls to Ember.meta()');
+      assert.strictEqual(
+        meta(obj).foo,
+        'bar',
+        'returns same hash with multiple calls to Ember.meta()'
+      );
     }
 
     ['@test meta is not enumerable'](assert) {

--- a/packages/@ember/-internals/metal/tests/accessors/get_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/get_test.js
@@ -25,27 +25,27 @@ moduleFor(
         if (!Object.prototype.hasOwnProperty.call(obj, key)) {
           continue;
         }
-        assert.equal(get(obj, key), obj[key], key);
+        assert.strictEqual(get(obj, key), obj[key], key);
       }
     }
 
     ['@test should retrieve a number key on an object'](assert) {
       let obj = { 1: 'first' };
 
-      assert.equal(get(obj, 1), 'first');
+      assert.strictEqual(get(obj, 1), 'first');
     }
 
     ['@test should retrieve an array index'](assert) {
       let arr = ['first', 'second'];
 
-      assert.equal(get(arr, 0), 'first');
-      assert.equal(get(arr, 1), 'second');
+      assert.strictEqual(get(arr, 0), 'first');
+      assert.strictEqual(get(arr, 1), 'second');
     }
 
     ['@test should retrieve an empty string key on an object'](assert) {
       let obj = { '': 'empty-string' };
 
-      assert.equal(get(obj, ''), 'empty-string');
+      assert.strictEqual(get(obj, ''), 'empty-string');
     }
 
     ['@test should return undefined when passed an empty string if that key does not exist on an object'](
@@ -53,7 +53,7 @@ moduleFor(
     ) {
       let obj = { tomster: true };
 
-      assert.equal(get(obj, ''), undefined);
+      assert.strictEqual(get(obj, ''), undefined);
     }
 
     ['@test should not access a property more than once'](assert) {
@@ -66,7 +66,7 @@ moduleFor(
 
       get(obj, 'id');
 
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
     }
 
     ['@test should call unknownProperty on watched values if the value is undefined using getFromEmberMetal()/set()'](
@@ -74,11 +74,11 @@ moduleFor(
     ) {
       let obj = {
         unknownProperty(key) {
-          assert.equal(key, 'foo', 'should pass key');
+          assert.strictEqual(key, 'foo', 'should pass key');
           return 'FOO';
         },
       };
-      assert.equal(get(obj, 'foo'), 'FOO', 'should return value from unknown');
+      assert.strictEqual(get(obj, 'foo'), 'FOO', 'should return value from unknown');
     }
 
     ['@test should call unknownProperty on watched values if the value is undefined using accessors'](
@@ -87,11 +87,11 @@ moduleFor(
       if (ENV.USES_ACCESSORS) {
         let obj = {
           unknownProperty(key) {
-            assert.equal(key, 'foo', 'should pass key');
+            assert.strictEqual(key, 'foo', 'should pass key');
             return 'FOO';
           },
         };
-        assert.equal(aget(obj, 'foo'), 'FOO', 'should return value from unknown');
+        assert.strictEqual(aget(obj, 'foo'), 'FOO', 'should return value from unknown');
       } else {
         assert.ok('SKIPPING ACCESSORS');
       }
@@ -104,17 +104,17 @@ moduleFor(
       let destroyedObj = EmberObject.create({ bar: 'great' });
       run(() => destroyedObj.destroy());
 
-      assert.equal(get({ foo: null }, 'foo.bar'), undefined);
-      assert.equal(get({ foo: { bar: 'hello' } }, 'foo.bar.length'), 5);
-      assert.equal(get({ foo: func }, 'foo.bar'), 'awesome');
-      assert.equal(get({ foo: func }, 'foo.bar.length'), 7);
-      assert.equal(get({}, 'foo.bar.length'), undefined);
-      assert.equal(
+      assert.strictEqual(get({ foo: null }, 'foo.bar'), undefined);
+      assert.strictEqual(get({ foo: { bar: 'hello' } }, 'foo.bar.length'), 5);
+      assert.strictEqual(get({ foo: func }, 'foo.bar'), 'awesome');
+      assert.strictEqual(get({ foo: func }, 'foo.bar.length'), 7);
+      assert.strictEqual(get({}, 'foo.bar.length'), undefined);
+      assert.strictEqual(
         get(function () {}, 'foo.bar.length'),
         undefined
       );
-      assert.equal(get('', 'foo.bar.length'), undefined);
-      assert.equal(get({ foo: destroyedObj }, 'foo.bar'), undefined);
+      assert.strictEqual(get('', 'foo.bar.length'), undefined);
+      assert.strictEqual(get({ foo: destroyedObj }, 'foo.bar'), undefined);
     }
 
     ['@test warn on attempts to call get with no arguments']() {
@@ -194,7 +194,7 @@ moduleFor(
       let baseObject = MyMixin.apply({});
       let theRealObject = Object.create(baseObject);
 
-      assert.equal(
+      assert.strictEqual(
         get(theRealObject, 'someProperty'),
         'foo',
         'should return the set value, not false'

--- a/packages/@ember/-internals/metal/tests/accessors/set_path_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_path_test.js
@@ -42,7 +42,7 @@ moduleFor(
       }; // Behave like an Ember.Namespace
 
       set(lookup.Foo, 'bar', 'baz');
-      assert.equal(get(lookup.Foo, 'bar'), 'baz');
+      assert.strictEqual(get(lookup.Foo, 'bar'), 'baz');
     }
 
     // ..........................................................
@@ -51,12 +51,12 @@ moduleFor(
 
     ['@test [obj, foo] -> obj.foo'](assert) {
       set(obj, 'foo', 'BAM');
-      assert.equal(get(obj, 'foo'), 'BAM');
+      assert.strictEqual(get(obj, 'foo'), 'BAM');
     }
 
     ['@test [obj, foo.bar] -> obj.foo.bar'](assert) {
       set(obj, 'foo.bar', 'BAM');
-      assert.equal(get(obj, 'foo.bar'), 'BAM');
+      assert.strictEqual(get(obj, 'foo.bar'), 'BAM');
     }
   }
 );
@@ -81,7 +81,7 @@ moduleFor(
       try {
         set(obj, 'bla.bla', 'BAM');
       } catch (ex) {
-        assert.equal(ex.message, exceptionMessage);
+        assert.strictEqual(ex.message, exceptionMessage);
       }
     }
 

--- a/packages/@ember/-internals/metal/tests/accessors/set_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_test.js
@@ -22,10 +22,10 @@ moduleFor(
           continue;
         }
 
-        assert.equal(set(newObj, key, obj[key]), obj[key], 'should return value');
+        assert.strictEqual(set(newObj, key, obj[key]), obj[key], 'should return value');
         assert.ok(key in newObj, 'should have key');
         assert.ok(Object.prototype.hasOwnProperty.call(newObj, key), 'should have key');
-        assert.equal(get(newObj, key), obj[key], 'should set value');
+        assert.strictEqual(get(newObj, key), obj[key], 'should set value');
       }
     }
 
@@ -33,7 +33,7 @@ moduleFor(
       let obj = {};
 
       set(obj, 1, 'first');
-      assert.equal(obj[1], 'first');
+      assert.strictEqual(obj[1], 'first');
     }
 
     ['@test should set an array index'](assert) {
@@ -52,15 +52,15 @@ moduleFor(
         },
 
         setUnknownProperty(key, value) {
-          assert.equal(key, 'foo', 'should pass key');
-          assert.equal(value, 'BAR', 'should pass key');
+          assert.strictEqual(key, 'foo', 'should pass key');
+          assert.strictEqual(value, 'BAR', 'should pass key');
           this.count++;
           return 'FOO';
         },
       };
 
-      assert.equal(set(obj, 'foo', 'BAR'), 'BAR', 'should return set value');
-      assert.equal(obj.count, 1, 'should have invoked');
+      assert.strictEqual(set(obj, 'foo', 'BAR'), 'BAR', 'should return set value');
+      assert.strictEqual(obj.count, 1, 'should have invoked');
     }
 
     ['@test warn on attempts to call set with undefined as object']() {
@@ -111,14 +111,14 @@ moduleFor(
 
       set(obj, 'foo', 'bar');
 
-      assert.equal(obj.foo, 'bar');
+      assert.strictEqual(obj.foo, 'bar');
     }
 
     ['@test does not warn on attempts of calling set on a destroyed object with `trySet`'](assert) {
       let obj = { isDestroyed: true };
 
       trySet(obj, 'favoriteFood', 'hot dogs');
-      assert.equal(obj.favoriteFood, undefined, 'does not set and does not error');
+      assert.strictEqual(obj.favoriteFood, undefined, 'does not set and does not error');
     }
 
     ['@test should work with native setters'](assert) {
@@ -139,9 +139,9 @@ moduleFor(
 
       let obj = new Foo();
 
-      assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
-      assert.equal(count, 1, 'should have native setter');
-      assert.equal(get(obj, 'foo'), 'computed bar', 'should return new value');
+      assert.strictEqual(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
+      assert.strictEqual(count, 1, 'should have native setter');
+      assert.strictEqual(get(obj, 'foo'), 'computed bar', 'should return new value');
     }
 
     ['@test should respect prototypical inheritance when subclasses override CPs'](assert) {

--- a/packages/@ember/-internals/metal/tests/alias_test.js
+++ b/packages/@ember/-internals/metal/tests/alias_test.js
@@ -37,13 +37,13 @@ moduleFor(
 
     ['@test should proxy get to alt key'](assert) {
       defineProperty(obj, 'bar', alias('foo.faz'));
-      assert.equal(get(obj, 'bar'), 'FOO');
+      assert.strictEqual(get(obj, 'bar'), 'FOO');
     }
 
     ['@test should proxy set to alt key'](assert) {
       defineProperty(obj, 'bar', alias('foo.faz'));
       set(obj, 'bar', 'BAR');
-      assert.equal(get(obj, 'foo.faz'), 'BAR');
+      assert.strictEqual(get(obj, 'foo.faz'), 'BAR');
     }
 
     async ['@test old dependent keys should not trigger property changes'](assert) {
@@ -58,14 +58,14 @@ moduleFor(
       set(obj1, 'foo', 'FOO');
       await runLoopSettled();
 
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       removeObserver(obj1, 'baz', incrementCount);
 
       set(obj1, 'foo', 'OOF');
       await runLoopSettled();
 
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
     }
 
     ['@test nested aliases should trigger computed property invalidation [GH#19279]'](assert) {
@@ -84,9 +84,9 @@ moduleFor(
       });
 
       let model = RootModel.create();
-      assert.equal(model.allAdditives.length, 0);
+      assert.strictEqual(model.allAdditives.length, 0);
       model.metaAttributes[0].additives.pushObject('foo');
-      assert.equal(model.allAdditives.length, 1);
+      assert.strictEqual(model.allAdditives.length, 1);
     }
 
     async [`@test inheriting an observer of the alias from the prototype then
@@ -108,14 +108,14 @@ moduleFor(
       set(obj2, 'foo', 'FOO');
       await runLoopSettled();
 
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       removeObserver(obj2, 'baz', null, 'incrementCount');
 
       set(obj2, 'foo', 'OOF');
       await runLoopSettled();
 
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
     }
 
     async ['@test an observer of the alias works if added after defining the alias'](assert) {
@@ -125,7 +125,7 @@ moduleFor(
       set(obj, 'foo.faz', 'BAR');
 
       await runLoopSettled();
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
     }
 
     async ['@test an observer of the alias works if added before defining the alias'](assert) {
@@ -135,7 +135,7 @@ moduleFor(
       set(obj, 'foo.faz', 'BAR');
 
       await runLoopSettled();
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
     }
 
     ['@test alias is dirtied if interior object of alias is set after consumption'](assert) {
@@ -178,7 +178,7 @@ moduleFor(
       defineProperty(obj, 'bar', alias('foo.faz'));
 
       assertPropertyTagUnchanged(obj, 'bar', () => {
-        assert.equal(get(obj, 'bar'), 'FOO');
+        assert.strictEqual(get(obj, 'bar'), 'FOO');
       });
 
       assertPropertyTagChanged(obj, 'bar', () => {
@@ -186,7 +186,7 @@ moduleFor(
       });
 
       assertPropertyTagUnchanged(obj, 'bar', () => {
-        assert.equal(get(obj, 'bar'), 'BAR');
+        assert.strictEqual(get(obj, 'bar'), 'BAR');
       });
 
       assertPropertyTagUnchanged(obj, 'bar', () => {
@@ -199,7 +199,7 @@ moduleFor(
       });
 
       assertPropertyTagUnchanged(obj, 'bar', () => {
-        assert.equal(get(obj, 'bar'), 'FOO');
+        assert.strictEqual(get(obj, 'bar'), 'FOO');
       });
     }
 
@@ -226,14 +226,14 @@ moduleFor(
 
       let outer = new Outer();
 
-      assert.equal(outer.value, 123, 'Property works');
+      assert.strictEqual(outer.value, 123, 'Property works');
 
       outer.value;
-      assert.equal(count, 1, 'Property was properly cached');
+      assert.strictEqual(count, 1, 'Property was properly cached');
 
       set(outer, 'inner.pojo.value', 456);
 
-      assert.equal(outer.value, 456, 'Property was invalidated correctly');
+      assert.strictEqual(outer.value, 456, 'Property was invalidated correctly');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/computed_decorator_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_decorator_test.js
@@ -28,8 +28,8 @@ moduleFor(
       let obj1 = new Class1();
       let obj2 = Class2.create();
 
-      assert.equal(firstName, obj1.otherFirstName);
-      assert.equal(firstName, obj2.otherFirstName);
+      assert.strictEqual(firstName, obj1.otherFirstName);
+      assert.strictEqual(firstName, obj2.otherFirstName);
     }
 
     ['@test decorator can still have a configuration object'](assert) {
@@ -47,7 +47,7 @@ moduleFor(
 
       let obj1 = new Foo();
 
-      assert.equal('something', obj1.baz);
+      assert.strictEqual('something', obj1.baz);
     }
 
     ['@test it works with functions'](assert) {
@@ -58,8 +58,8 @@ moduleFor(
         last = 'jackson';
 
         @computed('first', 'last', function () {
-          assert.equal(this.first, 'rob');
-          assert.equal(this.last, 'jackson');
+          assert.strictEqual(this.first, 'rob');
+          assert.strictEqual(this.last, 'jackson');
         })
         fullName;
       }
@@ -81,10 +81,10 @@ moduleFor(
         }
       }
 
-      assert.equal(Obj.foo, 123, 'should return value');
+      assert.strictEqual(Obj.foo, 123, 'should return value');
       Obj.foo;
 
-      assert.equal(count, 1, 'should only call getter once');
+      assert.strictEqual(count, 1, 'should only call getter once');
     }
 
     ['@test it works with computed desc'](assert) {
@@ -100,13 +100,13 @@ moduleFor(
 
         @computed('first', 'last', {
           get() {
-            assert.equal(this.first, expectedFirst, 'getter: first name matches');
-            assert.equal(this.last, expectedLast, 'getter: last name matches');
+            assert.strictEqual(this.first, expectedFirst, 'getter: first name matches');
+            assert.strictEqual(this.last, expectedLast, 'getter: last name matches');
             return `${this.first} ${this.last}`;
           },
 
           set(key, name) {
-            assert.equal(name, expectedName, 'setter: name matches');
+            assert.strictEqual(name, expectedName, 'setter: name matches');
 
             let [first, last] = name.split(' ');
             setProperties(this, { first, last });
@@ -212,10 +212,10 @@ moduleFor(
       }
 
       let instance = new TestObj();
-      assert.equal(instance.someGetter, 'true');
+      assert.strictEqual(instance.someGetter, 'true');
 
       set(instance, 'other', false);
-      assert.equal(instance.someGetter, 'false');
+      assert.strictEqual(instance.someGetter, 'false');
     }
 
     ['@test computed property can be accessed without `get`'](assert) {
@@ -229,8 +229,8 @@ moduleFor(
       }
       let obj = new Obj();
 
-      assert.equal(obj.foo, 'computed foo', 'should return value');
-      assert.equal(count, 1, 'should have invoked computed property');
+      assert.strictEqual(obj.foo, 'computed foo', 'should return value');
+      assert.strictEqual(count, 1, 'should have invoked computed property');
     }
 
     ['@test defining computed property should invoke property on get'](assert) {
@@ -244,8 +244,8 @@ moduleFor(
       }
       let obj = new Obj();
 
-      assert.equal(obj.foo, 'computed foo', 'should return value');
-      assert.equal(count, 1, 'should have invoked computed property');
+      assert.strictEqual(obj.foo, 'computed foo', 'should return value');
+      assert.strictEqual(count, 1, 'should have invoked computed property');
     }
 
     ['@test setter is invoked with correct parameters'](assert) {
@@ -264,9 +264,9 @@ moduleFor(
       }
       let obj = new Obj();
 
-      assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
-      assert.equal(count, 1, 'should have invoked computed property');
-      assert.equal(get(obj, 'foo'), 'computed bar', 'should return new value with get()');
+      assert.strictEqual(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
+      assert.strictEqual(count, 1, 'should have invoked computed property');
+      assert.strictEqual(get(obj, 'foo'), 'computed bar', 'should return new value with get()');
     }
 
     ['@test when not returning from setter, getter is called'](assert) {
@@ -285,8 +285,8 @@ moduleFor(
       }
       let obj = new Obj();
 
-      assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
-      assert.equal(count, 1, 'should have invoked getter');
+      assert.strictEqual(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
+      assert.strictEqual(count, 1, 'should have invoked getter');
     }
 
     ['@test when returning from setter, getter is not called'](assert) {
@@ -307,8 +307,8 @@ moduleFor(
       }
       let obj = new Obj();
 
-      assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
-      assert.equal(count, 0, 'should not have invoked getter');
+      assert.strictEqual(set(obj, 'foo', 'bar'), 'bar', 'should return set value with set()');
+      assert.strictEqual(count, 0, 'should not have invoked getter');
     }
 
     ['@test throws if a value is decorated twice']() {

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -90,8 +90,8 @@ moduleFor(
         })
       );
 
-      assert.equal(obj.foo, 'computed foo', 'should return value');
-      assert.equal(count, 1, 'should have invoked computed property');
+      assert.strictEqual(obj.foo, 'computed foo', 'should return value');
+      assert.strictEqual(count, 1, 'should have invoked computed property');
     }
 
     ['@test defining computed property should invoke property on get'](assert) {
@@ -106,8 +106,8 @@ moduleFor(
         })
       );
 
-      assert.equal(get(obj, 'foo'), 'computed foo', 'should return value');
-      assert.equal(count, 1, 'should have invoked computed property');
+      assert.strictEqual(get(obj, 'foo'), 'computed foo', 'should return value');
+      assert.strictEqual(count, 1, 'should have invoked computed property');
     }
 
     ['@test computed property can be defined and accessed on a class constructor'](assert) {
@@ -123,10 +123,10 @@ moduleFor(
         }),
       });
 
-      assert.equal(Obj.foo, 123, 'should return value');
+      assert.strictEqual(Obj.foo, 123, 'should return value');
       Obj.foo;
 
-      assert.equal(count, 1, 'should only call getter once');
+      assert.strictEqual(count, 1, 'should only call getter once');
     }
 
     ['@test defining computed property should invoke property on set'](assert) {
@@ -147,9 +147,9 @@ moduleFor(
         })
       );
 
-      assert.equal(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
-      assert.equal(count, 1, 'should have invoked computed property');
-      assert.equal(get(obj, 'foo'), 'computed bar', 'should return new value');
+      assert.strictEqual(set(obj, 'foo', 'bar'), 'bar', 'should return set value');
+      assert.strictEqual(count, 1, 'should have invoked computed property');
+      assert.strictEqual(get(obj, 'foo'), 'computed bar', 'should return new value');
     }
 
     // this should be a unit test elsewhere
@@ -232,20 +232,20 @@ moduleFor(
     }
 
     ['@test using get() and set()'](assert) {
-      assert.equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
-      assert.equal(get(objB, 'foo'), 'FOO', 'should get FOO from B');
+      assert.strictEqual(get(objA, 'foo'), 'FOO', 'should get FOO from A');
+      assert.strictEqual(get(objB, 'foo'), 'FOO', 'should get FOO from B');
 
       set(objA, 'foo', 'BIFF');
-      assert.equal(get(objA, 'foo'), 'computed BIFF', 'should change A');
-      assert.equal(get(objB, 'foo'), 'FOO', 'should NOT change B');
+      assert.strictEqual(get(objA, 'foo'), 'computed BIFF', 'should change A');
+      assert.strictEqual(get(objB, 'foo'), 'FOO', 'should NOT change B');
 
       set(objB, 'foo', 'bar');
-      assert.equal(get(objB, 'foo'), 'computed bar', 'should change B');
-      assert.equal(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
+      assert.strictEqual(get(objB, 'foo'), 'computed bar', 'should change B');
+      assert.strictEqual(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
 
       set(objA, 'foo', 'BAZ');
-      assert.equal(get(objA, 'foo'), 'computed BAZ', 'should change A');
-      assert.equal(get(objB, 'foo'), 'computed bar', 'should NOT change B');
+      assert.strictEqual(get(objA, 'foo'), 'computed BAZ', 'should change A');
+      assert.strictEqual(get(objB, 'foo'), 'computed bar', 'should NOT change B');
     }
   }
 );
@@ -274,20 +274,20 @@ moduleFor(
     }
 
     ['@test using get() and set()'](assert) {
-      assert.equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
-      assert.equal(get(objB, 'foo'), undefined, 'should get undefined from B');
+      assert.strictEqual(get(objA, 'foo'), 'FOO', 'should get FOO from A');
+      assert.strictEqual(get(objB, 'foo'), undefined, 'should get undefined from B');
 
       set(objA, 'foo', 'BIFF');
-      assert.equal(get(objA, 'foo'), 'computed BIFF', 'should change A');
-      assert.equal(get(objB, 'foo'), undefined, 'should NOT change B');
+      assert.strictEqual(get(objA, 'foo'), 'computed BIFF', 'should change A');
+      assert.strictEqual(get(objB, 'foo'), undefined, 'should NOT change B');
 
       set(objB, 'foo', 'bar');
-      assert.equal(get(objB, 'foo'), 'bar', 'should change B');
-      assert.equal(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
+      assert.strictEqual(get(objB, 'foo'), 'bar', 'should change B');
+      assert.strictEqual(get(objA, 'foo'), 'computed BIFF', 'should NOT change A');
 
       set(objA, 'foo', 'BAZ');
-      assert.equal(get(objA, 'foo'), 'computed BAZ', 'should change A');
-      assert.equal(get(objB, 'foo'), 'bar', 'should NOT change B');
+      assert.strictEqual(get(objA, 'foo'), 'computed BAZ', 'should change A');
+      assert.strictEqual(get(objB, 'foo'), 'bar', 'should NOT change B');
     }
   }
 );
@@ -329,20 +329,20 @@ moduleFor(
     }
 
     ['@test using get() and set()'](assert) {
-      assert.equal(get(objA, 'foo'), 'FOO', 'should get FOO from A');
-      assert.equal(get(objB, 'foo'), 'FOO', 'should get FOO from B');
+      assert.strictEqual(get(objA, 'foo'), 'FOO', 'should get FOO from A');
+      assert.strictEqual(get(objB, 'foo'), 'FOO', 'should get FOO from B');
 
       set(objA, 'foo', 'BIFF');
-      assert.equal(get(objA, 'foo'), 'A BIFF', 'should change A');
-      assert.equal(get(objB, 'foo'), 'FOO', 'should NOT change B');
+      assert.strictEqual(get(objA, 'foo'), 'A BIFF', 'should change A');
+      assert.strictEqual(get(objB, 'foo'), 'FOO', 'should NOT change B');
 
       set(objB, 'foo', 'bar');
-      assert.equal(get(objB, 'foo'), 'B bar', 'should change B');
-      assert.equal(get(objA, 'foo'), 'A BIFF', 'should NOT change A');
+      assert.strictEqual(get(objB, 'foo'), 'B bar', 'should change B');
+      assert.strictEqual(get(objA, 'foo'), 'A BIFF', 'should NOT change A');
 
       set(objA, 'foo', 'BAZ');
-      assert.equal(get(objA, 'foo'), 'A BAZ', 'should change A');
-      assert.equal(get(objB, 'foo'), 'B bar', 'should NOT change B');
+      assert.strictEqual(get(objA, 'foo'), 'A BAZ', 'should change A');
+      assert.strictEqual(get(objB, 'foo'), 'B bar', 'should NOT change B');
     }
   }
 );
@@ -354,7 +354,7 @@ moduleFor(
       let computedProperty = computed(function () {});
       computedProperty.meta({ key: 'keyValue' });
 
-      assert.equal(
+      assert.strictEqual(
         computedProperty.meta().key,
         'keyValue',
         'saves passed meta hash to the _meta property'
@@ -386,40 +386,44 @@ moduleFor(
     }
 
     ['@test cacheable should cache'](assert) {
-      assert.equal(get(obj, 'foo'), 'bar 1', 'first get');
-      assert.equal(get(obj, 'foo'), 'bar 1', 'second get');
-      assert.equal(count, 1, 'should only invoke once');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1', 'first get');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1', 'second get');
+      assert.strictEqual(count, 1, 'should only invoke once');
     }
 
     ['@test modifying a cacheable property should update cache'](assert) {
-      assert.equal(get(obj, 'foo'), 'bar 1', 'first get');
-      assert.equal(get(obj, 'foo'), 'bar 1', 'second get');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1', 'first get');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1', 'second get');
 
-      assert.equal(set(obj, 'foo', 'baz'), 'baz', 'setting');
-      assert.equal(get(obj, 'foo'), 'bar 2', 'third get');
-      assert.equal(count, 2, 'should not invoke again');
+      assert.strictEqual(set(obj, 'foo', 'baz'), 'baz', 'setting');
+      assert.strictEqual(get(obj, 'foo'), 'bar 2', 'third get');
+      assert.strictEqual(count, 2, 'should not invoke again');
     }
 
     ['@test inherited property should not pick up cache'](assert) {
       let objB = Object.create(obj);
 
-      assert.equal(get(obj, 'foo'), 'bar 1', 'obj first get');
-      assert.equal(get(objB, 'foo'), 'bar 2', 'objB first get');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1', 'obj first get');
+      assert.strictEqual(get(objB, 'foo'), 'bar 2', 'objB first get');
 
-      assert.equal(get(obj, 'foo'), 'bar 1', 'obj second get');
-      assert.equal(get(objB, 'foo'), 'bar 2', 'objB second get');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1', 'obj second get');
+      assert.strictEqual(get(objB, 'foo'), 'bar 2', 'objB second get');
 
       set(obj, 'foo', 'baz'); // modify A
-      assert.equal(get(obj, 'foo'), 'bar 3', 'obj third get');
-      assert.equal(get(objB, 'foo'), 'bar 2', 'objB third get');
+      assert.strictEqual(get(obj, 'foo'), 'bar 3', 'obj third get');
+      assert.strictEqual(get(objB, 'foo'), 'bar 2', 'objB third get');
     }
 
     ['@test meta.valueFor should return the cached value'](assert) {
-      assert.equal(metaFor(obj).valueFor('foo'), undefined, 'should not yet be a cached value');
+      assert.strictEqual(
+        metaFor(obj).valueFor('foo'),
+        undefined,
+        'should not yet be a cached value'
+      );
 
       get(obj, 'foo');
 
-      assert.equal(metaFor(obj).valueFor('foo'), 'bar 1', 'should retrieve cached value');
+      assert.strictEqual(metaFor(obj).valueFor('foo'), 'bar 1', 'should retrieve cached value');
     }
 
     ['@test meta.valueFor should return falsy cached values'](assert) {
@@ -431,11 +435,15 @@ moduleFor(
         })
       );
 
-      assert.equal(metaFor(obj).valueFor('falsy'), undefined, 'should not yet be a cached value');
+      assert.strictEqual(
+        metaFor(obj).valueFor('falsy'),
+        undefined,
+        'should not yet be a cached value'
+      );
 
       get(obj, 'falsy');
 
-      assert.equal(metaFor(obj).valueFor('falsy'), false, 'should retrieve cached value');
+      assert.strictEqual(metaFor(obj).valueFor('falsy'), false, 'should retrieve cached value');
     }
 
     ['@test setting a cached computed property passes the old value as the third argument'](
@@ -512,17 +520,17 @@ moduleFor(
         })
       );
 
-      assert.equal(get(obj, 'foo'), 'foo 1', 'get once');
-      assert.equal(get(obj, 'foo'), 'foo 1', 'cached retrieve');
+      assert.strictEqual(get(obj, 'foo'), 'foo 1', 'get once');
+      assert.strictEqual(get(obj, 'foo'), 'foo 1', 'cached retrieve');
 
       set(obj, 'bar', 'BIFF'); // should invalidate bar -> foo -> bar
 
-      assert.equal(get(obj, 'foo'), 'foo 3', 'should recache');
-      assert.equal(get(obj, 'foo'), 'foo 3', 'cached retrieve');
+      assert.strictEqual(get(obj, 'foo'), 'foo 3', 'should recache');
+      assert.strictEqual(get(obj, 'foo'), 'foo 3', 'cached retrieve');
     }
 
     ['@test redefining a property should undo old dependent keys'](assert) {
-      assert.equal(get(obj, 'foo'), 'bar 1');
+      assert.strictEqual(get(obj, 'foo'), 'bar 1');
 
       defineProperty(
         obj,
@@ -533,13 +541,13 @@ moduleFor(
         })
       );
 
-      assert.equal(get(obj, 'foo'), 'baz 2');
+      assert.strictEqual(get(obj, 'foo'), 'baz 2');
 
       set(obj, 'bar', 'BIFF'); // should not kill cache
-      assert.equal(get(obj, 'foo'), 'baz 2');
+      assert.strictEqual(get(obj, 'foo'), 'baz 2');
 
       set(obj, 'baz', 'BOP');
-      assert.equal(get(obj, 'foo'), 'baz 3');
+      assert.strictEqual(get(obj, 'foo'), 'baz 3');
     }
 
     ['@test can watch multiple dependent keys specified declaratively via brace expansion'](
@@ -554,21 +562,21 @@ moduleFor(
         })
       );
 
-      assert.equal(get(obj, 'foo'), 'foo 1', 'get once');
-      assert.equal(get(obj, 'foo'), 'foo 1', 'cached retrieve');
+      assert.strictEqual(get(obj, 'foo'), 'foo 1', 'get once');
+      assert.strictEqual(get(obj, 'foo'), 'foo 1', 'cached retrieve');
 
       set(obj, 'qux', {});
       set(obj, 'qux.bar', 'bar'); // invalidate foo
 
-      assert.equal(get(obj, 'foo'), 'foo 2', 'foo invalidated from bar');
+      assert.strictEqual(get(obj, 'foo'), 'foo 2', 'foo invalidated from bar');
 
       set(obj, 'qux.baz', 'baz'); // invalidate foo
 
-      assert.equal(get(obj, 'foo'), 'foo 3', 'foo invalidated from baz');
+      assert.strictEqual(get(obj, 'foo'), 'foo 3', 'foo invalidated from baz');
 
       set(obj, 'qux.quux', 'quux'); // do not invalidate foo
 
-      assert.equal(get(obj, 'foo'), 'foo 3', 'foo not invalidated by quux');
+      assert.strictEqual(get(obj, 'foo'), 'foo 3', 'foo not invalidated by quux');
     }
 
     ['@test throws assertion if brace expansion notation has spaces']() {
@@ -608,7 +616,7 @@ moduleFor(
 
       run(() => destroy(obj));
 
-      assert.equal(get(obj, 'foo'), 'baz', 'CP calculated successfully');
+      assert.strictEqual(get(obj, 'foo'), 'baz', 'CP calculated successfully');
     }
   }
 );
@@ -642,43 +650,43 @@ moduleFor(
       // assign computed property
       defineProperty(obj, 'prop', computed('foo.bar.baz.biff', func));
 
-      assert.equal(get(obj, 'prop'), 'BIFF 1');
+      assert.strictEqual(get(obj, 'prop'), 'BIFF 1');
 
       set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-      assert.equal(get(obj, 'prop'), 'BUZZ 2');
-      assert.equal(get(obj, 'prop'), 'BUZZ 2');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 2');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 2');
 
       set(get(obj, 'foo.bar'), 'baz', { biff: 'BLOB' });
-      assert.equal(get(obj, 'prop'), 'BLOB 3');
-      assert.equal(get(obj, 'prop'), 'BLOB 3');
+      assert.strictEqual(get(obj, 'prop'), 'BLOB 3');
+      assert.strictEqual(get(obj, 'prop'), 'BLOB 3');
 
       set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-      assert.equal(get(obj, 'prop'), 'BUZZ 4');
-      assert.equal(get(obj, 'prop'), 'BUZZ 4');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 4');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 4');
 
       set(get(obj, 'foo'), 'bar', { baz: { biff: 'BOOM' } });
-      assert.equal(get(obj, 'prop'), 'BOOM 5');
-      assert.equal(get(obj, 'prop'), 'BOOM 5');
+      assert.strictEqual(get(obj, 'prop'), 'BOOM 5');
+      assert.strictEqual(get(obj, 'prop'), 'BOOM 5');
 
       set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-      assert.equal(get(obj, 'prop'), 'BUZZ 6');
-      assert.equal(get(obj, 'prop'), 'BUZZ 6');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 6');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 6');
 
       set(obj, 'foo', { bar: { baz: { biff: 'BLARG' } } });
-      assert.equal(get(obj, 'prop'), 'BLARG 7');
-      assert.equal(get(obj, 'prop'), 'BLARG 7');
+      assert.strictEqual(get(obj, 'prop'), 'BLARG 7');
+      assert.strictEqual(get(obj, 'prop'), 'BLARG 7');
 
       set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
-      assert.equal(get(obj, 'prop'), 'BUZZ 8');
-      assert.equal(get(obj, 'prop'), 'BUZZ 8');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 8');
+      assert.strictEqual(get(obj, 'prop'), 'BUZZ 8');
 
       defineProperty(obj, 'prop');
       set(obj, 'prop', 'NONE');
-      assert.equal(get(obj, 'prop'), 'NONE');
+      assert.strictEqual(get(obj, 'prop'), 'NONE');
 
       set(obj, 'foo', { bar: { baz: { biff: 'BLARG' } } });
-      assert.equal(get(obj, 'prop'), 'NONE'); // should do nothing
-      assert.equal(count, 8, 'should be not have invoked computed again');
+      assert.strictEqual(get(obj, 'prop'), 'NONE'); // should do nothing
+      assert.strictEqual(count, 8, 'should be not have invoked computed again');
     }
 
     ['@test chained dependent keys should evaluate computed properties lazily'](assert) {
@@ -688,7 +696,7 @@ moduleFor(
         'c',
         computed('bar.b', function () {})
       );
-      assert.equal(count, 0, 'b should not run');
+      assert.strictEqual(count, 0, 'b should not run');
     }
   }
 );
@@ -706,13 +714,13 @@ moduleFor(
         b: '2',
         aInt: computed('a', {
           get(keyName) {
-            assert.equal(keyName, 'aInt', 'getter receives the keyName');
+            assert.strictEqual(keyName, 'aInt', 'getter receives the keyName');
             return parseInt(this.get('a'));
           },
           set(keyName, value, oldValue) {
-            assert.equal(keyName, 'aInt', 'setter receives the keyName');
-            assert.equal(value, 123, 'setter receives the new value');
-            assert.equal(oldValue, 1, 'setter receives the old value');
+            assert.strictEqual(keyName, 'aInt', 'setter receives the keyName');
+            assert.strictEqual(value, 123, 'setter receives the new value');
+            assert.strictEqual(oldValue, 1, 'setter receives the old value');
             this.set('a', String(value)); // side effect
             return parseInt(this.get('a'));
           },
@@ -731,7 +739,7 @@ moduleFor(
         b: '2',
         aInt: computed('a', {
           get(keyName) {
-            assert.equal(keyName, 'aInt', 'getter receives the keyName');
+            assert.strictEqual(keyName, 'aInt', 'getter receives the keyName');
             return parseInt(this.get('a'));
           },
         }),
@@ -871,21 +879,21 @@ moduleFor(
         lastNameDidChange++;
       });
 
-      assert.equal(get(obj, 'fullName'), 'Yehuda Katz');
+      assert.strictEqual(get(obj, 'fullName'), 'Yehuda Katz');
 
       set(obj, 'fullName', 'Yehuda Katz');
 
       set(obj, 'fullName', 'Kris Selden');
 
-      assert.equal(get(obj, 'fullName'), 'Kris Selden');
-      assert.equal(get(obj, 'firstName'), 'Kris');
-      assert.equal(get(obj, 'lastName'), 'Selden');
+      assert.strictEqual(get(obj, 'fullName'), 'Kris Selden');
+      assert.strictEqual(get(obj, 'firstName'), 'Kris');
+      assert.strictEqual(get(obj, 'lastName'), 'Selden');
 
       await runLoopSettled();
 
-      assert.equal(fullNameDidChange, 1);
-      assert.equal(firstNameDidChange, 1);
-      assert.equal(lastNameDidChange, 1);
+      assert.strictEqual(fullNameDidChange, 1);
+      assert.strictEqual(firstNameDidChange, 1);
+      assert.strictEqual(lastNameDidChange, 1);
     }
 
     async ['@test setting a cached computed property that modifies the value you give it'](assert) {
@@ -912,24 +920,24 @@ moduleFor(
         plusOneDidChange++;
       });
 
-      assert.equal(get(obj, 'plusOne'), 1);
+      assert.strictEqual(get(obj, 'plusOne'), 1);
 
       set(obj, 'plusOne', 1);
       await runLoopSettled();
 
-      assert.equal(get(obj, 'plusOne'), 2);
+      assert.strictEqual(get(obj, 'plusOne'), 2);
 
       set(obj, 'plusOne', 1);
       await runLoopSettled();
 
-      assert.equal(get(obj, 'plusOne'), 2);
-      assert.equal(plusOneDidChange, 1);
+      assert.strictEqual(get(obj, 'plusOne'), 2);
+      assert.strictEqual(plusOneDidChange, 1);
 
       set(obj, 'foo', 5);
       await runLoopSettled();
 
-      assert.equal(get(obj, 'plusOne'), 6);
-      assert.equal(plusOneDidChange, 2);
+      assert.strictEqual(get(obj, 'plusOne'), 6);
+      assert.strictEqual(plusOneDidChange, 2);
     }
   }
 );
@@ -971,7 +979,7 @@ moduleFor(
       let cp = computed(function () {});
       let readOnlyCp = cp.readOnly();
 
-      assert.equal(cp, readOnlyCp);
+      assert.strictEqual(cp, readOnlyCp);
     }
 
     ['@test throws assertion if called over a CP with a setter defined with the new syntax']() {
@@ -999,13 +1007,13 @@ moduleFor(
         }).readOnly()
       );
 
-      assert.equal(get(obj, 'bar'), 'barValue');
+      assert.strictEqual(get(obj, 'bar'), 'barValue');
 
       assert.throws(() => {
         set(obj, 'bar', 'newBar');
       }, /Cannot set read-only property "bar" on object:/);
 
-      assert.equal(get(obj, 'bar'), 'barValue');
+      assert.strictEqual(get(obj, 'bar'), 'barValue');
     }
   }
 );
@@ -1054,22 +1062,22 @@ moduleFor(
       obj = new ObjectWithLazyDep();
 
       // Get someProp and setup the lazy dependency
-      assert.equal(obj.someProp, 1, 'called the first time');
-      assert.equal(obj.someProp, 1, 'returned cached value the second time');
+      assert.strictEqual(obj.someProp, 1, 'called the first time');
+      assert.strictEqual(obj.someProp, 1, 'returned cached value the second time');
 
       // Finish the lazy dependency
-      assert.equal(obj.lazyObject.value, 123, 'lazyObject returns expected value');
-      assert.equal(
+      assert.strictEqual(obj.lazyObject.value, 123, 'lazyObject returns expected value');
+      assert.strictEqual(
         obj.someProp,
         1,
         'someProp was not dirtied by propB being calculated for the first time'
       );
 
       set(lazyObject, 'value', 456);
-      assert.equal(obj.someProp, 2, 'someProp dirtied by lazyObject.value changing');
+      assert.strictEqual(obj.someProp, 2, 'someProp dirtied by lazyObject.value changing');
 
       set(lazyObject, 'value', 789);
-      assert.equal(
+      assert.strictEqual(
         obj.someProp,
         3,
         'someProp still dirtied by otherProp when lazyObject.value is dirty'
@@ -1096,14 +1104,14 @@ moduleFor(
 
       obj = new ObjectWithLazyDep();
 
-      assert.equal(obj.someProp, 1, 'called the first time');
-      assert.equal(obj.someProp, 1, 'returned cached value the second time');
+      assert.strictEqual(obj.someProp, 1, 'called the first time');
+      assert.strictEqual(obj.someProp, 1, 'returned cached value the second time');
 
       // dirty the object value before the dependency has been finished
       set(lazyObject, 'value', 456);
 
-      assert.equal(obj.lazyObject.value, 456, 'propB returns expected value');
-      assert.equal(
+      assert.strictEqual(obj.lazyObject.value, 456, 'propB returns expected value');
+      assert.strictEqual(
         obj.someProp,
         1,
         'someProp was not dirtied by propB being dirtied before it has been calculated'
@@ -1132,12 +1140,12 @@ moduleFor(
 
       set(lazyObject, 'value', 456);
 
-      assert.equal(obj.someProp, 1, 'called the first time');
-      assert.equal(obj.someProp, 1, 'returned cached value the second time');
+      assert.strictEqual(obj.someProp, 1, 'called the first time');
+      assert.strictEqual(obj.someProp, 1, 'returned cached value the second time');
 
-      assert.equal(obj.lazyObject.value, 456, 'lazyObject returns expected value');
+      assert.strictEqual(obj.lazyObject.value, 456, 'lazyObject returns expected value');
 
-      assert.equal(
+      assert.strictEqual(
         obj.someProp,
         1,
         'someProp was not dirtied by lazyObject being dirtied before it has been calculated'
@@ -1183,7 +1191,7 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(get(obj, 'someProp'), 456, '');
+      assert.strictEqual(get(obj, 'someProp'), 456, '');
 
       addObserver(obj, 'anotherProp', obj, () => {}, false);
       set(obj, 'anotherProp', 123);

--- a/packages/@ember/-internals/metal/tests/events_test.js
+++ b/packages/@ember/-internals/metal/tests/events_test.js
@@ -13,16 +13,16 @@ moduleFor(
       }
 
       addListener(obj, 'event!', F);
-      assert.equal(count, 0, 'nothing yet');
+      assert.strictEqual(count, 0, 'nothing yet');
 
       sendEvent(obj, 'event!');
-      assert.equal(count, 1, 'received event');
+      assert.strictEqual(count, 1, 'received event');
 
       removeListener(obj, 'event!', F);
 
       count = 0;
       sendEvent(obj, 'event!');
-      assert.equal(count, 0, 'received event');
+      assert.strictEqual(count, 0, 'received event');
     }
 
     ['@test listeners should be inherited'](assert) {
@@ -38,19 +38,19 @@ moduleFor(
 
       let obj2 = Object.create(obj);
 
-      assert.equal(count, 0, 'nothing yet');
+      assert.strictEqual(count, 0, 'nothing yet');
 
       sendEvent(obj2, 'event!');
-      assert.equal(count, 1, 'received event');
+      assert.strictEqual(count, 1, 'received event');
 
       removeListener(obj2, 'event!', null, 'func');
 
       count = 0;
       sendEvent(obj2, 'event!');
-      assert.equal(count, 0, 'did not receive event');
+      assert.strictEqual(count, 0, 'did not receive event');
 
       sendEvent(obj, 'event!');
-      assert.equal(count, 1, 'should still invoke on parent');
+      assert.strictEqual(count, 1, 'should still invoke on parent');
     }
 
     ['@test adding a listener more than once should only invoke once'](assert) {
@@ -65,7 +65,7 @@ moduleFor(
       addListener(obj, 'event!', null, 'func');
 
       sendEvent(obj, 'event!');
-      assert.equal(count, 1, 'should only invoke once');
+      assert.strictEqual(count, 1, 'should only invoke once');
     }
 
     ['@test adding a listener with a target should invoke with target'](assert) {
@@ -81,7 +81,7 @@ moduleFor(
 
       addListener(obj, 'event!', target, target.method);
       sendEvent(obj, 'event!');
-      assert.equal(target.count, 1, 'should invoke');
+      assert.strictEqual(target.count, 1, 'should invoke');
     }
 
     ['@test adding a listener with string method should lookup method on event delivery'](assert) {
@@ -95,13 +95,13 @@ moduleFor(
 
       addListener(obj, 'event!', target, 'method');
       sendEvent(obj, 'event!');
-      assert.equal(target.count, 0, 'should invoke but do nothing');
+      assert.strictEqual(target.count, 0, 'should invoke but do nothing');
 
       target.method = function () {
         this.count++;
       };
       sendEvent(obj, 'event!');
-      assert.equal(target.count, 1, 'should invoke now');
+      assert.strictEqual(target.count, 1, 'should invoke now');
     }
 
     ['@test calling sendEvent with extra params should be passed to listeners'](assert) {
@@ -121,21 +121,21 @@ moduleFor(
       function F() {}
       function F2() {}
 
-      assert.equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
+      assert.strictEqual(hasListeners(obj, 'event!'), false, 'no listeners at first');
 
       addListener(obj, 'event!', F);
       addListener(obj, 'event!', F2);
 
-      assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
+      assert.strictEqual(hasListeners(obj, 'event!'), true, 'has listeners');
 
       removeListener(obj, 'event!', F);
-      assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
+      assert.strictEqual(hasListeners(obj, 'event!'), true, 'has listeners');
 
       removeListener(obj, 'event!', F2);
-      assert.equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
+      assert.strictEqual(hasListeners(obj, 'event!'), false, 'has no more listeners');
 
       addListener(obj, 'event!', F);
-      assert.equal(hasListeners(obj, 'event!'), true, 'has listeners');
+      assert.strictEqual(hasListeners(obj, 'event!'), true, 'has listeners');
     }
 
     ['@test a listener can be added as part of a mixin'](assert) {
@@ -154,7 +154,7 @@ moduleFor(
       MyMixin.apply(obj);
 
       sendEvent(obj, 'bar');
-      assert.equal(triggered, 2, 'should invoke listeners');
+      assert.strictEqual(triggered, 2, 'should invoke listeners');
     }
 
     [`@test 'on' asserts for invalid arguments`]() {
@@ -189,10 +189,10 @@ moduleFor(
       SecondMixin.apply(obj);
 
       sendEvent(obj, 'bar');
-      assert.equal(triggered, 0, 'should not invoke from overridden property');
+      assert.strictEqual(triggered, 0, 'should not invoke from overridden property');
 
       sendEvent(obj, 'baz');
-      assert.equal(triggered, 1, 'should invoke from subclass property');
+      assert.strictEqual(triggered, 1, 'should invoke from subclass property');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/injected_property_test.js
+++ b/packages/@ember/-internals/metal/tests/injected_property_test.js
@@ -15,7 +15,7 @@ moduleFor(
 
       set(obj, 'foo', 'bar');
 
-      assert.equal(get(obj, 'foo'), 'bar', 'should return the overridden value');
+      assert.strictEqual(get(obj, 'foo'), 'bar', 'should return the overridden value');
     }
 
     ['@test getting on an object without an owner or container should fail assertion']() {
@@ -39,7 +39,11 @@ moduleFor(
 
       defineProperty(obj, 'foo', inject('type', 'name'));
 
-      assert.equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
+      assert.strictEqual(
+        get(obj, 'foo'),
+        'type:name',
+        'should return the value of container.lookup'
+      );
     }
 
     ['@test getting should return a lookup on the container'](assert) {
@@ -56,7 +60,11 @@ moduleFor(
 
       defineProperty(obj, 'foo', inject('type', 'name'));
 
-      assert.equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
+      assert.strictEqual(
+        get(obj, 'foo'),
+        'type:name',
+        'should return the value of container.lookup'
+      );
     }
 
     ['@test omitting the lookup name should default to the property name'](assert) {
@@ -70,7 +78,11 @@ moduleFor(
 
       defineProperty(obj, 'foo', inject('type'));
 
-      assert.equal(get(obj, 'foo'), 'type:foo', 'should lookup the type using the property name');
+      assert.strictEqual(
+        get(obj, 'foo'),
+        'type:foo',
+        'should lookup the type using the property name'
+      );
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/is_blank_test.js
+++ b/packages/@ember/-internals/metal/tests/is_blank_test.js
@@ -9,21 +9,21 @@ moduleFor(
       let fn = function () {};
       let object = { length: 0 };
 
-      assert.equal(true, isBlank(null), 'for null');
-      assert.equal(true, isBlank(undefined), 'for undefined');
-      assert.equal(true, isBlank(''), 'for an empty String');
-      assert.equal(true, isBlank('  '), 'for a whitespace String');
-      assert.equal(true, isBlank('\n\t'), 'for another whitespace String');
-      assert.equal(false, isBlank('\n\t Hi'), 'for a String with whitespaces');
-      assert.equal(false, isBlank(true), 'for true');
-      assert.equal(false, isBlank(false), 'for false');
-      assert.equal(false, isBlank(string), 'for a String');
-      assert.equal(false, isBlank(fn), 'for a Function');
-      assert.equal(false, isBlank(0), 'for 0');
-      assert.equal(true, isBlank([]), 'for an empty Array');
-      assert.equal(false, isBlank({}), 'for an empty Object');
-      assert.equal(true, isBlank(object), "for an Object that has zero 'length'");
-      assert.equal(false, isBlank([1, 2, 3]), 'for a non-empty array');
+      assert.strictEqual(true, isBlank(null), 'for null');
+      assert.strictEqual(true, isBlank(undefined), 'for undefined');
+      assert.strictEqual(true, isBlank(''), 'for an empty String');
+      assert.strictEqual(true, isBlank('  '), 'for a whitespace String');
+      assert.strictEqual(true, isBlank('\n\t'), 'for another whitespace String');
+      assert.strictEqual(false, isBlank('\n\t Hi'), 'for a String with whitespaces');
+      assert.strictEqual(false, isBlank(true), 'for true');
+      assert.strictEqual(false, isBlank(false), 'for false');
+      assert.strictEqual(false, isBlank(string), 'for a String');
+      assert.strictEqual(false, isBlank(fn), 'for a Function');
+      assert.strictEqual(false, isBlank(0), 'for 0');
+      assert.strictEqual(true, isBlank([]), 'for an empty Array');
+      assert.strictEqual(false, isBlank({}), 'for an empty Object');
+      assert.strictEqual(true, isBlank(object), "for an Object that has zero 'length'");
+      assert.strictEqual(false, isBlank([1, 2, 3]), 'for a non-empty array');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/is_empty_test.js
+++ b/packages/@ember/-internals/metal/tests/is_empty_test.js
@@ -11,20 +11,20 @@ moduleFor(
       let object = { length: 0 };
       let proxy = ObjectProxy.create({ content: { size: 0 } });
 
-      assert.equal(true, isEmpty(null), 'for null');
-      assert.equal(true, isEmpty(undefined), 'for undefined');
-      assert.equal(true, isEmpty(''), 'for an empty String');
-      assert.equal(false, isEmpty('  '), 'for a whitespace String');
-      assert.equal(false, isEmpty('\n\t'), 'for another whitespace String');
-      assert.equal(false, isEmpty(true), 'for true');
-      assert.equal(false, isEmpty(false), 'for false');
-      assert.equal(false, isEmpty(string), 'for a String');
-      assert.equal(false, isEmpty(fn), 'for a Function');
-      assert.equal(false, isEmpty(0), 'for 0');
-      assert.equal(true, isEmpty([]), 'for an empty Array');
-      assert.equal(false, isEmpty({}), 'for an empty Object');
-      assert.equal(true, isEmpty(object), "for an Object that has zero 'length'");
-      assert.equal(true, isEmpty(proxy), "for a proxy that has zero 'size'");
+      assert.strictEqual(true, isEmpty(null), 'for null');
+      assert.strictEqual(true, isEmpty(undefined), 'for undefined');
+      assert.strictEqual(true, isEmpty(''), 'for an empty String');
+      assert.strictEqual(false, isEmpty('  '), 'for a whitespace String');
+      assert.strictEqual(false, isEmpty('\n\t'), 'for another whitespace String');
+      assert.strictEqual(false, isEmpty(true), 'for true');
+      assert.strictEqual(false, isEmpty(false), 'for false');
+      assert.strictEqual(false, isEmpty(string), 'for a String');
+      assert.strictEqual(false, isEmpty(fn), 'for a Function');
+      assert.strictEqual(false, isEmpty(0), 'for 0');
+      assert.strictEqual(true, isEmpty([]), 'for an empty Array');
+      assert.strictEqual(false, isEmpty({}), 'for an empty Object');
+      assert.strictEqual(true, isEmpty(object), "for an Object that has zero 'length'");
+      assert.strictEqual(true, isEmpty(proxy), "for a proxy that has zero 'size'");
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/is_none_test.js
+++ b/packages/@ember/-internals/metal/tests/is_none_test.js
@@ -8,16 +8,16 @@ moduleFor(
       let string = 'string';
       let fn = function () {};
 
-      assert.equal(true, isNone(null), 'for null');
-      assert.equal(true, isNone(undefined), 'for undefined');
-      assert.equal(false, isNone(''), 'for an empty String');
-      assert.equal(false, isNone(true), 'for true');
-      assert.equal(false, isNone(false), 'for false');
-      assert.equal(false, isNone(string), 'for a String');
-      assert.equal(false, isNone(fn), 'for a Function');
-      assert.equal(false, isNone(0), 'for 0');
-      assert.equal(false, isNone([]), 'for an empty Array');
-      assert.equal(false, isNone({}), 'for an empty Object');
+      assert.strictEqual(true, isNone(null), 'for null');
+      assert.strictEqual(true, isNone(undefined), 'for undefined');
+      assert.strictEqual(false, isNone(''), 'for an empty String');
+      assert.strictEqual(false, isNone(true), 'for true');
+      assert.strictEqual(false, isNone(false), 'for false');
+      assert.strictEqual(false, isNone(string), 'for a String');
+      assert.strictEqual(false, isNone(fn), 'for a Function');
+      assert.strictEqual(false, isNone(0), 'for 0');
+      assert.strictEqual(false, isNone([]), 'for an empty Array');
+      assert.strictEqual(false, isNone({}), 'for an empty Object');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/is_present_test.js
+++ b/packages/@ember/-internals/metal/tests/is_present_test.js
@@ -9,22 +9,22 @@ moduleFor(
       let fn = function () {};
       let object = { length: 0 };
 
-      assert.equal(false, isPresent(), 'for no params');
-      assert.equal(false, isPresent(null), 'for null');
-      assert.equal(false, isPresent(undefined), 'for undefined');
-      assert.equal(false, isPresent(''), 'for an empty String');
-      assert.equal(false, isPresent('  '), 'for a whitespace String');
-      assert.equal(false, isPresent('\n\t'), 'for another whitespace String');
-      assert.equal(true, isPresent('\n\t Hi'), 'for a String with whitespaces');
-      assert.equal(true, isPresent(true), 'for true');
-      assert.equal(true, isPresent(false), 'for false');
-      assert.equal(true, isPresent(string), 'for a String');
-      assert.equal(true, isPresent(fn), 'for a Function');
-      assert.equal(true, isPresent(0), 'for 0');
-      assert.equal(false, isPresent([]), 'for an empty Array');
-      assert.equal(true, isPresent({}), 'for an empty Object');
-      assert.equal(false, isPresent(object), "for an Object that has zero 'length'");
-      assert.equal(true, isPresent([1, 2, 3]), 'for a non-empty array');
+      assert.strictEqual(false, isPresent(), 'for no params');
+      assert.strictEqual(false, isPresent(null), 'for null');
+      assert.strictEqual(false, isPresent(undefined), 'for undefined');
+      assert.strictEqual(false, isPresent(''), 'for an empty String');
+      assert.strictEqual(false, isPresent('  '), 'for a whitespace String');
+      assert.strictEqual(false, isPresent('\n\t'), 'for another whitespace String');
+      assert.strictEqual(true, isPresent('\n\t Hi'), 'for a String with whitespaces');
+      assert.strictEqual(true, isPresent(true), 'for true');
+      assert.strictEqual(true, isPresent(false), 'for false');
+      assert.strictEqual(true, isPresent(string), 'for a String');
+      assert.strictEqual(true, isPresent(fn), 'for a Function');
+      assert.strictEqual(true, isPresent(0), 'for 0');
+      assert.strictEqual(false, isPresent([]), 'for an empty Array');
+      assert.strictEqual(true, isPresent({}), 'for an empty Object');
+      assert.strictEqual(false, isPresent(object), "for an Object that has zero 'length'");
+      assert.strictEqual(true, isPresent([1, 2, 3]), 'for a non-empty array');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/libraries_test.js
+++ b/packages/@ember/-internals/metal/tests/libraries_test.js
@@ -29,8 +29,8 @@ moduleFor(
       libs.register('my-lib', '2.0.0a');
       libs.registerCoreLibrary('DS', '1.0.0-beta.2');
 
-      assert.equal(registry[0].name, 'DS');
-      assert.equal(registry[1].name, 'my-lib');
+      assert.strictEqual(registry[0].name, 'DS');
+      assert.strictEqual(registry[1].name, 'my-lib');
     }
 
     ['@test only the first registration of a library is stored'](assert) {
@@ -41,22 +41,22 @@ moduleFor(
       libs.register('magic', 1.23);
       libs.register('magic', 2.23);
 
-      assert.equal(registry[0].name, 'magic');
-      assert.equal(registry[0].version, 1.23);
-      assert.equal(registry.length, 1);
+      assert.strictEqual(registry[0].name, 'magic');
+      assert.strictEqual(registry[0].version, 1.23);
+      assert.strictEqual(registry.length, 1);
     }
 
     ['@test isRegistered returns correct value'](assert) {
       if (EMBER_LIBRARIES_ISREGISTERED) {
         assert.expect(3);
 
-        assert.equal(libs.isRegistered('magic'), false);
+        assert.strictEqual(libs.isRegistered('magic'), false);
 
         libs.register('magic', 1.23);
-        assert.equal(libs.isRegistered('magic'), true);
+        assert.strictEqual(libs.isRegistered('magic'), true);
 
         libs.deRegister('magic');
-        assert.equal(libs.isRegistered('magic'), false);
+        assert.strictEqual(libs.isRegistered('magic'), false);
       } else {
         assert.expect(0);
       }
@@ -74,7 +74,7 @@ moduleFor(
 
       setDebugFunction('warn', function (msg, test) {
         if (!test) {
-          assert.equal(msg, 'Library "magic" is already registered with Ember.');
+          assert.strictEqual(msg, 'Library "magic" is already registered with Ember.');
         }
       });
 
@@ -92,8 +92,8 @@ moduleFor(
       libs.deRegister('lib1');
       libs.deRegister('lib3');
 
-      assert.equal(registry[0].name, 'lib2');
-      assert.equal(registry.length, 1);
+      assert.strictEqual(registry[0].name, 'lib2');
+      assert.strictEqual(registry.length, 1);
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/main_test.js
+++ b/packages/@ember/-internals/metal/tests/main_test.js
@@ -13,7 +13,7 @@ moduleFor(
 
     ['@test SEMVER_REGEX properly validates and invalidates version numbers'](assert) {
       function validateVersionString(versionString, expectedResult) {
-        assert.equal(SEMVER_REGEX.test(versionString), expectedResult);
+        assert.strictEqual(SEMVER_REGEX.test(versionString), expectedResult);
       }
 
       // Positive test cases

--- a/packages/@ember/-internals/metal/tests/mixin/accessor_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/accessor_test.js
@@ -16,8 +16,8 @@ moduleFor(
       let obj = {};
       MixinA.apply(obj);
 
-      assert.equal(obj.prop, 0, 'getter defined correctly');
-      assert.equal(obj.prop, 1, 'getter defined correctly');
+      assert.strictEqual(obj.prop, 0, 'getter defined correctly');
+      assert.strictEqual(obj.prop, 1, 'getter defined correctly');
     }
 
     ['@test works with setters'](assert) {
@@ -32,7 +32,7 @@ moduleFor(
 
       obj.prop = 0;
 
-      assert.equal(obj._prop, 1, 'setter defined correctly');
+      assert.strictEqual(obj._prop, 1, 'setter defined correctly');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/mixin/apply_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/apply_test.js
@@ -11,8 +11,8 @@ moduleFor(
       let obj = {};
       mixin(obj, MixinA);
 
-      assert.equal(get(obj, 'foo'), 'FOO', 'should apply foo');
-      assert.equal(get(obj, 'baz'), K, 'should apply foo');
+      assert.strictEqual(get(obj, 'foo'), 'FOO', 'should apply foo');
+      assert.strictEqual(get(obj, 'baz'), K, 'should apply foo');
     }
 
     ['@test applying anonymous properties'](assert) {
@@ -22,8 +22,8 @@ moduleFor(
         baz: K,
       });
 
-      assert.equal(get(obj, 'foo'), 'FOO', 'should apply foo');
-      assert.equal(get(obj, 'baz'), K, 'should apply foo');
+      assert.strictEqual(get(obj, 'foo'), 'FOO', 'should apply foo');
+      assert.strictEqual(get(obj, 'baz'), K, 'should apply foo');
     }
 
     ['@test applying null values']() {

--- a/packages/@ember/-internals/metal/tests/mixin/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/computed_test.js
@@ -40,17 +40,17 @@ moduleFor(
 
       obj = {};
       MixinB.apply(obj);
-      assert.equal(get(obj, 'aProp'), 'AB', 'should expose super for B');
+      assert.strictEqual(get(obj, 'aProp'), 'AB', 'should expose super for B');
 
       obj = {};
       MixinC.apply(obj);
-      assert.equal(get(obj, 'aProp'), 'AC', 'should expose super for C');
+      assert.strictEqual(get(obj, 'aProp'), 'AC', 'should expose super for C');
 
       obj = {};
 
       MixinA.apply(obj);
       MixinD.apply(obj);
-      assert.equal(get(obj, 'aProp'), 'AD', 'should define super for D');
+      assert.strictEqual(get(obj, 'aProp'), 'AD', 'should define super for D');
 
       obj = {};
       defineProperty(
@@ -61,7 +61,7 @@ moduleFor(
         })
       );
       MixinD.apply(obj);
-      assert.equal(get(obj, 'aProp'), 'objD', 'should preserve original computed property');
+      assert.strictEqual(get(obj, 'aProp'), 'objD', 'should preserve original computed property');
     }
 
     ['@test calling set on overridden computed properties'](assert) {

--- a/packages/@ember/-internals/metal/tests/mixin/detect_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/detect_test.js
@@ -8,10 +8,10 @@ moduleFor(
       let MixinA = Mixin.create();
       let obj = {};
 
-      assert.equal(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
+      assert.strictEqual(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
 
       MixinA.apply(obj);
-      assert.equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
+      assert.strictEqual(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
     }
 
     ['@test detect() finds nested mixins'](assert) {
@@ -19,22 +19,22 @@ moduleFor(
       let MixinB = Mixin.create(MixinA);
       let obj = {};
 
-      assert.equal(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
+      assert.strictEqual(MixinA.detect(obj), false, 'MixinA.detect(obj) before apply()');
 
       MixinB.apply(obj);
-      assert.equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
+      assert.strictEqual(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
     }
 
     ['@test detect() finds mixins on other mixins'](assert) {
       let MixinA = Mixin.create({});
       let MixinB = Mixin.create(MixinA);
-      assert.equal(MixinA.detect(MixinB), true, 'MixinA is part of MixinB');
-      assert.equal(MixinB.detect(MixinA), false, 'MixinB is not part of MixinA');
+      assert.strictEqual(MixinA.detect(MixinB), true, 'MixinA is part of MixinB');
+      assert.strictEqual(MixinB.detect(MixinA), false, 'MixinB is not part of MixinA');
     }
 
     ['@test detect handles null values'](assert) {
       let MixinA = Mixin.create();
-      assert.equal(MixinA.detect(null), false);
+      assert.strictEqual(MixinA.detect(null), false);
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/mixin/merged_properties_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/merged_properties_test.js
@@ -58,7 +58,7 @@ moduleFor(
       });
 
       let obj = mixin({}, MixinA, MixinB);
-      assert.equal(get(obj, 'foo'), null);
+      assert.strictEqual(get(obj, 'foo'), null);
     }
 
     ["@test mergedProperties' properties can get overwritten"](assert) {
@@ -118,8 +118,8 @@ moduleFor(
         },
       });
 
-      assert.equal(get(obj, 'options').a, 'A');
-      assert.equal(get(obj, 'options').b.c, 'ccc');
+      assert.strictEqual(get(obj, 'options').a, 'A');
+      assert.strictEqual(get(obj, 'options').b.c, 'ccc');
     }
 
     ['@test defining mergedProperties at create time should not modify the prototype'](assert) {
@@ -141,8 +141,8 @@ moduleFor(
         },
       });
 
-      assert.equal(get(objA, 'options').a, 2);
-      assert.equal(get(objB, 'options').a, 3);
+      assert.strictEqual(get(objA, 'options').a, 2);
+      assert.strictEqual(get(objB, 'options').a, 3);
     }
 
     ["@test mergedProperties' overwriting methods can call _super"](assert) {
@@ -152,7 +152,7 @@ moduleFor(
         mergedProperties: ['foo'],
         foo: {
           meth(a) {
-            assert.equal(a, 'WOOT', "_super successfully called MixinA's `foo.meth` method");
+            assert.strictEqual(a, 'WOOT', "_super successfully called MixinA's `foo.meth` method");
             return 'WAT';
           },
         },
@@ -177,7 +177,7 @@ moduleFor(
       });
 
       let obj = mixin({}, MixinA, MixinB, MixinC);
-      assert.equal(obj.foo.meth('WOOT'), 'WAT');
+      assert.strictEqual(obj.foo.meth('WOOT'), 'WAT');
     }
 
     ['@test Merging an Array should raise an error'](assert) {

--- a/packages/@ember/-internals/metal/tests/mixin/method_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/method_test.js
@@ -21,8 +21,8 @@ moduleFor(
       MixinA.apply(obj);
 
       // but should be defined
-      assert.equal(props.publicMethod(), 'publicMethod', 'publicMethod is func');
-      assert.equal(props._privateMethod(), 'privateMethod', 'privateMethod is func');
+      assert.strictEqual(props.publicMethod(), 'publicMethod', 'publicMethod is func');
+      assert.strictEqual(props._privateMethod(), 'privateMethod', 'privateMethod is func');
     }
 
     ['@test overriding public methods'](assert) {
@@ -54,16 +54,16 @@ moduleFor(
 
       obj = {};
       MixinB.apply(obj);
-      assert.equal(obj.publicMethod(), 'AB', 'should define super for A and B');
+      assert.strictEqual(obj.publicMethod(), 'AB', 'should define super for A and B');
 
       obj = {};
       MixinD.apply(obj);
-      assert.equal(obj.publicMethod(), 'AD', 'should define super for A and B');
+      assert.strictEqual(obj.publicMethod(), 'AD', 'should define super for A and B');
 
       obj = {};
       MixinA.apply(obj);
       MixinF.apply(obj);
-      assert.equal(obj.publicMethod(), 'AF', 'should define super for A and F');
+      assert.strictEqual(obj.publicMethod(), 'AF', 'should define super for A and F');
 
       obj = {
         publicMethod() {
@@ -71,7 +71,7 @@ moduleFor(
         },
       };
       MixinF.apply(obj);
-      assert.equal(obj.publicMethod(), 'objF', 'should define super for F');
+      assert.strictEqual(obj.publicMethod(), 'objF', 'should define super for F');
     }
 
     ['@test overriding inherited objects'](assert) {
@@ -97,11 +97,11 @@ moduleFor(
 
       cnt = 0;
       objB.foo();
-      assert.equal(cnt, 2, 'should invoke both methods');
+      assert.strictEqual(cnt, 2, 'should invoke both methods');
 
       cnt = 0;
       objA.foo();
-      assert.equal(cnt, 1, 'should not screw w/ parent obj');
+      assert.strictEqual(cnt, 1, 'should not screw w/ parent obj');
     }
 
     ['@test Including the same mixin more than once will only run once'](assert) {
@@ -137,7 +137,7 @@ moduleFor(
       cnt = 0;
       obj.foo();
 
-      assert.equal(cnt, 1, 'should invoke MixinA.foo one time');
+      assert.strictEqual(cnt, 1, 'should invoke MixinA.foo one time');
     }
 
     ['@test _super from a single mixin with no superclass does not error'](assert) {
@@ -197,7 +197,7 @@ moduleFor(
 
       let obj = {};
       MixinA.apply(obj);
-      assert.equal(obj.toString(), 'FOO', 'should override toString w/o error');
+      assert.strictEqual(obj.toString(), 'FOO', 'should override toString w/o error');
 
       obj = {};
       mixin(obj, {
@@ -205,7 +205,7 @@ moduleFor(
           return 'FOO';
         },
       });
-      assert.equal(obj.toString(), 'FOO', 'should override toString w/o error');
+      assert.strictEqual(obj.toString(), 'FOO', 'should override toString w/o error');
     }
   }
 );
@@ -246,7 +246,7 @@ moduleFor(
 
       cnt = 0;
       obj.foo();
-      assert.equal(cnt, 3, 'should invoke all 3 methods');
+      assert.strictEqual(cnt, 3, 'should invoke all 3 methods');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/mixin/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/observer_test.js
@@ -25,12 +25,12 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test global observer helper takes multiple params'](assert) {
@@ -43,7 +43,7 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
@@ -51,7 +51,7 @@ moduleFor(
       set(obj, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 2, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 2, 'should invoke observer after change');
 
       destroy(obj);
       await runLoopSettled();
@@ -73,17 +73,17 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin, Mixin2);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer after change');
 
       set(obj, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 10, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 10, 'should invoke observer after change');
     }
 
     async ['@test observing chain with property before'](assert) {
@@ -98,12 +98,12 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test observing chain with property after'](assert) {
@@ -118,12 +118,12 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test observing chain with property in mixin applied later'](assert) {
@@ -139,15 +139,15 @@ moduleFor(
       let MyMixin2 = Mixin.create({ bar: obj2 });
 
       obj = mixin({}, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       MyMixin2.apply(obj);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test observing chain with existing property'](assert) {
@@ -161,12 +161,12 @@ moduleFor(
       });
 
       obj = mixin({ bar: obj2 }, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test observing chain with property in mixin before'](assert) {
@@ -181,12 +181,12 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin2, MyMixin);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test observing chain with property in mixin after'](assert) {
@@ -201,12 +201,12 @@ moduleFor(
       });
 
       obj = mixin({}, MyMixin, MyMixin2);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
     async ['@test observing chain with overridden property'](assert) {
@@ -223,17 +223,17 @@ moduleFor(
       });
 
       obj = mixin({ bar: obj2 }, MyMixin, MyMixin2);
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj2, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer after change');
 
       set(obj3, 'baz', 'BEAR');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/mixin/reopen_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/reopen_test.js
@@ -12,9 +12,9 @@ moduleFor(
       let obj = {};
       MixinA.apply(obj);
 
-      assert.equal(get(obj, 'foo'), 'FOO2', 'mixin() should override');
-      assert.equal(get(obj, 'baz'), 'BAZ', 'preserve MixinA props');
-      assert.equal(get(obj, 'bar'), 'BAR', 'include MixinB props');
+      assert.strictEqual(get(obj, 'foo'), 'FOO2', 'mixin() should override');
+      assert.strictEqual(get(obj, 'baz'), 'BAZ', 'preserve MixinA props');
+      assert.strictEqual(get(obj, 'bar'), 'BAR', 'include MixinB props');
     }
 
     ['@test using reopen() and calling _super where there is not a super function does not cause infinite recursion'](
@@ -47,7 +47,7 @@ moduleFor(
         }
       });
 
-      assert.equal(result, 'Breakfast!');
+      assert.strictEqual(result, 'Breakfast!');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/mixin/without_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/without_test.js
@@ -15,8 +15,8 @@ moduleFor(
       let obj = {};
       MixinB.apply(obj);
 
-      assert.equal(obj.foo, 'FOO', 'should defined foo');
-      assert.equal(obj.bar, undefined, 'should not define bar');
+      assert.strictEqual(obj.foo, 'FOO', 'should defined foo');
+      assert.strictEqual(obj.bar, undefined, 'should not define bar');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/namespace_search_test.js
+++ b/packages/@ember/-internals/metal/tests/namespace_search_test.js
@@ -6,7 +6,7 @@ moduleFor(
   class extends AbstractTestCase {
     ['@test classToString: null as this inside class must not throw error'](assert) {
       let mixin = Mixin.create();
-      assert.equal(
+      assert.strictEqual(
         mixin.toString(),
         '(unknown mixin)',
         'this = null should be handled on Mixin.toString() call'

--- a/packages/@ember/-internals/metal/tests/native_desc_decorator_test.js
+++ b/packages/@ember/-internals/metal/tests/native_desc_decorator_test.js
@@ -159,7 +159,7 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         let source = factory.source();
 
@@ -169,7 +169,7 @@ classes.forEach((TestClass) => {
 
         Object.defineProperty(source, 'foo', { configurable: true, value: 'baz' });
 
-        assert.equal(obj.foo, 'baz');
+        assert.strictEqual(obj.foo, 'baz');
       }
 
       ['@test defining a non-configurable property'](assert) {
@@ -178,7 +178,7 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         let source = factory.source();
 
@@ -193,7 +193,7 @@ classes.forEach((TestClass) => {
           TypeError
         );
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
       }
 
       ['@test defining an enumerable property'](assert) {
@@ -202,7 +202,7 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         let source = factory.source();
 
@@ -215,7 +215,7 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         let source = factory.source();
 
@@ -228,17 +228,17 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         let source = factory.source();
 
         source.foo = 'baz';
 
-        assert.equal(obj.foo, 'baz');
+        assert.strictEqual(obj.foo, 'baz');
 
         obj.foo = 'bat';
 
-        assert.equal(obj.foo, 'bat');
+        assert.strictEqual(obj.foo, 'bat');
       }
 
       ['@test defining a non-writable property'](assert) {
@@ -247,14 +247,14 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         let source = factory.source();
 
         assert.throws(() => (source.foo = 'baz'), TypeError);
         assert.throws(() => (obj.foo = 'baz'), TypeError);
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
       }
 
       ['@test defining a getter'](assert) {
@@ -273,11 +273,11 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.foo, 'bar');
+        assert.strictEqual(obj.foo, 'bar');
 
         obj.__foo__ = 'baz';
 
-        assert.equal(obj.foo, 'baz');
+        assert.strictEqual(obj.foo, 'baz');
       }
 
       ['@test defining a setter'](assert) {
@@ -296,11 +296,11 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.__foo__, 'bar');
+        assert.strictEqual(obj.__foo__, 'bar');
 
         obj.foo = 'baz';
 
-        assert.equal(obj.__foo__, 'baz');
+        assert.strictEqual(obj.__foo__, 'baz');
       }
 
       ['@test combining multiple setter and getters'](assert) {
@@ -349,19 +349,19 @@ classes.forEach((TestClass) => {
 
         let obj = factory.finalize();
 
-        assert.equal(obj.fooBar, 'foo-bar');
+        assert.strictEqual(obj.fooBar, 'foo-bar');
 
         obj.foo = 'FOO';
 
-        assert.equal(obj.fooBar, 'FOO-bar');
+        assert.strictEqual(obj.fooBar, 'FOO-bar');
 
         obj.__bar__ = 'BAR';
 
-        assert.equal(obj.fooBar, 'FOO-BAR');
+        assert.strictEqual(obj.fooBar, 'FOO-BAR');
 
         assert.throws(() => (obj.fooBar = 'foobar'), TypeError);
 
-        assert.equal(obj.fooBar, 'FOO-BAR');
+        assert.strictEqual(obj.fooBar, 'FOO-BAR');
       }
     }
   );

--- a/packages/@ember/-internals/metal/tests/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/observer_test.js
@@ -75,14 +75,14 @@ moduleFor(
       let count = 0;
 
       addObserver(obj, 'foo', function () {
-        assert.equal(get(obj, 'foo'), 'bar', 'should invoke AFTER value changed');
+        assert.strictEqual(get(obj, 'foo'), 'bar', 'should invoke AFTER value changed');
         count++;
       });
 
       set(obj, 'foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should have invoked observer');
+      assert.strictEqual(count, 1, 'should have invoked observer');
     }
 
     async ['@test observer supports keys with colons'](assert) {
@@ -90,14 +90,14 @@ moduleFor(
       let count = 0;
 
       addObserver(obj, 'foo:bar:baz', function () {
-        assert.equal(get(obj, 'foo:bar:baz'), 'bar', 'should invoke AFTER value changed');
+        assert.strictEqual(get(obj, 'foo:bar:baz'), 'bar', 'should invoke AFTER value changed');
         count++;
       });
 
       set(obj, 'foo:bar:baz', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should have invoked observer');
+      assert.strictEqual(count, 1, 'should have invoked observer');
     }
 
     async ['@test observer should fire when dependent property is modified'](assert) {
@@ -114,14 +114,14 @@ moduleFor(
 
       let count = 0;
       addObserver(obj, 'foo', function () {
-        assert.equal(get(obj, 'foo'), 'BAZ', 'should have invoked after prop change');
+        assert.strictEqual(get(obj, 'foo'), 'BAZ', 'should have invoked after prop change');
         count++;
       });
 
       set(obj, 'bar', 'baz');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should have invoked observer');
+      assert.strictEqual(count, 1, 'should have invoked observer');
     }
 
     // https://github.com/emberjs/ember.js/issues/18246
@@ -144,15 +144,15 @@ moduleFor(
 
       let count = 0;
       addObserver(obj, 'foo', function () {
-        assert.equal(get(obj, 'foo'), 'baz', 'should have invoked after prop change');
+        assert.strictEqual(get(obj, 'foo'), 'baz', 'should have invoked after prop change');
         count++;
       });
 
       set(obj, 'foo', 'baz');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should have invoked observer');
-      assert.equal(get(obj, 'foo'), 'baz', 'computed should have correct value');
+      assert.strictEqual(count, 1, 'should have invoked observer');
+      assert.strictEqual(get(obj, 'foo'), 'baz', 'computed should have correct value');
     }
 
     async ['@test observer should continue to fire after dependent properties are accessed'](
@@ -187,7 +187,7 @@ moduleFor(
         await runLoopSettled();
       }
 
-      assert.equal(observerCount, 10, 'should continue to fire indefinitely');
+      assert.strictEqual(observerCount, 10, 'should continue to fire indefinitely');
     }
 
     async ['@test observers watching multiple properties via brace expansion should fire when the properties change'](
@@ -205,17 +205,25 @@ moduleFor(
       set(obj, 'foo', 'foo');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'observer specified via brace expansion invoked on property change');
+      assert.strictEqual(
+        count,
+        1,
+        'observer specified via brace expansion invoked on property change'
+      );
 
       set(obj, 'bar', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 2, 'observer specified via brace expansion invoked on property change');
+      assert.strictEqual(
+        count,
+        2,
+        'observer specified via brace expansion invoked on property change'
+      );
 
       set(obj, 'baz', 'baz');
       await runLoopSettled();
 
-      assert.equal(count, 2, 'observer not invoked on unspecified property');
+      assert.strictEqual(count, 2, 'observer not invoked on unspecified property');
     }
 
     async ['@test observers watching multiple properties via brace expansion should fire when dependent properties change'](
@@ -251,7 +259,7 @@ moduleFor(
       await runLoopSettled();
 
       // fire once for foo, once for bar
-      assert.equal(
+      assert.strictEqual(
         count,
         2,
         'observer specified via brace expansion invoked on dependent property change'
@@ -260,7 +268,7 @@ moduleFor(
       set(obj, 'quux', 'Quux');
       await runLoopSettled();
 
-      assert.equal(count, 2, 'observer not fired on unspecified property');
+      assert.strictEqual(count, 2, 'observer not fired on unspecified property');
     }
 
     async ['@test removing an chain observer on change should not fail'](assert) {
@@ -298,10 +306,10 @@ moduleFor(
       set(foo, 'bar', 'baz');
       await runLoopSettled();
 
-      assert.equal(count1, 1, 'observer1 fired');
-      assert.equal(count2, 1, 'observer2 fired');
-      assert.equal(count3, 1, 'observer3 fired');
-      assert.equal(count4, 0, 'observer4 did not fire');
+      assert.strictEqual(count1, 1, 'observer1 fired');
+      assert.strictEqual(count2, 1, 'observer2 fired');
+      assert.strictEqual(count3, 1, 'observer3 fired');
+      assert.strictEqual(count4, 0, 'observer4 did not fire');
 
       destroy(obj1);
       destroy(obj2);
@@ -326,7 +334,7 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(fooCount, 1, 'foo should have fired once');
+      assert.strictEqual(fooCount, 1, 'foo should have fired once');
     }
 
     async ['@test addObserver should respect targets with methods'](assert) {
@@ -336,10 +344,10 @@ moduleFor(
 
         didChange(obj, keyName) {
           let value = get(obj, keyName);
-          assert.equal(this, target1, 'should invoke with this');
-          assert.equal(obj, observed, 'param1 should be observed object');
-          assert.equal(keyName, 'foo', 'param2 should be keyName');
-          assert.equal(value, 'BAZ', 'param3 should new value');
+          assert.strictEqual(this, target1, 'should invoke with this');
+          assert.strictEqual(obj, observed, 'param1 should be observed object');
+          assert.strictEqual(keyName, 'foo', 'param2 should be keyName');
+          assert.strictEqual(value, 'BAZ', 'param3 should new value');
           this.count++;
         },
       };
@@ -349,10 +357,10 @@ moduleFor(
 
         didChange(obj, keyName) {
           let value = get(obj, keyName);
-          assert.equal(this, target2, 'should invoke with this');
-          assert.equal(obj, observed, 'param1 should be observed object');
-          assert.equal(keyName, 'foo', 'param2 should be keyName');
-          assert.equal(value, 'BAZ', 'param3 should new value');
+          assert.strictEqual(this, target2, 'should invoke with this');
+          assert.strictEqual(obj, observed, 'param1 should be observed object');
+          assert.strictEqual(keyName, 'foo', 'param2 should be keyName');
+          assert.strictEqual(value, 'BAZ', 'param3 should new value');
           this.count++;
         },
       };
@@ -363,8 +371,8 @@ moduleFor(
       set(observed, 'foo', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(target1.count, 1, 'target1 observer should have fired');
-      assert.equal(target2.count, 1, 'target2 observer should have fired');
+      assert.strictEqual(target1.count, 1, 'target1 observer should have fired');
+      assert.strictEqual(target2.count, 1, 'target2 observer should have fired');
     }
 
     async ['@test addObserver should allow multiple objects to observe a property'](assert) {
@@ -392,8 +400,8 @@ moduleFor(
       set(observed, 'foo', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(target1.count, 1, 'target1 observer should have fired');
-      assert.equal(target2.count, 1, 'target2 observer should have fired');
+      assert.strictEqual(target1.count, 1, 'target1 observer should have fired');
+      assert.strictEqual(target2.count, 1, 'target2 observer should have fired');
     }
   }
 );
@@ -424,14 +432,14 @@ moduleFor(
       set(obj, 'foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should have invoked observer');
+      assert.strictEqual(count, 1, 'should have invoked observer');
 
       removeObserver(obj, 'foo', F);
 
       set(obj, 'foo', 'baz');
       await runLoopSettled();
 
-      assert.equal(count, 1, "removed observer shouldn't fire");
+      assert.strictEqual(count, 1, "removed observer shouldn't fire");
     }
 
     async ['@test local observers can be removed'](assert) {
@@ -453,7 +461,7 @@ moduleFor(
       set(obj, 'bar', 'HI!');
       await runLoopSettled();
 
-      assert.equal(barObserved, 2, 'precond - observers should be fired');
+      assert.strictEqual(barObserved, 2, 'precond - observers should be fired');
 
       removeObserver(obj, 'bar', null, 'foo1');
 
@@ -461,7 +469,7 @@ moduleFor(
       set(obj, 'bar', 'HI AGAIN!');
       await runLoopSettled();
 
-      assert.equal(barObserved, 1, 'removed observers should not be called');
+      assert.strictEqual(barObserved, 1, 'removed observers should not be called');
     }
 
     async ['@test removeObserver should respect targets with methods'](assert) {
@@ -489,8 +497,8 @@ moduleFor(
       set(observed, 'foo', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(target1.count, 1, 'target1 observer should have fired');
-      assert.equal(target2.count, 1, 'target2 observer should have fired');
+      assert.strictEqual(target1.count, 1, 'target1 observer should have fired');
+      assert.strictEqual(target2.count, 1, 'target2 observer should have fired');
 
       removeObserver(observed, 'foo', target1, 'didChange');
       removeObserver(observed, 'foo', target2, target2.didChange);
@@ -499,8 +507,8 @@ moduleFor(
       set(observed, 'foo', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(target1.count, 0, 'target1 observer should not fire again');
-      assert.equal(target2.count, 0, 'target2 observer should not fire again');
+      assert.strictEqual(target1.count, 0, 'target1 observer should not fire again');
+      assert.strictEqual(target2.count, 0, 'target2 observer should not fire again');
     }
   }
 );
@@ -561,7 +569,7 @@ moduleFor(
         changed++;
       });
 
-      assert.equal(
+      assert.strictEqual(
         metaFor(obj).valueFor('computed'),
         undefined,
         'addObserver should not compute CP'
@@ -570,7 +578,7 @@ moduleFor(
       set(obj, 'computed.foo', 'baz');
       await runLoopSettled();
 
-      assert.equal(changed, 1, 'should fire observer');
+      assert.strictEqual(changed, 1, 'should fire observer');
     }
 
     async ['@test depending on a simple chain'](assert) {
@@ -583,45 +591,45 @@ moduleFor(
       set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
       await runLoopSettled();
 
-      assert.equal(val, 'BUZZ');
-      assert.equal(count, 1);
+      assert.strictEqual(val, 'BUZZ');
+      assert.strictEqual(count, 1);
 
       set(get(obj, 'foo.bar'), 'baz', { biff: 'BLARG' });
       await runLoopSettled();
 
-      assert.equal(val, 'BLARG');
-      assert.equal(count, 2);
+      assert.strictEqual(val, 'BLARG');
+      assert.strictEqual(count, 2);
 
       set(get(obj, 'foo'), 'bar', { baz: { biff: 'BOOM' } });
       await runLoopSettled();
 
-      assert.equal(val, 'BOOM');
-      assert.equal(count, 3);
+      assert.strictEqual(val, 'BOOM');
+      assert.strictEqual(count, 3);
 
       set(obj, 'foo', { bar: { baz: { biff: 'BLARG' } } });
       await runLoopSettled();
 
-      assert.equal(val, 'BLARG');
-      assert.equal(count, 4);
+      assert.strictEqual(val, 'BLARG');
+      assert.strictEqual(count, 4);
 
       set(get(obj, 'foo.bar.baz'), 'biff', 'BUZZ');
       await runLoopSettled();
 
-      assert.equal(val, 'BUZZ');
-      assert.equal(count, 5);
+      assert.strictEqual(val, 'BUZZ');
+      assert.strictEqual(count, 5);
 
       let foo = get(obj, 'foo');
 
       set(obj, 'foo', 'BOO');
       await runLoopSettled();
 
-      assert.equal(val, undefined);
-      assert.equal(count, 6);
+      assert.strictEqual(val, undefined);
+      assert.strictEqual(count, 6);
 
       set(foo.bar.baz, 'biff', 'BOOM');
       await runLoopSettled();
 
-      assert.equal(count, 6, 'should be not have invoked observer');
+      assert.strictEqual(count, 6, 'should be not have invoked observer');
     }
 
     async ['@test depending on a chain with a capitalized first key'](assert) {
@@ -635,45 +643,45 @@ moduleFor(
       set(get(obj, 'Capital.foo.bar.baz'), 'biff', 'BUZZ');
       await runLoopSettled();
 
-      assert.equal(val, 'BUZZ');
-      assert.equal(count, 1);
+      assert.strictEqual(val, 'BUZZ');
+      assert.strictEqual(count, 1);
 
       set(get(obj, 'Capital.foo.bar'), 'baz', { biff: 'BLARG' });
       await runLoopSettled();
 
-      assert.equal(val, 'BLARG');
-      assert.equal(count, 2);
+      assert.strictEqual(val, 'BLARG');
+      assert.strictEqual(count, 2);
 
       set(get(obj, 'Capital.foo'), 'bar', { baz: { biff: 'BOOM' } });
       await runLoopSettled();
 
-      assert.equal(val, 'BOOM');
-      assert.equal(count, 3);
+      assert.strictEqual(val, 'BOOM');
+      assert.strictEqual(count, 3);
 
       set(obj, 'Capital.foo', { bar: { baz: { biff: 'BLARG' } } });
       await runLoopSettled();
 
-      assert.equal(val, 'BLARG');
-      assert.equal(count, 4);
+      assert.strictEqual(val, 'BLARG');
+      assert.strictEqual(count, 4);
 
       set(get(obj, 'Capital.foo.bar.baz'), 'biff', 'BUZZ');
       await runLoopSettled();
 
-      assert.equal(val, 'BUZZ');
-      assert.equal(count, 5);
+      assert.strictEqual(val, 'BUZZ');
+      assert.strictEqual(count, 5);
 
       let foo = get(obj, 'foo');
 
       set(obj, 'Capital.foo', 'BOO');
       await runLoopSettled();
 
-      assert.equal(val, undefined);
-      assert.equal(count, 6);
+      assert.strictEqual(val, undefined);
+      assert.strictEqual(count, 6);
 
       set(foo.bar.baz, 'biff', 'BOOM');
       await runLoopSettled();
 
-      assert.equal(count, 6, 'should be not have invoked observer');
+      assert.strictEqual(count, 6, 'should be not have invoked observer');
     }
   }
 );
@@ -706,17 +714,17 @@ moduleFor(
       set(obj, 'foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 0, 'should not trigger observer');
+      assert.strictEqual(count, 0, 'should not trigger observer');
 
       set(obj, 'foo', 'baz');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should trigger observer');
+      assert.strictEqual(count, 1, 'should trigger observer');
 
       set(obj, 'foo', 'baz');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'should not trigger observer again');
+      assert.strictEqual(count, 1, 'should not trigger observer again');
     }
 
     // The issue here is when a computed property is directly set with a value, then has a
@@ -748,20 +756,20 @@ moduleFor(
       set(obj, 'foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 1);
-      assert.equal(get(obj, 'foo'), 'bar');
+      assert.strictEqual(count, 1);
+      assert.strictEqual(get(obj, 'foo'), 'bar');
 
       set(obj, 'baz', 'qux');
       await runLoopSettled();
 
-      assert.equal(count, 2);
-      assert.equal(get(obj, 'foo'), 'qux');
+      assert.strictEqual(count, 2);
+      assert.strictEqual(get(obj, 'foo'), 'qux');
 
       set(obj, 'foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 3);
-      assert.equal(get(obj, 'foo'), 'bar');
+      assert.strictEqual(count, 3);
+      assert.strictEqual(get(obj, 'foo'), 'bar');
     }
   }
 );
@@ -961,7 +969,7 @@ moduleFor(
 
         set(obj, 'foo', 1);
 
-        assert.equal(
+        assert.strictEqual(
           addedBeforeFirstChangeObserver.didChangeCount,
           0,
           'addObserver called before the first change is deferred'
@@ -972,7 +980,7 @@ moduleFor(
 
         set(obj, 'foo', 2);
 
-        assert.equal(
+        assert.strictEqual(
           addedAfterFirstChangeObserver.didChangeCount,
           0,
           'addObserver called after the first change is deferred'
@@ -982,32 +990,32 @@ moduleFor(
         removedAfterLastChangeObserver.remove();
       });
 
-      assert.equal(
+      assert.strictEqual(
         removedBeforeFirstChangeObserver.didChangeCount,
         0,
         'removeObserver called before the first change sees none'
       );
-      assert.equal(
+      assert.strictEqual(
         addedBeforeFirstChangeObserver.didChangeCount,
         1,
         'addObserver called before the first change sees only 1'
       );
-      assert.equal(
+      assert.strictEqual(
         addedAfterFirstChangeObserver.didChangeCount,
         1,
         'addObserver called after the first change sees 1'
       );
-      assert.equal(
+      assert.strictEqual(
         addedAfterLastChangeObserver.didChangeCount,
         1,
         'addObserver called after the last change sees 1'
       );
-      assert.equal(
+      assert.strictEqual(
         removedBeforeLastChangeObserver.didChangeCount,
         0,
         'removeObserver called before the last change sees none'
       );
-      assert.equal(
+      assert.strictEqual(
         removedAfterLastChangeObserver.didChangeCount,
         0,
         'removeObserver called after the last change sees none'
@@ -1033,7 +1041,7 @@ moduleFor(
         set(obj, 'foo', 1);
       });
 
-      assert.equal(fooDidChange, 1);
+      assert.strictEqual(fooDidChange, 1);
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/performance_test.js
+++ b/packages/@ember/-internals/metal/tests/performance_test.js
@@ -65,8 +65,8 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(cpCount, 1, 'The computed property is only invoked once');
-      assert.equal(obsCount, 1, 'The observer is only invoked once');
+      assert.strictEqual(cpCount, 1, 'The computed property is only invoked once');
+      assert.strictEqual(obsCount, 1, 'The observer is only invoked once');
     }
 
     ['@test computed properties are not executed if they are the last segment of an observer chain pain'](
@@ -88,7 +88,7 @@ moduleFor(
 
       notifyPropertyChange(get(obj, 'bar.baz'), 'bam');
 
-      assert.equal(count, 0, 'should not have recomputed property');
+      assert.strictEqual(count, 0, 'should not have recomputed property');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/properties_test.js
+++ b/packages/@ember/-internals/metal/tests/properties_test.js
@@ -9,7 +9,7 @@ moduleFor(
       defineProperty(obj, 'toString', undefined, function () {
         return 'FOO';
       });
-      assert.equal(obj.toString(), 'FOO', 'should replace toString');
+      assert.strictEqual(obj.toString(), 'FOO', 'should replace toString');
     }
   }
 );
@@ -26,10 +26,10 @@ moduleFor(
       deprecateProperty(obj, 'baz', 'foo', { id: 'baz-deprecation', until: 'some.version' });
 
       expectDeprecation();
-      assert.equal(obj.baz, obj.foo, 'baz and foo are equal');
+      assert.strictEqual(obj.baz, obj.foo, 'baz and foo are equal');
 
       obj.foo = 'blammo';
-      assert.equal(obj.baz, obj.foo, 'baz and foo are equal');
+      assert.strictEqual(obj.baz, obj.foo, 'baz and foo are equal');
     }
 
     ['@test deprecatedKey is not enumerable'](assert) {
@@ -55,8 +55,8 @@ moduleFor(
 
       expectDeprecation();
       obj.baz = 'bloop';
-      assert.equal(obj.foo, 'bloop', 'updating baz updates foo');
-      assert.equal(obj.baz, obj.foo, 'baz and foo are equal');
+      assert.strictEqual(obj.foo, 'bloop', 'updating baz updates foo');
+      assert.strictEqual(obj.baz, obj.foo, 'baz and foo are equal');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/property_events_test.js
+++ b/packages/@ember/-internals/metal/tests/property_events_test.js
@@ -8,7 +8,7 @@ moduleFor(
     ['@test notifies property changes on instances'](assert) {
       class Foo {
         [PROPERTY_DID_CHANGE](prop) {
-          assert.equal(prop, 'bar', 'property change notified');
+          assert.strictEqual(prop, 'bar', 'property change notified');
         }
       }
 
@@ -20,7 +20,7 @@ moduleFor(
     ['@test notifies property changes on instances with meta'](assert) {
       class Foo {
         [PROPERTY_DID_CHANGE](prop) {
-          assert.equal(prop, 'bar', 'property change notified');
+          assert.strictEqual(prop, 'bar', 'property change notified');
         }
       }
 
@@ -36,7 +36,7 @@ moduleFor(
 
       class Foo {
         [PROPERTY_DID_CHANGE](prop) {
-          assert.equal(prop, 'bar', 'property change notified');
+          assert.strictEqual(prop, 'bar', 'property change notified');
         }
       }
 
@@ -52,7 +52,7 @@ moduleFor(
 
       let foo = {
         [PROPERTY_DID_CHANGE](prop) {
-          assert.equal(prop, 'baz', 'property change notified');
+          assert.strictEqual(prop, 'baz', 'property change notified');
         },
       };
 

--- a/packages/@ember/-internals/metal/tests/tracked/classic_classes_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/classic_classes_test.js
@@ -37,22 +37,22 @@ moduleFor(
       let tag = track(() => obj.full);
       let snapshot = valueForTag(tag);
 
-      assert.equal(obj.full, 'Tom Dale', 'The full name starts correct');
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(obj.full, 'Tom Dale', 'The full name starts correct');
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       obj.full = 'Melanie Sumner';
 
-      assert.equal(validateTag(tag, snapshot), false);
+      assert.strictEqual(validateTag(tag, snapshot), false);
 
-      assert.equal(obj.full, 'Melanie Sumner');
-      assert.equal(obj.first, 'Melanie');
-      assert.equal(obj.last, 'Sumner');
+      assert.strictEqual(obj.full, 'Melanie Sumner');
+      assert.strictEqual(obj.first, 'Melanie');
+      assert.strictEqual(obj.last, 'Sumner');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     [`@test can pass a default value to the tracked decorator`](assert) {
@@ -67,7 +67,7 @@ moduleFor(
 
       let obj = new Tracked();
 
-      assert.equal(obj.full, 'Tom Dale', 'Default values are correctly assign');
+      assert.strictEqual(obj.full, 'Tom Dale', 'Default values are correctly assign');
     }
 
     [`@test errors if used directly on a classic class`]() {

--- a/packages/@ember/-internals/metal/tests/tracked/get_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/get_test.js
@@ -20,7 +20,7 @@ moduleFor(
       let obj = createObj();
 
       for (let key in obj) {
-        this.assert.equal(get(obj, key), obj[key], key);
+        this.assert.strictEqual(get(obj, key), obj[key], key);
       }
     }
 
@@ -40,7 +40,7 @@ moduleFor(
 
       let obj = new Obj();
 
-      this.assert.equal(get(obj, 'path.key.value'), 'value for some-key');
+      this.assert.strictEqual(get(obj, 'path.key.value'), 'value for some-key');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/tracked/set_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/set_test.js
@@ -27,8 +27,8 @@ moduleFor(
       let newObj = new Obj();
 
       for (let key in obj) {
-        assert.equal(set(newObj, key, obj[key]), obj[key], 'should return value');
-        assert.equal(get(newObj, key), obj[key], 'should set value');
+        assert.strictEqual(set(newObj, key, obj[key]), obj[key], 'should return value');
+        assert.strictEqual(get(newObj, key), obj[key], 'should set value');
       }
     }
 
@@ -45,7 +45,7 @@ moduleFor(
 
       set(newObj, 'value', 123);
 
-      assert.equal(newObj.value, 123, 'it worked');
+      assert.strictEqual(newObj.value, 123, 'it worked');
     }
   }
 );

--- a/packages/@ember/-internals/metal/tests/tracked/validation_test.js
+++ b/packages/@ember/-internals/metal/tests/tracked/validation_test.js
@@ -27,20 +27,20 @@ moduleFor(
       let tag = track(() => obj.first);
       let snapshot = valueForTag(tag);
 
-      assert.equal(obj.first, 'Tom', 'The full name starts correct');
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(obj.first, 'Tom', 'The full name starts correct');
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       obj.first = 'Thomas';
 
-      assert.equal(validateTag(tag, snapshot), false);
+      assert.strictEqual(validateTag(tag, snapshot), false);
 
-      assert.equal(obj.first, 'Thomas');
+      assert.strictEqual(obj.first, 'Thomas');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     [`@test autotracking should work with initializers`](assert) {
@@ -54,30 +54,30 @@ moduleFor(
       let tag = track(() => obj.first);
       let snapshot = valueForTag(tag);
 
-      assert.equal(obj.first, 'first: second', 'The value initializes correctly');
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(obj.first, 'first: second', 'The value initializes correctly');
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       obj.second = '2nd';
 
       // See: https://github.com/glimmerjs/glimmer-vm/pull/1018
-      // assert.equal(validate(tag, snapshot), true);
+      // assert.strictEqual(validate(tag, snapshot), true);
 
-      assert.equal(obj.first, 'first: second', 'The value stays the same once initialized');
+      assert.strictEqual(obj.first, 'first: second', 'The value stays the same once initialized');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       obj.first = 'FIRST!!!';
 
-      assert.equal(validateTag(tag, snapshot), false);
+      assert.strictEqual(validateTag(tag, snapshot), false);
 
-      assert.equal(obj.first, 'FIRST!!!');
+      assert.strictEqual(obj.first, 'FIRST!!!');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     [`@test autotracking should work with native getters`](assert) {
@@ -99,20 +99,20 @@ moduleFor(
       let tag = track(() => obj.full);
       let snapshot = valueForTag(tag);
 
-      assert.equal(obj.full, 'Tom Dale', 'The full name starts correct');
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(obj.full, 'Tom Dale', 'The full name starts correct');
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       obj.first = 'Thomas';
 
-      assert.equal(validateTag(tag, snapshot), false);
+      assert.strictEqual(validateTag(tag, snapshot), false);
 
-      assert.equal(obj.full, 'Thomas Dale');
+      assert.strictEqual(obj.full, 'Thomas Dale');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     [`@test autotracking should work with native setters`](assert) {
@@ -141,22 +141,22 @@ moduleFor(
       let tag = track(() => obj.full);
       let snapshot = valueForTag(tag);
 
-      assert.equal(obj.full, 'Tom Dale', 'The full name starts correct');
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(obj.full, 'Tom Dale', 'The full name starts correct');
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       obj.full = 'Melanie Sumner';
 
-      assert.equal(validateTag(tag, snapshot), false);
+      assert.strictEqual(validateTag(tag, snapshot), false);
 
-      assert.equal(obj.full, 'Melanie Sumner');
-      assert.equal(obj.first, 'Melanie');
-      assert.equal(obj.last, 'Sumner');
+      assert.strictEqual(obj.full, 'Melanie Sumner');
+      assert.strictEqual(obj.first, 'Melanie');
+      assert.strictEqual(obj.last, 'Sumner');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     [`@test interaction with Ember object model (tracked property depending on Ember property)`](
@@ -177,27 +177,27 @@ moduleFor(
       let obj = new Tracked(tom);
 
       let tag = track(() => obj.full);
-      assert.equal(obj.full, 'Tom Dale');
+      assert.strictEqual(obj.full, 'Tom Dale');
 
       let snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       set(tom, 'first', 'Thomas');
-      assert.equal(validateTag(tag, snapshot), false, 'invalid after setting with Ember set');
+      assert.strictEqual(validateTag(tag, snapshot), false, 'invalid after setting with Ember set');
 
-      assert.equal(obj.full, 'Thomas Dale');
+      assert.strictEqual(obj.full, 'Thomas Dale');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       set(obj, 'name', { first: 'Ricardo', last: 'Mendes' });
 
-      assert.equal(validateTag(tag, snapshot), false, 'invalid after setting with Ember set');
+      assert.strictEqual(validateTag(tag, snapshot), false, 'invalid after setting with Ember set');
 
-      assert.equal(obj.full, 'Ricardo Mendes');
+      assert.strictEqual(obj.full, 'Ricardo Mendes');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     [`@test interaction with Ember object model (Ember computed property depending on tracked property)`](
@@ -233,22 +233,22 @@ moduleFor(
 
       let tag = tagForProperty(obj, 'full');
       let full = get(obj, 'full');
-      assert.equal(full, 'Tom Dale');
+      assert.strictEqual(full, 'Tom Dale');
 
       let snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       tom.first = 'Thomas';
-      assert.equal(
+      assert.strictEqual(
         validateTag(tag, snapshot),
         false,
         'invalid after setting with tracked properties'
       );
 
-      assert.equal(get(obj, 'full'), 'Thomas Dale');
+      assert.strictEqual(get(obj, 'full'), 'Thomas Dale');
       snapshot = valueForTag(tag);
 
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
     }
 
     ['@test interaction with the Ember object model (paths going through tracked properties)'](
@@ -294,27 +294,27 @@ moduleFor(
 
       let tag = tagForProperty(obj, 'full');
       let full = get(obj, 'full');
-      assert.equal(full, 'Tom Dale');
+      assert.strictEqual(full, 'Tom Dale');
 
       let snapshot = valueForTag(tag);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       set(tom, 'first', 'Thomas');
-      assert.equal(validateTag(tag, snapshot), false, 'invalid after setting with Ember.set');
+      assert.strictEqual(validateTag(tag, snapshot), false, 'invalid after setting with Ember.set');
 
-      assert.equal(get(obj, 'full'), 'Thomas Dale');
+      assert.strictEqual(get(obj, 'full'), 'Thomas Dale');
       snapshot = valueForTag(tag);
 
       tom = contact.name = new EmberName('T', 'Dale');
-      assert.equal(validateTag(tag, snapshot), false, 'invalid after setting with Ember.set');
+      assert.strictEqual(validateTag(tag, snapshot), false, 'invalid after setting with Ember.set');
 
-      assert.equal(get(obj, 'full'), 'T Dale');
+      assert.strictEqual(get(obj, 'full'), 'T Dale');
       snapshot = valueForTag(tag);
 
       set(tom, 'first', 'Tizzle');
-      assert.equal(validateTag(tag, snapshot), false, 'invalid after setting with Ember.set');
+      assert.strictEqual(validateTag(tag, snapshot), false, 'invalid after setting with Ember.set');
 
-      assert.equal(get(obj, 'full'), 'Tizzle Dale');
+      assert.strictEqual(get(obj, 'full'), 'Tizzle Dale');
     }
 
     ['@test ember get interaction with arrays'](assert) {
@@ -329,11 +329,11 @@ moduleFor(
       let snapshot = valueForTag(tag);
 
       assert.deepEqual(array, []);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       array.push(1);
       notifyPropertyChange(array, '[]');
-      assert.equal(
+      assert.strictEqual(
         validateTag(tag, snapshot),
         false,
         'invalid after pushing an object and notifying on the array'
@@ -352,11 +352,11 @@ moduleFor(
       let snapshot = valueForTag(tag);
 
       assert.deepEqual(array, []);
-      assert.equal(validateTag(tag, snapshot), true);
+      assert.strictEqual(validateTag(tag, snapshot), true);
 
       array.push(1);
       notifyPropertyChange(array, '[]');
-      assert.equal(
+      assert.strictEqual(
         validateTag(tag, snapshot),
         false,
         'invalid after pushing an object and notifying on the array'

--- a/packages/@ember/-internals/routing/tests/location/auto_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/auto_location_test.js
@@ -90,7 +90,7 @@ moduleFor(
         return '/lincoln/park';
       };
 
-      assert.equal(location.getURL(), '/lincoln/park');
+      assert.strictEqual(location.getURL(), '/lincoln/park');
     }
 
     ['@test AutoLocation should use a HistoryLocation instance when pushStates is supported'](
@@ -177,7 +177,7 @@ moduleFor(
           port: '',
           search: '',
           replace(path) {
-            assert.equal(
+            assert.strictEqual(
               path,
               'http://test.com/#/test',
               'location.replace should be called with normalized HashLocation path'
@@ -198,7 +198,7 @@ moduleFor(
         get(location, 'concreteImplementation') instanceof NoneLocation,
         'NoneLocation should be used while we attempt to location.replace()'
       );
-      assert.equal(
+      assert.strictEqual(
         get(location, 'cancelRouterSetup'),
         true,
         'cancelRouterSetup should be set so the router knows.'
@@ -225,7 +225,7 @@ moduleFor(
       let browserHistory = mockBrowserHistory(
         {
           replaceState(state, title, path) {
-            assert.equal(
+            assert.strictEqual(
               path,
               '/test',
               'history.replaceState should be called with normalized HistoryLocation url'
@@ -279,7 +279,7 @@ moduleFor(
       location.detect();
 
       let concreteLocation = get(location, 'concreteImplementation');
-      assert.equal(location.rootURL, concreteLocation.rootURL);
+      assert.strictEqual(location.rootURL, concreteLocation.rootURL);
     }
 
     ['@test getHistoryPath() should return a normalized, HistoryLocation-supported path'](assert) {
@@ -293,7 +293,7 @@ moduleFor(
         assert
       );
 
-      assert.equal(
+      assert.strictEqual(
         getHistoryPath('/app/', browserLocation),
         '/app/about?foo=bar#foo',
         'URLs already in HistoryLocation form should come out the same'
@@ -308,7 +308,7 @@ moduleFor(
         },
         assert
       );
-      assert.equal(
+      assert.strictEqual(
         getHistoryPath('/app/', browserLocation),
         '/app/about?foo=bar#foo',
         'HashLocation formed URLs should be normalized'
@@ -323,7 +323,7 @@ moduleFor(
         },
         assert
       );
-      assert.equal(
+      assert.strictEqual(
         getHistoryPath('/app', browserLocation),
         '/app/#about?foo=bar#foo',
         "URLs with a hash not following #/ convention shouldn't be normalized as a route"
@@ -340,7 +340,7 @@ moduleFor(
         },
         assert
       );
-      assert.equal(
+      assert.strictEqual(
         getHashPath('/app/', browserLocation),
         '/app/#/about?foo=bar#foo',
         'URLs already in HistoryLocation form should come out the same'
@@ -355,7 +355,7 @@ moduleFor(
         },
         assert
       );
-      assert.equal(
+      assert.strictEqual(
         getHashPath('/app/', browserLocation),
         '/app/#/about?foo=bar#foo',
         'HistoryLocation formed URLs should be normalized'
@@ -371,7 +371,7 @@ moduleFor(
         assert
       );
 
-      assert.equal(
+      assert.strictEqual(
         getHashPath('/app/', browserLocation),
         '/app/#/#about?foo=bar#foo',
         "URLs with a hash not following #/ convention shouldn't be normalized as a route"

--- a/packages/@ember/-internals/routing/tests/location/hash_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/hash_location_test.js
@@ -70,7 +70,7 @@ moduleFor(
         assert
       );
 
-      assert.equal(location.getURL(), '/foo/bar');
+      assert.strictEqual(location.getURL(), '/foo/bar');
     }
 
     ['@test HashLocation.getURL() includes extra hashes'](assert) {
@@ -81,7 +81,7 @@ moduleFor(
         assert
       );
 
-      assert.equal(location.getURL(), '/foo#bar#car');
+      assert.strictEqual(location.getURL(), '/foo#bar#car');
     }
 
     ['@test HashLocation.getURL() assumes location.hash without #/ prefix is not a route path'](
@@ -94,7 +94,7 @@ moduleFor(
         assert
       );
 
-      assert.equal(location.getURL(), '/#foo#bar');
+      assert.strictEqual(location.getURL(), '/#foo#bar');
     }
 
     ['@test HashLocation.getURL() returns a normal forward slash when there is no location.hash'](
@@ -107,7 +107,7 @@ moduleFor(
         assert
       );
 
-      assert.equal(location.getURL(), '/');
+      assert.strictEqual(location.getURL(), '/');
     }
 
     ['@test HashLocation.setURL() correctly sets the url'](assert) {
@@ -115,8 +115,8 @@ moduleFor(
 
       location.setURL('/bar');
 
-      assert.equal(get(location, 'location.hash'), '/bar');
-      assert.equal(get(location, 'lastSetURL'), '/bar');
+      assert.strictEqual(get(location, 'location.hash'), '/bar');
+      assert.strictEqual(get(location, 'lastSetURL'), '/bar');
     }
 
     ['@test HashLocation.replaceURL() correctly replaces to the path with a page reload'](assert) {
@@ -126,7 +126,7 @@ moduleFor(
         {
           _location: {
             replace(path) {
-              assert.equal(path, '#/foo');
+              assert.strictEqual(path, '#/foo');
             },
           },
         },
@@ -135,7 +135,7 @@ moduleFor(
 
       location.replaceURL('/foo');
 
-      assert.equal(get(location, 'lastSetURL'), '/foo');
+      assert.strictEqual(get(location, 'lastSetURL'), '/foo');
     }
 
     ['@test HashLocation.onUpdateURL callback executes as expected'](assert) {
@@ -149,7 +149,7 @@ moduleFor(
       );
 
       let callback = function (param) {
-        assert.equal(param, '/foo/bar', 'path is passed as param');
+        assert.strictEqual(param, '/foo/bar', 'path is passed as param');
       };
 
       location.onUpdateURL(callback);
@@ -182,7 +182,7 @@ moduleFor(
     ['@test HashLocation.formatURL() prepends a # to the provided string'](assert) {
       createLocation({}, assert);
 
-      assert.equal(location.formatURL('/foo#bar'), '#/foo#bar');
+      assert.strictEqual(location.formatURL('/foo#bar'), '#/foo#bar');
     }
 
     ['@test HashLocation.willDestroy() cleans up hashchange event listener'](assert) {

--- a/packages/@ember/-internals/routing/tests/location/history_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/history_location_test.js
@@ -89,7 +89,7 @@ moduleFor(
           this._super(...arguments);
           // these two should be equal to be able
           // to successfully detect webkit initial popstate
-          assert.equal(this._previousURL, this.getURL());
+          assert.strictEqual(this._previousURL, this.getURL());
         },
       });
 
@@ -147,7 +147,7 @@ moduleFor(
         initState() {
           this._super(...arguments);
 
-          assert.equal(this.getURL(), '/foo/bar');
+          assert.strictEqual(this.getURL(), '/foo/bar');
         },
       });
 
@@ -171,7 +171,7 @@ moduleFor(
       location.initState();
       location.setURL('/one/two');
 
-      assert.equal(location.history.state.path, '/base/one/two');
+      assert.strictEqual(location.history.state.path, '/base/one/two');
       assert.ok(location.history.state.uuid);
     }
 
@@ -182,7 +182,7 @@ moduleFor(
       FakeHistory.pushState(null);
       location.setURL('/three/four');
 
-      assert.equal(location.history.state.path, '/three/four');
+      assert.strictEqual(location.history.state.path, '/three/four');
       assert.ok(location.history.state.uuid);
     }
 
@@ -193,7 +193,7 @@ moduleFor(
       FakeHistory.pushState(null);
       location.replaceURL('/three/four');
 
-      assert.equal(location.history.state.path, '/three/four');
+      assert.strictEqual(location.history.state.path, '/three/four');
       assert.ok(location.history.state.uuid);
     }
 
@@ -212,7 +212,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar');
+      assert.strictEqual(location.getURL(), '/foo/bar');
     }
 
     ['@test HistoryLocation.getURL() returns the current url, does not remove rootURL if its not at start of url'](
@@ -229,7 +229,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar/baz');
+      assert.strictEqual(location.getURL(), '/foo/bar/baz');
     }
 
     ['@test HistoryLocation.getURL() will not remove the rootURL when only a partial match'](
@@ -245,7 +245,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/bars/baz');
+      assert.strictEqual(location.getURL(), '/bars/baz');
     }
 
     ['@test HistoryLocation.getURL() returns the current url, does not remove baseURL if its not at start of url'](
@@ -262,7 +262,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar/baz');
+      assert.strictEqual(location.getURL(), '/foo/bar/baz');
     }
 
     ['@test HistoryLocation.getURL() will not remove the baseURL when only a partial match'](
@@ -278,7 +278,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/bars/baz');
+      assert.strictEqual(location.getURL(), '/bars/baz');
     }
 
     ['@test HistoryLocation.getURL() includes location.search'](assert) {
@@ -291,7 +291,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar?time=morphin');
+      assert.strictEqual(location.getURL(), '/foo/bar?time=morphin');
     }
 
     ['@test HistoryLocation.getURL() includes location.hash'](assert) {
@@ -304,7 +304,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar#pink-power-ranger');
+      assert.strictEqual(location.getURL(), '/foo/bar#pink-power-ranger');
     }
 
     ['@test HistoryLocation.getURL() includes location.hash and location.search'](assert) {
@@ -317,7 +317,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar?time=morphin#pink-power-ranger');
+      assert.strictEqual(location.getURL(), '/foo/bar?time=morphin#pink-power-ranger');
     }
 
     ['@test HistoryLocation.getURL() drops duplicate slashes'](assert) {
@@ -332,7 +332,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/admin/profile/');
+      assert.strictEqual(location.getURL(), '/admin/profile/');
     }
 
     ['@test Existing state is preserved on init'](assert) {

--- a/packages/@ember/-internals/routing/tests/location/none_location_test.js
+++ b/packages/@ember/-internals/routing/tests/location/none_location_test.js
@@ -38,7 +38,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.formatURL('/foo/bar'), '/en/foo/bar');
+      assert.strictEqual(location.formatURL('/foo/bar'), '/en/foo/bar');
     }
 
     ['@test NoneLocation.getURL() returns the current path minus rootURL'](assert) {
@@ -52,7 +52,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/bar');
+      assert.strictEqual(location.getURL(), '/bar');
     }
 
     ['@test NoneLocation.getURL() will remove the rootURL only from the beginning of a url'](
@@ -68,7 +68,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/foo/bar/baz');
+      assert.strictEqual(location.getURL(), '/foo/bar/baz');
     }
 
     ['@test NoneLocation.getURL() will not remove the rootURL when only a partial match'](assert) {
@@ -82,7 +82,7 @@ moduleFor(
 
       createLocation();
 
-      assert.equal(location.getURL(), '/bars/baz');
+      assert.strictEqual(location.getURL(), '/bars/baz');
     }
   }
 );

--- a/packages/@ember/-internals/routing/tests/location/util_test.js
+++ b/packages/@ember/-internals/routing/tests/location/util_test.js
@@ -31,7 +31,7 @@ moduleFor(
         port: '1337',
 
         replace(url) {
-          assert.equal(url, expectedURL);
+          assert.strictEqual(url, expectedURL);
         },
       };
 
@@ -43,10 +43,14 @@ moduleFor(
       assert
     ) {
       let location = mockBrowserLocation({ pathname: 'test' }, assert);
-      assert.equal(getPath(location), '/test', 'When there is no leading slash, one is added.');
+      assert.strictEqual(
+        getPath(location),
+        '/test',
+        'When there is no leading slash, one is added.'
+      );
 
       location = mockBrowserLocation({ pathname: '/test' }, assert);
-      assert.equal(
+      assert.strictEqual(
         getPath(location),
         '/test',
         "When a leading slash is already there, it isn't added again"
@@ -55,7 +59,7 @@ moduleFor(
 
     ['@test getQuery() should return location.search as-is'](assert) {
       let location = mockBrowserLocation({ search: '?foo=bar' }, assert);
-      assert.equal(getQuery(location), '?foo=bar');
+      assert.strictEqual(getQuery(location), '?foo=bar');
     }
 
     ['@test getFullPath() should return full pathname including query and hash'](assert) {
@@ -69,26 +73,26 @@ moduleFor(
         assert
       );
 
-      assert.equal(getFullPath(location), '/about?foo=bar#foo');
+      assert.strictEqual(getFullPath(location), '/about?foo=bar#foo');
     }
 
     ['@test Feature-Detecting onhashchange'](assert) {
-      assert.equal(
+      assert.strictEqual(
         supportsHashChange(undefined, { onhashchange() {} }),
         true,
         'When not in IE, use onhashchange existence as evidence of the feature'
       );
-      assert.equal(
+      assert.strictEqual(
         supportsHashChange(undefined, {}),
         false,
         'When not in IE, use onhashchange absence as evidence of the feature absence'
       );
-      assert.equal(
+      assert.strictEqual(
         supportsHashChange(7, { onhashchange() {} }),
         false,
         'When in IE7 compatibility mode, never report existence of the feature'
       );
-      assert.equal(
+      assert.strictEqual(
         supportsHashChange(8, { onhashchange() {} }),
         true,
         'When in IE8+, use onhashchange existence as evidence of the feature'
@@ -96,19 +100,23 @@ moduleFor(
     }
 
     ['@test Feature-detecting the history API'](assert) {
-      assert.equal(
+      assert.strictEqual(
         supportsHistory('', { pushState: true }),
         true,
         'returns true if not Android Gingerbread and history.pushState exists'
       );
-      assert.equal(
+      assert.strictEqual(
         supportsHistory('', {}),
         false,
         "returns false if history.pushState doesn't exist"
       );
-      assert.equal(supportsHistory('', undefined), false, "returns false if history doesn't exist");
+      assert.strictEqual(
+        supportsHistory('', undefined),
+        false,
+        "returns false if history doesn't exist"
+      );
 
-      assert.equal(
+      assert.strictEqual(
         supportsHistory(
           'Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
           { pushState: true }
@@ -117,7 +125,7 @@ moduleFor(
         'returns false if Android 2.x stock browser (not Chrome) claiming to support pushState'
       );
 
-      assert.equal(
+      assert.strictEqual(
         supportsHistory(
           'Mozilla/5.0 (Linux; U; Android 4.0.3; nl-nl; GT-N7000 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
           { pushState: true }
@@ -126,7 +134,7 @@ moduleFor(
         'returns false for Android 4.0.x stock browser (not Chrome) claiming to support pushState'
       );
 
-      assert.equal(
+      assert.strictEqual(
         supportsHistory(
           'Mozilla/5.0 (Linux; U; Android 20.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
           { pushState: true }
@@ -135,7 +143,7 @@ moduleFor(
         'returns true if Android version begins with 2, but is greater than 2'
       );
 
-      assert.equal(
+      assert.strictEqual(
         supportsHistory(
           'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19',
           { pushState: true }
@@ -145,7 +153,7 @@ moduleFor(
       );
 
       // Windows Phone UA and History API: https://github.com/Modernizr/Modernizr/issues/1471
-      assert.equal(
+      assert.strictEqual(
         supportsHistory(
           'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Virtual) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537',
           { pushState: true }

--- a/packages/@ember/-internals/routing/tests/system/controller_for_test.js
+++ b/packages/@ember/-internals/routing/tests/system/controller_for_test.js
@@ -26,7 +26,7 @@ moduleFor(
         let appInstance = this.applicationInstance;
         let appController = appInstance.lookup('controller:app');
         let controller = controllerFor(appInstance, 'app');
-        assert.equal(appController, controller, 'should find app controller');
+        assert.strictEqual(appController, controller, 'should find app controller');
       });
     }
   }

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -40,7 +40,7 @@ moduleFor(
             return true;
           },
           factoryFor(fullName) {
-            assert.equal(fullName, 'model:post', 'correct factory was looked up');
+            assert.strictEqual(fullName, 'model:post', 'correct factory was looked up');
 
             return {
               class: Post,
@@ -58,8 +58,8 @@ moduleFor(
       // Override the computed property by redefining it
       defineProperty(route, '_qp', null, null);
 
-      assert.equal(route.model({ post_id: 1 }), post);
-      assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+      assert.strictEqual(route.model({ post_id: 1 }), post);
+      assert.strictEqual(route.findModel('post', 1), post, '#findModel returns the correct post');
 
       runDestroy(owner);
     }
@@ -158,9 +158,9 @@ moduleFor(
       let route = EmberRoute.extend({
         actions: {
           returnsTrue(foo, bar) {
-            assert.equal(foo, 1);
-            assert.equal(bar, 2);
-            assert.equal(this, route);
+            assert.strictEqual(foo, 1);
+            assert.strictEqual(bar, 2);
+            assert.strictEqual(this, route);
             return true;
           },
 
@@ -171,9 +171,9 @@ moduleFor(
         },
       }).create();
 
-      assert.equal(route.send('returnsTrue', 1, 2), true);
-      assert.equal(route.send('returnsFalse'), false);
-      assert.equal(route.send('nonexistent', 1, 2, 3), undefined);
+      assert.strictEqual(route.send('returnsTrue', 1, 2), true);
+      assert.strictEqual(route.send('returnsFalse'), false);
+      assert.strictEqual(route.send('nonexistent', 1, 2, 3), undefined);
 
       runDestroy(route);
     }
@@ -184,9 +184,9 @@ moduleFor(
         router: {},
         actions: {
           returnsTrue(foo, bar) {
-            assert.equal(foo, 1);
-            assert.equal(bar, 2);
-            assert.equal(this, route);
+            assert.strictEqual(foo, 1);
+            assert.strictEqual(bar, 2);
+            assert.strictEqual(this, route);
             return true;
           },
 
@@ -197,9 +197,9 @@ moduleFor(
         },
       }).create();
 
-      assert.equal(true, route.send('returnsTrue', 1, 2));
-      assert.equal(false, route.send('returnsFalse'));
-      assert.equal(undefined, route.send('nonexistent', 1, 2, 3));
+      assert.strictEqual(true, route.send('returnsTrue', 1, 2));
+      assert.strictEqual(false, route.send('returnsFalse'));
+      assert.strictEqual(undefined, route.send('nonexistent', 1, 2, 3));
 
       runDestroy(route);
     }
@@ -256,7 +256,11 @@ moduleFor(
     }
 
     ['@test returns undefined if model is not set'](assert) {
-      assert.equal(route.serialize(undefined, ['post_id']), undefined, 'serialized correctly');
+      assert.strictEqual(
+        route.serialize(undefined, ['post_id']),
+        undefined,
+        'serialized correctly'
+      );
     }
   }
 );
@@ -307,7 +311,7 @@ moduleFor(
 
       routeOne.controllerName = 'test';
 
-      assert.equal(routeTwo.controllerFor('one'), testController);
+      assert.strictEqual(routeTwo.controllerFor('one'), testController);
     }
   }
 );
@@ -330,7 +334,7 @@ moduleFor(
       let appRoute = owner.lookup('route:application');
       let authService = owner.lookup('service:auth');
 
-      assert.equal(authService, appRoute.get('authService'), 'service.auth is injected');
+      assert.strictEqual(authService, appRoute.get('authService'), 'service.auth is injected');
     }
   }
 );

--- a/packages/@ember/-internals/routing/tests/system/router_test.js
+++ b/packages/@ember/-internals/routing/tests/system/router_test.js
@@ -69,11 +69,11 @@ moduleFor(
 
     ['@test should not reify location until setupRouter is called'](assert) {
       let router = createRouter({ options: { disableSetup: true } });
-      assert.equal(typeof router.location, 'string', 'location is specified as a string');
+      assert.strictEqual(typeof router.location, 'string', 'location is specified as a string');
 
       router.setupRouter();
 
-      assert.equal(typeof router.location, 'object', 'location is reified into an object');
+      assert.strictEqual(typeof router.location, 'object', 'location is reified into an object');
     }
 
     ['@test should destroy its location upon destroying the routers owner.'](assert) {
@@ -94,7 +94,7 @@ moduleFor(
 
       let location = router.get('location');
 
-      assert.equal(location.get('rootURL'), '/rootdir/');
+      assert.strictEqual(location.get('rootURL'), '/rootdir/');
     }
 
     ['@test replacePath should be called with the right path'](assert) {
@@ -109,7 +109,7 @@ moduleFor(
         hash: '',
         search: '',
         replace(url) {
-          assert.equal(url, 'http://test.com/rootdir/#/welcome');
+          assert.strictEqual(url, 'http://test.com/rootdir/#/welcome');
         },
       };
 
@@ -137,17 +137,17 @@ moduleFor(
         return Router._routePath(routeInfos);
       }
 
-      assert.equal(routePath('foo'), 'foo');
-      assert.equal(routePath('foo', 'bar', 'baz'), 'foo.bar.baz');
-      assert.equal(routePath('foo', 'foo.bar'), 'foo.bar');
-      assert.equal(routePath('foo', 'foo.bar', 'foo.bar.baz'), 'foo.bar.baz');
-      assert.equal(routePath('foo', 'foo.bar', 'foo.bar.baz.wow'), 'foo.bar.baz.wow');
-      assert.equal(routePath('foo', 'foo.bar.baz.wow'), 'foo.bar.baz.wow');
-      assert.equal(routePath('foo.bar', 'bar.baz.wow'), 'foo.bar.baz.wow');
+      assert.strictEqual(routePath('foo'), 'foo');
+      assert.strictEqual(routePath('foo', 'bar', 'baz'), 'foo.bar.baz');
+      assert.strictEqual(routePath('foo', 'foo.bar'), 'foo.bar');
+      assert.strictEqual(routePath('foo', 'foo.bar', 'foo.bar.baz'), 'foo.bar.baz');
+      assert.strictEqual(routePath('foo', 'foo.bar', 'foo.bar.baz.wow'), 'foo.bar.baz.wow');
+      assert.strictEqual(routePath('foo', 'foo.bar.baz.wow'), 'foo.bar.baz.wow');
+      assert.strictEqual(routePath('foo.bar', 'bar.baz.wow'), 'foo.bar.baz.wow');
 
       // This makes no sense, not trying to handle it, just
       // making sure it doesn't go boom.
-      assert.equal(routePath('foo.bar.baz', 'foo'), 'foo.bar.baz.foo');
+      assert.strictEqual(routePath('foo.bar.baz', 'foo'), 'foo.bar.baz.foo');
     }
 
     ['@test Router should cancel routing setup when the Location class says so via cancelRouterSetup'](
@@ -188,7 +188,7 @@ moduleFor(
         hash: '',
         search: '',
         replace(url) {
-          assert.equal(url, 'http://test.com/rootdir/#/welcome');
+          assert.strictEqual(url, 'http://test.com/rootdir/#/welcome');
         },
       };
       location.history = null;
@@ -210,8 +210,8 @@ moduleFor(
       let router = createRouter({
         settings: {
           _doURLTransition(routerJsMethod, url) {
-            assert.equal(routerJsMethod, 'handleURL');
-            assert.equal(url, '/foo/bar?time=morphin');
+            assert.strictEqual(routerJsMethod, 'handleURL');
+            assert.strictEqual(url, '/foo/bar?time=morphin');
           },
         },
       });
@@ -301,7 +301,7 @@ moduleFor(
 
     ['@test computed url when location is a string should not crash'](assert) {
       let router = createRouter({ options: { disableSetup: true } });
-      assert.equal(router.url, undefined);
+      assert.strictEqual(router.url, undefined);
     }
   }
 );

--- a/packages/@ember/-internals/routing/tests/utils_test.js
+++ b/packages/@ember/-internals/routing/tests/utils_test.js
@@ -10,8 +10,8 @@ moduleFor(
       let normalized = normalizeControllerQueryParams(params);
 
       assert.ok(normalized[paramName], 'turns the query param name into key');
-      assert.equal(normalized[paramName].as, null, "includes a blank alias in 'as' key");
-      assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+      assert.strictEqual(normalized[paramName].as, null, "includes a blank alias in 'as' key");
+      assert.strictEqual(normalized[paramName].scope, 'model', 'defaults scope to model');
     }
 
     ["@test converts object style [{foo: 'an_alias'}]"](assert) {
@@ -20,8 +20,12 @@ moduleFor(
       let normalized = normalizeControllerQueryParams(params);
 
       assert.ok(normalized[paramName], 'retains the query param name as key');
-      assert.equal(normalized[paramName].as, 'an_alias', "includes the provided alias in 'as' key");
-      assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+      assert.strictEqual(
+        normalized[paramName].as,
+        'an_alias',
+        "includes the provided alias in 'as' key"
+      );
+      assert.strictEqual(normalized[paramName].scope, 'model', 'defaults scope to model');
     }
 
     ["@test retains maximally verbose object style [{foo: {as: 'foo'}}]"](assert) {
@@ -30,8 +34,12 @@ moduleFor(
       let normalized = normalizeControllerQueryParams(params);
 
       assert.ok(normalized[paramName], 'retains the query param name as key');
-      assert.equal(normalized[paramName].as, 'an_alias', "includes the provided alias in 'as' key");
-      assert.equal(normalized[paramName].scope, 'model', 'defaults scope to model');
+      assert.strictEqual(
+        normalized[paramName].as,
+        'an_alias',
+        "includes the provided alias in 'as' key"
+      );
+      assert.strictEqual(normalized[paramName].scope, 'model', 'defaults scope to model');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/array/any-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/any-test.js
@@ -14,7 +14,7 @@ class AnyTests extends AbstractTestCase {
       return false;
     });
 
-    this.assert.equal(result, false, 'return value of obj.any');
+    this.assert.strictEqual(result, false, 'return value of obj.any');
     this.assert.deepEqual(found, ary, 'items passed during any() should match');
   }
 
@@ -30,8 +30,8 @@ class AnyTests extends AbstractTestCase {
       found.push(i);
       return --cnt <= 0;
     });
-    this.assert.equal(result, true, 'return value of obj.any');
-    this.assert.equal(found.length, exp, 'should invoke proper number of times');
+    this.assert.strictEqual(result, true, 'return value of obj.any');
+    this.assert.strictEqual(found.length, exp, 'should invoke proper number of times');
     this.assert.deepEqual(found, ary.slice(0, -2), 'items passed during any() should match');
   }
 
@@ -40,7 +40,7 @@ class AnyTests extends AbstractTestCase {
     let result;
 
     result = obj.any((i) => Boolean(i));
-    this.assert.equal(result, true, 'return value of obj.any');
+    this.assert.strictEqual(result, true, 'return value of obj.any');
   }
 
   '@test any should produce correct results even if the matching element is undefined'(assert) {
@@ -48,7 +48,7 @@ class AnyTests extends AbstractTestCase {
     let result;
 
     result = obj.any(() => true);
-    assert.equal(result, true, 'return value of obj.any');
+    assert.strictEqual(result, true, 'return value of obj.any');
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/every-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/every-test.js
@@ -13,7 +13,7 @@ class EveryTest extends AbstractTestCase {
       found.push(i);
       return true;
     });
-    this.assert.equal(result, true, 'return value of obj.every');
+    this.assert.strictEqual(result, true, 'return value of obj.every');
     this.assert.deepEqual(found, ary, 'items passed during every() should match');
   }
 
@@ -29,8 +29,8 @@ class EveryTest extends AbstractTestCase {
       found.push(i);
       return --cnt > 0;
     });
-    this.assert.equal(result, false, 'return value of obj.every');
-    this.assert.equal(found.length, exp, 'should invoke proper number of times');
+    this.assert.strictEqual(result, false, 'return value of obj.every');
+    this.assert.strictEqual(found.length, exp, 'should invoke proper number of times');
     this.assert.deepEqual(found, ary.slice(0, -2), 'items passed during every() should match');
   }
 }
@@ -42,8 +42,8 @@ class IsEveryTest extends AbstractTestCase {
       EmberObject.create({ foo: 'foo', bar: 'bar' }),
     ]);
 
-    this.assert.equal(obj.isEvery('foo', 'foo'), true, 'isEvery(foo)');
-    this.assert.equal(obj.isEvery('bar', 'bar'), false, 'isEvery(bar)');
+    this.assert.strictEqual(obj.isEvery('foo', 'foo'), true, 'isEvery(foo)');
+    this.assert.strictEqual(obj.isEvery('bar', 'bar'), false, 'isEvery(bar)');
   }
 
   '@test should return true of every property is true'() {
@@ -53,8 +53,8 @@ class IsEveryTest extends AbstractTestCase {
     ]);
 
     // different values - all eval to true
-    this.assert.equal(obj.isEvery('foo'), true, 'isEvery(foo)');
-    this.assert.equal(obj.isEvery('bar'), false, 'isEvery(bar)');
+    this.assert.strictEqual(obj.isEvery('foo'), true, 'isEvery(foo)');
+    this.assert.strictEqual(obj.isEvery('bar'), false, 'isEvery(bar)');
   }
 
   '@test should return true if every property matches null'() {
@@ -63,8 +63,8 @@ class IsEveryTest extends AbstractTestCase {
       EmberObject.create({ foo: null, bar: null }),
     ]);
 
-    this.assert.equal(obj.isEvery('foo', null), true, "isEvery('foo', null)");
-    this.assert.equal(obj.isEvery('bar', null), false, "isEvery('bar', null)");
+    this.assert.strictEqual(obj.isEvery('foo', null), true, "isEvery('foo', null)");
+    this.assert.strictEqual(obj.isEvery('bar', null), false, "isEvery('bar', null)");
   }
 
   '@test should return true if every property is undefined'() {
@@ -73,8 +73,8 @@ class IsEveryTest extends AbstractTestCase {
       EmberObject.create({ bar: undefined }),
     ]);
 
-    this.assert.equal(obj.isEvery('foo', undefined), true, "isEvery('foo', undefined)");
-    this.assert.equal(obj.isEvery('bar', undefined), false, "isEvery('bar', undefined)");
+    this.assert.strictEqual(obj.isEvery('foo', undefined), true, "isEvery('foo', undefined)");
+    this.assert.strictEqual(obj.isEvery('bar', undefined), false, "isEvery('bar', undefined)");
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/find-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/find-test.js
@@ -13,7 +13,7 @@ class FindTests extends AbstractTestCase {
       found.push(i);
       return false;
     });
-    this.assert.equal(result, undefined, 'return value of obj.find');
+    this.assert.strictEqual(result, undefined, 'return value of obj.find');
     this.assert.deepEqual(found, ary, 'items passed during find() should match');
   }
 
@@ -29,8 +29,8 @@ class FindTests extends AbstractTestCase {
       found.push(i);
       return --cnt >= 0;
     });
-    this.assert.equal(result, ary[exp - 1], 'return value of obj.find');
-    this.assert.equal(found.length, exp, 'should invoke proper number of times');
+    this.assert.strictEqual(result, ary[exp - 1], 'return value of obj.find');
+    this.assert.strictEqual(found.length, exp, 'should invoke proper number of times');
     this.assert.deepEqual(found, ary.slice(0, -2), 'items passed during find() should match');
   }
 }
@@ -43,8 +43,8 @@ class FindByTests extends AbstractTestCase {
 
     obj = this.newObject(ary);
 
-    this.assert.equal(obj.findBy('foo', 'foo'), ary[0], 'findBy(foo)');
-    this.assert.equal(obj.findBy('bar', 'bar'), ary[1], 'findBy(bar)');
+    this.assert.strictEqual(obj.findBy('foo', 'foo'), ary[0], 'findBy(foo)');
+    this.assert.strictEqual(obj.findBy('bar', 'bar'), ary[1], 'findBy(bar)');
   }
 
   '@test should return first object with truthy prop'() {
@@ -55,8 +55,8 @@ class FindByTests extends AbstractTestCase {
     obj = this.newObject(ary);
 
     // different values - all eval to true
-    this.assert.equal(obj.findBy('foo'), ary[0], 'findBy(foo)');
-    this.assert.equal(obj.findBy('bar'), ary[1], 'findBy(bar)');
+    this.assert.strictEqual(obj.findBy('foo'), ary[0], 'findBy(foo)');
+    this.assert.strictEqual(obj.findBy('bar'), ary[1], 'findBy(bar)');
   }
 
   '@test should return first null property match'() {
@@ -66,8 +66,8 @@ class FindByTests extends AbstractTestCase {
 
     obj = this.newObject(ary);
 
-    this.assert.equal(obj.findBy('foo', null), ary[0], "findBy('foo', null)");
-    this.assert.equal(obj.findBy('bar', null), ary[1], "findBy('bar', null)");
+    this.assert.strictEqual(obj.findBy('foo', null), ary[0], "findBy('foo', null)");
+    this.assert.strictEqual(obj.findBy('bar', null), ary[1], "findBy('bar', null)");
   }
 
   '@test should return first undefined property match'() {
@@ -77,8 +77,8 @@ class FindByTests extends AbstractTestCase {
 
     obj = this.newObject(ary);
 
-    this.assert.equal(obj.findBy('foo', undefined), ary[0], "findBy('foo', undefined)");
-    this.assert.equal(obj.findBy('bar', undefined), ary[1], "findBy('bar', undefined)");
+    this.assert.strictEqual(obj.findBy('foo', undefined), ary[0], "findBy('foo', undefined)");
+    this.assert.strictEqual(obj.findBy('bar', undefined), ary[1], "findBy('bar', undefined)");
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/firstObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/firstObject-test.js
@@ -5,18 +5,18 @@ import { runArrayTests } from '../helpers/array';
 class FirstObjectTests extends AbstractTestCase {
   '@test returns first item in enumerable'() {
     let obj = this.newObject();
-    this.assert.equal(get(obj, 'firstObject'), this.toArray(obj)[0]);
+    this.assert.strictEqual(get(obj, 'firstObject'), this.toArray(obj)[0]);
   }
 
   '@test returns undefined if enumerable is empty'() {
     let obj = this.newObject([]);
-    this.assert.equal(get(obj, 'firstObject'), undefined);
+    this.assert.strictEqual(get(obj, 'firstObject'), undefined);
   }
 
   '@test can not be set'() {
     let obj = this.newObject([]);
 
-    this.assert.equal(get(obj, 'firstObject'), this.toArray(obj)[0]);
+    this.assert.strictEqual(get(obj, 'firstObject'), this.toArray(obj)[0]);
 
     this.assert.throws(() => {
       set(obj, 'firstObject', 'foo!');

--- a/packages/@ember/-internals/runtime/tests/array/forEach-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/forEach-test.js
@@ -47,7 +47,11 @@ class ForEachTests extends AbstractTestCase {
     });
 
     obj.forEach(() => {
-      this.assert.equal(guidFor(this), guidFor(target), 'should pass target as this if context');
+      this.assert.strictEqual(
+        guidFor(this),
+        guidFor(target),
+        'should pass target as this if context'
+      );
     }, target);
   }
 
@@ -57,9 +61,9 @@ class ForEachTests extends AbstractTestCase {
     let loc = 0;
 
     obj.forEach((item, idx, enumerable) => {
-      this.assert.equal(item, ary[loc], 'item param');
-      this.assert.equal(idx, loc, 'idx param');
-      this.assert.equal(guidFor(enumerable), guidFor(obj), 'enumerable param');
+      this.assert.strictEqual(item, ary[loc], 'item param');
+      this.assert.strictEqual(idx, loc, 'idx param');
+      this.assert.strictEqual(guidFor(enumerable), guidFor(obj), 'enumerable param');
       loc++;
     });
   }

--- a/packages/@ember/-internals/runtime/tests/array/includes-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/includes-test.js
@@ -6,24 +6,28 @@ class IncludesTests extends AbstractTestCase {
     let data = newFixture(3);
     let obj = this.newObject(data);
 
-    this.assert.equal(obj.includes(data[1], 1), true, 'should return true if included');
-    this.assert.equal(obj.includes(data[0], 1), false, 'should return false if not included');
+    this.assert.strictEqual(obj.includes(data[1], 1), true, 'should return true if included');
+    this.assert.strictEqual(obj.includes(data[0], 1), false, 'should return false if not included');
   }
 
   '@test includes returns correct value if startAt is negative'() {
     let data = newFixture(3);
     let obj = this.newObject(data);
 
-    this.assert.equal(obj.includes(data[1], -2), true, 'should return true if included');
-    this.assert.equal(obj.includes(data[0], -2), false, 'should return false if not included');
+    this.assert.strictEqual(obj.includes(data[1], -2), true, 'should return true if included');
+    this.assert.strictEqual(
+      obj.includes(data[0], -2),
+      false,
+      'should return false if not included'
+    );
   }
 
   '@test includes returns true if startAt + length is still negative'() {
     let data = newFixture(1);
     let obj = this.newObject(data);
 
-    this.assert.equal(obj.includes(data[0], -2), true, 'should return true if included');
-    this.assert.equal(
+    this.assert.strictEqual(obj.includes(data[0], -2), true, 'should return true if included');
+    this.assert.strictEqual(
       obj.includes(newFixture(1), -2),
       false,
       'should return false if not included'
@@ -34,8 +38,12 @@ class IncludesTests extends AbstractTestCase {
     let data = newFixture(1);
     let obj = this.newObject(data);
 
-    this.assert.equal(obj.includes(data[0], 2), false, 'should return false if startAt >= length');
-    this.assert.equal(
+    this.assert.strictEqual(
+      obj.includes(data[0], 2),
+      false,
+      'should return false if startAt >= length'
+    );
+    this.assert.strictEqual(
       obj.includes(newFixture(1), 2),
       false,
       'should return false if startAt >= length'

--- a/packages/@ember/-internals/runtime/tests/array/indexOf-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/indexOf-test.js
@@ -8,7 +8,7 @@ class IndexOfTests extends AbstractTestCase {
     let len = 3;
 
     for (let idx = 0; idx < len; idx++) {
-      this.assert.equal(
+      this.assert.strictEqual(
         obj.indexOf(expected[idx]),
         idx,
         `obj.indexOf(${expected[idx]}) should match idx`
@@ -20,7 +20,7 @@ class IndexOfTests extends AbstractTestCase {
     let obj = this.newObject(newFixture(3));
     let foo = {};
 
-    this.assert.equal(obj.indexOf(foo), -1, 'obj.indexOf(foo) should be < 0');
+    this.assert.strictEqual(obj.indexOf(foo), -1, 'obj.indexOf(foo) should be < 0');
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/invoke-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/invoke-test.js
@@ -22,11 +22,11 @@ class InvokeTests extends AbstractTestCase {
 
     obj = this.newObject(ary);
     obj.invoke('foo');
-    this.assert.equal(cnt, 3, 'should have invoked 3 times');
+    this.assert.strictEqual(cnt, 3, 'should have invoked 3 times');
 
     cnt = 0;
     obj.invoke('foo', 2);
-    this.assert.equal(cnt, 6, 'should have invoked 3 times, passing param');
+    this.assert.strictEqual(cnt, 6, 'should have invoked 3 times, passing param');
   }
 
   '@test invoke should return an array containing the results of each invoked method'(assert) {

--- a/packages/@ember/-internals/runtime/tests/array/isAny-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/isAny-test.js
@@ -9,9 +9,9 @@ class IsAnyTests extends AbstractTestCase {
       EmberObject.create({ foo: 'foo', bar: 'bar' }),
     ]);
 
-    this.assert.equal(obj.isAny('foo', 'foo'), true, 'isAny(foo)');
-    this.assert.equal(obj.isAny('bar', 'bar'), true, 'isAny(bar)');
-    this.assert.equal(obj.isAny('bar', 'BIFF'), false, 'isAny(BIFF)');
+    this.assert.strictEqual(obj.isAny('foo', 'foo'), true, 'isAny(foo)');
+    this.assert.strictEqual(obj.isAny('bar', 'bar'), true, 'isAny(bar)');
+    this.assert.strictEqual(obj.isAny('bar', 'BIFF'), false, 'isAny(BIFF)');
   }
 
   '@test should return true of any property is true'() {
@@ -21,9 +21,9 @@ class IsAnyTests extends AbstractTestCase {
     ]);
 
     // different values - all eval to true
-    this.assert.equal(obj.isAny('foo'), true, 'isAny(foo)');
-    this.assert.equal(obj.isAny('bar'), true, 'isAny(bar)');
-    this.assert.equal(obj.isAny('BIFF'), false, 'isAny(biff)');
+    this.assert.strictEqual(obj.isAny('foo'), true, 'isAny(foo)');
+    this.assert.strictEqual(obj.isAny('bar'), true, 'isAny(bar)');
+    this.assert.strictEqual(obj.isAny('BIFF'), false, 'isAny(biff)');
   }
 
   '@test should return true if any property matches null'() {
@@ -32,21 +32,21 @@ class IsAnyTests extends AbstractTestCase {
       EmberObject.create({ foo: 'foo', bar: null }),
     ]);
 
-    this.assert.equal(obj.isAny('foo', null), true, "isAny('foo', null)");
-    this.assert.equal(obj.isAny('bar', null), true, "isAny('bar', null)");
+    this.assert.strictEqual(obj.isAny('foo', null), true, "isAny('foo', null)");
+    this.assert.strictEqual(obj.isAny('bar', null), true, "isAny('bar', null)");
   }
 
   '@test should return true if any property is undefined'() {
     let obj = this.newObject([{ foo: undefined, bar: 'bar' }, EmberObject.create({ foo: 'foo' })]);
 
-    this.assert.equal(obj.isAny('foo', undefined), true, "isAny('foo', undefined)");
-    this.assert.equal(obj.isAny('bar', undefined), true, "isAny('bar', undefined)");
+    this.assert.strictEqual(obj.isAny('foo', undefined), true, "isAny('foo', undefined)");
+    this.assert.strictEqual(obj.isAny('bar', undefined), true, "isAny('bar', undefined)");
   }
 
   '@test should not match undefined properties without second argument'() {
     let obj = this.newObject([{ foo: undefined }, EmberObject.create({})]);
 
-    this.assert.equal(obj.isAny('foo'), false, "isAny('foo', undefined)");
+    this.assert.strictEqual(obj.isAny('foo'), false, "isAny('foo', undefined)");
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/lastIndexOf-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/lastIndexOf-test.js
@@ -9,7 +9,7 @@ class LastIndexOfTests extends AbstractTestCase {
     let len = 3;
 
     for (let idx = 0; idx < len; idx++) {
-      this.assert.equal(
+      this.assert.strictEqual(
         obj.lastIndexOf(expected[idx]),
         idx,
         `obj.lastIndexOf(${expected[idx]}) should match idx`
@@ -23,7 +23,7 @@ class LastIndexOfTests extends AbstractTestCase {
     let len = 3;
 
     for (let idx = 0; idx < len; idx++) {
-      this.assert.equal(
+      this.assert.strictEqual(
         obj.lastIndexOf(expected[idx], len),
         idx,
         `obj.lastIndexOfs(${expected[idx]}) should match idx`
@@ -37,7 +37,7 @@ class LastIndexOfTests extends AbstractTestCase {
     let len = 3;
 
     for (let idx = 0; idx < len; idx++) {
-      this.assert.equal(
+      this.assert.strictEqual(
         obj.lastIndexOf(expected[idx], len + 1),
         idx,
         `obj.lastIndexOf(${expected[idx]}) should match idx`
@@ -49,14 +49,14 @@ class LastIndexOfTests extends AbstractTestCase {
     let obj = this.newObject(newFixture(3));
     let foo = {};
 
-    this.assert.equal(obj.lastIndexOf(foo), -1, 'obj.lastIndexOf(foo) should be -1');
+    this.assert.strictEqual(obj.lastIndexOf(foo), -1, 'obj.lastIndexOf(foo) should be -1');
   }
 
   '@test should return -1 when no match is found even startAt search location is equal to length'() {
     let obj = this.newObject(newFixture(3));
     let foo = {};
 
-    this.assert.equal(
+    this.assert.strictEqual(
       obj.lastIndexOf(foo, get(obj, 'length')),
       -1,
       'obj.lastIndexOf(foo) should be -1'
@@ -67,7 +67,7 @@ class LastIndexOfTests extends AbstractTestCase {
     let obj = this.newObject(newFixture(3));
     let foo = {};
 
-    this.assert.equal(
+    this.assert.strictEqual(
       obj.lastIndexOf(foo, get(obj, 'length') + 1),
       -1,
       'obj.lastIndexOf(foo) should be -1'

--- a/packages/@ember/-internals/runtime/tests/array/lastObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/lastObject-test.js
@@ -7,20 +7,20 @@ class LastObjectTests extends AbstractTestCase {
     let obj = this.newObject();
     let ary = this.toArray(obj);
 
-    this.assert.equal(get(obj, 'lastObject'), ary[ary.length - 1]);
+    this.assert.strictEqual(get(obj, 'lastObject'), ary[ary.length - 1]);
   }
 
   '@test returns undefined if enumerable is empty'() {
     let obj = this.newObject([]);
 
-    this.assert.equal(get(obj, 'lastObject'), undefined);
+    this.assert.strictEqual(get(obj, 'lastObject'), undefined);
   }
 
   '@test can not be set'() {
     let obj = this.newObject();
     let ary = this.toArray(obj);
 
-    this.assert.equal(get(obj, 'lastObject'), ary[ary.length - 1]);
+    this.assert.strictEqual(get(obj, 'lastObject'), ary[ary.length - 1]);
 
     this.assert.throws(function () {
       set(obj, 'lastObject', 'foo!');

--- a/packages/@ember/-internals/runtime/tests/array/map-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/map-test.js
@@ -47,7 +47,11 @@ class MapTests extends AbstractTestCase {
     });
 
     obj.map(() => {
-      this.assert.equal(guidFor(this), guidFor(target), 'should pass target as this if context');
+      this.assert.strictEqual(
+        guidFor(this),
+        guidFor(target),
+        'should pass target as this if context'
+      );
     }, target);
   }
 
@@ -57,9 +61,9 @@ class MapTests extends AbstractTestCase {
     let loc = 0;
 
     obj.map((item, idx, enumerable) => {
-      this.assert.equal(item, ary[loc], 'item param');
-      this.assert.equal(idx, loc, 'idx param');
-      this.assert.equal(guidFor(enumerable), guidFor(obj), 'enumerable param');
+      this.assert.strictEqual(item, ary[loc], 'item param');
+      this.assert.strictEqual(idx, loc, 'idx param');
+      this.assert.strictEqual(guidFor(enumerable), guidFor(obj), 'enumerable param');
       loc++;
     });
   }

--- a/packages/@ember/-internals/runtime/tests/array/mapBy-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/mapBy-test.js
@@ -4,12 +4,12 @@ import { runArrayTests } from '../helpers/array';
 class MapByTests extends AbstractTestCase {
   '@test get value of each property'() {
     let obj = this.newObject([{ a: 1 }, { a: 2 }]);
-    this.assert.equal(obj.mapBy('a').join(''), '12');
+    this.assert.strictEqual(obj.mapBy('a').join(''), '12');
   }
 
   '@test should work also through getEach alias'() {
     let obj = this.newObject([{ a: 1 }, { a: 2 }]);
-    this.assert.equal(obj.getEach('a').join(''), '12');
+    this.assert.strictEqual(obj.getEach('a').join(''), '12');
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/objectAt-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/objectAt-test.js
@@ -8,7 +8,11 @@ class ObjectAtTests extends AbstractTestCase {
     let len = expected.length;
 
     for (let idx = 0; idx < len; idx++) {
-      this.assert.equal(obj.objectAt(idx), expected[idx], `obj.objectAt(${idx}) should match`);
+      this.assert.strictEqual(
+        obj.objectAt(idx),
+        expected[idx],
+        `obj.objectAt(${idx}) should match`
+      );
     }
   }
 
@@ -16,14 +20,14 @@ class ObjectAtTests extends AbstractTestCase {
     let obj;
 
     obj = this.newObject(newFixture(3));
-    this.assert.equal(
+    this.assert.strictEqual(
       obj.objectAt(obj, 5),
       undefined,
       'should return undefined for obj.objectAt(5) when len = 3'
     );
 
     obj = this.newObject([]);
-    this.assert.equal(
+    this.assert.strictEqual(
       obj.objectAt(obj, 0),
       undefined,
       'should return undefined for obj.objectAt(0) when len = 0'

--- a/packages/@ember/-internals/runtime/tests/array/reduce-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/reduce-test.js
@@ -5,19 +5,19 @@ class ReduceTests extends AbstractTestCase {
   '@test collects a summary value from an enumeration'() {
     let obj = this.newObject([1, 2, 3]);
     let res = obj.reduce((previousValue, item) => previousValue + item, 0);
-    this.assert.equal(res, 6);
+    this.assert.strictEqual(res, 6);
   }
 
   '@test passes index of item to callback'() {
     let obj = this.newObject([1, 2, 3]);
     let res = obj.reduce((previousValue, item, index) => previousValue + index, 0);
-    this.assert.equal(res, 3);
+    this.assert.strictEqual(res, 3);
   }
 
   '@test passes enumerable object to callback'() {
     let obj = this.newObject([1, 2, 3]);
     let res = obj.reduce((previousValue, item, index, enumerable) => enumerable, 0);
-    this.assert.equal(res, obj);
+    this.assert.strictEqual(res, obj);
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/sortBy-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/sortBy-test.js
@@ -7,8 +7,8 @@ class SortByTests extends AbstractTestCase {
     let obj = this.newObject([{ a: 2 }, { a: 1 }]);
     let sorted = obj.sortBy('a');
 
-    this.assert.equal(get(sorted[0], 'a'), 1);
-    this.assert.equal(get(sorted[1], 'a'), 2);
+    this.assert.strictEqual(get(sorted[0], 'a'), 1);
+    this.assert.strictEqual(get(sorted[1], 'a'), 2);
   }
 
   '@test supports multiple propertyNames'() {
@@ -18,8 +18,8 @@ class SortByTests extends AbstractTestCase {
     ]);
     let sorted = obj.sortBy('a', 'b');
 
-    this.assert.equal(get(sorted[0], 'b'), 1);
-    this.assert.equal(get(sorted[1], 'b'), 2);
+    this.assert.strictEqual(get(sorted[0], 'b'), 1);
+    this.assert.strictEqual(get(sorted[1], 'b'), 2);
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/array/uniqBy-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/uniqBy-test.js
@@ -22,7 +22,7 @@ class UniqByTests extends AbstractTestCase {
     ]);
 
     let keyFunction = (val) => {
-      this.assert.equal(arguments.length, 1);
+      this.assert.strictEqual(arguments.length, 1);
       return val.value;
     };
 

--- a/packages/@ember/-internals/runtime/tests/array/without-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/without-test.js
@@ -32,7 +32,7 @@ class WithoutTests extends AbstractTestCase {
     obj = this.newObject(newFixture(3));
 
     ret = obj.without(item);
-    this.assert.equal(ret, obj, 'should be same instance');
+    this.assert.strictEqual(ret, obj, 'should be same instance');
   }
 }
 

--- a/packages/@ember/-internals/runtime/tests/core/compare_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/compare_test.js
@@ -43,7 +43,7 @@ moduleFor(
       for (suspectIndex = 0; suspectIndex < data.length; suspectIndex++) {
         suspect = data[suspectIndex];
 
-        assert.equal(compare(suspect, suspect), 0, suspectIndex + ' should equal itself');
+        assert.strictEqual(compare(suspect, suspect), 0, suspectIndex + ' should equal itself');
 
         for (comparableIndex = suspectIndex + 1; comparableIndex < data.length; comparableIndex++) {
           comparable = data[comparableIndex];
@@ -59,7 +59,7 @@ moduleFor(
             typeOf(comparable) +
             ')';
 
-          assert.equal(compare(suspect, comparable), -1, failureMessage);
+          assert.strictEqual(compare(suspect, comparable), -1, failureMessage);
         }
       }
     }
@@ -77,13 +77,17 @@ moduleFor(
         val: 1,
       });
 
-      assert.equal(compare(negOne, 'a'), -1, 'First item comparable - returns -1 (not negated)');
-      assert.equal(compare(zero, 'b'), 0, 'First item comparable - returns  0 (not negated)');
-      assert.equal(compare(one, 'c'), 1, 'First item comparable - returns  1 (not negated)');
+      assert.strictEqual(
+        compare(negOne, 'a'),
+        -1,
+        'First item comparable - returns -1 (not negated)'
+      );
+      assert.strictEqual(compare(zero, 'b'), 0, 'First item comparable - returns  0 (not negated)');
+      assert.strictEqual(compare(one, 'c'), 1, 'First item comparable - returns  1 (not negated)');
 
-      assert.equal(compare('a', negOne), 1, 'Second item comparable - returns -1 (negated)');
-      assert.equal(compare('b', zero), 0, 'Second item comparable - returns  0 (negated)');
-      assert.equal(compare('c', one), -1, 'Second item comparable - returns  1 (negated)');
+      assert.strictEqual(compare('a', negOne), 1, 'Second item comparable - returns -1 (negated)');
+      assert.strictEqual(compare('b', zero), 0, 'Second item comparable - returns  0 (negated)');
+      assert.strictEqual(compare('c', one), -1, 'Second item comparable - returns  1 (negated)');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/core/isEqual_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/isEqual_test.js
@@ -59,7 +59,11 @@ moduleFor(
           return false;
         },
       };
-      assert.equal(isEqual(obj, obj), false, 'should return false because isEqual returns false');
+      assert.strictEqual(
+        isEqual(obj, obj),
+        false,
+        'should return false because isEqual returns false'
+      );
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/core/is_array_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_array_test.js
@@ -21,17 +21,17 @@ moduleFor(
       let asyncFn = async function () {};
       let arrayProxy = ArrayProxy.create({ content: emberA() });
 
-      assert.equal(isArray(numarray), true, '[1,2,3]');
-      assert.equal(isArray(number), false, '23');
-      assert.equal(isArray(strarray), true, '["Hello", "Hi"]');
-      assert.equal(isArray(string), false, '"Hello"');
-      assert.equal(isArray(object), false, '{}');
-      assert.equal(isArray(length), true, '{ length: 12 }');
-      assert.equal(isArray(strangeLength), false, '{ length: "yes" }');
-      assert.equal(isArray(global), false, 'global');
-      assert.equal(isArray(fn), false, 'function() {}');
-      assert.equal(isArray(asyncFn), false, 'async function() {}');
-      assert.equal(isArray(arrayProxy), true, '[]');
+      assert.strictEqual(isArray(numarray), true, '[1,2,3]');
+      assert.strictEqual(isArray(number), false, '23');
+      assert.strictEqual(isArray(strarray), true, '["Hello", "Hi"]');
+      assert.strictEqual(isArray(string), false, '"Hello"');
+      assert.strictEqual(isArray(object), false, '{}');
+      assert.strictEqual(isArray(length), true, '{ length: 12 }');
+      assert.strictEqual(isArray(strangeLength), false, '{ length: "yes" }');
+      assert.strictEqual(isArray(global), false, 'global');
+      assert.strictEqual(isArray(fn), false, 'function() {}');
+      assert.strictEqual(isArray(asyncFn), false, 'async function() {}');
+      assert.strictEqual(isArray(arrayProxy), true, '[]');
     }
 
     '@test Ember.isArray does not trigger proxy assertion when probing for length GH#16495'(
@@ -44,7 +44,7 @@ moduleFor(
         },
       }).create();
 
-      assert.equal(isArray(instance), false);
+      assert.strictEqual(isArray(instance), false);
     }
 
     ['@test Ember.isArray(fileList)'](assert) {
@@ -52,7 +52,7 @@ moduleFor(
         let fileListElement = document.createElement('input');
         fileListElement.type = 'file';
         let fileList = fileListElement.files;
-        assert.equal(isArray(fileList), false, 'fileList');
+        assert.strictEqual(isArray(fileList), false, 'fileList');
       } else {
         assert.ok(true, 'FileList is not present on window');
       }

--- a/packages/@ember/-internals/runtime/tests/core/is_empty_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_empty_test.js
@@ -9,7 +9,7 @@ moduleFor(
     ['@test Ember.isEmpty'](assert) {
       let arrayProxy = ArrayProxy.create({ content: emberA() });
 
-      assert.equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
+      assert.strictEqual(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/core/type_of_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/type_of_test.js
@@ -22,26 +22,26 @@ moduleFor(
         async asyncMethod() {},
       });
 
-      assert.equal(typeOf(), 'undefined', 'undefined');
-      assert.equal(typeOf(null), 'null', 'null');
-      assert.equal(typeOf('Cyril'), 'string', 'Cyril');
-      assert.equal(typeOf(101), 'number', '101');
-      assert.equal(typeOf(true), 'boolean', 'true');
-      assert.equal(typeOf([1, 2, 90]), 'array', '[1,2,90]');
-      assert.equal(typeOf(/abc/), 'regexp', '/abc/');
-      assert.equal(typeOf(date), 'date', 'new Date()');
-      assert.equal(typeOf(mockedDate), 'date', 'mocked date');
-      assert.equal(typeOf(error), 'error', 'error');
-      assert.equal(typeOf(object), 'object', 'object');
-      assert.equal(typeOf(undefined), 'undefined', 'item of type undefined');
-      assert.equal(typeOf(a), 'null', 'item of type null');
-      assert.equal(typeOf(arr), 'array', 'item of type array');
-      assert.equal(typeOf(obj), 'object', 'item of type object');
-      assert.equal(typeOf(instance), 'instance', 'item of type instance');
-      assert.equal(typeOf(instance.method), 'function', 'item of type function');
-      assert.equal(typeOf(instance.asyncMethod), 'function', 'item of type async function');
-      assert.equal(typeOf(EmberObject.extend()), 'class', 'item of type class');
-      assert.equal(typeOf(new Error()), 'error', 'item of type error');
+      assert.strictEqual(typeOf(), 'undefined', 'undefined');
+      assert.strictEqual(typeOf(null), 'null', 'null');
+      assert.strictEqual(typeOf('Cyril'), 'string', 'Cyril');
+      assert.strictEqual(typeOf(101), 'number', '101');
+      assert.strictEqual(typeOf(true), 'boolean', 'true');
+      assert.strictEqual(typeOf([1, 2, 90]), 'array', '[1,2,90]');
+      assert.strictEqual(typeOf(/abc/), 'regexp', '/abc/');
+      assert.strictEqual(typeOf(date), 'date', 'new Date()');
+      assert.strictEqual(typeOf(mockedDate), 'date', 'mocked date');
+      assert.strictEqual(typeOf(error), 'error', 'error');
+      assert.strictEqual(typeOf(object), 'object', 'object');
+      assert.strictEqual(typeOf(undefined), 'undefined', 'item of type undefined');
+      assert.strictEqual(typeOf(a), 'null', 'item of type null');
+      assert.strictEqual(typeOf(arr), 'array', 'item of type array');
+      assert.strictEqual(typeOf(obj), 'object', 'item of type object');
+      assert.strictEqual(typeOf(instance), 'instance', 'item of type instance');
+      assert.strictEqual(typeOf(instance.method), 'function', 'item of type function');
+      assert.strictEqual(typeOf(instance.asyncMethod), 'function', 'item of type async function');
+      assert.strictEqual(typeOf(EmberObject.extend()), 'class', 'item of type class');
+      assert.strictEqual(typeOf(new Error()), 'error', 'item of type error');
     }
 
     ['@test Ember.typeOf(fileList)'](assert) {
@@ -49,7 +49,7 @@ moduleFor(
         let fileListElement = document.createElement('input');
         fileListElement.type = 'file';
         let fileList = fileListElement.files;
-        assert.equal(typeOf(fileList), 'filelist', 'item of type filelist');
+        assert.strictEqual(typeOf(fileList), 'filelist', 'item of type filelist');
       } else {
         assert.ok(true, 'FileList is not present on window');
       }

--- a/packages/@ember/-internals/runtime/tests/ext/rsvp_test.js
+++ b/packages/@ember/-internals/runtime/tests/ext/rsvp_test.js
@@ -24,7 +24,7 @@ moduleFor(
         });
         assert.ok(false, 'expected assertion to be thrown');
       } catch (e) {
-        assert.equal(e, error, 'error was re-thrown');
+        assert.strictEqual(e, error, 'error was re-thrown');
       }
     }
 
@@ -45,7 +45,7 @@ moduleFor(
       try {
         run(RSVP, 'reject', 'foo');
       } catch (e) {
-        assert.equal(e, 'foo', 'should throw with rejection message');
+        assert.strictEqual(e, 'foo', 'should throw with rejection message');
       } finally {
         setTesting(wasEmberTesting);
       }
@@ -76,8 +76,8 @@ moduleFor(
       try {
         setTesting(false);
         setOnerror((error) => {
-          assert.equal(error, actualError, 'expected the real error on the jqXHR');
-          assert.equal(
+          assert.strictEqual(error, actualError, 'expected the real error on the jqXHR');
+          assert.strictEqual(
             error.__reason_with_error_thrown__,
             jqXHR,
             'also retains a helpful reference to the rejection reason'
@@ -107,8 +107,8 @@ moduleFor(
       try {
         setTesting(false);
         setOnerror((error) => {
-          assert.equal(error.message, actualError, 'expected the real error on the jqXHR');
-          assert.equal(
+          assert.strictEqual(error.message, actualError, 'expected the real error on the jqXHR');
+          assert.strictEqual(
             error.__reason_with_error_thrown__,
             jqXHR,
             'also retains a helpful reference to the rejection reason'
@@ -136,7 +136,7 @@ moduleFor(
       try {
         setTesting(false);
         setOnerror((error) => {
-          assert.equal(error.message, 'a fail');
+          assert.strictEqual(error.message, 'a fail');
           assert.ok(JSON.stringify(error), 'Error can be serialized');
         });
 

--- a/packages/@ember/-internals/runtime/tests/helpers/array.js
+++ b/packages/@ember/-internals/runtime/tests/helpers/array.js
@@ -79,12 +79,12 @@ const ArrayTestsObserverClass = EmberObject.extend({
   },
 
   arrayWillChange() {
-    this.assert.equal(this._before, null, 'should only call once');
+    this.assert.strictEqual(this._before, null, 'should only call once');
     this._before = Array.prototype.slice.call(arguments);
   },
 
   arrayDidChange() {
-    this.assert.equal(this._after, null, 'should only call once');
+    this.assert.strictEqual(this._after, null, 'should only call once');
     this._after = Array.prototype.slice.call(arguments);
   },
 

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -42,19 +42,23 @@ moduleFor(
         momma.children[i].set('name', 'Juan');
         await runLoopSettled();
       }
-      assert.equal(observerFiredCount, 3, 'observer fired after changing child names');
+      assert.strictEqual(observerFiredCount, 3, 'observer fired after changing child names');
 
       observerFiredCount = 0;
       get(momma, 'children').pushObject(child4);
       await runLoopSettled();
 
-      assert.equal(observerFiredCount, 1, 'observer fired after adding a new item');
+      assert.strictEqual(observerFiredCount, 1, 'observer fired after adding a new item');
 
       observerFiredCount = 0;
       set(child4, 'name', 'Herbert');
       await runLoopSettled();
 
-      assert.equal(observerFiredCount, 1, 'observer fired after changing property on new object');
+      assert.strictEqual(
+        observerFiredCount,
+        1,
+        'observer fired after changing property on new object'
+      );
 
       set(momma, 'children', []);
       await runLoopSettled();
@@ -63,7 +67,7 @@ moduleFor(
       set(child1, 'name', 'Hanna');
       await runLoopSettled();
 
-      assert.equal(
+      assert.strictEqual(
         observerFiredCount,
         0,
         'observer did not fire after removing changing property on a removed object'

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -79,25 +79,25 @@ moduleFor(
     }
 
     ['@test should get normal properties'](assert) {
-      assert.equal(object.get('normal'), 'value');
+      assert.strictEqual(object.get('normal'), 'value');
     }
 
     ['@test should call computed properties and return their result'](assert) {
-      assert.equal(object.get('computed'), 'value');
+      assert.strictEqual(object.get('computed'), 'value');
     }
 
     ['@test should return the function for a non-computed property'](assert) {
       let value = object.get('method');
-      assert.equal(typeof value, 'function');
+      assert.strictEqual(typeof value, 'function');
     }
 
     ['@test should return null when property value is null'](assert) {
-      assert.equal(object.get('nullProperty'), null);
+      assert.strictEqual(object.get('nullProperty'), null);
     }
 
     ['@test should call unknownProperty when value is undefined'](assert) {
-      assert.equal(object.get('unknown'), 'unknown');
-      assert.equal(object.lastUnknownProperty, 'unknown');
+      assert.strictEqual(object.get('unknown'), 'unknown');
+      assert.strictEqual(object.lastUnknownProperty, 'unknown');
     }
   }
 );
@@ -133,33 +133,33 @@ moduleFor(
     }
 
     ['@test should get normal properties on Ember.Observable'](assert) {
-      assert.equal(get(objectA, 'normal'), 'value');
+      assert.strictEqual(get(objectA, 'normal'), 'value');
     }
 
     ['@test should call computed properties on Ember.Observable and return their result'](assert) {
-      assert.equal(get(objectA, 'computed'), 'value');
+      assert.strictEqual(get(objectA, 'computed'), 'value');
     }
 
     ['@test should return the function for a non-computed property on Ember.Observable'](assert) {
       let value = get(objectA, 'method');
-      assert.equal(typeof value, 'function');
+      assert.strictEqual(typeof value, 'function');
     }
 
     ['@test should return null when property value is null on Ember.Observable'](assert) {
-      assert.equal(get(objectA, 'nullProperty'), null);
+      assert.strictEqual(get(objectA, 'nullProperty'), null);
     }
 
     ['@test should call unknownProperty when value is undefined on Ember.Observable'](assert) {
-      assert.equal(get(objectA, 'unknown'), 'unknown');
-      assert.equal(objectA.lastUnknownProperty, 'unknown');
+      assert.strictEqual(get(objectA, 'unknown'), 'unknown');
+      assert.strictEqual(objectA.lastUnknownProperty, 'unknown');
     }
 
     ['@test should get normal properties on standard objects'](assert) {
-      assert.equal(get(objectB, 'normal'), 'value');
+      assert.strictEqual(get(objectB, 'normal'), 'value');
     }
 
     ['@test should return null when property is null on standard objects'](assert) {
-      assert.equal(get(objectB, 'nullProperty'), null);
+      assert.strictEqual(get(objectB, 'nullProperty'), null);
     }
 
     ['@test raise if the provided object is undefined']() {
@@ -182,7 +182,7 @@ moduleFor(
         }).create(),
       });
 
-      assert.equal(get(foo, 'bar.baz'), 'blargh');
+      assert.strictEqual(get(foo, 'bar.baz'), 'blargh');
     }
 
     ['@test should return a property at a given path relative to the passed object - JavaScript hash'](
@@ -194,7 +194,7 @@ moduleFor(
         },
       };
 
-      assert.equal(get(foo, 'bar.baz'), 'blargh');
+      assert.strictEqual(get(foo, 'bar.baz'), 'blargh');
     }
   }
 );
@@ -251,39 +251,39 @@ moduleFor(
 
     ['@test should change normal properties and return the value'](assert) {
       let ret = object.set('normal', 'changed');
-      assert.equal(object.get('normal'), 'changed');
-      assert.equal(ret, 'changed');
+      assert.strictEqual(object.get('normal'), 'changed');
+      assert.strictEqual(ret, 'changed');
     }
 
     ['@test should call computed properties passing value and return the value'](assert) {
       let ret = object.set('computed', 'changed');
-      assert.equal(object.get('_computed'), 'changed');
-      assert.equal(ret, 'changed');
+      assert.strictEqual(object.get('_computed'), 'changed');
+      assert.strictEqual(ret, 'changed');
     }
 
     ['@test should change normal properties when passing undefined'](assert) {
       let ret = object.set('normal', undefined);
-      assert.equal(object.get('normal'), undefined);
-      assert.equal(ret, undefined);
+      assert.strictEqual(object.get('normal'), undefined);
+      assert.strictEqual(ret, undefined);
     }
 
     ['@test should replace the function for a non-computed property and return the value'](assert) {
       let ret = object.set('method', 'changed');
-      assert.equal(object.get('_method'), 'method'); // make sure this was NOT run
+      assert.strictEqual(object.get('_method'), 'method'); // make sure this was NOT run
       assert.ok(typeof object.get('method') !== 'function');
-      assert.equal(ret, 'changed');
+      assert.strictEqual(ret, 'changed');
     }
 
     ['@test should replace prover when property value is null'](assert) {
       let ret = object.set('nullProperty', 'changed');
-      assert.equal(object.get('nullProperty'), 'changed');
-      assert.equal(ret, 'changed');
+      assert.strictEqual(object.get('nullProperty'), 'changed');
+      assert.strictEqual(ret, 'changed');
     }
 
     ['@test should call unknownProperty with value when property is undefined'](assert) {
       let ret = object.set('unknown', 'changed');
-      assert.equal(object.get('_unknown'), 'changed');
-      assert.equal(ret, 'changed');
+      assert.strictEqual(object.get('_unknown'), 'changed');
+      assert.strictEqual(ret, 'changed');
     }
   }
 );
@@ -362,13 +362,13 @@ moduleFor(
       let keys = w('computed dependent');
 
       keys.forEach(function (key) {
-        assert.equal(object.get(key), key, `Try #1: object.get(${key}) should run function`);
-        assert.equal(object.get(key), key, `Try #2: object.get(${key}) should run function`);
+        assert.strictEqual(object.get(key), key, `Try #1: object.get(${key}) should run function`);
+        assert.strictEqual(object.get(key), key, `Try #2: object.get(${key}) should run function`);
       });
 
       // verify each call count. cached should only be called once
       w('computedCalls dependentCalls').forEach((key) => {
-        assert.equal(object[key].length, 1, `non-cached property ${key} should be called 1x`);
+        assert.strictEqual(object[key].length, 1, `non-cached property ${key} should be called 1x`);
       });
     }
 
@@ -378,19 +378,19 @@ moduleFor(
       let values = w('value1 value2');
 
       keys.forEach((key) => {
-        assert.equal(
+        assert.strictEqual(
           object.set(key, values[0]),
           values[0],
           `Try #1: object.set(${key}, ${values[0]}) should run function`
         );
 
-        assert.equal(
+        assert.strictEqual(
           object.set(key, values[1]),
           values[1],
           `Try #2: object.set(${key}, ${values[1]}) should run function`
         );
 
-        assert.equal(
+        assert.strictEqual(
           object.set(key, values[1]),
           values[1],
           `Try #3: object.set(${key}, ${values[1]}) should not run function since it is setting same value as before`
@@ -405,13 +405,13 @@ moduleFor(
         // Cached properties first check their cached value before setting the
         // property. Other properties blindly call set.
         expectedLength = 3;
-        assert.equal(
+        assert.strictEqual(
           calls.length,
           expectedLength,
           `set(${key}) should be called the right amount of times`
         );
         for (idx = 0; idx < 2; idx++) {
-          assert.equal(
+          assert.strictEqual(
             calls[idx],
             values[idx],
             `call #${idx + 1} to set(${key}) should have passed value ${values[idx]}`
@@ -428,37 +428,49 @@ moduleFor(
       object.notifyPropertyChange('computed');
 
       object.get('computed'); // should run again
-      assert.equal(object.computedCalls.length, 2, 'should have invoked method 2x');
+      assert.strictEqual(object.computedCalls.length, 2, 'should have invoked method 2x');
     }
 
     ['@test change dependent should clear cache'](assert) {
       // call get several times to collect call count
       let ret1 = object.get('inc'); // should run func
-      assert.equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
+      assert.strictEqual(object.get('inc'), ret1, 'multiple calls should not run cached prop');
 
       object.set('changer', 'bar');
 
-      assert.equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+      assert.strictEqual(
+        object.get('inc'),
+        ret1 + 1,
+        'should increment after dependent key changes'
+      ); // should run again
     }
 
     ['@test just notifying change of dependent should clear cache'](assert) {
       // call get several times to collect call count
       let ret1 = object.get('inc'); // should run func
-      assert.equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
+      assert.strictEqual(object.get('inc'), ret1, 'multiple calls should not run cached prop');
 
       object.notifyPropertyChange('changer');
 
-      assert.equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+      assert.strictEqual(
+        object.get('inc'),
+        ret1 + 1,
+        'should increment after dependent key changes'
+      ); // should run again
     }
 
     ['@test changing dependent should clear nested cache'](assert) {
       // call get several times to collect call count
       let ret1 = object.get('nestedInc'); // should run func
-      assert.equal(object.get('nestedInc'), ret1, 'multiple calls should not run cached prop');
+      assert.strictEqual(
+        object.get('nestedInc'),
+        ret1,
+        'multiple calls should not run cached prop'
+      );
 
       object.set('changer', 'bar');
 
-      assert.equal(
+      assert.strictEqual(
         object.get('nestedInc'),
         ret1 + 1,
         'should increment after dependent key changes'
@@ -468,11 +480,15 @@ moduleFor(
     ['@test just notifying change of dependent should clear nested cache'](assert) {
       // call get several times to collect call count
       let ret1 = object.get('nestedInc'); // should run func
-      assert.equal(object.get('nestedInc'), ret1, 'multiple calls should not run cached prop');
+      assert.strictEqual(
+        object.get('nestedInc'),
+        ret1,
+        'multiple calls should not run cached prop'
+      );
 
       object.notifyPropertyChange('changer');
 
-      assert.equal(
+      assert.strictEqual(
         object.get('nestedInc'),
         ret1 + 1,
         'should increment after dependent key changes'
@@ -484,11 +500,15 @@ moduleFor(
     ['@test change dependent should clear cache when observers of dependent are called'](assert) {
       // call get several times to collect call count
       let ret1 = object.get('inc'); // should run func
-      assert.equal(object.get('inc'), ret1, 'multiple calls should not run cached prop');
+      assert.strictEqual(object.get('inc'), ret1, 'multiple calls should not run cached prop');
 
       // add observer to verify change...
       object.addObserver('inc', this, function () {
-        assert.equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
+        assert.strictEqual(
+          object.get('inc'),
+          ret1 + 1,
+          'should increment after dependent key changes'
+        ); // should run again
       });
 
       // now run
@@ -504,8 +524,8 @@ moduleFor(
 
       // setting isOff to true should clear the kvo cache
       object.set('isOff', true);
-      assert.equal(object.get('isOff'), true, 'object.isOff should be true');
-      assert.equal(object.get('isOn'), false, 'object.isOn should be false');
+      assert.strictEqual(object.get('isOff'), true, 'object.isOff should be true');
+      assert.strictEqual(object.get('isOn'), false, 'object.isOn should be false');
     }
 
     ['@test dependent keys should be able to be specified as property paths'](assert) {
@@ -519,11 +539,11 @@ moduleFor(
         }),
       });
 
-      assert.equal(depObj.get('menuPrice'), 5, 'precond - initial value returns 5');
+      assert.strictEqual(depObj.get('menuPrice'), 5, 'precond - initial value returns 5');
 
       depObj.set('menu.price', 6);
 
-      assert.equal(
+      assert.strictEqual(
         depObj.get('menuPrice'),
         6,
         'cache is properly invalidated after nested property changes'
@@ -549,12 +569,12 @@ moduleFor(
         });
       });
 
-      assert.equal(DepObj.get('price'), 5, 'precond - computed property is correct');
+      assert.strictEqual(DepObj.get('price'), 5, 'precond - computed property is correct');
 
       run(function () {
         DepObj.set('restaurant.menu.price', 10);
       });
-      assert.equal(
+      assert.strictEqual(
         DepObj.get('price'),
         10,
         'cacheable computed properties are invalidated even if no run loop occurred'
@@ -563,12 +583,12 @@ moduleFor(
       run(function () {
         DepObj.set('restaurant.menu.price', 20);
       });
-      assert.equal(
+      assert.strictEqual(
         DepObj.get('price'),
         20,
         'cacheable computed properties are invalidated after a second get before a run loop'
       );
-      assert.equal(
+      assert.strictEqual(
         DepObj.get('price'),
         20,
         'precond - computed properties remain correct after a run loop'
@@ -583,7 +603,7 @@ moduleFor(
         );
       });
 
-      assert.equal(
+      assert.strictEqual(
         DepObj.get('price'),
         15,
         'cacheable computed properties are invalidated after a middle property changes'
@@ -598,7 +618,7 @@ moduleFor(
         );
       });
 
-      assert.equal(
+      assert.strictEqual(
         DepObj.get('price'),
         25,
         'cacheable computed properties are invalidated after a middle property changes again, before a run loop'
@@ -650,19 +670,19 @@ moduleFor(
     ['@test incrementProperty and decrementProperty'](assert) {
       let newValue = object.incrementProperty('numberVal');
 
-      assert.equal(25, newValue, 'numerical value incremented');
+      assert.strictEqual(25, newValue, 'numerical value incremented');
       object.numberVal = 24;
       newValue = object.decrementProperty('numberVal');
-      assert.equal(23, newValue, 'numerical value decremented');
+      assert.strictEqual(23, newValue, 'numerical value decremented');
       object.numberVal = 25;
       newValue = object.incrementProperty('numberVal', 5);
-      assert.equal(30, newValue, 'numerical value incremented by specified increment');
+      assert.strictEqual(30, newValue, 'numerical value incremented by specified increment');
       object.numberVal = 25;
       newValue = object.incrementProperty('numberVal', -5);
-      assert.equal(20, newValue, 'minus numerical value incremented by specified increment');
+      assert.strictEqual(20, newValue, 'minus numerical value incremented by specified increment');
       object.numberVal = 25;
       newValue = object.incrementProperty('numberVal', 0);
-      assert.equal(25, newValue, 'zero numerical value incremented by specified increment');
+      assert.strictEqual(25, newValue, 'zero numerical value incremented by specified increment');
 
       expectAssertion(function () {
         newValue = object.incrementProperty('numberVal', 0 - void 0); // Increment by NaN
@@ -676,7 +696,7 @@ moduleFor(
         newValue = object.incrementProperty('numberVal', 1 / 0); // Increment by Infinity
       }, /Must pass a numeric value to incrementProperty/i);
 
-      assert.equal(
+      assert.strictEqual(
         25,
         newValue,
         'Attempting to increment by non-numeric values should not increment value'
@@ -684,13 +704,13 @@ moduleFor(
 
       object.numberVal = 25;
       newValue = object.decrementProperty('numberVal', 5);
-      assert.equal(20, newValue, 'numerical value decremented by specified increment');
+      assert.strictEqual(20, newValue, 'numerical value decremented by specified increment');
       object.numberVal = 25;
       newValue = object.decrementProperty('numberVal', -5);
-      assert.equal(30, newValue, 'minus numerical value decremented by specified increment');
+      assert.strictEqual(30, newValue, 'minus numerical value decremented by specified increment');
       object.numberVal = 25;
       newValue = object.decrementProperty('numberVal', 0);
-      assert.equal(25, newValue, 'zero numerical value decremented by specified increment');
+      assert.strictEqual(25, newValue, 'zero numerical value decremented by specified increment');
 
       expectAssertion(function () {
         newValue = object.decrementProperty('numberVal', 0 - void 0); // Decrement by NaN
@@ -704,7 +724,7 @@ moduleFor(
         newValue = object.decrementProperty('numberVal', 1 / 0); // Decrement by Infinity
       }, /Must pass a numeric value to decrementProperty/i);
 
-      assert.equal(
+      assert.strictEqual(
         25,
         newValue,
         'Attempting to decrement by non-numeric values should not decrement value'
@@ -712,9 +732,9 @@ moduleFor(
     }
 
     ['@test toggle function, should be boolean'](assert) {
-      assert.equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
-      assert.equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
-      assert.equal(
+      assert.strictEqual(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
+      assert.strictEqual(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
+      assert.strictEqual(
         object.toggleProperty('toggleVal', undefined, undefined),
         object.get('toggleVal')
       );
@@ -724,7 +744,7 @@ moduleFor(
       get(object, 'normalArray').replace(0, 0, [6]);
       await runLoopSettled();
 
-      assert.equal(object.abnormal, 'notifiedObserver', 'observer should be notified');
+      assert.strictEqual(object.abnormal, 'notifiedObserver', 'observer should be notified');
     }
   }
 );
@@ -762,7 +782,7 @@ moduleFor(
       objectC.set('normal', 'newValue');
 
       await runLoopSettled();
-      assert.equal(objectC.normal1, 'newZeroValue');
+      assert.strictEqual(objectC.normal1, 'newZeroValue');
     }
 
     async ['@test should register an observer for a property - Special case of chained property'](
@@ -772,12 +792,12 @@ moduleFor(
       objectC.objectE.set('propertyVal', 'chainedPropertyValue');
       await runLoopSettled();
 
-      assert.equal('chainedPropertyObserved', objectC.normal2);
+      assert.strictEqual('chainedPropertyObserved', objectC.normal2);
       objectC.normal2 = 'dependentValue';
       objectC.set('objectE', '');
       await runLoopSettled();
 
-      assert.equal('chainedPropertyObserved', objectC.normal2);
+      assert.strictEqual('chainedPropertyObserved', objectC.normal2);
     }
   }
 );
@@ -829,14 +849,14 @@ moduleFor(
       objectD.set('normal', 'newValue');
       await runLoopSettled();
 
-      assert.equal(objectD.normal1, 'newZeroValue');
+      assert.strictEqual(objectD.normal1, 'newZeroValue');
 
       objectD.set('normal1', 'zeroValue');
       await runLoopSettled();
 
       objectD.removeObserver('normal', objectD, 'addAction');
       objectD.set('normal', 'newValue');
-      assert.equal(objectD.normal1, 'zeroValue');
+      assert.strictEqual(objectD.normal1, 'zeroValue');
     }
 
     async ["@test should unregister an observer for a property - special case when key has a '.' in it."](
@@ -852,12 +872,12 @@ moduleFor(
       objectD.objectF.set('propertyVal', 'removedPropertyValue');
       await runLoopSettled();
 
-      assert.equal('dependentValue', objectD.normal2);
+      assert.strictEqual('dependentValue', objectD.normal2);
 
       objectD.set('objectF', '');
       await runLoopSettled();
 
-      assert.equal('dependentValue', objectD.normal2);
+      assert.strictEqual('dependentValue', objectD.normal2);
     }
 
     async ['@test removing an observer inside of an observer shouldn’t cause any problems'](
@@ -877,7 +897,7 @@ moduleFor(
       } catch (e) {
         encounteredError = true;
       }
-      assert.equal(encounteredError, false);
+      assert.strictEqual(encounteredError, false);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/system/object/base_test.js
@@ -51,19 +51,19 @@ moduleFor(
     }
 
     ['@test Should return its properties when requested using EmberObject#get'](assert) {
-      assert.equal(get(obj, 'foo'), 'bar');
-      assert.equal(get(obj, 'total'), 12345);
+      assert.strictEqual(get(obj, 'foo'), 'bar');
+      assert.strictEqual(get(obj, 'total'), 12345);
     }
 
     ['@test Should allow changing of those properties by calling EmberObject#set'](assert) {
-      assert.equal(get(obj, 'foo'), 'bar');
-      assert.equal(get(obj, 'total'), 12345);
+      assert.strictEqual(get(obj, 'foo'), 'bar');
+      assert.strictEqual(get(obj, 'total'), 12345);
 
       set(obj, 'foo', 'Chunky Bacon');
       set(obj, 'total', 12);
 
-      assert.equal(get(obj, 'foo'), 'Chunky Bacon');
-      assert.equal(get(obj, 'total'), 12);
+      assert.strictEqual(get(obj, 'foo'), 'Chunky Bacon');
+      assert.strictEqual(get(obj, 'total'), 12);
     }
   }
 );
@@ -86,8 +86,8 @@ moduleFor(
     }
 
     ['@test Checking the detect() function on an object and its subclass'](assert) {
-      assert.equal(obj.detect(obj1), true);
-      assert.equal(obj1.detect(obj), false);
+      assert.strictEqual(obj.detect(obj1), true);
+      assert.strictEqual(obj1.detect(obj), false);
     }
 
     ['@test Checking the detectInstance() function on an object and its subclass'](assert) {

--- a/packages/@ember/-internals/runtime/tests/mixins/array_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/array_test.js
@@ -58,7 +58,7 @@ moduleFor(
         length: 0,
       });
       let y = x.slice(1);
-      assert.equal(EmberArray.detect(y), true, 'mixin should be applied');
+      assert.strictEqual(EmberArray.detect(y), true, 'mixin should be applied');
     }
 
     ['@test slice supports negative index arguments'](assert) {
@@ -109,13 +109,13 @@ moduleFor(
         _count: 0,
       });
 
-      assert.equal(obj._count, 0, 'should not have invoked yet');
+      assert.strictEqual(obj._count, 0, 'should not have invoked yet');
 
       arrayContentWillChange(obj, 0, 1, 1);
       arrayContentDidChange(obj, 0, 1, 1);
       await runLoopSettled();
 
-      assert.equal(obj._count, 1, 'should have invoked');
+      assert.strictEqual(obj._count, 1, 'should have invoked');
     }
 
     afterEach() {
@@ -141,7 +141,7 @@ moduleFor(
         _after: 0,
       });
 
-      assert.equal(obj._after, 0, 'should not have fired yet');
+      assert.strictEqual(obj._after, 0, 'should not have fired yet');
     }
 
     afterEach() {
@@ -153,12 +153,12 @@ moduleFor(
       arrayContentWillChange(obj);
       await runLoopSettled();
 
-      assert.equal(obj._after, 0);
+      assert.strictEqual(obj._after, 0);
 
       arrayContentDidChange(obj);
       await runLoopSettled();
 
-      assert.equal(obj._after, 1);
+      assert.strictEqual(obj._after, 1);
     }
 
     // API variation that included items only
@@ -166,24 +166,24 @@ moduleFor(
       arrayContentWillChange(obj, 0, 1, 1);
       await runLoopSettled();
 
-      assert.equal(obj._after, 0);
+      assert.strictEqual(obj._after, 0);
 
       arrayContentDidChange(obj, 0, 1, 1);
       await runLoopSettled();
 
-      assert.equal(obj._after, 0);
+      assert.strictEqual(obj._after, 0);
     }
 
     async ['@test should notify when passed lengths are different'](assert) {
       arrayContentWillChange(obj, 0, 1, 2);
       await runLoopSettled();
 
-      assert.equal(obj._after, 0);
+      assert.strictEqual(obj._after, 0);
 
       arrayContentDidChange(obj, 0, 1, 2);
       await runLoopSettled();
 
-      assert.equal(obj._after, 1);
+      assert.strictEqual(obj._after, 1);
     }
   }
 );
@@ -202,12 +202,12 @@ moduleFor(
 
       observer = EmberObject.extend({
         arrayWillChange() {
-          assert.equal(this._before, null); // should only call once
+          assert.strictEqual(this._before, null); // should only call once
           this._before = Array.prototype.slice.call(arguments);
         },
 
         arrayDidChange() {
-          assert.equal(this._after, null); // should only call once
+          assert.strictEqual(this._after, null); // should only call once
           this._after = Array.prototype.slice.call(arguments);
         },
       }).create({
@@ -257,7 +257,7 @@ moduleFor(
     }
 
     ['@test hasArrayObservers should work'](assert) {
-      assert.equal(
+      assert.strictEqual(
         obj.hasArrayObservers,
         true,
         'correctly shows it has an array observer when one exists'
@@ -265,7 +265,7 @@ moduleFor(
 
       removeArrayObserver(obj, observer);
 
-      assert.equal(
+      assert.strictEqual(
         obj.hasArrayObservers,
         false,
         'correctly shows it has an array observer when one exists'
@@ -318,7 +318,7 @@ moduleFor(
       );
 
       await runLoopSettled();
-      assert.equal(called, 1, 'calls observer when object is pushed');
+      assert.strictEqual(called, 1, 'calls observer when object is pushed');
     }
 
     async ['@test using @each to observe arrays that does not return objects raise error'](assert) {
@@ -346,13 +346,13 @@ moduleFor(
       }, /When using @each to observe the array/);
 
       await runLoopSettled();
-      assert.equal(called, 0, 'not calls observer when object is pushed');
+      assert.strictEqual(called, 0, 'not calls observer when object is pushed');
     }
 
     ['@test `objectAt` returns correct object'](assert) {
       let arr = ['first', 'second', 'third', 'fourth'];
-      assert.equal(objectAt(arr, 2), 'third');
-      assert.equal(objectAt(arr, 4), undefined);
+      assert.strictEqual(objectAt(arr, 2), 'third');
+      assert.strictEqual(objectAt(arr, 4), undefined);
     }
 
     ['@test should be clear caches for computed properties that have dependent keys on arrays that are changed after object initialization'](
@@ -370,10 +370,10 @@ moduleFor(
       }).create();
 
       get(obj, 'resources').pushObject(EmberObject.create({ common: 'HI!' }));
-      assert.equal('HI!', get(obj, 'common'));
+      assert.strictEqual('HI!', get(obj, 'common'));
 
       set(objectAt(get(obj, 'resources'), 0), 'common', 'BYE!');
-      assert.equal('BYE!', get(obj, 'common'));
+      assert.strictEqual('BYE!', get(obj, 'common'));
     }
 
     async ['@test observers that contain @each in the path should fire only once the first time they are accessed'](
@@ -399,7 +399,7 @@ moduleFor(
       set(objectAt(get(obj, 'resources'), 0), 'common', 'BYE!');
       await runLoopSettled();
 
-      assert.equal(count, 2, 'observers should be called twice');
+      assert.strictEqual(count, 2, 'observers should be called twice');
 
       obj.destroy();
     }

--- a/packages/@ember/-internals/runtime/tests/mixins/comparable_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/comparable_test.js
@@ -28,10 +28,10 @@ moduleFor(
     }
 
     ['@test should be comparable and return the correct result'](assert) {
-      assert.equal(Comparable.detect(r1), true);
-      assert.equal(compare(r1, r1), 0);
-      assert.equal(compare(r1, r2), -1);
-      assert.equal(compare(r2, r1), 1);
+      assert.strictEqual(Comparable.detect(r1), true);
+      assert.strictEqual(compare(r1, r1), 0);
+      assert.strictEqual(compare(r1, r2), -1);
+      assert.strictEqual(compare(r2, r1), 1);
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/mixins/container_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/container_proxy_test.js
@@ -23,7 +23,11 @@ moduleFor(
     ['@test provides ownerInjection helper method'](assert) {
       let result = this.instance.ownerInjection();
 
-      assert.equal(getOwner(result), this.instance, 'returns an object with an associated owner');
+      assert.strictEqual(
+        getOwner(result),
+        this.instance,
+        'returns an object with an associated owner'
+      );
     }
 
     ['@test actions queue completes before destruction'](assert) {

--- a/packages/@ember/-internals/runtime/tests/mixins/observable_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/observable_test.js
@@ -13,8 +13,8 @@ moduleFor(
       });
 
       let pojo = obj.getProperties('firstName', 'lastName');
-      assert.equal('Steve', pojo.firstName);
-      assert.equal('Jobs', pojo.lastName);
+      assert.strictEqual('Steve', pojo.firstName);
+      assert.strictEqual('Jobs', pojo.lastName);
     }
 
     ['@test should be able to use getProperties with array parameter to get a POJO of provided keys'](
@@ -27,8 +27,8 @@ moduleFor(
       });
 
       let pojo = obj.getProperties(['firstName', 'lastName']);
-      assert.equal('Steve', pojo.firstName);
-      assert.equal('Jobs', pojo.lastName);
+      assert.strictEqual('Steve', pojo.firstName);
+      assert.strictEqual('Jobs', pojo.lastName);
     }
 
     ['@test should be able to use setProperties to set multiple properties at once'](assert) {
@@ -39,8 +39,8 @@ moduleFor(
       });
 
       obj.setProperties({ firstName: 'Tim', lastName: 'Cook' });
-      assert.equal('Tim', obj.get('firstName'));
-      assert.equal('Cook', obj.get('lastName'));
+      assert.strictEqual('Tim', obj.get('firstName'));
+      assert.strictEqual('Cook', obj.get('lastName'));
     }
 
     async ['@test calling setProperties completes safely despite exceptions'](assert) {
@@ -77,7 +77,7 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(firstNameChangedCount, 1, 'firstName should have fired once');
+      assert.strictEqual(firstNameChangedCount, 1, 'firstName should have fired once');
 
       obj.destroy();
     }
@@ -93,21 +93,21 @@ moduleFor(
         bar: 'bar',
       });
 
-      assert.equal(
+      assert.strictEqual(
         obj.cacheFor('foo'),
         undefined,
         'should return undefined if no value has been cached'
       );
       get(obj, 'foo');
 
-      assert.equal(get(obj, 'foo'), 'foo', 'precond - should cache the value');
-      assert.equal(
+      assert.strictEqual(get(obj, 'foo'), 'foo', 'precond - should cache the value');
+      assert.strictEqual(
         obj.cacheFor('foo'),
         'foo',
         'should return the cached value after it is invoked'
       );
 
-      assert.equal(
+      assert.strictEqual(
         obj.cacheFor('bar'),
         undefined,
         'returns undefined if the value is not a computed property'
@@ -119,7 +119,7 @@ moduleFor(
         age: '24',
       });
       obj.incrementProperty('age');
-      assert.equal(25, obj.get('age'));
+      assert.strictEqual(25, obj.get('age'));
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/promise_proxy_test.js
@@ -61,55 +61,59 @@ moduleFor(
         () => didRejectCount++
       );
 
-      assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-      assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+      assert.strictEqual(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
+      assert.strictEqual(
         get(proxy, 'isPending'),
         true,
         'expects the proxy to indicate that it is loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         false,
         'expects the proxy to indicate that it is not settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
       );
 
-      assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-      assert.equal(didRejectCount, 0, 'should not yet have been rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 0, 'should not yet have been rejected');
 
       run(deferred, 'resolve', value);
 
-      assert.equal(didFulfillCount, 1, 'should have been fulfilled');
-      assert.equal(didRejectCount, 0, 'should not have been rejected');
+      assert.strictEqual(didFulfillCount, 1, 'should have been fulfilled');
+      assert.strictEqual(didRejectCount, 0, 'should not have been rejected');
 
-      assert.equal(get(proxy, 'content'), value, 'expects the proxy to have content');
-      assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to still have no reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), value, 'expects the proxy to have content');
+      assert.strictEqual(
+        get(proxy, 'reason'),
+        undefined,
+        'expects the proxy to still have no reason'
+      );
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is no longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         true,
         'expects the proxy to indicate that it is fulfilled'
@@ -117,36 +121,40 @@ moduleFor(
 
       run(deferred, 'resolve', value);
 
-      assert.equal(didFulfillCount, 1, 'should still have been only fulfilled once');
-      assert.equal(didRejectCount, 0, 'should still not have been rejected');
+      assert.strictEqual(didFulfillCount, 1, 'should still have been only fulfilled once');
+      assert.strictEqual(didRejectCount, 0, 'should still not have been rejected');
 
       run(deferred, 'reject', value);
 
-      assert.equal(didFulfillCount, 1, 'should still have been only fulfilled once');
-      assert.equal(didRejectCount, 0, 'should still not have been rejected');
+      assert.strictEqual(didFulfillCount, 1, 'should still have been only fulfilled once');
+      assert.strictEqual(didRejectCount, 0, 'should still not have been rejected');
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'content'),
         value,
         'expects the proxy to have still have same content'
       );
-      assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy still to have no reason');
-      assert.equal(
+      assert.strictEqual(
+        get(proxy, 'reason'),
+        undefined,
+        'expects the proxy still to have no reason'
+      );
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is no longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         true,
         'expects the proxy to indicate that it is fulfilled'
@@ -170,55 +178,55 @@ moduleFor(
         () => didRejectCount++
       );
 
-      assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-      assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+      assert.strictEqual(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
+      assert.strictEqual(
         get(proxy, 'isPending'),
         true,
         'expects the proxy to indicate that it is loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         false,
         'expects the proxy to indicate that it is not settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
       );
 
-      assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-      assert.equal(didRejectCount, 0, 'should not yet have been rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 0, 'should not yet have been rejected');
 
       run(deferred, 'reject', reason);
 
-      assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-      assert.equal(didRejectCount, 1, 'should have been rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 1, 'should have been rejected');
 
-      assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-      assert.equal(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+      assert.strictEqual(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is not longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         true,
         'expects the proxy to indicate that it is  rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
@@ -226,32 +234,32 @@ moduleFor(
 
       run(deferred, 'reject', reason);
 
-      assert.equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
-      assert.equal(didRejectCount, 1, 'should still remain rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should stll not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 1, 'should still remain rejected');
 
       run(deferred, 'resolve', 1);
 
-      assert.equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
-      assert.equal(didRejectCount, 1, 'should still remain rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should stll not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 1, 'should still remain rejected');
 
-      assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-      assert.equal(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+      assert.strictEqual(get(proxy, 'reason'), reason, 'expects the proxy to have a reason');
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is not longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         true,
         'expects the proxy to indicate that it is  rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
@@ -273,55 +281,55 @@ moduleFor(
         () => didRejectCount++
       );
 
-      assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-      assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+      assert.strictEqual(get(proxy, 'reason'), undefined, 'expects the proxy to have no reason');
+      assert.strictEqual(
         get(proxy, 'isPending'),
         true,
         'expects the proxy to indicate that it is loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         false,
         'expects the proxy to indicate that it is not settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
       );
 
-      assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-      assert.equal(didRejectCount, 0, 'should not yet have been rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 0, 'should not yet have been rejected');
 
       run(deferred, 'reject');
 
-      assert.equal(didFulfillCount, 0, 'should not yet have been fulfilled');
-      assert.equal(didRejectCount, 1, 'should have been rejected');
+      assert.strictEqual(didFulfillCount, 0, 'should not yet have been fulfilled');
+      assert.strictEqual(didRejectCount, 1, 'should have been rejected');
 
-      assert.equal(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
-      assert.equal(get(proxy, 'reason'), undefined, 'expects the proxy to have a reason');
-      assert.equal(
+      assert.strictEqual(get(proxy, 'content'), undefined, 'expects the proxy to have no content');
+      assert.strictEqual(get(proxy, 'reason'), undefined, 'expects the proxy to have a reason');
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is not longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         true,
         'expects the proxy to indicate that it is  rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
@@ -344,7 +352,7 @@ moduleFor(
       proxy.get('promise');
 
       function onerror(reason) {
-        assert.equal(reason, expectedReason, 'expected reason');
+        assert.strictEqual(reason, expectedReason, 'expected reason');
       }
 
       RSVP.on('error', onerror);
@@ -378,22 +386,22 @@ moduleFor(
         promise: deferred.promise,
       });
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isPending'),
         true,
         'expects the proxy to indicate that it is loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         false,
         'expects the proxy to indicate that it is not settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
@@ -401,22 +409,22 @@ moduleFor(
 
       run(deferred, 'resolve');
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is no longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         true,
         'expects the proxy to indicate that it is fulfilled'
@@ -425,22 +433,22 @@ moduleFor(
       let anotherDeferred = EmberRSVP.defer();
       proxy.set('promise', anotherDeferred.promise);
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isPending'),
         true,
         'expects the proxy to indicate that it is loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         false,
         'expects the proxy to indicate that it is not settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         false,
         'expects the proxy to indicate that it is not rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
@@ -448,22 +456,22 @@ moduleFor(
 
       run(anotherDeferred, 'reject');
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isPending'),
         false,
         'expects the proxy to indicate that it is not longer loading'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isSettled'),
         true,
         'expects the proxy to indicate that it is settled'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isRejected'),
         true,
         'expects the proxy to indicate that it is  rejected'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'isFulfilled'),
         false,
         'expects the proxy to indicate that it is not fulfilled'
@@ -477,7 +485,7 @@ moduleFor(
         promise: deferred.promise,
       });
 
-      proxy.addObserver('isFulfilled', () => assert.equal(get(proxy, 'content'), true));
+      proxy.addObserver('isFulfilled', () => assert.strictEqual(get(proxy, 'content'), true));
 
       run(deferred, 'resolve', true);
     }
@@ -490,12 +498,12 @@ moduleFor(
         promise: deferred.promise,
       });
 
-      proxy.addObserver('isRejected', () => assert.equal(get(proxy, 'reason'), error));
+      proxy.addObserver('isRejected', () => assert.strictEqual(get(proxy, 'reason'), error));
 
       try {
         run(deferred, 'reject', error);
       } catch (e) {
-        assert.equal(e, error);
+        assert.strictEqual(e, error);
       }
     }
 
@@ -567,8 +575,8 @@ moduleFor(
 
       run(deferred, 'resolve', expectedValue);
 
-      assert.equal(didResolveCount, 1, 'callback called');
-      assert.equal(
+      assert.strictEqual(didResolveCount, 1, 'callback called');
+      assert.strictEqual(
         receivedValue,
         expectedValue,
         'passed value is the value the promise was resolved with'
@@ -599,8 +607,8 @@ moduleFor(
 
       run(deferred, 'reject', expectedReason);
 
-      assert.equal(didRejectCount, 1, 'callback called');
-      assert.equal(
+      assert.strictEqual(didRejectCount, 1, 'callback called');
+      assert.strictEqual(
         receivedReason,
         expectedReason,
         'passed reason is the reason the promise was rejected for'

--- a/packages/@ember/-internals/runtime/tests/mixins/target_action_support_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/target_action_support_test.js
@@ -47,8 +47,8 @@ moduleFor(
       let obj = EmberObject.extend(TargetActionSupport).create({
         target: EmberObject.create({
           send(evt, context) {
-            assert.equal(evt, 'anEvent', 'send() method was invoked with correct event name');
-            assert.equal(context, obj, 'send() method was invoked with correct context');
+            assert.strictEqual(evt, 'anEvent', 'send() method was invoked with correct event name');
+            assert.strictEqual(context, obj, 'send() method was invoked with correct context');
           },
         }),
 

--- a/packages/@ember/-internals/runtime/tests/mutable-array/addObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/addObject-test.js
@@ -6,7 +6,7 @@ class AddObjectTest extends AbstractTestCase {
   '@test should return receiver'() {
     let before = newFixture(3);
     let obj = this.newObject(before);
-    this.assert.equal(obj.addObject(before[1]), obj, 'should return receiver');
+    this.assert.strictEqual(obj.addObject(before[1]), obj, 'should return receiver');
   }
 
   async '@test [A,B].addObject(C) => [A,B,C] + notify'() {
@@ -24,19 +24,27 @@ class AddObjectTest extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-      this.assert.equal(
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('@each'),
+        0,
+        'should not have notified @each once'
+      );
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
+      this.assert.strictEqual(
         observer.timesCalled('lastObject'),
         1,
         'should have notified lastObject once'
       );
 
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject once'
@@ -61,18 +69,22 @@ class AddObjectTest extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.validate('[]'), false, 'should NOT have notified []');
-      this.assert.equal(observer.validate('@each'), false, 'should NOT have notified @each');
-      this.assert.equal(observer.validate('length'), false, 'should NOT have notified length');
-      this.assert.equal(
+      this.assert.strictEqual(observer.validate('[]'), false, 'should NOT have notified []');
+      this.assert.strictEqual(observer.validate('@each'), false, 'should NOT have notified @each');
+      this.assert.strictEqual(
+        observer.validate('length'),
+        false,
+        'should NOT have notified length'
+      );
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject once'
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/clear-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/clear-test.js
@@ -14,20 +14,28 @@ class ClearTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.clear(), obj, 'return self');
+    this.assert.strictEqual(obj.clear(), obj, 'return self');
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.validate('[]'), false, 'should NOT have notified [] once');
-    this.assert.equal(observer.validate('@each'), false, 'should NOT have notified @each once');
-    this.assert.equal(observer.validate('length'), false, 'should NOT have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.validate('[]'), false, 'should NOT have notified [] once');
+    this.assert.strictEqual(
+      observer.validate('@each'),
+      false,
+      'should NOT have notified @each once'
+    );
+    this.assert.strictEqual(
+      observer.validate('length'),
+      false,
+      'should NOT have notified length once'
+    );
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -45,23 +53,27 @@ class ClearTests extends AbstractTestCase {
     observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.clear(), obj, 'return self');
+    this.assert.strictEqual(obj.clear(), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/insertAt-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/insertAt-test.js
@@ -16,25 +16,29 @@ class InsertAtTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] did change once');
-    this.assert.equal(
+    this.assert.strictEqual(
+      observer.timesCalled('[]'),
+      1,
+      'should have notified [] did change once'
+    );
+    this.assert.strictEqual(
       observer.timesCalled('@each'),
       0,
       'should not have notified @each did change once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('length'),
       1,
       'should have notified length did change once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject did change once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject did change once'
@@ -64,18 +68,22 @@ class InsertAtTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -99,18 +107,22 @@ class InsertAtTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'
@@ -140,18 +152,22 @@ class InsertAtTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -186,18 +202,22 @@ class InsertAtTests extends AbstractTestCase {
     this.assert.deepEqual(objectAtCalls, [], 'objectAt is not called when only inserting items');
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -221,18 +241,22 @@ class InsertAtTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/popObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/popObject-test.js
@@ -9,22 +9,22 @@ class PopObjectTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.popObject(), undefined, 'popObject results');
+    this.assert.strictEqual(obj.popObject(), undefined, 'popObject results');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), [], 'post item results');
 
-    this.assert.equal(observer.validate('[]'), false, 'should NOT have notified []');
-    this.assert.equal(observer.validate('@each'), false, 'should NOT have notified @each');
-    this.assert.equal(observer.validate('length'), false, 'should NOT have notified length');
-    this.assert.equal(
+    this.assert.strictEqual(observer.validate('[]'), false, 'should NOT have notified []');
+    this.assert.strictEqual(observer.validate('@each'), false, 'should NOT have notified @each');
+    this.assert.strictEqual(observer.validate('length'), false, 'should NOT have notified length');
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -46,19 +46,23 @@ class PopObjectTests extends AbstractTestCase {
     // flush observers
     await runLoopSettled();
 
-    this.assert.equal(ret, before[0], 'return object');
+    this.assert.strictEqual(ret, before[0], 'return object');
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -80,20 +84,24 @@ class PopObjectTests extends AbstractTestCase {
     // flush observers
     await runLoopSettled();
 
-    this.assert.equal(ret, before[2], 'return object');
+    this.assert.strictEqual(ret, before[2], 'return object');
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/pushObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/pushObject-test.js
@@ -7,7 +7,7 @@ class PushObjectTests extends AbstractTestCase {
     let exp = newFixture(1)[0];
     let obj = this.newObject([]);
 
-    this.assert.equal(obj.pushObject(exp), exp, 'should return pushed object');
+    this.assert.strictEqual(obj.pushObject(exp), exp, 'should return pushed object');
   }
 
   async '@test [].pushObject(X) => [X] + notify'() {
@@ -24,17 +24,21 @@ class PushObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -58,18 +62,22 @@ class PushObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'
@@ -93,18 +101,26 @@ class PushObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject'
     );
-    this.assert.equal(observer.validate('lastObject'), true, 'should have notified lastObject');
+    this.assert.strictEqual(
+      observer.validate('lastObject'),
+      true,
+      'should have notified lastObject'
+    );
 
     obj.destroy();
   }

--- a/packages/@ember/-internals/runtime/tests/mutable-array/removeAt-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/removeAt-test.js
@@ -12,23 +12,27 @@ class RemoveAtTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(removeAt(obj, 0), obj, 'return self');
+    this.assert.strictEqual(removeAt(obj, 0), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -50,24 +54,28 @@ class RemoveAtTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(removeAt(obj, 0), obj, 'return self');
+    this.assert.strictEqual(removeAt(obj, 0), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -84,24 +92,28 @@ class RemoveAtTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(removeAt(obj, 1), obj, 'return self');
+    this.assert.strictEqual(removeAt(obj, 1), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
@@ -118,24 +130,28 @@ class RemoveAtTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(removeAt(obj, 1), obj, 'return self');
+    this.assert.strictEqual(removeAt(obj, 1), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -152,24 +168,28 @@ class RemoveAtTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(removeAt(obj, 1, 2), obj, 'return self');
+    this.assert.strictEqual(removeAt(obj, 1, 2), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -187,24 +207,28 @@ class RemoveAtTests extends AbstractTestCase {
     observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.removeAt(1, 2), obj, 'return self');
+    this.assert.strictEqual(obj.removeAt(1, 2), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/removeObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/removeObject-test.js
@@ -7,7 +7,7 @@ class RemoveObjectTests extends AbstractTestCase {
     let before = newFixture(3);
     let obj = this.newObject(before);
 
-    this.assert.equal(obj.removeObject(before[1]), obj, 'should return receiver');
+    this.assert.strictEqual(obj.removeObject(before[1]), obj, 'should return receiver');
 
     obj.destroy();
   }
@@ -26,19 +26,27 @@ class RemoveObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('@each'),
+        0,
+        'should not have notified @each once'
+      );
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject once'
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject once'
@@ -63,19 +71,23 @@ class RemoveObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.validate('[]'), false, 'should NOT have notified []');
-      this.assert.equal(observer.validate('@each'), false, 'should NOT have notified @each');
-      this.assert.equal(observer.validate('length'), false, 'should NOT have notified length');
+      this.assert.strictEqual(observer.validate('[]'), false, 'should NOT have notified []');
+      this.assert.strictEqual(observer.validate('@each'), false, 'should NOT have notified @each');
+      this.assert.strictEqual(
+        observer.validate('length'),
+        false,
+        'should NOT have notified length'
+      );
 
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject once'
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/removeObjects-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/removeObjects-test.js
@@ -9,7 +9,7 @@ class RemoveObjectsTests extends AbstractTestCase {
     let before = emberA(newFixture(3));
     let obj = before;
 
-    this.assert.equal(obj.removeObjects(before[1]), obj, 'should return receiver');
+    this.assert.strictEqual(obj.removeObjects(before[1]), obj, 'should return receiver');
   }
 
   async '@test [A,B,C].removeObjects([B]) => [A,C] + notify'() {
@@ -26,18 +26,22 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject'
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject'
@@ -61,18 +65,22 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject'
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject'
@@ -96,14 +104,22 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject');
-      this.assert.equal(
+      this.assert.strictEqual(
+        observer.timesCalled('firstObject'),
+        1,
+        'should have notified firstObject'
+      );
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject'
@@ -127,14 +143,22 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject');
-      this.assert.equal(
+      this.assert.strictEqual(
+        observer.timesCalled('firstObject'),
+        1,
+        'should have notified firstObject'
+      );
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject'
@@ -158,14 +182,26 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject');
-      this.assert.equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject');
+      this.assert.strictEqual(
+        observer.timesCalled('firstObject'),
+        1,
+        'should have notified firstObject'
+      );
+      this.assert.strictEqual(
+        observer.timesCalled('lastObject'),
+        1,
+        'should have notified lastObject'
+      );
     }
 
     destroy(obj);
@@ -185,14 +221,26 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-      this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+      this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+      this.assert.strictEqual(
+        observer.timesCalled('length'),
+        1,
+        'should have notified length once'
+      );
 
-      this.assert.equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject');
-      this.assert.equal(observer.validate('lastObject'), 1, 'should have notified lastObject');
+      this.assert.strictEqual(
+        observer.timesCalled('firstObject'),
+        1,
+        'should have notified firstObject'
+      );
+      this.assert.strictEqual(
+        observer.validate('lastObject'),
+        1,
+        'should have notified lastObject'
+      );
     }
 
     destroy(obj);
@@ -213,18 +261,22 @@ class RemoveObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
     if (observer.isEnabled) {
-      this.assert.equal(observer.validate('[]'), false, 'should NOT have notified []');
-      this.assert.equal(observer.validate('length'), false, 'should NOT have notified length');
+      this.assert.strictEqual(observer.validate('[]'), false, 'should NOT have notified []');
+      this.assert.strictEqual(
+        observer.validate('length'),
+        false,
+        'should NOT have notified length'
+      );
 
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('firstObject'),
         false,
         'should NOT have notified firstObject'
       );
-      this.assert.equal(
+      this.assert.strictEqual(
         observer.validate('lastObject'),
         false,
         'should NOT have notified lastObject'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/replace-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/replace-test.js
@@ -16,15 +16,19 @@ class ReplaceTests extends AbstractTestCase {
 
     this.assert.deepEqual(this.toArray(obj), exp, 'post item results');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -48,17 +52,17 @@ class ReplaceTests extends AbstractTestCase {
     // flush observers
     await runLoopSettled();
 
-    this.assert.equal(
+    this.assert.strictEqual(
       called,
       0,
       'should NOT have called objectAt upon replace when firstObject/lastObject are not cached'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject since not cached'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject since not cached'
@@ -84,16 +88,20 @@ class ReplaceTests extends AbstractTestCase {
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -119,16 +127,20 @@ class ReplaceTests extends AbstractTestCase {
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.validate('length'), false, 'should NOT have notified length');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.validate('length'), false, 'should NOT have notified length');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -154,16 +166,20 @@ class ReplaceTests extends AbstractTestCase {
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -188,16 +204,20 @@ class ReplaceTests extends AbstractTestCase {
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
@@ -222,16 +242,20 @@ class ReplaceTests extends AbstractTestCase {
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/reverseObjects-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/reverseObjects-test.js
@@ -11,23 +11,27 @@ class ReverseObjectsTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.reverseObjects(), obj, 'return self');
+    this.assert.strictEqual(obj.reverseObjects(), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 0, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 0, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/setObjects-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/setObjects-test.js
@@ -11,23 +11,27 @@ class SetObjectsTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.setObjects(after), obj, 'return self');
+    this.assert.strictEqual(obj.setObjects(after), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -44,23 +48,27 @@ class SetObjectsTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.setObjects(after), obj, 'return self');
+    this.assert.strictEqual(obj.setObjects(after), obj, 'return self');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/shiftObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/shiftObject-test.js
@@ -11,36 +11,36 @@ class ShiftObjectTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.shiftObject(), undefined);
+    this.assert.strictEqual(obj.shiftObject(), undefined);
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('[]', undefined, 1),
       false,
       'should NOT have notified [] once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('@each', undefined, 1),
       false,
       'should NOT have notified @each once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('length', undefined, 1),
       false,
       'should NOT have notified length once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       false,
       'should NOT have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'
@@ -57,23 +57,27 @@ class ShiftObjectTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.shiftObject(), before[0], 'should return object');
+    this.assert.strictEqual(obj.shiftObject(), before[0], 'should return object');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -90,24 +94,28 @@ class ShiftObjectTests extends AbstractTestCase {
 
     obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
 
-    this.assert.equal(obj.shiftObject(), before[0], 'should return object');
+    this.assert.strictEqual(obj.shiftObject(), before[0], 'should return object');
 
     // flush observers
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject once'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/unshiftObject-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/unshiftObject-test.js
@@ -7,7 +7,7 @@ class UnshiftObjectTests extends AbstractTestCase {
     let obj = this.newObject([]);
     let item = newFixture(1)[0];
 
-    this.assert.equal(obj.unshiftObject(item), item, 'should return unshifted object');
+    this.assert.strictEqual(obj.unshiftObject(item), item, 'should return unshifted object');
   }
 
   async '@test [].unshiftObject(X) => [X] + notify'() {
@@ -25,17 +25,21 @@ class UnshiftObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -59,18 +63,22 @@ class UnshiftObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -94,14 +102,22 @@ class UnshiftObjectTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(observer.validate('firstObject'), true, 'should have notified firstObject');
-    this.assert.equal(
+    this.assert.strictEqual(
+      observer.validate('firstObject'),
+      true,
+      'should have notified firstObject'
+    );
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'

--- a/packages/@ember/-internals/runtime/tests/mutable-array/unshiftObjects-test.js
+++ b/packages/@ember/-internals/runtime/tests/mutable-array/unshiftObjects-test.js
@@ -7,7 +7,7 @@ class UnshiftObjectsTests extends AbstractTestCase {
     let obj = this.newObject([]);
     let items = newFixture(3);
 
-    this.assert.equal(obj.unshiftObjects(items), obj, 'should return receiver');
+    this.assert.strictEqual(obj.unshiftObjects(items), obj, 'should return receiver');
   }
 
   async '@test [].unshiftObjects([A,B,C]) => [A,B,C] + notify'() {
@@ -24,17 +24,21 @@ class UnshiftObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), items, 'post item results');
-    this.assert.equal(get(obj, 'length'), items.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), items.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.timesCalled('lastObject'),
       1,
       'should have notified lastObject once'
@@ -58,18 +62,22 @@ class UnshiftObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
-    this.assert.equal(
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(
       observer.timesCalled('firstObject'),
       1,
       'should have notified firstObject once'
     );
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'
@@ -93,18 +101,22 @@ class UnshiftObjectsTests extends AbstractTestCase {
     await runLoopSettled();
 
     this.assert.deepEqual(this.toArray(obj), after, 'post item results');
-    this.assert.equal(get(obj, 'length'), after.length, 'length');
+    this.assert.strictEqual(get(obj, 'length'), after.length, 'length');
 
-    this.assert.equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
-    this.assert.equal(observer.timesCalled('@each'), 0, 'should not have notified @each once');
-    this.assert.equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    this.assert.strictEqual(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    this.assert.strictEqual(
+      observer.timesCalled('@each'),
+      0,
+      'should not have notified @each once'
+    );
+    this.assert.strictEqual(observer.timesCalled('length'), 1, 'should have notified length once');
 
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('firstObject'),
       true,
       'should NOT have notified firstObject'
     );
-    this.assert.equal(
+    this.assert.strictEqual(
       observer.validate('lastObject'),
       false,
       'should NOT have notified lastObject'

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/arranged_content_test.js
@@ -46,21 +46,21 @@ moduleFor(
     }
 
     ['@test indexOf - returns index of object in arrangedContent'](assert) {
-      assert.equal(array.indexOf(4), 1, 'returns arranged index');
+      assert.strictEqual(array.indexOf(4), 1, 'returns arranged index');
     }
 
     ['@test lastIndexOf - returns last index of object in arrangedContent'](assert) {
       array.get('content').pushObject(4);
-      assert.equal(array.lastIndexOf(4), 2, 'returns last arranged index');
+      assert.strictEqual(array.lastIndexOf(4), 2, 'returns last arranged index');
     }
 
     ['@test objectAt - returns object at index in arrangedContent'](assert) {
-      assert.equal(objectAt(array, 1), 4, 'returns object at index');
+      assert.strictEqual(objectAt(array, 1), 4, 'returns object at index');
     }
 
     // Not sure if we need a specific test for it, since it's internal
     ['@test objectAtContent - returns object at index in arrangedContent'](assert) {
-      assert.equal(array.objectAtContent(1), 4, 'returns object at index');
+      assert.strictEqual(array.objectAtContent(1), 4, 'returns object at index');
     }
 
     ['@test objectsAt - returns objects at indices in arrangedContent'](assert) {
@@ -91,11 +91,11 @@ moduleFor(
     }
 
     ['@test lastObject - returns last arranged object'](assert) {
-      assert.equal(array.get('lastObject'), 1, 'returns last arranged object');
+      assert.strictEqual(array.get('lastObject'), 1, 'returns last arranged object');
     }
 
     ['@test firstObject - returns first arranged object'](assert) {
-      assert.equal(array.get('firstObject'), 5, 'returns first arranged object');
+      assert.strictEqual(array.get('firstObject'), 5, 'returns first arranged object');
     }
   }
 );
@@ -181,21 +181,21 @@ moduleFor(
     }
 
     ['@test indexOf - returns index of object in arrangedContent'](assert) {
-      assert.equal(array.indexOf('4'), 1, 'returns arranged index');
+      assert.strictEqual(array.indexOf('4'), 1, 'returns arranged index');
     }
 
     ['@test lastIndexOf - returns last index of object in arrangedContent'](assert) {
       array.get('content').pushObject(4);
-      assert.equal(array.lastIndexOf('4'), 2, 'returns last arranged index');
+      assert.strictEqual(array.lastIndexOf('4'), 2, 'returns last arranged index');
     }
 
     ['@test objectAt - returns object at index in arrangedContent'](assert) {
-      assert.equal(objectAt(array, 1), '4', 'returns object at index');
+      assert.strictEqual(objectAt(array, 1), '4', 'returns object at index');
     }
 
     // Not sure if we need a specific test for it, since it's internal
     ['@test objectAtContent - returns object at index in arrangedContent'](assert) {
-      assert.equal(array.objectAtContent(1), '4', 'returns object at index');
+      assert.strictEqual(array.objectAtContent(1), '4', 'returns object at index');
     }
 
     ['@test objectsAt - returns objects at indices in arrangedContent'](assert) {
@@ -219,11 +219,11 @@ moduleFor(
     }
 
     ['@test lastObject - returns last arranged object'](assert) {
-      assert.equal(array.get('lastObject'), '1', 'returns last arranged object');
+      assert.strictEqual(array.get('lastObject'), '1', 'returns last arranged object');
     }
 
     ['@test firstObject - returns first arranged object'](assert) {
-      assert.equal(array.get('firstObject'), '5', 'returns first arranged object');
+      assert.strictEqual(array.get('firstObject'), '5', 'returns first arranged object');
     }
   }
 );
@@ -252,7 +252,7 @@ moduleFor(
 
     ['@test popObject - removes last object in arrangedContent'](assert) {
       let popped = array.popObject();
-      assert.equal(popped, '5', 'returns last object');
+      assert.strictEqual(popped, '5', 'returns last object');
       assert.deepEqual(array.toArray(), ['1', '2', '4'], 'removes from content');
     }
 
@@ -268,7 +268,7 @@ moduleFor(
 
     ['@test shiftObject - removes from start of arrangedContent'](assert) {
       let shifted = array.shiftObject();
-      assert.equal(shifted, '1', 'returns first object');
+      assert.strictEqual(shifted, '1', 'returns first object');
       assert.deepEqual(array.toArray(), ['2', '4', '5'], 'removes object from content');
     }
   }

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
@@ -15,11 +15,11 @@ moduleFor(
         content: a([1, 2, 3]),
       });
 
-      assert.equal(proxy.get('length'), 3, 'precond - length is 3');
+      assert.strictEqual(proxy.get('length'), 3, 'precond - length is 3');
 
       proxy.set('content', null);
 
-      assert.equal(proxy.get('length'), 0, 'length updates');
+      assert.strictEqual(proxy.get('length'), 0, 'length updates');
     }
 
     ['@test should update length for null content when there is a computed property watching length'](
@@ -31,7 +31,7 @@ moduleFor(
         content: a([1, 2, 3]),
       });
 
-      assert.equal(proxy.get('length'), 3, 'precond - length is 3');
+      assert.strictEqual(proxy.get('length'), 3, 'precond - length is 3');
 
       // Consume computed property that depends on length
       proxy.get('isEmpty');
@@ -39,7 +39,7 @@ moduleFor(
       // update content
       proxy.set('content', null);
 
-      assert.equal(proxy.get('length'), 0, 'length updates');
+      assert.strictEqual(proxy.get('length'), 0, 'length updates');
     }
 
     ['@test getting length does not recompute the object cache'](assert) {
@@ -54,28 +54,28 @@ moduleFor(
         content: a([1, 2, 3, 4, 5]),
       });
 
-      assert.equal(get(proxy, 'length'), 5);
+      assert.strictEqual(get(proxy, 'length'), 5);
       assert.deepEqual(indexes, []);
 
       indexes.length = 0;
       proxy.set('content', a([6, 7, 8]));
-      assert.equal(get(proxy, 'length'), 3);
+      assert.strictEqual(get(proxy, 'length'), 3);
       assert.deepEqual(indexes, []);
 
       indexes.length = 0;
       proxy.content.replace(1, 0, [1, 2, 3]);
-      assert.equal(get(proxy, 'length'), 6);
+      assert.strictEqual(get(proxy, 'length'), 6);
       assert.deepEqual(indexes, []);
     }
 
     '@test accessing length after content set to null'(assert) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       set(obj, 'content', null);
 
-      assert.equal(obj.length, 0, 'length is 0 without content');
+      assert.strictEqual(obj.length, 0, 'length is 0 without content');
       assert.deepEqual(obj.content, null, 'content was updated');
     }
 
@@ -89,67 +89,67 @@ moduleFor(
         content: ['foo', 'bar'],
       });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       runTask(() => obj.destroy());
 
-      assert.equal(obj.length, 0, 'length is 0 without content');
+      assert.strictEqual(obj.length, 0, 'length is 0 without content');
       assert.deepEqual(obj.content, null, 'content was updated');
     }
 
     '@test setting length to 0'(assert) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       set(obj, 'length', 0);
 
-      assert.equal(obj.length, 0, 'length was updated');
+      assert.strictEqual(obj.length, 0, 'length was updated');
       assert.deepEqual(obj.content, [], 'content length was truncated');
     }
 
     '@test setting length to smaller value'(assert) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       set(obj, 'length', 1);
 
-      assert.equal(obj.length, 1, 'length was updated');
+      assert.strictEqual(obj.length, 1, 'length was updated');
       assert.deepEqual(obj.content, ['foo'], 'content length was truncated');
     }
 
     '@test setting length to larger value'(assert) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       set(obj, 'length', 3);
 
-      assert.equal(obj.length, 3, 'length was updated');
+      assert.strictEqual(obj.length, 3, 'length was updated');
       assert.deepEqual(obj.content, ['foo', 'bar', undefined], 'content length was updated');
     }
 
     '@test setting length after content set to null'(assert) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       set(obj, 'content', null);
-      assert.equal(obj.length, 0, 'length was updated');
+      assert.strictEqual(obj.length, 0, 'length was updated');
 
       set(obj, 'length', 0);
-      assert.equal(obj.length, 0, 'length is still updated');
+      assert.strictEqual(obj.length, 0, 'length is still updated');
     }
 
     '@test setting length to greater than zero'(assert) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
-      assert.equal(obj.length, 2, 'precond');
+      assert.strictEqual(obj.length, 2, 'precond');
 
       set(obj, 'length', 1);
 
-      assert.equal(obj.length, 1, 'length was updated');
+      assert.strictEqual(obj.length, 1, 'length was updated');
       assert.deepEqual(obj.content, ['foo'], 'content length was truncated');
     }
 
@@ -181,28 +181,32 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(obj.get('colors.content.length'), 3);
-      assert.equal(obj.get('colors.length'), 3);
-      assert.equal(obj.get('length'), 3);
+      assert.strictEqual(obj.get('colors.content.length'), 3);
+      assert.strictEqual(obj.get('colors.length'), 3);
+      assert.strictEqual(obj.get('length'), 3);
 
-      assert.equal(aCalled, 1, 'expected observer `length` to be called ONCE');
-      assert.equal(bCalled, 1, 'expected observer `colors.length` to be called ONCE');
-      assert.equal(cCalled, 1, 'expected observer `colors.content.length` to be called ONCE');
-      assert.equal(dCalled, 1, 'expected observer `colors.[]` to be called ONCE');
-      assert.equal(eCalled, 1, 'expected observer `colors.content.[]` to be called ONCE');
+      assert.strictEqual(aCalled, 1, 'expected observer `length` to be called ONCE');
+      assert.strictEqual(bCalled, 1, 'expected observer `colors.length` to be called ONCE');
+      assert.strictEqual(cCalled, 1, 'expected observer `colors.content.length` to be called ONCE');
+      assert.strictEqual(dCalled, 1, 'expected observer `colors.[]` to be called ONCE');
+      assert.strictEqual(eCalled, 1, 'expected observer `colors.content.[]` to be called ONCE');
 
       obj.get('colors').pushObjects(['green', 'red']);
       await runLoopSettled();
 
-      assert.equal(obj.get('colors.content.length'), 5);
-      assert.equal(obj.get('colors.length'), 5);
-      assert.equal(obj.get('length'), 5);
+      assert.strictEqual(obj.get('colors.content.length'), 5);
+      assert.strictEqual(obj.get('colors.length'), 5);
+      assert.strictEqual(obj.get('length'), 5);
 
-      assert.equal(aCalled, 2, 'expected observer `length` to be called TWICE');
-      assert.equal(bCalled, 2, 'expected observer `colors.length` to be called TWICE');
-      assert.equal(cCalled, 2, 'expected observer `colors.content.length` to be called TWICE');
-      assert.equal(dCalled, 2, 'expected observer `colors.[]` to be called TWICE');
-      assert.equal(eCalled, 2, 'expected observer `colors.content.[]` to be called TWICE');
+      assert.strictEqual(aCalled, 2, 'expected observer `length` to be called TWICE');
+      assert.strictEqual(bCalled, 2, 'expected observer `colors.length` to be called TWICE');
+      assert.strictEqual(
+        cCalled,
+        2,
+        'expected observer `colors.content.length` to be called TWICE'
+      );
+      assert.strictEqual(dCalled, 2, 'expected observer `colors.[]` to be called TWICE');
+      assert.strictEqual(eCalled, 2, 'expected observer `colors.content.[]` to be called TWICE');
 
       obj.destroy();
     }
@@ -214,19 +218,19 @@ moduleFor(
 
       let lengthCache = createCache(() => proxy.length);
 
-      assert.equal(getValue(lengthCache), 3, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 3, 'length is correct');
 
       proxy.pushObject(4);
 
-      assert.equal(getValue(lengthCache), 4, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 4, 'length is correct');
 
       proxy.removeObject(1);
 
-      assert.equal(getValue(lengthCache), 3, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 3, 'length is correct');
 
       proxy.set('content', []);
 
-      assert.equal(getValue(lengthCache), 0, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 0, 'length is correct');
     }
 
     async ['@test array proxy length is reactive when accessed using get'](assert) {
@@ -236,19 +240,19 @@ moduleFor(
 
       let lengthCache = createCache(() => get(proxy, 'length'));
 
-      assert.equal(getValue(lengthCache), 3, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 3, 'length is correct');
 
       proxy.pushObject(4);
 
-      assert.equal(getValue(lengthCache), 4, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 4, 'length is correct');
 
       proxy.removeObject(1);
 
-      assert.equal(getValue(lengthCache), 3, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 3, 'length is correct');
 
       proxy.set('content', []);
 
-      assert.equal(getValue(lengthCache), 0, 'length is correct');
+      assert.strictEqual(getValue(lengthCache), 0, 'length is correct');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/core_object_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/core_object_test.js
@@ -35,7 +35,7 @@ moduleFor(
       });
 
       let proxy = get(obj, 'someProxyishThing');
-      assert.equal(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
+      assert.strictEqual(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
     }
 
     ['@test should not trigger proxy assertion when retrieving a re-registered proxy (GH#16610)'](
@@ -53,7 +53,7 @@ moduleFor(
       // by the host app down to the engine
       owner.register('thing:one', someProxyishThing, { instantiate: false });
 
-      assert.equal(owner.lookup('thing:one'), someProxyishThing);
+      assert.strictEqual(owner.lookup('thing:one'), someProxyishThing);
     }
 
     ['@test should not trigger proxy assertion when probing for a "symbol"'](assert) {
@@ -63,7 +63,7 @@ moduleFor(
         },
       }).create();
 
-      assert.equal(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
+      assert.strictEqual(get(proxy, 'lolol'), true, 'should be able to get data from a proxy');
 
       // should not trigger an assertion
       getOwner(proxy);
@@ -79,7 +79,7 @@ moduleFor(
           this._super(...arguments);
           let localOwner = getOwner(this);
 
-          assert.equal(localOwner, owner, 'should be able to `getOwner` in init');
+          assert.strictEqual(localOwner, owner, 'should be able to `getOwner` in init');
         },
         unknownProperty() {
           return undefined;
@@ -108,7 +108,7 @@ moduleFor(
       assert.deepEqual(Object.keys(test).sort(), ['anotherProp', 'id', 'myProp']);
       await runLoopSettled();
 
-      assert.equal(callCount, 1);
+      assert.strictEqual(callCount, 1);
 
       test.destroy();
     }

--- a/packages/@ember/-internals/runtime/tests/system/namespace/base_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/namespace/base_test.js
@@ -45,14 +45,14 @@ moduleFor(
 
     ['@test Namespace is found and named'](assert) {
       let nsA = (lookup.NamespaceA = Namespace.create());
-      assert.equal(
+      assert.strictEqual(
         nsA.toString(),
         'NamespaceA',
         'namespaces should have a name if they are on lookup'
       );
 
       let nsB = (lookup.NamespaceB = Namespace.create());
-      assert.equal(
+      assert.strictEqual(
         nsB.toString(),
         'NamespaceB',
         'namespaces work if created after the first namespace processing pass'
@@ -63,16 +63,24 @@ moduleFor(
       let nsA = (lookup.NamespaceA = Namespace.create());
       nsA.Foo = EmberObject.extend();
       Namespace.processAll();
-      assert.equal(getName(nsA.Foo), 'NamespaceA.Foo', 'Classes pick up their parent namespace');
+      assert.strictEqual(
+        getName(nsA.Foo),
+        'NamespaceA.Foo',
+        'Classes pick up their parent namespace'
+      );
 
       nsA.Bar = EmberObject.extend();
       Namespace.processAll();
-      assert.equal(getName(nsA.Bar), 'NamespaceA.Bar', 'New Classes get the naming treatment too');
+      assert.strictEqual(
+        getName(nsA.Bar),
+        'NamespaceA.Bar',
+        'New Classes get the naming treatment too'
+      );
 
       let nsB = (lookup.NamespaceB = Namespace.create());
       nsB.Foo = EmberObject.extend();
       Namespace.processAll();
-      assert.equal(
+      assert.strictEqual(
         getName(nsB.Foo),
         'NamespaceB.Foo',
         'Classes in new namespaces get the naming treatment'
@@ -88,7 +96,7 @@ moduleFor(
     ['@test Lowercase namespaces are no longer supported'](assert) {
       let nsC = (lookup.namespaceC = Namespace.create());
       Namespace.processAll();
-      assert.equal(getName(nsC), guidFor(nsC));
+      assert.strictEqual(getName(nsC), guidFor(nsC));
     }
 
     ['@test A namespace can be assigned a custom name'](assert) {
@@ -106,12 +114,12 @@ moduleFor(
 
         Namespace.processAll();
 
-        assert.equal(
+        assert.strictEqual(
           getName(nsA.Foo),
           'NamespaceA.Foo',
           "The namespace's name is used when the namespace is not in the lookup object"
         );
-        assert.equal(
+        assert.strictEqual(
           getName(nsB.Foo),
           'CustomNamespaceB.Foo',
           "The namespace's name is used when the namespace is in the lookup object"
@@ -131,8 +139,8 @@ moduleFor(
 
       Namespace.processAll();
 
-      assert.equal(getName(namespace.ClassA), 'NS.ClassA');
-      assert.equal(getName(namespace.ClassB), 'NS.ClassB');
+      assert.strictEqual(getName(namespace.ClassA), 'NS.ClassA');
+      assert.strictEqual(getName(namespace.ClassB), 'NS.ClassB');
     }
 
     ['@test A namespace can be looked up by its name'](assert) {
@@ -140,16 +148,16 @@ moduleFor(
       let UI = (lookup.UI = Namespace.create());
       let CF = (lookup.CF = Namespace.create());
 
-      assert.equal(Namespace.byName('NS'), NS);
-      assert.equal(Namespace.byName('UI'), UI);
-      assert.equal(Namespace.byName('CF'), CF);
+      assert.strictEqual(Namespace.byName('NS'), NS);
+      assert.strictEqual(Namespace.byName('UI'), UI);
+      assert.strictEqual(Namespace.byName('CF'), CF);
     }
 
     ['@test A nested namespace can be looked up by its name'](assert) {
       let UI = (lookup.UI = Namespace.create());
       UI.Nav = Namespace.create();
 
-      assert.equal(Namespace.byName('UI.Nav'), UI.Nav);
+      assert.strictEqual(Namespace.byName('UI.Nav'), UI.Nav);
 
       run(UI.Nav, 'destroy');
     }
@@ -160,7 +168,11 @@ moduleFor(
       let CF = (lookup.CF = Namespace.create());
 
       run(CF, 'destroy');
-      assert.equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
+      assert.strictEqual(
+        Namespace.byName('CF'),
+        undefined,
+        'namespace can not be found after destroyed'
+      );
     }
 
     ['@test Destroying a namespace after looking up removes it from the list of namespaces'](
@@ -168,10 +180,18 @@ moduleFor(
     ) {
       let CF = (lookup.CF = Namespace.create());
 
-      assert.equal(Namespace.byName('CF'), CF, 'precondition - namespace can be looked up by name');
+      assert.strictEqual(
+        Namespace.byName('CF'),
+        CF,
+        'precondition - namespace can be looked up by name'
+      );
 
       run(CF, 'destroy');
-      assert.equal(Namespace.byName('CF'), undefined, 'namespace can not be found after destroyed');
+      assert.strictEqual(
+        Namespace.byName('CF'),
+        undefined,
+        'namespace can not be found after destroyed'
+      );
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/computed_test.js
@@ -17,9 +17,9 @@ function K() {
 }
 
 function testGet(assert, expect, x, y) {
-  assert.equal(get(x, y), expect);
-  assert.equal(get(x, y), expect);
-  assert.equal(x.get(y), expect);
+  assert.strictEqual(get(x, y), expect);
+  assert.strictEqual(get(x, y), expect);
+  assert.strictEqual(x.get(y), expect);
 }
 
 moduleFor(
@@ -146,7 +146,7 @@ moduleFor(
         computedProperty: computed(function () {}).meta({ key: 'keyValue' }),
       });
 
-      assert.equal(
+      assert.strictEqual(
         get(MyClass.metaForProperty('computedProperty'), 'key'),
         'keyValue',
         'metadata saved on the computed property can be retrieved'
@@ -158,7 +158,7 @@ moduleFor(
         staticProperty: 12,
       });
 
-      assert.equal(
+      assert.strictEqual(
         typeof ClassWithNoMetadata.metaForProperty('computedProperty'),
         'object',
         'returns empty hash if no metadata has been saved'
@@ -356,8 +356,8 @@ moduleFor(
       let obj1 = Obj.create({ name: '1' });
       let obj2 = Obj.create({ name: '2' });
 
-      assert.equal(obj1.get('name'), '1');
-      assert.equal(obj2.get('name'), '2');
+      assert.strictEqual(obj1.get('name'), '1');
+      assert.strictEqual(obj2.get('name'), '2');
 
       obj1.destroy();
       obj2.destroy();
@@ -380,9 +380,9 @@ moduleFor(
 
       let instance = MyClass.create();
 
-      assert.equal(instance.foo, 123, 'getters work');
+      assert.strictEqual(instance.foo, 123, 'getters work');
       instance.foo = 456;
-      assert.equal(instance.bar, 456, 'setters work');
+      assert.strictEqual(instance.bar, 456, 'setters work');
     }
 
     ['@test @each on maybe array'](assert) {

--- a/packages/@ember/-internals/runtime/tests/system/object/create_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/create_test.js
@@ -14,7 +14,7 @@ moduleFor(
       expectNoDeprecation();
 
       let o = EmberObject.create({ ohai: 'there' });
-      assert.equal(o.get('ohai'), 'there');
+      assert.strictEqual(o.get('ohai'), 'there');
     }
 
     ['@test explicit injection does not raise deprecation'](assert) {
@@ -32,7 +32,7 @@ moduleFor(
       owner.register('foo:main', FooObject);
 
       let obj = owner.lookup('foo:main');
-      assert.equal(obj.foo.bar, 'foo');
+      assert.strictEqual(obj.foo.bar, 'foo');
     }
 
     ['@test implicit injections raises deprecation']() {
@@ -64,7 +64,7 @@ moduleFor(
       });
 
       let o = MyClass.create({ foo: 'bar' });
-      assert.equal(o.get('foo'), 'bar');
+      assert.strictEqual(o.get('foo'), 'bar');
     }
 
     ['@test sets up mandatory setters for simple properties watched with observers'](assert) {
@@ -76,7 +76,7 @@ moduleFor(
         });
 
         let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-        assert.equal(o.get('foo'), 'bar');
+        assert.strictEqual(o.get('foo'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(descriptor.set, 'Mandatory setter was setup');
@@ -101,7 +101,7 @@ moduleFor(
         });
 
         let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-        assert.equal(o.get('fooAlias'), 'bar');
+        assert.strictEqual(o.get('fooAlias'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(descriptor.set, 'Mandatory setter was setup');
@@ -124,7 +124,7 @@ moduleFor(
         });
 
         let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-        assert.equal(o.get('fooAlias'), 'bar');
+        assert.strictEqual(o.get('fooAlias'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(descriptor.set, 'Mandatory setter was setup');
@@ -148,7 +148,7 @@ moduleFor(
         });
 
         let o = MyClass.create({});
-        assert.equal(o.get('foo'), 'bar');
+        assert.strictEqual(o.get('foo'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(!descriptor, 'Mandatory setter was not setup');
@@ -222,7 +222,7 @@ moduleFor(
       let baseObj = EmberObject.create({ foo: 'bar' });
       let secondaryObj = EmberObject.create(baseObj);
 
-      assert.equal(
+      assert.strictEqual(
         secondaryObj.foo,
         baseObj.foo,
         'Em.O.create inherits properties from EmberObject parameter'
@@ -250,7 +250,7 @@ moduleFor(
           this._super(...arguments);
           let localOwner = getOwner(this);
 
-          assert.equal(localOwner, owner, 'should be able to `getOwner` in init');
+          assert.strictEqual(localOwner, owner, 'should be able to `getOwner` in init');
         },
         unknownProperty() {
           return undefined;
@@ -271,7 +271,7 @@ moduleFor(
       let instance = componentFactory.create();
 
       assert.deepEqual(Object.keys(instance), [], 'no enumerable properties were added');
-      assert.equal(getOwner(instance), container.owner, 'owner was defined on the instance');
+      assert.strictEqual(getOwner(instance), container.owner, 'owner was defined on the instance');
       assert.ok(getFactoryFor(instance), 'factory was defined on the instance');
     }
 
@@ -287,7 +287,7 @@ moduleFor(
       let instance = container.lookup('component:foo-bar');
 
       assert.deepEqual(Object.keys(instance), [], 'no enumerable properties were added');
-      assert.equal(getOwner(instance), container.owner, 'owner was defined on the instance');
+      assert.strictEqual(getOwner(instance), container.owner, 'owner was defined on the instance');
       assert.ok(getFactoryFor(instance), 'factory was defined on the instance');
     }
   }

--- a/packages/@ember/-internals/runtime/tests/system/object/destroy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/destroy_test.js
@@ -62,7 +62,7 @@ moduleFor(
       obj.set('foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 1, 'observer was fired once');
+      assert.strictEqual(count, 1, 'observer was fired once');
 
       beginPropertyChanges();
       obj.set('foo', 'quux');
@@ -70,7 +70,7 @@ moduleFor(
       endPropertyChanges();
       await runLoopSettled();
 
-      assert.equal(count, 1, 'observer was not called after object was destroyed');
+      assert.strictEqual(count, 1, 'observer was not called after object was destroyed');
     }
 
     async ['@test destroyed objects should not see each others changes during teardown but a long lived object should'](
@@ -144,8 +144,12 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(shouldNotChange, 0, 'destroyed graph objs should not see change in willDestroy');
-      assert.equal(shouldChange, 1, 'long lived should see change in willDestroy');
+      assert.strictEqual(
+        shouldNotChange,
+        0,
+        'destroyed graph objs should not see change in willDestroy'
+      );
+      assert.strictEqual(shouldChange, 1, 'long lived should see change in willDestroy');
 
       longLived.destroy();
     }

--- a/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/es-compatibility-test.js
@@ -36,17 +36,17 @@ moduleFor(
       let myObject = MyObject.create({ passedProperty: 'passed-property' });
 
       assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (create)');
-      assert.equal(
+      assert.strictEqual(
         myObject.postInitProperty,
         'post-init-property',
         'constructor property available on instance (create)'
       );
-      assert.equal(
+      assert.strictEqual(
         myObject.initProperty,
         'init-property',
         'init property available on instance (create)'
       );
-      assert.equal(
+      assert.strictEqual(
         myObject.passedProperty,
         'passed-property',
         'passed property available on instance (create)'
@@ -185,8 +185,8 @@ moduleFor(
       class MyObject extends EmberObject.extend(Mixin1, Mixin2) {}
 
       let myObject = MyObject.create();
-      assert.equal(myObject.property1, 'data-1', 'includes the first mixin');
-      assert.equal(myObject.property2, 'data-2', 'includes the second mixin');
+      assert.strictEqual(myObject.property1, 'data-1', 'includes the first mixin');
+      assert.strictEqual(myObject.property2, 'data-2', 'includes the second mixin');
     }
 
     ['@test using instanceof'](assert) {
@@ -259,8 +259,8 @@ moduleFor(
         bar: 789,
       });
 
-      assert.equal(obj.foo, 456, 'sets class fields on instance correctly');
-      assert.equal(obj.bar, 789, 'sets passed in properties on instance correctly');
+      assert.strictEqual(obj.foo, 456, 'sets class fields on instance correctly');
+      assert.strictEqual(obj.bar, 789, 'sets passed in properties on instance correctly');
     }
 
     ['@test calling metaForProperty on a native class works'](assert) {
@@ -329,40 +329,40 @@ moduleFor(
       removeObserver(B.prototype, 'foo', null, 'fooDidChange');
       removeListener(B.prototype, 'someEvent', null, 'onSomeEvent');
 
-      assert.equal(fooDidChangeBase, 0);
-      assert.equal(fooDidChangeA, 0);
-      assert.equal(fooDidChangeB, 0);
+      assert.strictEqual(fooDidChangeBase, 0);
+      assert.strictEqual(fooDidChangeA, 0);
+      assert.strictEqual(fooDidChangeB, 0);
 
-      assert.equal(someEventBase, 0);
-      assert.equal(someEventA, 0);
-      assert.equal(someEventB, 0);
+      assert.strictEqual(someEventBase, 0);
+      assert.strictEqual(someEventA, 0);
+      assert.strictEqual(someEventB, 0);
 
       let a = A.create();
       a.set('foo', 'something');
 
       // TODO: Generator transpilation code doesn't play nice with class definitions/hoisting
       return runLoopSettled().then(async () => {
-        assert.equal(fooDidChangeBase, 1);
-        assert.equal(fooDidChangeA, 1);
-        assert.equal(fooDidChangeB, 0);
+        assert.strictEqual(fooDidChangeBase, 1);
+        assert.strictEqual(fooDidChangeA, 1);
+        assert.strictEqual(fooDidChangeB, 0);
 
         sendEvent(a, 'someEvent');
-        assert.equal(someEventBase, 1);
-        assert.equal(someEventA, 1);
-        assert.equal(someEventB, 0);
+        assert.strictEqual(someEventBase, 1);
+        assert.strictEqual(someEventA, 1);
+        assert.strictEqual(someEventB, 0);
 
         let b = B.create();
         b.set('foo', 'something');
         await runLoopSettled();
 
-        assert.equal(fooDidChangeBase, 1);
-        assert.equal(fooDidChangeA, 1);
-        assert.equal(fooDidChangeB, 0);
+        assert.strictEqual(fooDidChangeBase, 1);
+        assert.strictEqual(fooDidChangeA, 1);
+        assert.strictEqual(fooDidChangeB, 0);
 
         sendEvent(b, 'someEvent');
-        assert.equal(someEventBase, 1);
-        assert.equal(someEventA, 1);
-        assert.equal(someEventB, 0);
+        assert.strictEqual(someEventBase, 1);
+        assert.strictEqual(someEventA, 1);
+        assert.strictEqual(someEventB, 0);
 
         a.destroy();
         b.destroy();
@@ -512,7 +512,7 @@ moduleFor(
         last: 'Jackson',
       });
 
-      assert.equal(d.full, 'Robert Jackson');
+      assert.strictEqual(d.full, 'Robert Jackson');
 
       d.setProperties({ first: 'Kris', last: 'Selden' });
 
@@ -524,7 +524,7 @@ moduleFor(
           'D fullNameDidChange after super.fullNameDidChange',
         ]);
 
-        assert.equal(d.full, 'Kris Selden');
+        assert.strictEqual(d.full, 'Kris Selden');
 
         d.triggerSomeEvent('event arg');
         assert.deepEqual(events, [

--- a/packages/@ember/-internals/runtime/tests/system/object/events_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/events_test.js
@@ -16,11 +16,11 @@ moduleFor(
       obj.on('event!', F);
       obj.trigger('event!');
 
-      assert.equal(count, 1, 'the event was triggered');
+      assert.strictEqual(count, 1, 'the event was triggered');
 
       obj.trigger('event!');
 
-      assert.equal(count, 2, 'the event was triggered');
+      assert.strictEqual(count, 2, 'the event was triggered');
     }
 
     ['@test a listener can be added and removed automatically the first time it is triggered'](
@@ -36,11 +36,11 @@ moduleFor(
       obj.one('event!', F);
       obj.trigger('event!');
 
-      assert.equal(count, 1, 'the event was triggered');
+      assert.strictEqual(count, 1, 'the event was triggered');
 
       obj.trigger('event!');
 
-      assert.equal(count, 1, 'the event was not triggered again');
+      assert.strictEqual(count, 1, 'the event was not triggered again');
     }
 
     ['@test triggering an event can have arguments'](assert) {
@@ -56,7 +56,7 @@ moduleFor(
       obj.trigger('event!', 'foo', 'bar');
 
       assert.deepEqual(args, ['foo', 'bar']);
-      assert.equal(self, obj);
+      assert.strictEqual(self, obj);
     }
 
     ['@test a listener can be added and removed automatically and have arguments'](assert) {
@@ -74,14 +74,14 @@ moduleFor(
       obj.trigger('event!', 'foo', 'bar');
 
       assert.deepEqual(args, ['foo', 'bar']);
-      assert.equal(self, obj);
-      assert.equal(count, 1, 'the event is triggered once');
+      assert.strictEqual(self, obj);
+      assert.strictEqual(count, 1, 'the event is triggered once');
 
       obj.trigger('event!', 'baz', 'bat');
 
       assert.deepEqual(args, ['foo', 'bar']);
-      assert.equal(count, 1, 'the event was not triggered again');
-      assert.equal(self, obj);
+      assert.strictEqual(count, 1, 'the event was not triggered again');
+      assert.strictEqual(self, obj);
     }
 
     ['@test binding an event can specify a different target'](assert) {
@@ -98,7 +98,7 @@ moduleFor(
       obj.trigger('event!', 'foo', 'bar');
 
       assert.deepEqual(args, ['foo', 'bar']);
-      assert.equal(self, target);
+      assert.strictEqual(self, target);
     }
 
     ['@test a listener registered with one can take method as string and can be added with different target'](
@@ -115,11 +115,11 @@ moduleFor(
       obj.one('event!', target, 'fn');
       obj.trigger('event!');
 
-      assert.equal(count, 1, 'the event was triggered');
+      assert.strictEqual(count, 1, 'the event was triggered');
 
       obj.trigger('event!');
 
-      assert.equal(count, 1, 'the event was not triggered again');
+      assert.strictEqual(count, 1, 'the event was not triggered again');
     }
 
     ['@test a listener registered with one can be removed with off'](assert) {
@@ -131,12 +131,12 @@ moduleFor(
       obj.one('event!', F);
       obj.one('event!', obj, 'F');
 
-      assert.equal(obj.has('event!'), true, 'has events');
+      assert.strictEqual(obj.has('event!'), true, 'has events');
 
       obj.off('event!', F);
       obj.off('event!', obj, 'F');
 
-      assert.equal(obj.has('event!'), false, 'has no more events');
+      assert.strictEqual(obj.has('event!'), false, 'has no more events');
     }
 
     ['@test adding and removing listeners should be chainable'](assert) {
@@ -144,13 +144,13 @@ moduleFor(
       let F = function () {};
 
       let ret = obj.on('event!', F);
-      assert.equal(ret, obj, '#on returns self');
+      assert.strictEqual(ret, obj, '#on returns self');
 
       ret = obj.off('event!', F);
-      assert.equal(ret, obj, '#off returns self');
+      assert.strictEqual(ret, obj, '#off returns self');
 
       ret = obj.one('event!', F);
-      assert.equal(ret, obj, '#one returns self');
+      assert.strictEqual(ret, obj, '#one returns self');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/extend_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/extend_test.js
@@ -9,15 +9,15 @@ moduleFor(
       let SomeClass = EmberObject.extend({ foo: 'BAR' });
       assert.ok(SomeClass.isClass, 'A class has isClass of true');
       let obj = SomeClass.create();
-      assert.equal(obj.foo, 'BAR');
+      assert.strictEqual(obj.foo, 'BAR');
     }
 
     ['@test Sub-subclass'](assert) {
       let SomeClass = EmberObject.extend({ foo: 'BAR' });
       let AnotherClass = SomeClass.extend({ bar: 'FOO' });
       let obj = AnotherClass.create();
-      assert.equal(obj.foo, 'BAR');
-      assert.equal(obj.bar, 'FOO');
+      assert.strictEqual(obj.foo, 'BAR');
+      assert.strictEqual(obj.bar, 'FOO');
     }
 
     ['@test Overriding a method several layers deep'](assert) {
@@ -52,8 +52,8 @@ moduleFor(
       let obj = FinalClass.create();
       obj.foo();
       obj.bar();
-      assert.equal(obj.fooCnt, 2, 'should invoke both');
-      assert.equal(obj.barCnt, 2, 'should invoke both');
+      assert.strictEqual(obj.fooCnt, 2, 'should invoke both');
+      assert.strictEqual(obj.barCnt, 2, 'should invoke both');
 
       // Try overriding on create also
       obj = FinalClass.extend({
@@ -65,8 +65,8 @@ moduleFor(
 
       obj.foo();
       obj.bar();
-      assert.equal(obj.fooCnt, 3, 'should invoke final as well');
-      assert.equal(obj.barCnt, 2, 'should invoke both');
+      assert.strictEqual(obj.fooCnt, 3, 'should invoke final as well');
+      assert.strictEqual(obj.barCnt, 2, 'should invoke both');
     }
 
     ['@test With concatenatedProperties'](assert) {

--- a/packages/@ember/-internals/runtime/tests/system/object/framework_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/framework_test.js
@@ -13,13 +13,17 @@ moduleFor(
         constructor(owner) {
           super(owner);
 
-          assert.equal(
+          assert.strictEqual(
             getOwner(this),
             testContext.owner,
             'owner was assigned properly in the root constructor'
           );
 
-          assert.equal(owner, testContext.owner, 'owner was passed properly to the constructor');
+          assert.strictEqual(
+            owner,
+            testContext.owner,
+            'owner was passed properly to the constructor'
+          );
         }
       }
       this.owner.register('model:blah', Model);

--- a/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/observer_test.js
@@ -16,12 +16,12 @@ moduleFor(
       });
 
       let obj = MyClass.create();
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
 
       obj.destroy();
     }
@@ -33,22 +33,22 @@ moduleFor(
       });
 
       let obj = MyClass.create();
-      assert.equal(get(obj, 'mood'), 'good');
+      assert.strictEqual(get(obj, 'mood'), 'good');
 
       set(obj, 'mood', 'bad');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'mood'), 'bad');
+      assert.strictEqual(get(obj, 'mood'), 'bad');
 
       set(obj, 'mood', undefined);
       await runLoopSettled();
 
-      assert.equal(get(obj, 'mood'), undefined);
+      assert.strictEqual(get(obj, 'mood'), undefined);
 
       set(obj, 'mood', 'awesome');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'mood'), 'awesome');
+      assert.strictEqual(get(obj, 'mood'), 'awesome');
 
       obj.destroy();
     }
@@ -69,17 +69,17 @@ moduleFor(
       });
 
       let obj = Subclass.create();
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer after change');
 
       set(obj, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
 
       obj.destroy();
     }
@@ -93,12 +93,12 @@ moduleFor(
         count: 0,
       });
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
 
       obj.destroy();
       await runLoopSettled();
@@ -120,17 +120,17 @@ moduleFor(
         }),
       }).create();
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
       set(obj, 'bar', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer after change');
 
       set(obj, 'baz', 'BAZ');
       await runLoopSettled();
 
-      assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 1, 'should invoke observer after change');
 
       obj.destroy();
     }
@@ -143,7 +143,7 @@ moduleFor(
         }),
       }).create();
 
-      assert.equal(get(obj, 'count'), 0, 'precond - should not invoke observer immediately');
+      assert.strictEqual(get(obj, 'count'), 0, 'precond - should not invoke observer immediately');
 
       run(() => obj.destroy());
 
@@ -151,7 +151,7 @@ moduleFor(
         set(obj, 'bar', 'BAZ');
       }, `calling set on destroyed object: ${obj}.bar = BAZ`);
 
-      assert.equal(get(obj, 'count'), 0, 'should not invoke observer after change');
+      assert.strictEqual(get(obj, 'count'), 0, 'should not invoke observer after change');
 
       obj.destroy();
     }
@@ -177,20 +177,20 @@ moduleFor(
         bar: { baz: 'biff2' },
       });
 
-      assert.equal(get(obj1, 'count'), 0, 'should not invoke yet');
-      assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj1, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj2, 'count'), 0, 'should not invoke yet');
 
       set(get(obj1, 'bar'), 'baz', 'BIFF1');
       await runLoopSettled();
 
-      assert.equal(get(obj1, 'count'), 1, 'should invoke observer on obj1');
-      assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj1, 'count'), 1, 'should invoke observer on obj1');
+      assert.strictEqual(get(obj2, 'count'), 0, 'should not invoke yet');
 
       set(get(obj2, 'bar'), 'baz', 'BIFF2');
       await runLoopSettled();
 
-      assert.equal(get(obj1, 'count'), 1, 'should not invoke again');
-      assert.equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
+      assert.strictEqual(get(obj1, 'count'), 1, 'should not invoke again');
+      assert.strictEqual(get(obj2, 'count'), 1, 'should invoke observer on obj2');
 
       obj1.destroy();
       obj2.destroy();
@@ -218,26 +218,26 @@ moduleFor(
         bar2: { baz: 'biff3' },
       });
 
-      assert.equal(get(obj1, 'count'), 0, 'should not invoke yet');
-      assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj1, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj2, 'count'), 0, 'should not invoke yet');
 
       set(get(obj1, 'bar'), 'baz', 'BIFF1');
       await runLoopSettled();
 
-      assert.equal(get(obj1, 'count'), 1, 'should invoke observer on obj1');
-      assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj1, 'count'), 1, 'should invoke observer on obj1');
+      assert.strictEqual(get(obj2, 'count'), 0, 'should not invoke yet');
 
       set(get(obj2, 'bar'), 'baz', 'BIFF2');
       await runLoopSettled();
 
-      assert.equal(get(obj1, 'count'), 1, 'should not invoke again');
-      assert.equal(get(obj2, 'count'), 0, 'should not invoke yet');
+      assert.strictEqual(get(obj1, 'count'), 1, 'should not invoke again');
+      assert.strictEqual(get(obj2, 'count'), 0, 'should not invoke yet');
 
       set(get(obj2, 'bar2'), 'baz', 'BIFF3');
       await runLoopSettled();
 
-      assert.equal(get(obj1, 'count'), 1, 'should not invoke again');
-      assert.equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
+      assert.strictEqual(get(obj1, 'count'), 1, 'should not invoke again');
+      assert.strictEqual(get(obj2, 'count'), 1, 'should invoke observer on obj2');
 
       obj1.destroy();
       obj2.destroy();
@@ -268,17 +268,17 @@ moduleFor(
 
       let parent = ParentClass.create();
 
-      assert.equal(changed, false, 'precond');
+      assert.strictEqual(changed, false, 'precond');
 
       set(parent, 'one.two', 'new');
       await runLoopSettled();
 
-      assert.equal(changed, true, 'child should have been notified of change to path');
+      assert.strictEqual(changed, true, 'child should have been notified of change to path');
 
       set(parent, 'one', { two: 'newer' });
       await runLoopSettled();
 
-      assert.equal(changed, true, 'child should have been notified of change to path');
+      assert.strictEqual(changed, true, 'child should have been notified of change to path');
 
       parent.child.destroy();
       parent.destroy();
@@ -312,7 +312,7 @@ moduleFor(
 
       obj.notifyPropertyChange('foo');
 
-      assert.equal(changed, true, 'observer fired successfully');
+      assert.strictEqual(changed, true, 'observer fired successfully');
 
       obj.destroy();
     }

--- a/packages/@ember/-internals/runtime/tests/system/object/reopenClass_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/reopenClass_test.js
@@ -14,8 +14,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(Subclass.foo(), 'FOO', 'Adds method');
-      assert.equal(get(Subclass, 'bar'), 'BAR', 'Adds property');
+      assert.strictEqual(Subclass.foo(), 'FOO', 'Adds method');
+      assert.strictEqual(get(Subclass, 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test class properties inherited by subclasses'](assert) {
@@ -29,8 +29,8 @@ moduleFor(
 
       let SubSub = Subclass.extend();
 
-      assert.equal(SubSub.foo(), 'FOO', 'Adds method');
-      assert.equal(get(SubSub, 'bar'), 'BAR', 'Adds property');
+      assert.strictEqual(SubSub.foo(), 'FOO', 'Adds method');
+      assert.strictEqual(get(SubSub, 'bar'), 'BAR', 'Adds property');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/reopen_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/reopen_test.js
@@ -14,8 +14,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(Subclass.create().foo(), 'FOO', 'Adds method');
-      assert.equal(get(Subclass.create(), 'bar'), 'BAR', 'Adds property');
+      assert.strictEqual(Subclass.create().foo(), 'FOO', 'Adds method');
+      assert.strictEqual(get(Subclass.create(), 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test reopened properties inherited by subclasses'](assert) {
@@ -29,8 +29,8 @@ moduleFor(
         bar: 'BAR',
       });
 
-      assert.equal(SubSub.create().foo(), 'FOO', 'Adds method');
-      assert.equal(get(SubSub.create(), 'bar'), 'BAR', 'Adds property');
+      assert.strictEqual(SubSub.create().foo(), 'FOO', 'Adds method');
+      assert.strictEqual(get(SubSub.create(), 'bar'), 'BAR', 'Adds property');
     }
 
     ['@test allows reopening already instantiated classes'](assert) {
@@ -42,7 +42,7 @@ moduleFor(
         trololol: true,
       });
 
-      assert.equal(Subclass.create().get('trololol'), true, 'reopen works');
+      assert.strictEqual(Subclass.create().get('trololol'), true, 'reopen works');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/strict-mode-test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/strict-mode-test.js
@@ -25,7 +25,7 @@ moduleFor(
 
       let bar = Bar.create();
 
-      assert.equal(bar.callBlah(), 'bar', 'can call local function without call/apply');
+      assert.strictEqual(bar.callBlah(), 'bar', 'can call local function without call/apply');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/system/object/toString_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object/toString_test.js
@@ -19,12 +19,12 @@ moduleFor(
       setName(Foo, 'Foo');
       setName(Bar, 'Bar');
 
-      assert.equal(
+      assert.strictEqual(
         bar.toString(),
         '<(unknown):' + guidFor(bar) + '>',
         'does not include toStringExtension part'
       );
-      assert.equal(
+      assert.strictEqual(
         foo.toString(),
         '<(unknown):' + guidFor(foo) + ':fooey>',
         'Includes toStringExtension result'

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -23,8 +23,8 @@ moduleFor(
         cp: 'Bar',
       });
 
-      assert.equal(get(proxy, 'prop'), 'Foo', 'should not have tried to proxy set');
-      assert.equal(proxy._cp, 'Bar', 'should use CP setter');
+      assert.strictEqual(get(proxy, 'prop'), 'Foo', 'should not have tried to proxy set');
+      assert.strictEqual(proxy._cp, 'Bar', 'should use CP setter');
     }
 
     ['@test should proxy properties to content'](assert) {
@@ -37,7 +37,7 @@ moduleFor(
       };
       let proxy = ObjectProxy.create();
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'firstName'),
         undefined,
         'get on proxy without content should return undefined'
@@ -48,17 +48,17 @@ moduleFor(
 
       set(proxy, 'content', content);
 
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'firstName'),
         'Tom',
         'get on proxy with content should forward to content'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'lastName'),
         'Dale',
         'get on proxy with content should forward to content'
       );
-      assert.equal(
+      assert.strictEqual(
         get(proxy, 'foo'),
         'foo unknown',
         'get on proxy with content should forward to content'
@@ -66,17 +66,21 @@ moduleFor(
 
       set(proxy, 'lastName', 'Huda');
 
-      assert.equal(
+      assert.strictEqual(
         get(content, 'lastName'),
         'Huda',
         'content should have new value from set on proxy'
       );
-      assert.equal(get(proxy, 'lastName'), 'Huda', 'proxy should have new value from set on proxy');
+      assert.strictEqual(
+        get(proxy, 'lastName'),
+        'Huda',
+        'proxy should have new value from set on proxy'
+      );
 
       set(proxy, 'content', { firstName: 'Yehuda', lastName: 'Katz' });
 
-      assert.equal(get(proxy, 'firstName'), 'Yehuda', 'proxy should reflect updated content');
-      assert.equal(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
+      assert.strictEqual(get(proxy, 'firstName'), 'Yehuda', 'proxy should reflect updated content');
+      assert.strictEqual(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
     }
 
     ['@test getting proxied properties with Ember.get should work'](assert) {
@@ -86,7 +90,7 @@ moduleFor(
         },
       });
 
-      assert.equal(get(proxy, 'foo'), 'FOO');
+      assert.strictEqual(get(proxy, 'foo'), 'FOO');
     }
 
     [`@test JSON.stringify doens't assert`](assert) {
@@ -96,7 +100,7 @@ moduleFor(
         },
       });
 
-      assert.equal(JSON.stringify(proxy), JSON.stringify({ content: { foo: 'FOO' } }));
+      assert.strictEqual(JSON.stringify(proxy), JSON.stringify({ content: { foo: 'FOO' } }));
     }
 
     ['@test calling a function on the proxy avoids the assertion'](assert) {
@@ -118,7 +122,7 @@ moduleFor(
           },
         });
 
-        assert.equal(proxy.foobar(), 'xoxo', 'should be able to use a function from a proxy');
+        assert.strictEqual(proxy.foobar(), 'xoxo', 'should be able to use a function from a proxy');
       } else {
         assert.expect(0);
       }
@@ -134,7 +138,7 @@ moduleFor(
         },
       });
 
-      assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
+      assert.strictEqual(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
     }
 
     [`@test setting a property on the proxy's prototype avoids the assertion`](assert) {
@@ -148,7 +152,7 @@ moduleFor(
         },
       });
 
-      assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
+      assert.strictEqual(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
     }
 
     ['@test getting proxied properties with [] should be an error'](assert) {
@@ -199,46 +203,46 @@ moduleFor(
       });
 
       // proxy without content returns undefined
-      assert.equal(get(proxy, 'fullName'), undefined);
+      assert.strictEqual(get(proxy, 'fullName'), undefined);
 
       // setting content causes all watched properties to change
       set(proxy, 'content', content1);
       await runLoopSettled();
 
       // both dependent keys changed
-      assert.equal(count, 2);
-      assert.equal(last, 'Tom Dale');
+      assert.strictEqual(count, 2);
+      assert.strictEqual(last, 'Tom Dale');
 
       // setting property in content causes proxy property to change
       set(content1, 'lastName', 'Huda');
       await runLoopSettled();
 
-      assert.equal(count, 3);
-      assert.equal(last, 'Tom Huda');
+      assert.strictEqual(count, 3);
+      assert.strictEqual(last, 'Tom Huda');
 
       // replacing content causes all watched properties to change
       set(proxy, 'content', content2);
       await runLoopSettled();
 
       // both dependent keys changed
-      assert.equal(count, 5);
-      assert.equal(last, 'Yehuda Katz');
+      assert.strictEqual(count, 5);
+      assert.strictEqual(last, 'Yehuda Katz');
 
       // setting property in new content
       set(content2, 'firstName', 'Tomhuda');
       await runLoopSettled();
 
-      assert.equal(last, 'Tomhuda Katz');
-      assert.equal(count, 6);
+      assert.strictEqual(last, 'Tomhuda Katz');
+      assert.strictEqual(count, 6);
 
       // setting property in proxy syncs with new content
       set(proxy, 'lastName', 'Katzdale');
       await runLoopSettled();
 
-      assert.equal(count, 7);
-      assert.equal(last, 'Tomhuda Katzdale');
-      assert.equal(get(content2, 'firstName'), 'Tomhuda');
-      assert.equal(get(content2, 'lastName'), 'Katzdale');
+      assert.strictEqual(count, 7);
+      assert.strictEqual(last, 'Tomhuda Katzdale');
+      assert.strictEqual(get(content2, 'firstName'), 'Tomhuda');
+      assert.strictEqual(get(content2, 'lastName'), 'Katzdale');
 
       proxy.destroy();
     }
@@ -249,8 +253,8 @@ moduleFor(
       let count = 0;
 
       proxy.set('foo.bar', 'hello');
-      assert.equal(proxy.get('foo.bar'), 'hello');
-      assert.equal(proxy.get('content.foo.bar'), 'hello');
+      assert.strictEqual(proxy.get('foo.bar'), 'hello');
+      assert.strictEqual(proxy.get('content.foo.bar'), 'hello');
 
       proxy.addObserver('foo.bar', function () {
         count++;
@@ -259,9 +263,9 @@ moduleFor(
       proxy.set('foo.bar', 'bye');
       await runLoopSettled();
 
-      assert.equal(count, 1);
-      assert.equal(proxy.get('foo.bar'), 'bye');
-      assert.equal(proxy.get('content.foo.bar'), 'bye');
+      assert.strictEqual(count, 1);
+      assert.strictEqual(proxy.get('foo.bar'), 'bye');
+      assert.strictEqual(proxy.get('content.foo.bar'), 'bye');
 
       proxy.destroy();
     }
@@ -275,45 +279,45 @@ moduleFor(
         count++;
       }
 
-      assert.equal(get(proxy, 'foo'), 'foo');
+      assert.strictEqual(get(proxy, 'foo'), 'foo');
 
       set(content, 'foo', 'bar');
 
-      assert.equal(get(proxy, 'foo'), 'bar');
+      assert.strictEqual(get(proxy, 'foo'), 'bar');
 
       set(proxy, 'foo', 'foo');
 
-      assert.equal(get(content, 'foo'), 'foo');
-      assert.equal(get(proxy, 'foo'), 'foo');
+      assert.strictEqual(get(content, 'foo'), 'foo');
+      assert.strictEqual(get(proxy, 'foo'), 'foo');
 
       addObserver(proxy, 'foo', observer);
 
-      assert.equal(count, 0);
-      assert.equal(get(proxy, 'foo'), 'foo');
+      assert.strictEqual(count, 0);
+      assert.strictEqual(get(proxy, 'foo'), 'foo');
 
       set(content, 'foo', 'bar');
       await runLoopSettled();
 
-      assert.equal(count, 1);
-      assert.equal(get(proxy, 'foo'), 'bar');
+      assert.strictEqual(count, 1);
+      assert.strictEqual(get(proxy, 'foo'), 'bar');
 
       set(proxy, 'foo', 'foo');
       await runLoopSettled();
 
-      assert.equal(count, 2);
-      assert.equal(get(content, 'foo'), 'foo');
-      assert.equal(get(proxy, 'foo'), 'foo');
+      assert.strictEqual(count, 2);
+      assert.strictEqual(get(content, 'foo'), 'foo');
+      assert.strictEqual(get(proxy, 'foo'), 'foo');
 
       removeObserver(proxy, 'foo', observer);
 
       set(content, 'foo', 'bar');
 
-      assert.equal(get(proxy, 'foo'), 'bar');
+      assert.strictEqual(get(proxy, 'foo'), 'bar');
 
       set(proxy, 'foo', 'foo');
 
-      assert.equal(get(content, 'foo'), 'foo');
-      assert.equal(get(proxy, 'foo'), 'foo');
+      assert.strictEqual(get(content, 'foo'), 'foo');
+      assert.strictEqual(get(proxy, 'foo'), 'foo');
     }
 
     ['@test setting `undefined` to a proxied content property should override its existing value'](
@@ -325,7 +329,7 @@ moduleFor(
         },
       });
       set(proxyObject, 'prop', undefined);
-      assert.equal(
+      assert.strictEqual(
         get(proxyObject, 'prop'),
         undefined,
         'sets the `undefined` value to the proxied content'
@@ -367,9 +371,9 @@ moduleFor(
       proxy.set('foo', 456);
       await runLoopSettled();
 
-      assert.equal(count, 1);
-      assert.equal(proxy.get('foo'), 456);
-      assert.equal(proxy.get('locals.foo'), 456);
+      assert.strictEqual(count, 1);
+      assert.strictEqual(proxy.get('foo'), 456);
+      assert.strictEqual(proxy.get('locals.foo'), 456);
 
       proxy.destroy();
     }

--- a/packages/@ember/-internals/utils/tests/cache_test.js
+++ b/packages/@ember/-internals/utils/tests/cache_test.js
@@ -7,19 +7,19 @@ moduleFor(
     ['@test basic'](assert) {
       let cache = new Cache(100, (key) => key.toUpperCase());
 
-      assert.equal(cache.get('foo'), 'FOO');
-      assert.equal(cache.get('bar'), 'BAR');
-      assert.equal(cache.get('foo'), 'FOO');
+      assert.strictEqual(cache.get('foo'), 'FOO');
+      assert.strictEqual(cache.get('bar'), 'BAR');
+      assert.strictEqual(cache.get('foo'), 'FOO');
     }
 
     ['@test explicit sets'](assert) {
       let cache = new Cache(100, (key) => key.toUpperCase());
 
-      assert.equal(cache.get('foo'), 'FOO');
+      assert.strictEqual(cache.get('foo'), 'FOO');
 
-      assert.equal(cache.set('foo', 'FOO!!!'), 'FOO!!!');
+      assert.strictEqual(cache.set('foo', 'FOO!!!'), 'FOO!!!');
 
-      assert.equal(cache.get('foo'), 'FOO!!!');
+      assert.strictEqual(cache.get('foo'), 'FOO!!!');
 
       assert.strictEqual(cache.set('foo', undefined), undefined);
 
@@ -33,15 +33,15 @@ moduleFor(
         return key.toUpperCase();
       });
 
-      assert.equal(count, 0);
+      assert.strictEqual(count, 0);
       cache.get('foo');
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
       cache.get('bar');
-      assert.equal(count, 2);
+      assert.strictEqual(count, 2);
       cache.get('bar');
-      assert.equal(count, 2);
+      assert.strictEqual(count, 2);
       cache.get('foo');
-      assert.equal(count, 2);
+      assert.strictEqual(count, 2);
     }
 
     ['@test handles undefined value correctly'](assert) {
@@ -50,15 +50,15 @@ moduleFor(
         count++;
       });
 
-      assert.equal(count, 0);
+      assert.strictEqual(count, 0);
       assert.strictEqual(cache.get('foo'), undefined);
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
       assert.strictEqual(cache.get('bar'), undefined);
-      assert.equal(count, 2);
+      assert.strictEqual(count, 2);
       assert.strictEqual(cache.get('bar'), undefined);
-      assert.equal(count, 2);
+      assert.strictEqual(count, 2);
       assert.strictEqual(cache.get('foo'), undefined);
-      assert.equal(count, 2);
+      assert.strictEqual(count, 2);
     }
 
     ['@test continues working after reaching cache limit'](assert) {
@@ -68,10 +68,10 @@ moduleFor(
       cache.get('b');
       cache.get('c');
 
-      assert.equal(cache.get('d'), 'D');
-      assert.equal(cache.get('a'), 'A');
-      assert.equal(cache.get('b'), 'B');
-      assert.equal(cache.get('c'), 'C');
+      assert.strictEqual(cache.get('d'), 'D');
+      assert.strictEqual(cache.get('a'), 'A');
+      assert.strictEqual(cache.get('b'), 'B');
+      assert.strictEqual(cache.get('c'), 'C');
     }
   }
 );

--- a/packages/@ember/-internals/utils/tests/can_invoke_test.js
+++ b/packages/@ember/-internals/utils/tests/can_invoke_test.js
@@ -20,27 +20,27 @@ moduleFor(
     }
 
     ["@test should return false if the object doesn't exist"](assert) {
-      assert.equal(canInvoke(undefined, 'aMethodThatDoesNotExist'), false);
+      assert.strictEqual(canInvoke(undefined, 'aMethodThatDoesNotExist'), false);
     }
 
     ['@test should return true for falsy values that have methods'](assert) {
-      assert.equal(canInvoke(false, 'valueOf'), true);
-      assert.equal(canInvoke('', 'charAt'), true);
-      assert.equal(canInvoke(0, 'toFixed'), true);
+      assert.strictEqual(canInvoke(false, 'valueOf'), true);
+      assert.strictEqual(canInvoke('', 'charAt'), true);
+      assert.strictEqual(canInvoke(0, 'toFixed'), true);
     }
 
     ['@test should return true if the method exists on the object'](assert) {
-      assert.equal(canInvoke(obj, 'aMethodThatExists'), true);
+      assert.strictEqual(canInvoke(obj, 'aMethodThatExists'), true);
     }
 
     ["@test should return false if the method doesn't exist on the object"](assert) {
-      assert.equal(canInvoke(obj, 'aMethodThatDoesNotExist'), false);
+      assert.strictEqual(canInvoke(obj, 'aMethodThatDoesNotExist'), false);
     }
 
     ['@test should return false if the property exists on the object but is a non-function'](
       assert
     ) {
-      assert.equal(canInvoke(obj, 'foobar'), false);
+      assert.strictEqual(canInvoke(obj, 'foobar'), false);
     }
   }
 );

--- a/packages/@ember/-internals/utils/tests/get-debug-name-test.js
+++ b/packages/@ember/-internals/utils/tests/get-debug-name-test.js
@@ -9,19 +9,19 @@ if (DEBUG) {
       '@test basic'(assert) {
         class Person {}
 
-        assert.equal(getDebugName({}), '(unknown object)');
-        assert.equal(
+        assert.strictEqual(getDebugName({}), '(unknown object)');
+        assert.strictEqual(
           getDebugName(() => {}),
           '(unknown function)'
         );
-        assert.equal(getDebugName(Person), 'Person');
-        assert.equal(getDebugName(new Person()), 'Person');
-        assert.equal(
+        assert.strictEqual(getDebugName(Person), 'Person');
+        assert.strictEqual(getDebugName(new Person()), 'Person');
+        assert.strictEqual(
           getDebugName(function foo() {}),
           'foo'
         );
 
-        assert.equal(
+        assert.strictEqual(
           getDebugName({
             toString() {
               return 'bar';
@@ -36,8 +36,8 @@ if (DEBUG) {
           }
         }
 
-        assert.equal(getDebugName(ClassWithToString), 'ClassWithToString');
-        assert.equal(getDebugName(new ClassWithToString()), 'baz');
+        assert.strictEqual(getDebugName(ClassWithToString), 'ClassWithToString');
+        assert.strictEqual(getDebugName(new ClassWithToString()), 'baz');
 
         class ClassWithEmberLikeToString {
           toString() {
@@ -45,15 +45,15 @@ if (DEBUG) {
           }
         }
 
-        assert.equal(getDebugName(ClassWithEmberLikeToString), 'ClassWithEmberLikeToString');
-        assert.equal(
+        assert.strictEqual(getDebugName(ClassWithEmberLikeToString), 'ClassWithEmberLikeToString');
+        assert.strictEqual(
           getDebugName(new ClassWithEmberLikeToString()),
           '<ClassWithEmberLikeToString:ember1234>'
         );
 
-        assert.equal(getDebugName(true), 'true');
-        assert.equal(getDebugName(123), '123');
-        assert.equal(getDebugName('string'), 'string');
+        assert.strictEqual(getDebugName(true), 'true');
+        assert.strictEqual(getDebugName(123), '123');
+        assert.strictEqual(getDebugName('string'), 'string');
       }
     }
   );

--- a/packages/@ember/-internals/utils/tests/guid_for_test.js
+++ b/packages/@ember/-internals/utils/tests/guid_for_test.js
@@ -2,7 +2,7 @@ import { guidFor } from '..';
 import { AbstractTestCase as TestCase, moduleFor } from 'internal-test-helpers';
 
 function sameGuid(assert, a, b, message) {
-  assert.equal(guidFor(a), guidFor(b), message);
+  assert.strictEqual(guidFor(a), guidFor(b), message);
 }
 
 function diffGuid(assert, a, b, message) {

--- a/packages/@ember/-internals/utils/tests/inspect_test.js
+++ b/packages/@ember/-internals/utils/tests/inspect_test.js
@@ -5,49 +5,49 @@ moduleFor(
   'Ember.inspect',
   class extends TestCase {
     ['@test strings'](assert) {
-      assert.equal(inspect('foo'), '"foo"');
+      assert.strictEqual(inspect('foo'), '"foo"');
     }
 
     ['@test numbers'](assert) {
-      assert.equal(inspect(2.6), '2.6');
+      assert.strictEqual(inspect(2.6), '2.6');
     }
 
     ['@test null'](assert) {
-      assert.equal(inspect(null), 'null');
+      assert.strictEqual(inspect(null), 'null');
     }
 
     ['@test undefined'](assert) {
-      assert.equal(inspect(undefined), 'undefined');
+      assert.strictEqual(inspect(undefined), 'undefined');
     }
 
     ['@test true'](assert) {
-      assert.equal(inspect(true), 'true');
+      assert.strictEqual(inspect(true), 'true');
     }
 
     ['@test false'](assert) {
-      assert.equal(inspect(false), 'false');
+      assert.strictEqual(inspect(false), 'false');
     }
 
     ['@test object'](assert) {
-      assert.equal(inspect({}), '{ }');
-      assert.equal(inspect({ foo: 'bar' }), '{ foo: "bar" }');
+      assert.strictEqual(inspect({}), '{ }');
+      assert.strictEqual(inspect({ foo: 'bar' }), '{ foo: "bar" }');
       let obj = {
         foo() {
           return this;
         },
       };
-      assert.equal(inspect(obj), `{ foo: [Function:foo] }`);
+      assert.strictEqual(inspect(obj), `{ foo: [Function:foo] }`);
     }
 
     ['@test objects without a prototype'](assert) {
       let prototypelessObj = Object.create(null);
       prototypelessObj.a = 1;
       prototypelessObj.b = [Object.create(null)];
-      assert.equal(inspect({ foo: prototypelessObj }), '{ foo: { a: 1, b: [ { } ] } }');
+      assert.strictEqual(inspect({ foo: prototypelessObj }), '{ foo: { a: 1, b: [ { } ] } }');
     }
 
     ['@test array'](assert) {
-      assert.equal(inspect([1, 2, 3]), '[ 1, 2, 3 ]');
+      assert.strictEqual(inspect([1, 2, 3]), '[ 1, 2, 3 ]');
     }
 
     ['@test array list limit'](assert) {
@@ -55,7 +55,7 @@ moduleFor(
       for (let i = 0; i < 120; i++) {
         a.push(1);
       }
-      assert.equal(inspect(a), `[ ${a.slice(0, 100).join(', ')}, ... 20 more items ]`);
+      assert.strictEqual(inspect(a), `[ ${a.slice(0, 100).join(', ')}, ... 20 more items ]`);
     }
 
     ['@test object list limit'](assert) {
@@ -65,18 +65,18 @@ moduleFor(
         obj['key' + i] = i;
         pairs.push(`key${i}: ${i}`);
       }
-      assert.equal(inspect(obj), `{ ${pairs.slice(0, 100).join(', ')}, ... 20 more keys }`);
+      assert.strictEqual(inspect(obj), `{ ${pairs.slice(0, 100).join(', ')}, ... 20 more keys }`);
     }
 
     ['@test depth limit'](assert) {
-      assert.equal(
+      assert.strictEqual(
         inspect([[[['here', { a: 1 }, [1]]]]]),
         '[ [ [ [ "here", [Object], [Array] ] ] ] ]'
       );
     }
 
     ['@test odd key'](assert) {
-      assert.equal(
+      assert.strictEqual(
         inspect({
           [`Hello world!
 How are you?`]: 1,
@@ -90,7 +90,7 @@ How are you?`]: 1,
       obj.inspect = inspect;
       let depth = 2;
       let options = {};
-      assert.equal(obj.inspect(depth, options), obj);
+      assert.strictEqual(obj.inspect(depth, options), obj);
     }
 
     ['@test cycle'](assert) {
@@ -98,7 +98,7 @@ How are you?`]: 1,
       obj.a = obj;
       let arr = [obj];
       arr.push(arr);
-      assert.equal(inspect(arr), '[ { a: [Circular] }, [Circular] ]');
+      assert.strictEqual(inspect(arr), '[ { a: [Circular] }, [Circular] ]');
     }
 
     ['@test custom toString'](assert) {
@@ -112,14 +112,14 @@ How are you?`]: 1,
         }
       }
 
-      assert.equal(
+      assert.strictEqual(
         inspect([new Component(), Component]),
         '[ <@ember/component:ember234>, @ember/component ]'
       );
     }
 
     ['@test regexp'](assert) {
-      assert.equal(inspect(/regexp/), '/regexp/');
+      assert.strictEqual(inspect(/regexp/), '/regexp/');
     }
 
     ['@test date'](assert) {
@@ -131,7 +131,7 @@ How are you?`]: 1,
 
     ['@test inspect outputs the toString() representation of Symbols'](assert) {
       let symbol = Symbol('test');
-      assert.equal(inspect(symbol), 'Symbol(test)');
+      assert.strictEqual(inspect(symbol), 'Symbol(test)');
     }
   }
 );

--- a/packages/@ember/-internals/utils/tests/is_proxy_test.js
+++ b/packages/@ember/-internals/utils/tests/is_proxy_test.js
@@ -8,11 +8,11 @@ moduleFor(
       let proxy = {};
       setProxy(proxy);
 
-      assert.equal(isProxy(proxy), true);
+      assert.strictEqual(isProxy(proxy), true);
 
-      assert.equal(isProxy({}), false);
-      assert.equal(isProxy(undefined), false);
-      assert.equal(isProxy(null), false);
+      assert.strictEqual(isProxy({}), false);
+      assert.strictEqual(isProxy(undefined), false);
+      assert.strictEqual(isProxy(null), false);
     }
   }
 );

--- a/packages/@ember/-internals/utils/tests/trackable-object-test.js
+++ b/packages/@ember/-internals/utils/tests/trackable-object-test.js
@@ -13,7 +13,7 @@ moduleFor(
 
       let instance = new Test();
 
-      assert.equal(isEmberArray(instance), true);
+      assert.strictEqual(isEmberArray(instance), true);
     }
   }
 );

--- a/packages/@ember/application/tests/application_instance_test.js
+++ b/packages/@ember/application/tests/application_instance_test.js
@@ -55,7 +55,11 @@ moduleFor(
       appInstance = run(() => ApplicationInstance.create({ application }));
 
       assert.ok(appInstance, 'instance should be created');
-      assert.equal(appInstance.application, application, 'application should be set to parent');
+      assert.strictEqual(
+        appInstance.application,
+        application,
+        'application should be set to parent'
+      );
     }
 
     ['@test customEvents added to the application before setupEventDispatcher'](assert) {
@@ -70,7 +74,7 @@ moduleFor(
 
       let eventDispatcher = appInstance.lookup('event_dispatcher:main');
       eventDispatcher.setup = function (events) {
-        assert.equal(events.awesome, 'sauce');
+        assert.strictEqual(events.awesome, 'sauce');
       };
 
       appInstance.setupEventDispatcher();
@@ -88,7 +92,7 @@ moduleFor(
 
       let eventDispatcher = appInstance.lookup('event_dispatcher:main');
       eventDispatcher.setup = function (events) {
-        assert.equal(events.awesome, 'sauce');
+        assert.strictEqual(events.awesome, 'sauce');
       };
 
       appInstance.setupEventDispatcher();
@@ -107,7 +111,7 @@ moduleFor(
       let postController1 = appInstance.lookup('controller:post');
       let postController1Factory = appInstance.factoryFor('controller:post');
       assert.ok(postController1 instanceof PostController1, 'precond - lookup creates instance');
-      assert.equal(
+      assert.strictEqual(
         PostController1,
         postController1Factory.class,
         'precond - factoryFor().class matches'
@@ -119,7 +123,11 @@ moduleFor(
       let postController2 = appInstance.lookup('controller:post');
       let postController2Factory = appInstance.factoryFor('controller:post');
       assert.ok(postController2 instanceof PostController2, 'lookup creates instance');
-      assert.equal(PostController2, postController2Factory.class, 'factoryFor().class matches');
+      assert.strictEqual(
+        PostController2,
+        postController2Factory.class,
+        'factoryFor().class matches'
+      );
 
       assert.notStrictEqual(
         postController1,
@@ -217,7 +225,7 @@ moduleFor(
 
       ApplicationInstance.setupRegistry(registry);
 
-      assert.equal(registry.resolve('service:-document'), document);
+      assert.strictEqual(registry.resolve('service:-document'), document);
     }
   }
 );

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -215,8 +215,8 @@ moduleFor(
       // This is not a public way to access the container; we just
       // need to make some assertions about the created router
       let router = this.applicationInstance.lookup('router:main');
-      assert.equal(router instanceof Router, true, 'Router was set from initialize call');
-      assert.equal(
+      assert.strictEqual(router instanceof Router, true, 'Router was set from initialize call');
+      assert.strictEqual(
         router.location instanceof NoneLocation,
         true,
         'Location was set from location implementation name'
@@ -233,7 +233,7 @@ moduleFor(
       // This is not a public way to access the container; we just
       // need to make some assertions about the created router
       let router = this.application.__deprecatedInstance__.lookup('router:main');
-      assert.equal(router instanceof Router, true, 'Router was set from initialize call');
+      assert.strictEqual(router instanceof Router, true, 'Router was set from initialize call');
       this.assertText('Hello!');
     }
 
@@ -267,8 +267,8 @@ moduleFor(
 
       runTask(() => this.createApplication());
 
-      assert.equal(messages[1], 'Ember  : ' + VERSION);
-      assert.equal(messages[2], 'my-lib : ' + '2.0.0a');
+      assert.strictEqual(messages[1], 'Ember  : ' + VERSION);
+      assert.strictEqual(messages[2], 'my-lib : ' + '2.0.0a');
 
       libraries.deRegister('my-lib');
     }
@@ -300,11 +300,11 @@ moduleFor(
     }
 
     [`@test does not leak itself in onLoad._loaded`](assert) {
-      assert.equal(_loaded.application, undefined);
+      assert.strictEqual(_loaded.application, undefined);
       runTask(() => this.createApplication());
-      assert.equal(_loaded.application, this.application);
+      assert.strictEqual(_loaded.application, this.application);
       runTask(() => this.application.destroy());
-      assert.equal(_loaded.application, undefined);
+      assert.strictEqual(_loaded.application, undefined);
     }
 
     [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](
@@ -316,7 +316,7 @@ moduleFor(
 
       let registry = Application.buildRegistry(namespace);
 
-      assert.equal(registry.resolve('application:main'), namespace);
+      assert.strictEqual(registry.resolve('application:main'), namespace);
     }
   }
 );
@@ -333,7 +333,7 @@ moduleFor(
 
       let registry = Application.buildRegistry(namespace);
 
-      assert.equal(registry.resolve('application:main'), namespace);
+      assert.strictEqual(registry.resolve('application:main'), namespace);
     }
   }
 );

--- a/packages/@ember/application/tests/dependency_injection_test.js
+++ b/packages/@ember/application/tests/dependency_injection_test.js
@@ -55,13 +55,13 @@ moduleFor(
     }
 
     ['@test registered entities can be looked up later'](assert) {
-      assert.equal(registry.resolve('model:person'), application.Person);
-      assert.equal(registry.resolve('model:user'), application.User);
-      assert.equal(registry.resolve('fruit:favorite'), application.Orange);
-      assert.equal(registry.resolve('communication:main'), application.Email);
-      assert.equal(registry.resolve('controller:postIndex'), application.PostIndexController);
+      assert.strictEqual(registry.resolve('model:person'), application.Person);
+      assert.strictEqual(registry.resolve('model:user'), application.User);
+      assert.strictEqual(registry.resolve('fruit:favorite'), application.Orange);
+      assert.strictEqual(registry.resolve('communication:main'), application.Email);
+      assert.strictEqual(registry.resolve('controller:postIndex'), application.PostIndexController);
 
-      assert.equal(
+      assert.strictEqual(
         locator.lookup('fruit:favorite'),
         locator.lookup('fruit:favorite'),
         'singleton lookup worked'

--- a/packages/@ember/application/tests/initializers_test.js
+++ b/packages/@ember/application/tests/initializers_test.js
@@ -81,7 +81,7 @@ moduleFor(
             },
             (error) => {
               assert.ok(error instanceof Error, 'The boot promise should reject with an error');
-              assert.equal(error.message, 'boot failure');
+              assert.strictEqual(error.message, 'boot failure');
             }
           );
         });
@@ -293,13 +293,13 @@ moduleFor(
 
       runTask(() => this.createApplication({}, FirstApp));
 
-      assert.equal(firstInitializerRunCount, 1, 'first initializer only was run');
-      assert.equal(secondInitializerRunCount, 0, 'first initializer only was run');
+      assert.strictEqual(firstInitializerRunCount, 1, 'first initializer only was run');
+      assert.strictEqual(secondInitializerRunCount, 0, 'first initializer only was run');
 
       runTask(() => this.createSecondApplication({}, SecondApp));
 
-      assert.equal(firstInitializerRunCount, 1, 'second initializer only was run');
-      assert.equal(secondInitializerRunCount, 1, 'second initializer only was run');
+      assert.strictEqual(firstInitializerRunCount, 1, 'second initializer only was run');
+      assert.strictEqual(secondInitializerRunCount, 1, 'second initializer only was run');
     }
 
     [`@test initializers are concatenated`](assert) {
@@ -324,12 +324,12 @@ moduleFor(
 
       runTask(() => this.createApplication({}, FirstApp));
 
-      assert.equal(
+      assert.strictEqual(
         firstInitializerRunCount,
         1,
         'first initializer only was run when base class created'
       );
-      assert.equal(
+      assert.strictEqual(
         secondInitializerRunCount,
         0,
         'first initializer only was run when base class created'
@@ -338,8 +338,12 @@ moduleFor(
       firstInitializerRunCount = 0;
       runTask(() => this.createSecondApplication({}, SecondApp));
 
-      assert.equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
-      assert.equal(
+      assert.strictEqual(
+        firstInitializerRunCount,
+        1,
+        'first initializer was run when subclass created'
+      );
+      assert.strictEqual(
         secondInitializerRunCount,
         1,
         'second initializers was run when subclass created'
@@ -380,7 +384,7 @@ moduleFor(
         name: 'coolInitializer',
         myProperty: 'cool',
         initialize() {
-          assert.equal(this.myProperty, 'cool', 'should have access to its own context');
+          assert.strictEqual(this.myProperty, 'cool', 'should have access to its own context');
         },
       });
 

--- a/packages/@ember/application/tests/instance_initializers_test.js
+++ b/packages/@ember/application/tests/instance_initializers_test.js
@@ -255,13 +255,13 @@ moduleFor(
 
       runTask(() => this.createApplication({}, FirstApp));
 
-      assert.equal(firstInitializerRunCount, 1, 'first initializer only was run');
-      assert.equal(secondInitializerRunCount, 0, 'first initializer only was run');
+      assert.strictEqual(firstInitializerRunCount, 1, 'first initializer only was run');
+      assert.strictEqual(secondInitializerRunCount, 0, 'first initializer only was run');
 
       runTask(() => this.createSecondApplication({}, SecondApp));
 
-      assert.equal(firstInitializerRunCount, 1, 'second initializer only was run');
-      assert.equal(secondInitializerRunCount, 1, 'second initializer only was run');
+      assert.strictEqual(firstInitializerRunCount, 1, 'second initializer only was run');
+      assert.strictEqual(secondInitializerRunCount, 1, 'second initializer only was run');
     }
 
     [`@test initializers are concatenated`](assert) {
@@ -286,12 +286,12 @@ moduleFor(
 
       runTask(() => this.createApplication({}, FirstApp));
 
-      assert.equal(
+      assert.strictEqual(
         firstInitializerRunCount,
         1,
         'first initializer only was run when base class created'
       );
-      assert.equal(
+      assert.strictEqual(
         secondInitializerRunCount,
         0,
         'first initializer only was run when base class created'
@@ -300,8 +300,12 @@ moduleFor(
       firstInitializerRunCount = 0;
       runTask(() => this.createSecondApplication({}, SecondApp));
 
-      assert.equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
-      assert.equal(
+      assert.strictEqual(
+        firstInitializerRunCount,
+        1,
+        'first initializer was run when subclass created'
+      );
+      assert.strictEqual(
         secondInitializerRunCount,
         1,
         'second initializers was run when subclass created'
@@ -367,7 +371,7 @@ moduleFor(
         name: 'coolInitializer',
         myProperty: 'cool',
         initialize() {
-          assert.equal(this.myProperty, 'cool', 'should have access to its own context');
+          assert.strictEqual(this.myProperty, 'cool', 'should have access to its own context');
         },
       });
 

--- a/packages/@ember/application/tests/lazy_load_test.js
+++ b/packages/@ember/application/tests/lazy_load_test.js
@@ -25,7 +25,7 @@ moduleFor(
         runLoadHooks('__test_hook__', 1);
       });
 
-      assert.equal(count, 1, 'the object was passed into the load hook');
+      assert.strictEqual(count, 1, 'the object was passed into the load hook');
     }
 
     ['@test if runLoadHooks was already run, it executes newly added hooks immediately'](assert) {
@@ -41,7 +41,7 @@ moduleFor(
         onLoad('__test_hook__', (object) => (count += object));
       });
 
-      assert.equal(count, 1, 'the original object was passed into the load hook');
+      assert.strictEqual(count, 1, 'the original object was passed into the load hook');
     }
 
     ["@test hooks in EmberENV.EMBER_LOAD_HOOKS['hookName'] get executed"](assert) {
@@ -52,7 +52,7 @@ moduleFor(
         runLoadHooks('__before_ember_test_hook__', 1);
       });
 
-      assert.equal(
+      assert.strictEqual(
         window.EmberENV.__test_hook_count__,
         1,
         'the object was passed into the load hook'
@@ -69,7 +69,7 @@ moduleFor(
 
         window.addEventListener('__test_hook_for_events__', function (e) {
           assert.ok(true, 'custom event was fired');
-          assert.equal(e.detail, eventObject, 'event details are provided properly');
+          assert.strictEqual(e.detail, eventObject, 'event details are provided properly');
         });
 
         run(() => {

--- a/packages/@ember/application/tests/logging_test.js
+++ b/packages/@ember/application/tests/logging_test.js
@@ -51,7 +51,7 @@ moduleFor(
       }
 
       return this.visit('/posts').then(() => {
-        assert.equal(Object.keys(this.logs).length, 4, 'expected logs');
+        assert.strictEqual(Object.keys(this.logs).length, 4, 'expected logs');
       });
     }
 
@@ -62,15 +62,23 @@ moduleFor(
       }
 
       return this.visit('/posts').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.logs['controller:application'],
           1,
           'expected: ApplicationController was generated'
         );
-        assert.equal(this.logs['controller:posts'], 1, 'expected: PostsController was generated');
+        assert.strictEqual(
+          this.logs['controller:posts'],
+          1,
+          'expected: PostsController was generated'
+        );
 
-        assert.equal(this.logs['route:application'], 1, 'expected: ApplicationRoute was generated');
-        assert.equal(this.logs['route:posts'], 1, 'expected: PostsRoute was generated');
+        assert.strictEqual(
+          this.logs['route:application'],
+          1,
+          'expected: ApplicationRoute was generated'
+        );
+        assert.strictEqual(this.logs['route:posts'], 1, 'expected: PostsRoute was generated');
       });
     }
 
@@ -108,7 +116,7 @@ moduleFor(
 
     [`@test do NOT log class generation if logging disabled`](assert) {
       return this.visit('/posts').then(() => {
-        assert.equal(Object.keys(this.logs).length, 0, 'expected logs');
+        assert.strictEqual(Object.keys(this.logs).length, 0, 'expected logs');
       });
     }
   }
@@ -134,17 +142,17 @@ moduleFor(
       return this.visit('/')
         .then(() => this.visit('/posts'))
         .then(() => {
-          assert.equal(
+          assert.strictEqual(
             this.logs['template:application'],
             undefined,
             'expected: Should not log template:application since it exists.'
           );
-          assert.equal(
+          assert.strictEqual(
             this.logs['template:index'],
             1,
             'expected: Could not find "index" template or view.'
           );
-          assert.equal(
+          assert.strictEqual(
             this.logs['template:posts'],
             1,
             'expected: Could not find "posts" template or view.'
@@ -165,13 +173,13 @@ moduleFor(
 
     [`@test do not log when template and view are missing when flag is not true`](assert) {
       return this.visit('/posts').then(() => {
-        assert.equal(Object.keys(this.logs).length, 0, 'expected no logs');
+        assert.strictEqual(Object.keys(this.logs).length, 0, 'expected no logs');
       });
     }
 
     [`@test do not log which views are used with templates when flag is not true`](assert) {
       return this.visit('/posts').then(() => {
-        assert.equal(Object.keys(this.logs).length, 0, 'expected no logs');
+        assert.strictEqual(Object.keys(this.logs).length, 0, 'expected no logs');
       });
     }
   }

--- a/packages/@ember/application/tests/readiness_test.js
+++ b/packages/@ember/application/tests/readiness_test.js
@@ -56,15 +56,15 @@ moduleFor(
           router: false,
         });
 
-        assert.equal(readyWasCalled, 0, 'ready is not called until later');
+        assert.strictEqual(readyWasCalled, 0, 'ready is not called until later');
       });
 
-      assert.equal(readyWasCalled, 1, 'ready was called');
+      assert.strictEqual(readyWasCalled, 1, 'ready was called');
 
       application.domReady();
 
-      assert.equal(callbacks['DOMContentLoaded'], undefined);
-      assert.equal(readyWasCalled, 1, "application's ready was not called again");
+      assert.strictEqual(callbacks['DOMContentLoaded'], undefined);
+      assert.strictEqual(readyWasCalled, 1, "application's ready was not called again");
     }
 
     ["@test Application's ready event is called after the document becomes ready"](assert) {
@@ -72,15 +72,15 @@ moduleFor(
 
       run(() => {
         application = Application.create({ router: false });
-        assert.equal(callbacks['DOMContentLoaded'].length, 1);
+        assert.strictEqual(callbacks['DOMContentLoaded'].length, 1);
       });
 
-      assert.equal(readyWasCalled, 0, "ready wasn't called yet");
+      assert.strictEqual(readyWasCalled, 0, "ready wasn't called yet");
 
       dispatchEvent('DOMContentLoaded');
 
-      assert.equal(callbacks['DOMContentLoaded'].length, 0);
-      assert.equal(readyWasCalled, 1, 'ready was called now that DOM is ready');
+      assert.strictEqual(callbacks['DOMContentLoaded'].length, 0);
+      assert.strictEqual(readyWasCalled, 1, 'ready was called now that DOM is ready');
     }
 
     ["@test Application's ready event can be deferred by other components"](assert) {
@@ -89,26 +89,30 @@ moduleFor(
       run(() => {
         application = Application.create({ router: false });
         application.deferReadiness();
-        assert.equal(readyWasCalled, 0, "ready wasn't called yet");
-        assert.equal(callbacks['DOMContentLoaded'].length, 1);
+        assert.strictEqual(readyWasCalled, 0, "ready wasn't called yet");
+        assert.strictEqual(callbacks['DOMContentLoaded'].length, 1);
       });
 
-      assert.equal(readyWasCalled, 0, "ready wasn't called yet");
+      assert.strictEqual(readyWasCalled, 0, "ready wasn't called yet");
 
       application.domReady();
 
-      assert.equal(readyWasCalled, 0, "ready wasn't called yet");
+      assert.strictEqual(readyWasCalled, 0, "ready wasn't called yet");
 
       run(() => {
         application.advanceReadiness();
-        assert.equal(readyWasCalled, 0);
+        assert.strictEqual(readyWasCalled, 0);
       });
 
-      assert.equal(readyWasCalled, 1, 'ready was called now all readiness deferrals are advanced');
+      assert.strictEqual(
+        readyWasCalled,
+        1,
+        'ready was called now all readiness deferrals are advanced'
+      );
 
       dispatchEvent('DOMContentLoaded');
 
-      assert.equal(callbacks['DOMContentLoaded'].length, 0);
+      assert.strictEqual(callbacks['DOMContentLoaded'].length, 0);
 
       expectAssertion(() => {
         application.deferReadiness();

--- a/packages/@ember/application/tests/reset_test.js
+++ b/packages/@ember/application/tests/reset_test.js
@@ -90,17 +90,17 @@ moduleFor(
         this.createApplication();
         this.add('event_dispatcher:main', FakeEventDispatcher);
 
-        assert.equal(eventDispatcherWasSetup, 0, 'not setup yet');
-        assert.equal(eventDispatcherWasDestroyed, 0, 'not destroyed yet');
+        assert.strictEqual(eventDispatcherWasSetup, 0, 'not setup yet');
+        assert.strictEqual(eventDispatcherWasDestroyed, 0, 'not destroyed yet');
       });
 
-      assert.equal(eventDispatcherWasSetup, 1, 'setup');
-      assert.equal(eventDispatcherWasDestroyed, 0, 'still not destroyed');
+      assert.strictEqual(eventDispatcherWasSetup, 1, 'setup');
+      assert.strictEqual(eventDispatcherWasDestroyed, 0, 'still not destroyed');
 
       this.application.reset();
 
-      assert.equal(eventDispatcherWasDestroyed, 1, 'destroyed');
-      assert.equal(eventDispatcherWasSetup, 2, 'setup called after reset');
+      assert.strictEqual(eventDispatcherWasDestroyed, 1, 'destroyed');
+      assert.strictEqual(eventDispatcherWasSetup, 2, 'setup called after reset');
     }
 
     ['@test When an application is reset, the router URL is reset to `/`'](assert) {
@@ -127,8 +127,8 @@ moduleFor(
           initialRouter = this.applicationInstance.lookup('router:main');
           let location = initialRouter.get('location');
 
-          assert.equal(location.getURL(), '/one');
-          assert.equal(initialRouter.currentPath, 'one');
+          assert.strictEqual(location.getURL(), '/one');
+          assert.strictEqual(initialRouter.currentPath, 'one');
 
           this.application.reset();
 
@@ -156,8 +156,8 @@ moduleFor(
             'a different application controller is created'
           );
 
-          assert.equal(location.getURL(), '/one');
-          assert.equal(router.currentPath, 'one');
+          assert.strictEqual(location.getURL(), '/one');
+          assert.strictEqual(router.currentPath, 'one');
         });
     }
 
@@ -174,16 +174,16 @@ moduleFor(
         });
 
         this.application.deferReadiness();
-        assert.equal(readyCallCount, 0, 'ready has not yet been called');
+        assert.strictEqual(readyCallCount, 0, 'ready has not yet been called');
       });
 
       run(this.application, 'advanceReadiness');
 
-      assert.equal(readyCallCount, 1, 'ready was called once');
+      assert.strictEqual(readyCallCount, 1, 'ready was called once');
 
       this.application.reset();
 
-      assert.equal(readyCallCount, 2, 'ready was called twice');
+      assert.strictEqual(readyCallCount, 2, 'ready was called twice');
     }
   }
 );

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -52,7 +52,7 @@ moduleFor(
 
       ENV._APPLICATION_TEMPLATE_WRAPPER = false;
       return this.visit('/', bootOptions).then(() => {
-        assert.equal(
+        assert.strictEqual(
           rootElement.innerHTML,
           templateContent,
           'without serialize flag renders as expected'
@@ -96,7 +96,7 @@ moduleFor(
           };
 
           this.application.visit('/', bootOptions).then((instance) => {
-            assert.equal(
+            assert.strictEqual(
               instance.rootElement.innerHTML,
               indexTemplate,
               'was not properly rehydrated'
@@ -246,7 +246,7 @@ moduleFor(
         },
         (error) => {
           assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-          assert.equal(error.message, 'boot failure');
+          assert.strictEqual(error.message, 'boot failure');
         }
       );
     }
@@ -267,7 +267,7 @@ moduleFor(
         },
         (error) => {
           assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-          assert.equal(error.message, 'boot failure');
+          assert.strictEqual(error.message, 'boot failure');
         }
       );
     }
@@ -310,7 +310,7 @@ moduleFor(
           instance instanceof ApplicationInstance,
           'promise is resolved with an ApplicationInstance'
         );
-        assert.equal(instance.getURL(), '/c/zomg', 'It should follow all redirects');
+        assert.strictEqual(instance.getURL(), '/c/zomg', 'It should follow all redirects');
       });
     }
 
@@ -360,7 +360,7 @@ moduleFor(
         },
         (error) => {
           assert.ok(error instanceof Error, 'It should reject the promise with the boot error');
-          assert.equal(error.message, 'transition failure');
+          assert.strictEqual(error.message, 'transition failure');
         }
       );
     }
@@ -378,7 +378,7 @@ moduleFor(
             instance instanceof ApplicationInstance,
             'promise is resolved with an ApplicationInstance'
           );
-          assert.equal(instance.getURL(), '/');
+          assert.strictEqual(instance.getURL(), '/');
 
           return instance.visit('/a');
         })
@@ -387,7 +387,7 @@ moduleFor(
             instance instanceof ApplicationInstance,
             'promise is resolved with an ApplicationInstance'
           );
-          assert.equal(instance.getURL(), '/a');
+          assert.strictEqual(instance.getURL(), '/a');
 
           return instance.visit('/b');
         })
@@ -396,7 +396,7 @@ moduleFor(
             instance instanceof ApplicationInstance,
             'promise is resolved with an ApplicationInstance'
           );
-          assert.equal(instance.getURL(), '/b');
+          assert.strictEqual(instance.getURL(), '/b');
 
           return instance.visit('/c');
         })
@@ -405,7 +405,7 @@ moduleFor(
             instance instanceof ApplicationInstance,
             'promise is resolved with an ApplicationInstance'
           );
-          assert.equal(instance.getURL(), '/c');
+          assert.strictEqual(instance.getURL(), '/c');
         });
     }
 
@@ -419,7 +419,7 @@ moduleFor(
           instance instanceof ApplicationInstance,
           'promise is resolved with an ApplicationInstance'
         );
-        assert.equal(
+        assert.strictEqual(
           this.element.textContent,
           'Hello world',
           'the application was rendered once the promise resolves'
@@ -760,37 +760,46 @@ moduleFor(
           assert.ok(xBarInitCalled);
           assert.ok(xBarDidInsertElementCalled);
 
-          assert.equal(foo.querySelector('h1').textContent, 'X-Foo');
-          assert.equal(
+          assert.strictEqual(foo.querySelector('h1').textContent, 'X-Foo');
+          assert.strictEqual(
             foo.querySelector('p').textContent,
             'Hello Godfrey, I have been clicked 0 times (0 times combined)!'
           );
           assert.ok(foo.textContent.indexOf('X-Bar') === -1);
 
-          assert.equal(bar.querySelector('h1').textContent, 'X-Bar');
-          assert.equal(bar.querySelector('button').textContent, 'Join 0 others in clicking me!');
+          assert.strictEqual(bar.querySelector('h1').textContent, 'X-Bar');
+          assert.strictEqual(
+            bar.querySelector('button').textContent,
+            'Join 0 others in clicking me!'
+          );
           assert.ok(bar.textContent.indexOf('X-Foo') === -1);
 
           runTask(() => {
             this.click(foo.querySelector('x-foo'));
           });
 
-          assert.equal(
+          assert.strictEqual(
             foo.querySelector('p').textContent,
             'Hello Godfrey, I have been clicked 1 times (1 times combined)!'
           );
-          assert.equal(bar.querySelector('button').textContent, 'Join 1 others in clicking me!');
+          assert.strictEqual(
+            bar.querySelector('button').textContent,
+            'Join 1 others in clicking me!'
+          );
 
           runTask(() => {
             this.click(bar.querySelector('button'));
             this.click(bar.querySelector('button'));
           });
 
-          assert.equal(
+          assert.strictEqual(
             foo.querySelector('p').textContent,
             'Hello Godfrey, I have been clicked 1 times (3 times combined)!'
           );
-          assert.equal(bar.querySelector('button').textContent, 'Join 3 others in clicking me!');
+          assert.strictEqual(
+            bar.querySelector('button').textContent,
+            'Join 3 others in clicking me!'
+          );
         })
         .finally(() => {
           runTask(() => {

--- a/packages/@ember/controller/tests/controller_test.js
+++ b/packages/@ember/controller/tests/controller_test.js
@@ -64,7 +64,7 @@ moduleFor(
 
       await this.visit('/');
       runTask(() => this.$('button').click());
-      assert.equal(observerRunCount, 1, 'observer ran exactly once');
+      assert.strictEqual(observerRunCount, 1, 'observer ran exactly once');
     }
   }
 );
@@ -124,7 +124,7 @@ moduleFor(
             assert.ok(true, 'foo');
           },
           bar(msg) {
-            assert.equal(msg, 'HELLO');
+            assert.strictEqual(msg, 'HELLO');
           },
         },
       });
@@ -132,7 +132,7 @@ moduleFor(
       let BarControllerMixin = Mixin.create({
         actions: {
           bar(msg) {
-            assert.equal(msg, 'HELLO');
+            assert.strictEqual(msg, 'HELLO');
             this._super(msg);
           },
         },
@@ -188,7 +188,7 @@ moduleFor(
       });
 
       assert.notEqual(controller.get('model'), 'foo-bar', 'model is set properly');
-      assert.equal(controller.get('content'), 'foo-bar', 'content is not set properly');
+      assert.strictEqual(controller.get('content'), 'foo-bar', 'content is not set properly');
     }
 
     ['@test specifying `content` (without `model` specified) does not result in deprecation'](
@@ -201,7 +201,7 @@ moduleFor(
         content: 'foo-bar',
       }).create();
 
-      assert.equal(get(controller, 'content'), 'foo-bar');
+      assert.strictEqual(get(controller, 'content'), 'foo-bar');
     }
 
     ['@test specifying `content` (with `model` specified) does not result in deprecation'](assert) {
@@ -213,8 +213,8 @@ moduleFor(
         model: 'blammo',
       });
 
-      assert.equal(get(controller, 'content'), 'foo-bar');
-      assert.equal(get(controller, 'model'), 'blammo');
+      assert.strictEqual(get(controller, 'content'), 'foo-bar');
+      assert.strictEqual(get(controller, 'model'), 'blammo');
     }
   }
 );
@@ -252,7 +252,7 @@ moduleFor(
       let postController = owner.lookup('controller:post');
       let postsController = owner.lookup('controller:posts');
 
-      assert.equal(
+      assert.strictEqual(
         postsController,
         postController.get('postsController'),
         'controller.posts is injected'
@@ -274,7 +274,7 @@ moduleFor(
       let appController = owner.lookup('controller:application');
       let authService = owner.lookup('service:auth');
 
-      assert.equal(authService, appController.get('authService'), 'service.auth is injected');
+      assert.strictEqual(authService, appController.get('authService'), 'service.auth is injected');
     }
   }
 );

--- a/packages/@ember/debug/tests/handlers-test.js
+++ b/packages/@ember/debug/tests/handlers-test.js
@@ -13,7 +13,7 @@ moduleFor(
 
       function handler(message) {
         assert.ok(true, 'called handler');
-        assert.equal(message, 'Foo bar');
+        assert.strictEqual(message, 'Foo bar');
       }
 
       registerHandler('blarz', handler);
@@ -81,8 +81,16 @@ moduleFor(
 
       function generateHandler(item) {
         return function (message, options, next) {
-          assert.equal(message, expectedMessage, `message supplied to ${item} handler is correct`);
-          assert.equal(options, expectedOptions, `options supplied to ${item} handler is correct`);
+          assert.strictEqual(
+            message,
+            expectedMessage,
+            `message supplied to ${item} handler is correct`
+          );
+          assert.strictEqual(
+            options,
+            expectedOptions,
+            `options supplied to ${item} handler is correct`
+          );
 
           actualCalls.push(item);
 
@@ -124,13 +132,13 @@ moduleFor(
       let handler2Options = { id: 'handler-2' };
 
       function handler1(message, options) {
-        assert.equal(message, handler2Message, 'handler2 message provided to handler1');
-        assert.equal(options, handler2Options, 'handler2 options provided to handler1');
+        assert.strictEqual(message, handler2Message, 'handler2 message provided to handler1');
+        assert.strictEqual(options, handler2Options, 'handler2 options provided to handler1');
       }
 
       function handler2(message, options, next) {
-        assert.equal(message, initialMessage, 'initial message provided to handler2');
-        assert.equal(options, initialOptions, 'initial options proivided to handler2');
+        assert.strictEqual(message, initialMessage, 'initial message provided to handler2');
+        assert.strictEqual(options, initialOptions, 'initial options proivided to handler2');
 
         next(handler2Message, handler2Options);
       }

--- a/packages/@ember/debug/tests/main_test.js
+++ b/packages/@ember/debug/tests/main_test.js
@@ -391,7 +391,7 @@ moduleFor(
       assert.expect(1);
 
       registerWarnHandler(function (message) {
-        assert.equal(message, 'foo', 'warning was triggered');
+        assert.strictEqual(message, 'foo', 'warning was triggered');
       });
 
       warn('foo', { id: 'ember-debug.do-not-raise' });

--- a/packages/@ember/engine/tests/engine_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_initializers_test.js
@@ -265,14 +265,14 @@ moduleFor(
       let firstEngine = FirstEngine.create();
       let firstEngineInstance = firstEngine.buildInstance();
 
-      assert.equal(firstInitializerRunCount, 1, 'first initializer only was run');
-      assert.equal(secondInitializerRunCount, 0, 'first initializer only was run');
+      assert.strictEqual(firstInitializerRunCount, 1, 'first initializer only was run');
+      assert.strictEqual(secondInitializerRunCount, 0, 'first initializer only was run');
 
       let secondEngine = SecondEngine.create();
       let secondEngineInstance = secondEngine.buildInstance();
 
-      assert.equal(firstInitializerRunCount, 1, 'second initializer only was run');
-      assert.equal(secondInitializerRunCount, 1, 'second initializer only was run');
+      assert.strictEqual(firstInitializerRunCount, 1, 'second initializer only was run');
+      assert.strictEqual(secondInitializerRunCount, 1, 'second initializer only was run');
 
       run(function () {
         firstEngineInstance.destroy();
@@ -309,12 +309,12 @@ moduleFor(
       let firstEngine = FirstEngine.create();
       let firstEngineInstance = firstEngine.buildInstance();
 
-      assert.equal(
+      assert.strictEqual(
         firstInitializerRunCount,
         1,
         'first initializer only was run when base class created'
       );
-      assert.equal(
+      assert.strictEqual(
         secondInitializerRunCount,
         0,
         'second initializer was not run when first base class created'
@@ -324,8 +324,12 @@ moduleFor(
       let secondEngine = SecondEngine.create();
       let secondEngineInstance = secondEngine.buildInstance();
 
-      assert.equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
-      assert.equal(
+      assert.strictEqual(
+        firstInitializerRunCount,
+        1,
+        'first initializer was run when subclass created'
+      );
+      assert.strictEqual(
         secondInitializerRunCount,
         1,
         'second initializers was run when subclass created'
@@ -381,7 +385,7 @@ moduleFor(
         name: 'coolInitializer',
         myProperty: 'cool',
         initialize() {
-          assert.equal(this.myProperty, 'cool', 'should have access to its own context');
+          assert.strictEqual(this.myProperty, 'cool', 'should have access to its own context');
         },
       });
 

--- a/packages/@ember/engine/tests/engine_instance_initializers_test.js
+++ b/packages/@ember/engine/tests/engine_instance_initializers_test.js
@@ -291,16 +291,16 @@ moduleFor(
       return firstEngineInstance
         .boot()
         .then(() => {
-          assert.equal(firstInitializerRunCount, 1, 'first initializer only was run');
-          assert.equal(secondInitializerRunCount, 0, 'first initializer only was run');
+          assert.strictEqual(firstInitializerRunCount, 1, 'first initializer only was run');
+          assert.strictEqual(secondInitializerRunCount, 0, 'first initializer only was run');
 
           secondEngine = SecondEngine.create();
           secondEngineInstance = buildEngineInstance(secondEngine);
           return secondEngineInstance.boot();
         })
         .then(() => {
-          assert.equal(firstInitializerRunCount, 1, 'second initializer only was run');
-          assert.equal(secondInitializerRunCount, 1, 'second initializer only was run');
+          assert.strictEqual(firstInitializerRunCount, 1, 'second initializer only was run');
+          assert.strictEqual(secondInitializerRunCount, 1, 'second initializer only was run');
 
           run(() => {
             firstEngineInstance.destroy();
@@ -343,12 +343,12 @@ moduleFor(
       return firstEngineInstance
         .boot()
         .then(() => {
-          assert.equal(
+          assert.strictEqual(
             firstInitializerRunCount,
             1,
             'first initializer only was run when base class created'
           );
-          assert.equal(
+          assert.strictEqual(
             secondInitializerRunCount,
             0,
             'second initializer was not run when first base class created'
@@ -360,12 +360,12 @@ moduleFor(
           return secondEngineInstance.boot();
         })
         .then(() => {
-          assert.equal(
+          assert.strictEqual(
             firstInitializerRunCount,
             1,
             'first initializer was run when subclass created'
           );
-          assert.equal(
+          assert.strictEqual(
             secondInitializerRunCount,
             1,
             'second initializers was run when subclass created'
@@ -422,7 +422,7 @@ moduleFor(
         name: 'coolInitializer',
         myProperty: 'cool',
         initialize() {
-          assert.equal(this.myProperty, 'cool', 'should have access to its own context');
+          assert.strictEqual(this.myProperty, 'cool', 'should have access to its own context');
         },
       });
 

--- a/packages/@ember/engine/tests/engine_instance_test.js
+++ b/packages/@ember/engine/tests/engine_instance_test.js
@@ -42,7 +42,7 @@ moduleFor(
       });
 
       assert.ok(engineInstance, 'instance should be created');
-      assert.equal(engineInstance.base, engine, 'base should be set to engine');
+      assert.strictEqual(engineInstance.base, engine, 'base should be set to engine');
     }
 
     ['@test unregistering a factory clears all cached instances of that factory'](assert) {

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -39,7 +39,11 @@ moduleFor(
     ['@test acts like a namespace'](assert) {
       engine.Foo = EmberObject.extend();
       processAllNamespaces();
-      assert.equal(getName(engine.Foo), 'TestEngine.Foo', 'Classes pick up their parent namespace');
+      assert.strictEqual(
+        getName(engine.Foo),
+        'TestEngine.Foo',
+        'Classes pick up their parent namespace'
+      );
     }
 
     ['@test builds a registry'](assert) {

--- a/packages/@ember/instrumentation/tests/index-test.js
+++ b/packages/@ember/instrumentation/tests/index-test.js
@@ -12,7 +12,7 @@ moduleFor(
       let result = instrument('render', {}, function () {
         return 'hello';
       });
-      assert.equal(result, 'hello', 'called block');
+      assert.strictEqual(result, 'hello', 'called block');
     }
 
     ['@test subscribing to a simple path receives the listener'](assert) {
@@ -198,11 +198,11 @@ moduleFor(
 
       let subscriber = subscribe('render', {
         before() {
-          assert.equal(count, 0);
+          assert.strictEqual(count, 0);
           assert.ok(true, 'Before callback was called');
         },
         after() {
-          assert.equal(count, 0);
+          assert.strictEqual(count, 0);
           assert.ok(true, 'After callback was called');
           count++;
         },

--- a/packages/@ember/object/tests/action_test.js
+++ b/packages/@ember/object/tests/action_test.js
@@ -43,11 +43,11 @@ moduleFor(
       let foo = Foo.create();
       let bar = Bar.create();
 
-      assert.equal(typeof foo.actions.foo, 'function', 'foo has foo action');
-      assert.equal(typeof foo.actions.bar, 'undefined', 'foo does not have bar action');
+      assert.strictEqual(typeof foo.actions.foo, 'function', 'foo has foo action');
+      assert.strictEqual(typeof foo.actions.bar, 'undefined', 'foo does not have bar action');
 
-      assert.equal(typeof bar.actions.foo, 'function', 'bar has foo action');
-      assert.equal(typeof bar.actions.bar, 'function', 'bar has bar action');
+      assert.strictEqual(typeof bar.actions.foo, 'function', 'bar has foo action');
+      assert.strictEqual(typeof bar.actions.bar, 'function', 'bar has bar action');
     }
 
     '@test actions are properly merged through traditional and ES6 prototype hierarchy'(assert) {
@@ -178,7 +178,7 @@ moduleFor(
 
         @action
         foo() {
-          assert.equal(this.bar, 'some value', 'context bound correctly');
+          assert.strictEqual(this.bar, 'some value', 'context bound correctly');
         }
       }
 
@@ -199,7 +199,7 @@ moduleFor(
 
         @action
         foo() {
-          assert.equal(this.bar, 'some value', 'context bound correctly');
+          assert.strictEqual(this.bar, 'some value', 'context bound correctly');
         }
       }
 

--- a/packages/@ember/object/tests/computed/computed_macros_test.js
+++ b/packages/@ember/object/tests/computed/computed_macros_test.js
@@ -34,14 +34,18 @@ moduleFor(
         lannisters: emberA(),
       });
 
-      assert.equal(get(obj, 'bestLannisterUnspecified'), true, 'bestLannister initially empty');
-      assert.equal(get(obj, 'noLannistersKnown'), true, 'lannisters initially empty');
+      assert.strictEqual(
+        get(obj, 'bestLannisterUnspecified'),
+        true,
+        'bestLannister initially empty'
+      );
+      assert.strictEqual(get(obj, 'noLannistersKnown'), true, 'lannisters initially empty');
 
       get(obj, 'lannisters').pushObject('Tyrion');
       set(obj, 'bestLannister', 'Tyrion');
 
-      assert.equal(get(obj, 'bestLannisterUnspecified'), false, 'empty respects strings');
-      assert.equal(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
+      assert.strictEqual(get(obj, 'bestLannisterUnspecified'), false, 'empty respects strings');
+      assert.strictEqual(get(obj, 'noLannistersKnown'), false, 'empty respects array mutations');
     }
 
     ['@test notEmpty part 1/2'](assert) {
@@ -55,24 +59,28 @@ moduleFor(
         lannisters: emberA(),
       });
 
-      assert.equal(get(obj, 'bestLannisterSpecified'), false, 'bestLannister initially empty');
-      assert.equal(get(obj, 'LannistersKnown'), false, 'lannisters initially empty');
+      assert.strictEqual(
+        get(obj, 'bestLannisterSpecified'),
+        false,
+        'bestLannister initially empty'
+      );
+      assert.strictEqual(get(obj, 'LannistersKnown'), false, 'lannisters initially empty');
 
       get(obj, 'lannisters').pushObject('Tyrion');
       set(obj, 'bestLannister', 'Tyrion');
 
-      assert.equal(get(obj, 'bestLannisterSpecified'), true, 'empty respects strings');
-      assert.equal(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
+      assert.strictEqual(get(obj, 'bestLannisterSpecified'), true, 'empty respects strings');
+      assert.strictEqual(get(obj, 'LannistersKnown'), true, 'empty respects array mutations');
     }
 
     ['@test not'](assert) {
       let obj = { foo: true };
       defineProperty(obj, 'notFoo', not('foo'));
-      assert.equal(get(obj, 'notFoo'), false);
+      assert.strictEqual(get(obj, 'notFoo'), false);
 
       obj = { foo: { bar: true } };
       defineProperty(obj, 'notFoo', not('foo.bar'));
-      assert.equal(get(obj, 'notFoo'), false);
+      assert.strictEqual(get(obj, 'notFoo'), false);
     }
 
     ['@test empty part 2/2'](assert) {
@@ -82,14 +90,14 @@ moduleFor(
       defineProperty(obj, 'bazEmpty', empty('baz'));
       defineProperty(obj, 'quzEmpty', empty('quz'));
 
-      assert.equal(get(obj, 'fooEmpty'), true);
+      assert.strictEqual(get(obj, 'fooEmpty'), true);
       set(obj, 'foo', [1]);
-      assert.equal(get(obj, 'fooEmpty'), false);
-      assert.equal(get(obj, 'barEmpty'), true);
-      assert.equal(get(obj, 'bazEmpty'), true);
-      assert.equal(get(obj, 'quzEmpty'), true);
+      assert.strictEqual(get(obj, 'fooEmpty'), false);
+      assert.strictEqual(get(obj, 'barEmpty'), true);
+      assert.strictEqual(get(obj, 'bazEmpty'), true);
+      assert.strictEqual(get(obj, 'quzEmpty'), true);
       set(obj, 'quz', 'asdf');
-      assert.equal(get(obj, 'quzEmpty'), false);
+      assert.strictEqual(get(obj, 'quzEmpty'), false);
     }
 
     ['@test bool'](assert) {
@@ -98,10 +106,10 @@ moduleFor(
       defineProperty(obj, 'barBool', bool('bar'));
       defineProperty(obj, 'bazBool', bool('baz'));
       defineProperty(obj, 'quzBool', bool('quz'));
-      assert.equal(get(obj, 'fooBool'), true);
-      assert.equal(get(obj, 'barBool'), true);
-      assert.equal(get(obj, 'bazBool'), false);
-      assert.equal(get(obj, 'quzBool'), false);
+      assert.strictEqual(get(obj, 'fooBool'), true);
+      assert.strictEqual(get(obj, 'barBool'), true);
+      assert.strictEqual(get(obj, 'bazBool'), false);
+      assert.strictEqual(get(obj, 'quzBool'), false);
     }
 
     ['@test alias'](assert) {
@@ -119,22 +127,22 @@ moduleFor(
       defineProperty(obj, 'quzAlias', alias('quz'));
       defineProperty(obj, 'bayAlias', alias('bay'));
 
-      assert.equal(get(obj, 'barAlias'), 'asdf');
-      assert.equal(get(obj, 'bazAlias'), null);
-      assert.equal(get(obj, 'quzAlias'), false);
-      assert.equal(get(obj, 'bayAlias'), 'apple');
+      assert.strictEqual(get(obj, 'barAlias'), 'asdf');
+      assert.strictEqual(get(obj, 'bazAlias'), null);
+      assert.strictEqual(get(obj, 'quzAlias'), false);
+      assert.strictEqual(get(obj, 'bayAlias'), 'apple');
 
       set(obj, 'barAlias', 'newBar');
       set(obj, 'bazAlias', 'newBaz');
       set(obj, 'quzAlias', null);
 
-      assert.equal(get(obj, 'barAlias'), 'newBar');
-      assert.equal(get(obj, 'bazAlias'), 'newBaz');
-      assert.equal(get(obj, 'quzAlias'), null);
+      assert.strictEqual(get(obj, 'barAlias'), 'newBar');
+      assert.strictEqual(get(obj, 'bazAlias'), 'newBaz');
+      assert.strictEqual(get(obj, 'quzAlias'), null);
 
-      assert.equal(get(obj, 'bar'), 'newBar');
-      assert.equal(get(obj, 'baz'), 'newBaz');
-      assert.equal(get(obj, 'quz'), null);
+      assert.strictEqual(get(obj, 'bar'), 'newBar');
+      assert.strictEqual(get(obj, 'baz'), 'newBaz');
+      assert.strictEqual(get(obj, 'quz'), null);
     }
 
     ['@test alias set'](assert) {
@@ -155,250 +163,250 @@ moduleFor(
       );
       defineProperty(obj, 'aliased', alias('original'));
 
-      assert.equal(get(obj, 'original'), constantValue);
-      assert.equal(get(obj, 'aliased'), constantValue);
+      assert.strictEqual(get(obj, 'original'), constantValue);
+      assert.strictEqual(get(obj, 'aliased'), constantValue);
 
       set(obj, 'aliased', 'should not set to this value');
 
-      assert.equal(get(obj, 'original'), constantValue);
-      assert.equal(get(obj, 'aliased'), constantValue);
+      assert.strictEqual(get(obj, 'original'), constantValue);
+      assert.strictEqual(get(obj, 'aliased'), constantValue);
     }
 
     ['@test match'](assert) {
       let obj = { name: 'Paul' };
       defineProperty(obj, 'isPaul', match('name', /Paul/));
 
-      assert.equal(get(obj, 'isPaul'), true, 'is Paul');
+      assert.strictEqual(get(obj, 'isPaul'), true, 'is Paul');
 
       set(obj, 'name', 'Pierre');
 
-      assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+      assert.strictEqual(get(obj, 'isPaul'), false, 'is not Paul anymore');
     }
 
     ['@test notEmpty part 2/2'](assert) {
       let obj = { items: [1] };
       defineProperty(obj, 'hasItems', notEmpty('items'));
 
-      assert.equal(get(obj, 'hasItems'), true, 'is not empty');
+      assert.strictEqual(get(obj, 'hasItems'), true, 'is not empty');
 
       set(obj, 'items', []);
 
-      assert.equal(get(obj, 'hasItems'), false, 'is empty');
+      assert.strictEqual(get(obj, 'hasItems'), false, 'is empty');
     }
 
     ['@test equal'](assert) {
       let obj = { name: 'Paul' };
       defineProperty(obj, 'isPaul', computedEqual('name', 'Paul'));
 
-      assert.equal(get(obj, 'isPaul'), true, 'is Paul');
+      assert.strictEqual(get(obj, 'isPaul'), true, 'is Paul');
 
       set(obj, 'name', 'Pierre');
 
-      assert.equal(get(obj, 'isPaul'), false, 'is not Paul anymore');
+      assert.strictEqual(get(obj, 'isPaul'), false, 'is not Paul anymore');
     }
 
     ['@test gt'](assert) {
       let obj = { number: 2 };
       defineProperty(obj, 'isGreaterThenOne', gt('number', 1));
 
-      assert.equal(get(obj, 'isGreaterThenOne'), true, 'is gt');
+      assert.strictEqual(get(obj, 'isGreaterThenOne'), true, 'is gt');
 
       set(obj, 'number', 1);
 
-      assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
+      assert.strictEqual(get(obj, 'isGreaterThenOne'), false, 'is not gt');
 
       set(obj, 'number', 0);
 
-      assert.equal(get(obj, 'isGreaterThenOne'), false, 'is not gt');
+      assert.strictEqual(get(obj, 'isGreaterThenOne'), false, 'is not gt');
     }
 
     ['@test gte'](assert) {
       let obj = { number: 2 };
       defineProperty(obj, 'isGreaterOrEqualThenOne', gte('number', 1));
 
-      assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
+      assert.strictEqual(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
 
       set(obj, 'number', 1);
 
-      assert.equal(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
+      assert.strictEqual(get(obj, 'isGreaterOrEqualThenOne'), true, 'is gte');
 
       set(obj, 'number', 0);
 
-      assert.equal(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
+      assert.strictEqual(get(obj, 'isGreaterOrEqualThenOne'), false, 'is not gte');
     }
 
     ['@test lt'](assert) {
       let obj = { number: 0 };
       defineProperty(obj, 'isLesserThenOne', lt('number', 1));
 
-      assert.equal(get(obj, 'isLesserThenOne'), true, 'is lt');
+      assert.strictEqual(get(obj, 'isLesserThenOne'), true, 'is lt');
 
       set(obj, 'number', 1);
 
-      assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
+      assert.strictEqual(get(obj, 'isLesserThenOne'), false, 'is not lt');
 
       set(obj, 'number', 2);
 
-      assert.equal(get(obj, 'isLesserThenOne'), false, 'is not lt');
+      assert.strictEqual(get(obj, 'isLesserThenOne'), false, 'is not lt');
     }
 
     ['@test lte'](assert) {
       let obj = { number: 0 };
       defineProperty(obj, 'isLesserOrEqualThenOne', lte('number', 1));
 
-      assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
+      assert.strictEqual(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
 
       set(obj, 'number', 1);
 
-      assert.equal(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
+      assert.strictEqual(get(obj, 'isLesserOrEqualThenOne'), true, 'is lte');
 
       set(obj, 'number', 2);
 
-      assert.equal(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
+      assert.strictEqual(get(obj, 'isLesserOrEqualThenOne'), false, 'is not lte');
     }
 
     ['@test and, with two properties'](assert) {
       let obj = { one: true, two: true };
       defineProperty(obj, 'oneAndTwo', and('one', 'two'));
 
-      assert.equal(get(obj, 'oneAndTwo'), true, 'one and two');
+      assert.strictEqual(get(obj, 'oneAndTwo'), true, 'one and two');
 
       set(obj, 'one', false);
 
-      assert.equal(get(obj, 'oneAndTwo'), false, 'one and not two');
+      assert.strictEqual(get(obj, 'oneAndTwo'), false, 'one and not two');
 
       set(obj, 'one', null);
       set(obj, 'two', 'Yes');
 
-      assert.equal(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
+      assert.strictEqual(get(obj, 'oneAndTwo'), null, 'returns falsy value as in &&');
 
       set(obj, 'one', true);
       set(obj, 'two', 2);
 
-      assert.equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
+      assert.strictEqual(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
     }
 
     ['@test and, with three properties'](assert) {
       let obj = { one: true, two: true, three: true };
       defineProperty(obj, 'oneTwoThree', and('one', 'two', 'three'));
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one and two and three');
 
       set(obj, 'one', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
 
       set(obj, 'one', true);
       set(obj, 'two', 2);
       set(obj, 'three', 3);
 
-      assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+      assert.strictEqual(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
     }
 
     ['@test and, with expand properties'](assert) {
       let obj = { one: true, two: true, three: true };
       defineProperty(obj, 'oneTwoThree', and('{one,two,three}'));
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one and two and three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one and two and three');
 
       set(obj, 'one', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), false, 'one and not two and not three');
 
       set(obj, 'one', true);
       set(obj, 'two', 2);
       set(obj, 'three', 3);
 
-      assert.equal(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
+      assert.strictEqual(get(obj, 'oneTwoThree'), 3, 'returns truthy value as in &&');
     }
 
     ['@test or, with two properties'](assert) {
       let obj = { one: true, two: true };
       defineProperty(obj, 'oneOrTwo', or('one', 'two'));
 
-      assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
+      assert.strictEqual(get(obj, 'oneOrTwo'), true, 'one or two');
 
       set(obj, 'one', false);
 
-      assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
+      assert.strictEqual(get(obj, 'oneOrTwo'), true, 'one or two');
 
       set(obj, 'two', false);
 
-      assert.equal(get(obj, 'oneOrTwo'), false, 'nor one nor two');
+      assert.strictEqual(get(obj, 'oneOrTwo'), false, 'nor one nor two');
 
       set(obj, 'two', null);
 
-      assert.equal(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
+      assert.strictEqual(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
 
       set(obj, 'two', true);
 
-      assert.equal(get(obj, 'oneOrTwo'), true, 'one or two');
+      assert.strictEqual(get(obj, 'oneOrTwo'), true, 'one or two');
 
       set(obj, 'one', 1);
 
-      assert.equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
+      assert.strictEqual(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
     }
 
     ['@test or, with three properties'](assert) {
       let obj = { one: true, two: true, three: true };
       defineProperty(obj, 'oneTwoThree', or('one', 'two', 'three'));
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'one', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'two', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'three', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), false, 'one or two or three');
 
       set(obj, 'three', null);
 
-      assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+      assert.strictEqual(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
 
       set(obj, 'two', true);
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'one', 1);
 
-      assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+      assert.strictEqual(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
     }
 
     ['@test or, with expand properties'](assert) {
       let obj = { one: true, two: true, three: true };
       defineProperty(obj, 'oneTwoThree', or('{one,two,three}'));
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'one', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'two', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'three', false);
 
-      assert.equal(get(obj, 'oneTwoThree'), false, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), false, 'one or two or three');
 
       set(obj, 'three', null);
 
-      assert.equal(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
+      assert.strictEqual(get(obj, 'oneTwoThree'), null, 'returns last falsy value as in ||');
 
       set(obj, 'two', true);
 
-      assert.equal(get(obj, 'oneTwoThree'), true, 'one or two or three');
+      assert.strictEqual(get(obj, 'oneTwoThree'), true, 'one or two or three');
 
       set(obj, 'one', 1);
 
-      assert.equal(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
+      assert.strictEqual(get(obj, 'oneTwoThree'), 1, 'returns truthy value as in ||');
     }
 
     ['@test or and and, warn about dependent keys with spaces']() {
@@ -420,20 +428,20 @@ moduleFor(
 
       defineProperty(obj, 'nickName', oneWay('firstName'));
 
-      assert.equal(get(obj, 'firstName'), 'Teddy');
-      assert.equal(get(obj, 'lastName'), 'Zeenny');
-      assert.equal(get(obj, 'nickName'), 'Teddy');
+      assert.strictEqual(get(obj, 'firstName'), 'Teddy');
+      assert.strictEqual(get(obj, 'lastName'), 'Zeenny');
+      assert.strictEqual(get(obj, 'nickName'), 'Teddy');
 
       set(obj, 'nickName', 'TeddyBear');
 
-      assert.equal(get(obj, 'firstName'), 'Teddy');
-      assert.equal(get(obj, 'lastName'), 'Zeenny');
+      assert.strictEqual(get(obj, 'firstName'), 'Teddy');
+      assert.strictEqual(get(obj, 'lastName'), 'Zeenny');
 
-      assert.equal(get(obj, 'nickName'), 'TeddyBear');
+      assert.strictEqual(get(obj, 'nickName'), 'TeddyBear');
 
       set(obj, 'firstName', 'TEDDDDDDDDYYY');
 
-      assert.equal(get(obj, 'nickName'), 'TeddyBear');
+      assert.strictEqual(get(obj, 'nickName'), 'TeddyBear');
     }
 
     ['@test readOnly'](assert) {
@@ -444,22 +452,22 @@ moduleFor(
 
       defineProperty(obj, 'nickName', readOnly('firstName'));
 
-      assert.equal(get(obj, 'firstName'), 'Teddy');
-      assert.equal(get(obj, 'lastName'), 'Zeenny');
-      assert.equal(get(obj, 'nickName'), 'Teddy');
+      assert.strictEqual(get(obj, 'firstName'), 'Teddy');
+      assert.strictEqual(get(obj, 'lastName'), 'Zeenny');
+      assert.strictEqual(get(obj, 'nickName'), 'Teddy');
 
       assert.throws(function () {
         set(obj, 'nickName', 'TeddyBear');
       }, / /);
 
-      assert.equal(get(obj, 'firstName'), 'Teddy');
-      assert.equal(get(obj, 'lastName'), 'Zeenny');
+      assert.strictEqual(get(obj, 'firstName'), 'Teddy');
+      assert.strictEqual(get(obj, 'lastName'), 'Zeenny');
 
-      assert.equal(get(obj, 'nickName'), 'Teddy');
+      assert.strictEqual(get(obj, 'nickName'), 'Teddy');
 
       set(obj, 'firstName', 'TEDDDDDDDDYYY');
 
-      assert.equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
+      assert.strictEqual(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
     }
 
     ['@test deprecatingAlias'](assert) {
@@ -494,19 +502,19 @@ moduleFor(
       );
 
       expectDeprecation(function () {
-        assert.equal(get(obj, 'barAlias'), 'asdf');
+        assert.strictEqual(get(obj, 'barAlias'), 'asdf');
       }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
 
       expectDeprecation(function () {
-        assert.equal(get(obj, 'bazAlias'), null);
+        assert.strictEqual(get(obj, 'bazAlias'), null);
       }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
 
       expectDeprecation(function () {
-        assert.equal(get(obj, 'quzAlias'), false);
+        assert.strictEqual(get(obj, 'quzAlias'), false);
       }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
 
       expectDeprecation(function () {
-        assert.equal(get(obj, 'bayAlias'), 'apple');
+        assert.strictEqual(get(obj, 'bayAlias'), 'apple');
       }, 'Usage of `bayAlias` is deprecated, use `bay` instead.');
 
       expectDeprecation(function () {
@@ -521,13 +529,13 @@ moduleFor(
         set(obj, 'quzAlias', null);
       }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
 
-      assert.equal(get(obj, 'barAlias'), 'newBar');
-      assert.equal(get(obj, 'bazAlias'), 'newBaz');
-      assert.equal(get(obj, 'quzAlias'), null);
+      assert.strictEqual(get(obj, 'barAlias'), 'newBar');
+      assert.strictEqual(get(obj, 'bazAlias'), 'newBaz');
+      assert.strictEqual(get(obj, 'quzAlias'), null);
 
-      assert.equal(get(obj, 'bar'), 'newBar');
-      assert.equal(get(obj, 'baz'), 'newBaz');
-      assert.equal(get(obj, 'quz'), null);
+      assert.strictEqual(get(obj, 'bar'), 'newBar');
+      assert.strictEqual(get(obj, 'baz'), 'newBaz');
+      assert.strictEqual(get(obj, 'quz'), null);
     }
   }
 );

--- a/packages/@ember/object/tests/computed/dependent-key-compat-test.js
+++ b/packages/@ember/object/tests/computed/dependent-key-compat-test.js
@@ -24,11 +24,11 @@ moduleFor(
 
       let tom = new Person();
 
-      assert.equal(tom.fullName, 'Tom Dale');
+      assert.strictEqual(tom.fullName, 'Tom Dale');
 
       tom.firstName = 'Thomas';
 
-      assert.equal(tom.fullName, 'Thomas Dale');
+      assert.strictEqual(tom.fullName, 'Thomas Dale');
     }
 
     '@test it works with classic classes'(assert) {
@@ -49,11 +49,11 @@ moduleFor(
 
       let tom = Person.create();
 
-      assert.equal(tom.fullName, 'Tom Dale');
+      assert.strictEqual(tom.fullName, 'Tom Dale');
 
       tom.firstName = 'Thomas';
 
-      assert.equal(tom.fullName, 'Thomas Dale');
+      assert.strictEqual(tom.fullName, 'Thomas Dale');
     }
 
     async '@test it works with async observers'(assert) {
@@ -80,15 +80,15 @@ moduleFor(
 
       let tom = Person.create();
 
-      assert.equal(count, 0);
+      assert.strictEqual(count, 0);
 
       // check the alias, and bootstrap it
-      assert.equal(tom.givenName, 'Tom', 'alias works');
+      assert.strictEqual(tom.givenName, 'Tom', 'alias works');
 
       tom.firstName = 'Thomas';
       await runLoopSettled();
 
-      assert.equal(count, 1);
+      assert.strictEqual(count, 1);
 
       tom.destroy();
     }
@@ -117,11 +117,11 @@ moduleFor(
 
       let tom = Person.create();
 
-      assert.equal(count, 0);
+      assert.strictEqual(count, 0);
 
       tom.firstName = 'Thomas';
 
-      assert.equal(count, 0);
+      assert.strictEqual(count, 0);
 
       tom.destroy();
     }

--- a/packages/@ember/object/tests/computed/reduce_computed_macros_test.js
+++ b/packages/@ember/object/tests/computed/reduce_computed_macros_test.js
@@ -97,7 +97,7 @@ moduleFor(
     ['@test it has the correct `this`'](assert) {
       obj = EmberObject.extend({
         mapped: map('array', function (item) {
-          assert.equal(this, obj, 'should have correct context');
+          assert.strictEqual(this, obj, 'should have correct context');
           return this.upperCase(item);
         }),
         upperCase(string) {
@@ -259,7 +259,7 @@ moduleFor(
       obj.get('array').pushObject({ v: 5 });
       await runLoopSettled();
 
-      assert.equal(calls, 1, 'mapBy is observable');
+      assert.strictEqual(calls, 1, 'mapBy is observable');
     }
   }
 );
@@ -306,7 +306,7 @@ moduleFor(
     ['@test it has the correct `this`'](assert) {
       obj = EmberObject.extend({
         filtered: filter('array', function (item, index) {
-          assert.equal(this, obj);
+          assert.strictEqual(this, obj);
           return this.isOne(index);
         }),
         isOne(value) {
@@ -1602,7 +1602,7 @@ moduleFor(
     ['@test sort has correct `this`'](assert) {
       let obj = EmberObject.extend({
         sortedItems: sort('items.@each.fname', function (a, b) {
-          assert.equal(this, obj, 'expected the object to be `this`');
+          assert.strictEqual(this, obj, 'expected the object to be `this`');
           return this.sortByLastName(a, b);
         }),
         sortByLastName(a, b) {
@@ -2070,29 +2070,29 @@ moduleFor(
     }
 
     ['@test max tracks the max number as objects are added'](assert) {
-      assert.equal(obj.get('max'), 3, 'precond - max is initially correct');
+      assert.strictEqual(obj.get('max'), 3, 'precond - max is initially correct');
 
       let items = obj.get('items');
 
       items.pushObject(5);
 
-      assert.equal(obj.get('max'), 5, 'max updates when a larger number is added');
+      assert.strictEqual(obj.get('max'), 5, 'max updates when a larger number is added');
 
       items.pushObject(2);
 
-      assert.equal(obj.get('max'), 5, 'max does not update when a smaller number is added');
+      assert.strictEqual(obj.get('max'), 5, 'max does not update when a smaller number is added');
     }
 
     ['@test max recomputes when the current max is removed'](assert) {
-      assert.equal(obj.get('max'), 3, 'precond - max is initially correct');
+      assert.strictEqual(obj.get('max'), 3, 'precond - max is initially correct');
 
       obj.get('items').removeObject(2);
 
-      assert.equal(obj.get('max'), 3, 'max is unchanged when a non-max item is removed');
+      assert.strictEqual(obj.get('max'), 3, 'max is unchanged when a non-max item is removed');
 
       obj.get('items').removeObject(3);
 
-      assert.equal(obj.get('max'), 1, 'max is recomputed when the current max is removed');
+      assert.strictEqual(obj.get('max'), 1, 'max is recomputed when the current max is removed');
     }
   }
 );
@@ -2119,29 +2119,29 @@ moduleFor(
     }
 
     ['@test min tracks the min number as objects are added'](assert) {
-      assert.equal(obj.get('min'), 1, 'precond - min is initially correct');
+      assert.strictEqual(obj.get('min'), 1, 'precond - min is initially correct');
 
       obj.get('items').pushObject(-2);
 
-      assert.equal(obj.get('min'), -2, 'min updates when a smaller number is added');
+      assert.strictEqual(obj.get('min'), -2, 'min updates when a smaller number is added');
 
       obj.get('items').pushObject(2);
 
-      assert.equal(obj.get('min'), -2, 'min does not update when a larger number is added');
+      assert.strictEqual(obj.get('min'), -2, 'min does not update when a larger number is added');
     }
 
     ['@test min recomputes when the current min is removed'](assert) {
       let items = obj.get('items');
 
-      assert.equal(obj.get('min'), 1, 'precond - min is initially correct');
+      assert.strictEqual(obj.get('min'), 1, 'precond - min is initially correct');
 
       items.removeObject(2);
 
-      assert.equal(obj.get('min'), 1, 'min is unchanged when a non-min item is removed');
+      assert.strictEqual(obj.get('min'), 1, 'min is unchanged when a non-min item is removed');
 
       items.removeObject(1);
 
-      assert.equal(obj.get('min'), 3, 'min is recomputed when the current min is removed');
+      assert.strictEqual(obj.get('min'), 3, 'min is recomputed when the current min is removed');
     }
   }
 );
@@ -2195,15 +2195,19 @@ moduleFor(
     ['@test filtering, sorting and reduce (max) can be combined'](assert) {
       let items = obj.get('items');
 
-      assert.equal(16, obj.get('oldestStarkAge'), 'precond - end of chain is initially correct');
+      assert.strictEqual(
+        16,
+        obj.get('oldestStarkAge'),
+        'precond - end of chain is initially correct'
+      );
 
       items.pushObject({ fname: 'Rickon', lname: 'Stark', age: 5 });
 
-      assert.equal(16, obj.get('oldestStarkAge'), 'chain is updated correctly');
+      assert.strictEqual(16, obj.get('oldestStarkAge'), 'chain is updated correctly');
 
       items.pushObject({ fname: 'Eddard', lname: 'Stark', age: 35 });
 
-      assert.equal(35, obj.get('oldestStarkAge'), 'chain is updated correctly');
+      assert.strictEqual(35, obj.get('oldestStarkAge'), 'chain is updated correctly');
     }
   }
 );
@@ -2299,7 +2303,7 @@ moduleFor(
     }
 
     async ['@test it computes interdependent array computed properties'](assert) {
-      assert.equal(obj.get('max'), 3, 'sanity - it properly computes the maximum value');
+      assert.strictEqual(obj.get('max'), 3, 'sanity - it properly computes the maximum value');
 
       let calls = 0;
 
@@ -2308,9 +2312,9 @@ moduleFor(
       obj.get('array').pushObject({ v: 5 });
       await runLoopSettled();
 
-      assert.equal(obj.get('max'), 5, 'maximum value is updated correctly');
-      assert.equal(userFnCalls, 1, 'object defined observers fire');
-      assert.equal(calls, 1, 'runtime created observers fire');
+      assert.strictEqual(obj.get('max'), 5, 'maximum value is updated correctly');
+      assert.strictEqual(userFnCalls, 1, 'object defined observers fire');
+      assert.strictEqual(calls, 1, 'runtime created observers fire');
     }
   }
 );
@@ -2337,28 +2341,28 @@ moduleFor(
     }
 
     ['@test sums the values in the dependentKey'](assert) {
-      assert.equal(obj.get('total'), 6, 'sums the values');
+      assert.strictEqual(obj.get('total'), 6, 'sums the values');
     }
 
     ['@test if the dependentKey is neither an array nor object, it will return `0`'](assert) {
       set(obj, 'array', null);
-      assert.equal(get(obj, 'total'), 0, 'returns 0');
+      assert.strictEqual(get(obj, 'total'), 0, 'returns 0');
 
       set(obj, 'array', undefined);
-      assert.equal(get(obj, 'total'), 0, 'returns 0');
+      assert.strictEqual(get(obj, 'total'), 0, 'returns 0');
 
       set(obj, 'array', 'not an array');
-      assert.equal(get(obj, 'total'), 0, 'returns 0');
+      assert.strictEqual(get(obj, 'total'), 0, 'returns 0');
     }
 
     ['@test updates when array is modified'](assert) {
       obj.get('array').pushObject(1);
 
-      assert.equal(obj.get('total'), 7, 'recomputed when elements are added');
+      assert.strictEqual(obj.get('total'), 7, 'recomputed when elements are added');
 
       obj.get('array').popObject();
 
-      assert.equal(obj.get('total'), 6, 'recomputes when elements are removed');
+      assert.strictEqual(obj.get('total'), 6, 'recomputes when elements are removed');
     }
   }
 );

--- a/packages/@ember/runloop/tests/later_test.js
+++ b/packages/@ember/runloop/tests/later_test.js
@@ -48,7 +48,7 @@ moduleFor(
       });
 
       wait(() => {
-        assert.equal(invoked, true, 'should have invoked later item');
+        assert.strictEqual(invoked, true, 'should have invoked later item');
         done();
       });
     }
@@ -68,7 +68,7 @@ moduleFor(
       });
 
       wait(() => {
-        assert.equal(obj.invoked, true, 'should have invoked later item');
+        assert.strictEqual(obj.invoked, true, 'should have invoked later item');
         done();
       });
     }
@@ -89,7 +89,7 @@ moduleFor(
       });
 
       wait(() => {
-        assert.equal(obj.invoked, 10, 'should have invoked later item');
+        assert.strictEqual(obj.invoked, 10, 'should have invoked later item');
         done();
       });
     }
@@ -117,10 +117,10 @@ moduleFor(
 
       assert.ok(firstRunLoop, 'first run loop captured');
       assert.ok(!_getCurrentRunLoop(), "shouldn't be in a run loop after flush");
-      assert.equal(obj.invoked, 0, "shouldn't have invoked later item yet");
+      assert.strictEqual(obj.invoked, 0, "shouldn't have invoked later item yet");
 
       wait(() => {
-        assert.equal(obj.invoked, 10, 'should have invoked later item');
+        assert.strictEqual(obj.invoked, 10, 'should have invoked later item');
         assert.ok(secondRunLoop, 'second run loop took place');
         assert.ok(secondRunLoop !== firstRunLoop, 'two different run loops took place');
         done();
@@ -250,7 +250,7 @@ moduleFor(
         }, 1);
 
         later(() => {
-          assert.equal(count, 1, 'callbacks called in order');
+          assert.strictEqual(count, 1, 'callbacks called in order');
         }, 50);
       });
 

--- a/packages/@ember/runloop/tests/next_test.js
+++ b/packages/@ember/runloop/tests/next_test.js
@@ -10,10 +10,10 @@ moduleFor(
 
       run(() => next(() => (invoked = true)));
 
-      assert.equal(invoked, false, 'should not have invoked yet');
+      assert.strictEqual(invoked, false, 'should not have invoked yet');
 
       setTimeout(() => {
-        assert.equal(invoked, true, 'should have invoked later item');
+        assert.strictEqual(invoked, true, 'should have invoked later item');
         done();
       }, 20);
     }

--- a/packages/@ember/runloop/tests/once_test.js
+++ b/packages/@ember/runloop/tests/once_test.js
@@ -15,7 +15,7 @@ moduleFor(
         once(F);
       });
 
-      assert.equal(count, 1, 'should have invoked once');
+      assert.strictEqual(count, 1, 'should have invoked once');
     }
 
     ['@test should differentiate based on target'](assert) {
@@ -31,8 +31,8 @@ moduleFor(
         once(B, F);
       });
 
-      assert.equal(A.count, 1, 'should have invoked once on A');
-      assert.equal(B.count, 1, 'should have invoked once on B');
+      assert.strictEqual(A.count, 1, 'should have invoked once on A');
+      assert.strictEqual(B.count, 1, 'should have invoked once on B');
     }
 
     ['@test should ignore other arguments - replacing previous ones'](assert) {
@@ -49,8 +49,8 @@ moduleFor(
         once(B, F, 40);
       });
 
-      assert.equal(A.count, 30, 'should have invoked once on A');
-      assert.equal(B.count, 40, 'should have invoked once on B');
+      assert.strictEqual(A.count, 30, 'should have invoked once on A');
+      assert.strictEqual(B.count, 40, 'should have invoked once on B');
     }
 
     ['@test should be inside of a runloop when running'](assert) {

--- a/packages/@ember/runloop/tests/run_bind_test.js
+++ b/packages/@ember/runloop/tests/run_bind_test.js
@@ -16,8 +16,8 @@ moduleFor(
       };
 
       let proxiedFunction = bind(obj, obj.increment, 1);
-      assert.equal(proxiedFunction(), 1);
-      assert.equal(obj.value, 1);
+      assert.strictEqual(proxiedFunction(), 1);
+      assert.strictEqual(obj.value, 1);
     }
 
     ['@test bind keeps the async callback arguments'](assert) {
@@ -25,9 +25,9 @@ moduleFor(
 
       function asyncCallback(increment, increment2, increment3) {
         assert.ok(_getCurrentRunLoop(), 'expected a run-loop');
-        assert.equal(increment, 1);
-        assert.equal(increment2, 2);
-        assert.equal(increment3, 3);
+        assert.strictEqual(increment, 1);
+        assert.strictEqual(increment2, 2);
+        assert.strictEqual(increment3, 3);
       }
 
       function asyncFunction(fn) {

--- a/packages/@ember/runloop/tests/run_test.js
+++ b/packages/@ember/runloop/tests/run_test.js
@@ -15,7 +15,7 @@ moduleFor(
         },
       };
 
-      assert.equal(
+      assert.strictEqual(
         run(() => 'FOO'),
         'FOO',
         'pass function only'

--- a/packages/@ember/runloop/tests/schedule_test.js
+++ b/packages/@ember/runloop/tests/schedule_test.js
@@ -10,10 +10,10 @@ moduleFor(
       run(() => {
         schedule('actions', () => cnt++);
         schedule('actions', () => cnt++);
-        assert.equal(cnt, 0, 'should not run action yet');
+        assert.strictEqual(cnt, 0, 'should not run action yet');
       });
 
-      assert.equal(cnt, 2, 'should flush actions now');
+      assert.strictEqual(cnt, 2, 'should flush actions now');
     }
 
     ['@test a scheduled item can be canceled'](assert) {
@@ -32,15 +32,15 @@ moduleFor(
 
       run(() => {
         schedule('actions', () => cnt++);
-        assert.equal(cnt, 0, 'should not run action yet');
+        assert.strictEqual(cnt, 0, 'should not run action yet');
 
         run(() => {
           schedule('actions', () => cnt++);
         });
-        assert.equal(cnt, 1, 'should not run action yet');
+        assert.strictEqual(cnt, 1, 'should not run action yet');
       });
 
-      assert.equal(cnt, 2, 'should flush actions now');
+      assert.strictEqual(cnt, 2, 'should flush actions now');
     }
 
     ['@test prior queues should be flushed before moving on to next queue'](assert) {
@@ -52,27 +52,27 @@ moduleFor(
 
         schedule('actions', () => {
           order.push('actions');
-          assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
+          assert.strictEqual(runLoop, _getCurrentRunLoop(), 'same run loop used');
         });
 
         schedule('afterRender', () => {
           order.push('afterRender');
-          assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
+          assert.strictEqual(runLoop, _getCurrentRunLoop(), 'same run loop used');
 
           schedule('afterRender', () => {
             order.push('afterRender');
-            assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
+            assert.strictEqual(runLoop, _getCurrentRunLoop(), 'same run loop used');
           });
 
           schedule('actions', () => {
             order.push('actions');
-            assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
+            assert.strictEqual(runLoop, _getCurrentRunLoop(), 'same run loop used');
           });
         });
 
         schedule('destroy', () => {
           order.push('destroy');
-          assert.equal(runLoop, _getCurrentRunLoop(), 'same run loop used');
+          assert.strictEqual(runLoop, _getCurrentRunLoop(), 'same run loop used');
         });
       });
 

--- a/packages/@ember/runloop/tests/unwind_test.js
+++ b/packages/@ember/runloop/tests/unwind_test.js
@@ -24,7 +24,7 @@ moduleFor(
       // tasks into the already-dead runloop, which will never get
       // flushed. I can't easily demonstrate this in a unit test because
       // autorun explicitly doesn't work in test mode. - ef4
-      assert.equal(
+      assert.strictEqual(
         _getCurrentRunLoop(),
         initialRunLoop,
         'Previous run loop should be cleaned up despite exception'
@@ -44,7 +44,7 @@ moduleFor(
         'boom!'
       );
 
-      assert.equal(
+      assert.strictEqual(
         _getCurrentRunLoop(),
         initialRunLoop,
         'Previous run loop should be cleaned up despite exception'

--- a/packages/ember-template-compiler/tests/basic-usage-test.js
+++ b/packages/ember-template-compiler/tests/basic-usage-test.js
@@ -37,7 +37,7 @@ moduleFor(
       // print back to a handlebars string
       let result = _print(transformedTemplateAST, { entityEncoding: 'raw' });
 
-      assert.equal(result, '<div data-blah="derp" class="hahaha">&nbsp;</div>');
+      assert.strictEqual(result, '<div data-blah="derp" class="hahaha">&nbsp;</div>');
     }
   }
 );

--- a/packages/ember-template-compiler/tests/system/bootstrap-test.js
+++ b/packages/ember-template-compiler/tests/system/bootstrap-test.js
@@ -40,7 +40,7 @@ function checkTemplate(templateName, assert) {
   component = owner.lookup('component:-top-level');
   runAppend(component);
 
-  assert.equal(qunitFixture.textContent.trim(), 'Tobias takes teamocil', 'template works');
+  assert.strictEqual(qunitFixture.textContent.trim(), 'Tobias takes teamocil', 'template works');
   runDestroy(owner);
 }
 
@@ -97,7 +97,7 @@ moduleFor(
       assert.ok(template, 'template with name funkyTemplate available');
 
       // This won't even work with Ember templates
-      assert.equal(template({ name: 'Tobias' }).trim(), 'Tobias');
+      assert.strictEqual(template({ name: 'Tobias' }).trim(), 'Tobias');
     }
 
     ['@test duplicated default application templates should throw exception'](assert) {

--- a/packages/ember-template-compiler/tests/system/dasherize-component-name-test.js
+++ b/packages/ember-template-compiler/tests/system/dasherize-component-name-test.js
@@ -5,20 +5,20 @@ moduleFor(
   'dasherize-component-name',
   class extends AbstractTestCase {
     ['@test names are correctly dasherized'](assert) {
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo'), 'foo');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('foo-bar'), 'foo-bar');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('FooBar'), 'foo-bar');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('F3Bar'), 'f3-bar');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo3Bar'), 'foo3-bar');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo3barBaz'), 'foo3bar-baz');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('FooB3ar'), 'foo-b3ar');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('XBlah'), 'x-blah');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('X-Blah'), 'x-blah');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo@BarBaz'), 'foo@bar-baz');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo@Bar-Baz'), 'foo@bar-baz');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo::BarBaz'), 'foo/bar-baz');
-      assert.equal(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo::Bar-Baz'), 'foo/bar-baz');
-      assert.equal(
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo'), 'foo');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('foo-bar'), 'foo-bar');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('FooBar'), 'foo-bar');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('F3Bar'), 'f3-bar');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo3Bar'), 'foo3-bar');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo3barBaz'), 'foo3bar-baz');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('FooB3ar'), 'foo-b3ar');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('XBlah'), 'x-blah');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('X-Blah'), 'x-blah');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo@BarBaz'), 'foo@bar-baz');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo@Bar-Baz'), 'foo@bar-baz');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo::BarBaz'), 'foo/bar-baz');
+      assert.strictEqual(COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo::Bar-Baz'), 'foo/bar-baz');
+      assert.strictEqual(
         COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE.get('Foo::BarBaz::Bang'),
         'foo/bar-baz/bang'
       );

--- a/packages/ember-testing/tests/adapters/adapter_test.js
+++ b/packages/ember-testing/tests/adapters/adapter_test.js
@@ -25,7 +25,7 @@ moduleFor(
       } catch (e) {
         thrown = e;
       }
-      assert.equal(thrown, error);
+      assert.strictEqual(thrown, error);
     }
   }
 );

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -133,12 +133,16 @@ moduleFor(
         caughtInCatch = e;
       }
 
-      assert.equal(
+      assert.strictEqual(
         caughtInAdapter,
         undefined,
         'test adapter should never receive synchronous errors'
       );
-      assert.equal(caughtInCatch, thrown, 'a "normal" try/catch should catch errors in sync run');
+      assert.strictEqual(
+        caughtInCatch,
+        thrown,
+        'a "normal" try/catch should catch errors in sync run'
+      );
     }
 
     ['@test when both Ember.onerror (which rethrows) and TestAdapter are registered - sync run'](
@@ -203,12 +207,12 @@ moduleFor(
       }
 
       setTimeout(() => {
-        assert.equal(
+        assert.strictEqual(
           caughtInAdapter,
           undefined,
           'test adapter should never catch errors in run loops'
         );
-        assert.equal(
+        assert.strictEqual(
           caughtInCatch,
           undefined,
           'a "normal" try/catch should never catch errors in an async run'

--- a/packages/ember-testing/tests/ext/rsvp_test.js
+++ b/packages/ember-testing/tests/ext/rsvp_test.js
@@ -44,46 +44,46 @@ moduleFor(
 
       setTesting(true);
 
-      assert.equal(asyncStarted, 0);
-      assert.equal(asyncEnded, 0);
+      assert.strictEqual(asyncStarted, 0);
+      assert.strictEqual(asyncEnded, 0);
 
       let user = RSVP.Promise.resolve({ name: 'tomster' });
 
-      assert.equal(asyncStarted, 0);
-      assert.equal(asyncEnded, 0);
+      assert.strictEqual(asyncStarted, 0);
+      assert.strictEqual(asyncEnded, 0);
 
       user
         .then(function (user) {
-          assert.equal(asyncStarted, 1);
-          assert.equal(asyncEnded, 1);
+          assert.strictEqual(asyncStarted, 1);
+          assert.strictEqual(asyncEnded, 1);
 
-          assert.equal(user.name, 'tomster');
+          assert.strictEqual(user.name, 'tomster');
 
           return RSVP.Promise.resolve(1).then(function () {
-            assert.equal(asyncStarted, 1);
-            assert.equal(asyncEnded, 1);
+            assert.strictEqual(asyncStarted, 1);
+            assert.strictEqual(asyncEnded, 1);
           });
         })
         .then(function () {
-          assert.equal(asyncStarted, 1);
-          assert.equal(asyncEnded, 1);
+          assert.strictEqual(asyncStarted, 1);
+          assert.strictEqual(asyncEnded, 1);
 
           return new RSVP.Promise(function (resolve) {
             setTimeout(function () {
-              assert.equal(asyncStarted, 1);
-              assert.equal(asyncEnded, 1);
+              assert.strictEqual(asyncStarted, 1);
+              assert.strictEqual(asyncEnded, 1);
 
               resolve({ name: 'async tomster' });
 
-              assert.equal(asyncStarted, 2);
-              assert.equal(asyncEnded, 1);
+              assert.strictEqual(asyncStarted, 2);
+              assert.strictEqual(asyncEnded, 1);
             }, 0);
           });
         })
         .then(function (user) {
-          assert.equal(user.name, 'async tomster');
-          assert.equal(asyncStarted, 2);
-          assert.equal(asyncEnded, 2);
+          assert.strictEqual(user.name, 'async tomster');
+          assert.strictEqual(asyncStarted, 2);
+          assert.strictEqual(asyncEnded, 2);
           done();
         });
     }

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -58,28 +58,28 @@ moduleFor(
       assert
     ) {
       let { indexController, applicationController } = this;
-      assert.equal(indexController.get('selectedMenuItem'), this.menuItem);
-      assert.equal(applicationController.get('selectedMenuItem'), this.menuItem);
+      assert.strictEqual(indexController.get('selectedMenuItem'), this.menuItem);
+      assert.strictEqual(applicationController.get('selectedMenuItem'), this.menuItem);
 
       this.application.reset();
 
-      assert.equal(indexController.get('selectedMenuItem'), null);
-      assert.equal(applicationController.get('selectedMenuItem'), null);
+      assert.strictEqual(indexController.get('selectedMenuItem'), null);
+      assert.strictEqual(applicationController.get('selectedMenuItem'), null);
     }
 
     [`@test Destroying the application resets the router before the appInstance is destroyed`](
       assert
     ) {
       let { indexController, applicationController } = this;
-      assert.equal(indexController.get('selectedMenuItem'), this.menuItem);
-      assert.equal(applicationController.get('selectedMenuItem'), this.menuItem);
+      assert.strictEqual(indexController.get('selectedMenuItem'), this.menuItem);
+      assert.strictEqual(applicationController.get('selectedMenuItem'), this.menuItem);
 
       runTask(() => {
         this.application.destroy();
       });
 
-      assert.equal(indexController.get('selectedMenuItem'), null);
-      assert.equal(applicationController.get('selectedMenuItem'), null);
+      assert.strictEqual(indexController.get('selectedMenuItem'), null);
+      assert.strictEqual(applicationController.get('selectedMenuItem'), null);
     }
   }
 );
@@ -111,13 +111,13 @@ moduleFor(
       let route = this.applicationInstance.lookup('route:index');
 
       runTask(() => router.destroy());
-      assert.equal(router._toplevelView, null, 'the toplevelView was cleared');
+      assert.strictEqual(router._toplevelView, null, 'the toplevelView was cleared');
 
       runTask(() => route.destroy());
-      assert.equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
+      assert.strictEqual(router._toplevelView, null, 'the toplevelView was not reinitialized');
 
       runTask(() => this.application.destroy());
-      assert.equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
+      assert.strictEqual(router._toplevelView, null, 'the toplevelView was not reinitialized');
     }
 
     [`@test initializers can augment an applications customEvents hash`](assert) {

--- a/packages/ember/tests/component_context_test.js
+++ b/packages/ember/tests/component_context_test.js
@@ -32,7 +32,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = getTextOf(this.element.querySelector('#wrapper'));
-        assert.equal(text, 'inner-outer', 'The component is composed correctly');
+        assert.strictEqual(text, 'inner-outer', 'The component is composed correctly');
       });
     }
 
@@ -62,7 +62,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = getTextOf(this.element.querySelector('#wrapper'));
-        assert.equal(text, 'outer', 'The component is composed correctly');
+        assert.strictEqual(text, 'outer', 'The component is composed correctly');
       });
     }
     ['@test Components without a block should have the proper content when a template is provided'](
@@ -90,7 +90,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = getTextOf(this.element.querySelector('#wrapper'));
-        assert.equal(text, 'inner', 'The component is composed correctly');
+        assert.strictEqual(text, 'inner', 'The component is composed correctly');
       });
     }
 
@@ -118,7 +118,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = getTextOf(this.element.querySelector('#wrapper'));
-        assert.equal(text, 'Some text inserted', 'The component is composed correctly');
+        assert.strictEqual(text, 'Some text inserted', 'The component is composed correctly');
       });
     }
 
@@ -148,7 +148,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = getTextOf(this.element.querySelector('#wrapper'));
-        assert.equal(text, 'Some text inserted', 'The component is composed correctly');
+        assert.strictEqual(text, 'Some text inserted', 'The component is composed correctly');
       });
     }
 
@@ -179,7 +179,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = getTextOf(this.element.querySelector('#wrapper'));
-        assert.equal(text, 'Some text inserted', 'The component is composed correctly');
+        assert.strictEqual(text, 'Some text inserted', 'The component is composed correctly');
       });
     }
 

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -67,7 +67,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = this.$('div.testing123').text().trim();
-        assert.equal(text, 'hello world', 'The component is composed correctly');
+        assert.strictEqual(text, 'hello world', 'The component is composed correctly');
       });
     }
 
@@ -89,7 +89,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = this.$('#wrapper').text().trim();
-        assert.equal(
+        assert.strictEqual(
           text,
           'there goes watch him as he GOES',
           'The component is composed correctly'
@@ -123,7 +123,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = this.$('#wrapper').text().trim();
-        assert.equal(
+        assert.strictEqual(
           text,
           'hello world funkytowny-funkytowny!!!',
           'The component is composed correctly'
@@ -151,7 +151,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = this.$('#wrapper').text().trim();
-        assert.equal(
+        assert.strictEqual(
           text,
           'hello world goodfreakingTIMES-goodfreakingTIMES!!!',
           'The component is composed correctly'
@@ -194,7 +194,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = this.$('#wrapper').text().trim();
-        assert.equal(text, 'inner-outer', 'The component is composed correctly');
+        assert.strictEqual(text, 'inner-outer', 'The component is composed correctly');
       });
     }
 
@@ -234,7 +234,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let text = this.$('#wrapper').text().trim();
-        assert.equal(text, 'inner-outer', 'The component is composed correctly');
+        assert.strictEqual(text, 'inner-outer', 'The component is composed correctly');
       });
     }
 

--- a/packages/ember/tests/ember-test-helpers-test.js
+++ b/packages/ember/tests/ember-test-helpers-test.js
@@ -128,7 +128,7 @@ module('@ember/test-helpers emulation test', function () {
       test('it basically works', async function (assert) {
         await render(compile('Hi!'), this);
 
-        assert.equal(this.element.textContent, 'Hi!');
+        assert.strictEqual(this.element.textContent, 'Hi!');
       });
     });
   });

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -38,10 +38,10 @@ moduleFor(
 
       let $ = this.$();
 
-      assert.equal($.findAll('h1').text(), 'People');
-      assert.equal($.findAll('li').length, 2);
-      assert.equal($.findAll('li:nth-of-type(1)').text(), 'Hello, Tom Dale!');
-      assert.equal($.findAll('li:nth-of-type(2)').text(), 'Hello, Yehuda Katz!');
+      assert.strictEqual($.findAll('h1').text(), 'People');
+      assert.strictEqual($.findAll('li').length, 2);
+      assert.strictEqual($.findAll('li:nth-of-type(1)').text(), 'Hello, Tom Dale!');
+      assert.strictEqual($.findAll('li:nth-of-type(2)').text(), 'Hello, Yehuda Katz!');
     }
   }
 );

--- a/packages/ember/tests/production_build_test.js
+++ b/packages/ember/tests/production_build_test.js
@@ -25,7 +25,7 @@ moduleFor(
         let fired = false;
         runInDebug(() => (fired = true));
 
-        assert.equal(fired, false, 'runInDebug callback should not be ran');
+        assert.strictEqual(fired, false, 'runInDebug callback should not be ran');
       } else {
         assert.expect(0);
       }

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -69,7 +69,7 @@ moduleFor(
     ['@skip Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
-        assert.equal(
+        assert.strictEqual(
           Ember.String.htmlSafe,
           glimmer.htmlSafe,
           'Ember.String.htmlSafe is exported correctly'
@@ -81,7 +81,7 @@ moduleFor(
     ['@skip Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
-        assert.equal(
+        assert.strictEqual(
           Ember.String.isHTMLSafe,
           glimmer.isHTMLSafe,
           'Ember.String.isHTMLSafe is exported correctly'
@@ -92,7 +92,7 @@ moduleFor(
 
     '@test Ember.FEATURES is exported'(assert) {
       for (let feature in FEATURES) {
-        assert.equal(
+        assert.strictEqual(
           Ember.FEATURES[feature],
           FEATURES[feature],
           'Ember.FEATURES contains ${feature} with correct value'

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -27,7 +27,7 @@ function handleURLRejectsWith(context, assert, path, expectedReason) {
       assert.ok(false, 'expected handleURLing: `' + path + '` to fail');
     })
     .catch((reason) => {
-      assert.equal(reason.message, expectedReason);
+      assert.strictEqual(reason.message, expectedReason);
     });
 }
 
@@ -87,10 +87,10 @@ moduleFor(
 
     ['@test The Homepage'](assert) {
       return this.visit('/').then(() => {
-        assert.equal(this.appRouter.currentPath, 'home', 'currently on the home route');
+        assert.strictEqual(this.appRouter.currentPath, 'home', 'currently on the home route');
 
         let text = this.$('.hours').text();
-        assert.equal(text, 'Hours', 'the home template was rendered');
+        assert.strictEqual(text, 'Hours', 'the home template was rendered');
       });
     }
 
@@ -101,18 +101,18 @@ moduleFor(
 
       return this.visit('/camelot')
         .then(() => {
-          assert.equal(this.appRouter.currentPath, 'camelot');
+          assert.strictEqual(this.appRouter.currentPath, 'camelot');
 
           let text = this.$('#camelot').text();
-          assert.equal(text, 'Is a silly place', 'the camelot template was rendered');
+          assert.strictEqual(text, 'Is a silly place', 'the camelot template was rendered');
 
           return this.visit('/');
         })
         .then(() => {
-          assert.equal(this.appRouter.currentPath, 'home');
+          assert.strictEqual(this.appRouter.currentPath, 'home');
 
           let text = this.$('.hours').text();
-          assert.equal(text, 'Hours', 'the home template was rendered');
+          assert.strictEqual(text, 'Hours', 'the home template was rendered');
         });
     }
 
@@ -182,7 +182,7 @@ moduleFor(
       return this.visit('/specials/1').then(() => {
         let text = this.$('p').text();
 
-        assert.equal(text, '1', 'The app is now in the specials state');
+        assert.strictEqual(text, '1', 'The app is now in the specials state');
       });
     }
 
@@ -214,7 +214,7 @@ moduleFor(
           },
           actions: {
             error(reason) {
-              assert.equal(
+              assert.strictEqual(
                 reason.message,
                 'Setup error',
                 'SpecialRoute#error received the error thrown from setup'
@@ -255,7 +255,7 @@ moduleFor(
         Route.extend({
           actions: {
             error(reason) {
-              assert.equal(
+              assert.strictEqual(
                 reason.message,
                 'Setup error',
                 'error was correctly passed to custom ApplicationRoute handler'
@@ -416,7 +416,7 @@ moduleFor(
             assert.ok(true, 'foo');
           },
           bar(msg) {
-            assert.equal(msg, 'HELLO', 'bar hander in super route');
+            assert.strictEqual(msg, 'HELLO', 'bar hander in super route');
           },
         },
       });
@@ -424,7 +424,7 @@ moduleFor(
       let RouteMixin = Mixin.create({
         actions: {
           bar(msg) {
-            assert.equal(msg, 'HELLO', 'bar handler in mixin');
+            assert.strictEqual(msg, 'HELLO', 'bar handler in mixin');
             this._super(msg);
           },
         },
@@ -569,15 +569,15 @@ moduleFor(
           set(this, 'path', path);
         };
 
-        assert.equal(urlSetCount, 0);
+        assert.strictEqual(urlSetCount, 0);
 
         run(function () {
           router.transitionTo('foo');
           router.transitionTo('bar');
         });
 
-        assert.equal(urlSetCount, 1);
-        assert.equal(router.get('location').getURL(), '/bar');
+        assert.strictEqual(urlSetCount, 1);
+        assert.strictEqual(router.get('location').getURL(), '/bar');
       });
     }
 
@@ -624,14 +624,14 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
-        assert.equal(setCount, 1);
-        assert.equal(replaceCount, 0);
+        assert.strictEqual(setCount, 1);
+        assert.strictEqual(replaceCount, 0);
 
         run(() => router.replaceWith('foo'));
 
-        assert.equal(setCount, 1, 'should not call setURL');
-        assert.equal(replaceCount, 1, 'should call replaceURL once');
-        assert.equal(router.get('location').getURL(), '/foo');
+        assert.strictEqual(setCount, 1, 'should not call setURL');
+        assert.strictEqual(replaceCount, 1, 'should call replaceURL once');
+        assert.strictEqual(router.get('location').getURL(), '/foo');
       });
     }
 
@@ -655,10 +655,10 @@ moduleFor(
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
 
-        assert.equal(setCount, 1);
+        assert.strictEqual(setCount, 1);
         run(() => router.replaceWith('foo'));
-        assert.equal(setCount, 2, 'should call setURL once');
-        assert.equal(router.get('location').getURL(), '/foo');
+        assert.strictEqual(setCount, 2, 'should call setURL once');
+        assert.strictEqual(router.get('location').getURL(), '/foo');
       });
     }
 
@@ -690,17 +690,17 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let rootElement = document.getElementById('qunit-fixture');
-        assert.equal(
+        assert.strictEqual(
           chooseFollowed,
           0,
           "The choose route wasn't entered since a transition occurred"
         );
-        assert.equal(
+        assert.strictEqual(
           rootElement.querySelectorAll('h3.hours').length,
           1,
           'The home template was rendered'
         );
-        assert.equal(this.appRouter.currentPath, 'home');
+        assert.strictEqual(this.appRouter.currentPath, 'home');
       });
     }
 
@@ -742,8 +742,8 @@ moduleFor(
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
         this.handleURLAborts(assert, '/foo/bar/baz');
-        assert.equal(router.currentPath, 'home');
-        assert.equal(router.get('location').getURL(), '/home');
+        assert.strictEqual(router.currentPath, 'home');
+        assert.strictEqual(router.get('location').getURL(), '/home');
       });
     }
 
@@ -791,8 +791,8 @@ moduleFor(
 
       return this.visit('/foo/bar/baz').then(() => {
         assert.ok(true, '/foo/bar/baz has been handled');
-        assert.equal(this.appRouter.currentPath, 'foo.bar.baz');
-        assert.equal(successCount, 1, 'transitionTo success handler was called once');
+        assert.strictEqual(this.appRouter.currentPath, 'foo.bar.baz');
+        assert.strictEqual(successCount, 1, 'transitionTo success handler was called once');
       });
     }
 
@@ -840,8 +840,8 @@ moduleFor(
 
       return this.visit('/').then(() => {
         this.handleURLAborts(assert, '/foo/bar/1/baz');
-        assert.equal(this.appRouter.currentPath, 'foo.bar.baz');
-        assert.equal(
+        assert.strictEqual(this.appRouter.currentPath, 'foo.bar.baz');
+        assert.strictEqual(
           this.applicationInstance.lookup('router:main').get('location').getURL(),
           '/foo/bar/2/baz'
         );
@@ -877,10 +877,10 @@ moduleFor(
         assert.ok(true, '/foo/bar/baz has been handled');
         let router = this.applicationInstance.lookup('router:main');
 
-        assert.equal(router.currentPath, 'foo.bar.baz');
+        assert.strictEqual(router.currentPath, 'foo.bar.baz');
         run(() => router.send('goToQux'));
-        assert.equal(router.currentPath, 'foo.qux');
-        assert.equal(router.get('location').getURL(), '/foo/qux');
+        assert.strictEqual(router.currentPath, 'foo.qux');
+        assert.strictEqual(router.get('location').getURL(), '/foo/qux');
       });
     }
 
@@ -953,7 +953,7 @@ moduleFor(
             pushState() {},
           },
           initState() {
-            assert.equal(this.get('rootURL'), rootURL);
+            assert.strictEqual(this.get('rootURL'), rootURL);
           },
         })
       );
@@ -994,11 +994,11 @@ moduleFor(
         assert.ok(true, '/posts/1 has been handled');
 
         let route = this.applicationInstance.lookup('route:post');
-        assert.equal(route.modelFor('post'), posts[1]);
+        assert.strictEqual(route.modelFor('post'), posts[1]);
 
         let url = this.applicationInstance.lookup('router:main').generate('post', posts[2]);
-        assert.equal(url, '/posts/2');
-        assert.equal(route.modelFor('post'), posts[1]);
+        assert.strictEqual(url, '/posts/2');
+        assert.strictEqual(route.modelFor('post'), posts[1]);
       });
     }
 
@@ -1042,13 +1042,13 @@ moduleFor(
 
       run(() => this.visit('/'));
       let rootElement = document.getElementById('qunit-fixture');
-      assert.equal(
+      assert.strictEqual(
         getTextOf(rootElement.querySelector('p')),
         'LOADING',
         'The loading state is displaying.'
       );
       run(deferred.resolve);
-      assert.equal(
+      assert.strictEqual(
         getTextOf(rootElement.querySelector('p')),
         'INDEX',
         'The index route is display.'
@@ -1215,7 +1215,7 @@ moduleFor(
 
       router.one('didTransition', function () {
         assert.ok(true, 'didTransition fired on the router');
-        assert.equal(
+        assert.strictEqual(
           router.get('url'),
           '/nork',
           'The url property is updated by the time didTransition fires'
@@ -1241,7 +1241,7 @@ moduleFor(
             this._super(...arguments);
 
             this.on('activate', function (transition) {
-              assert.equal(++eventFired, 1, 'activate event is fired once');
+              assert.strictEqual(++eventFired, 1, 'activate event is fired once');
               assert.ok(transition, 'transition is passed to activate event');
             });
           },
@@ -1273,7 +1273,7 @@ moduleFor(
             this._super(...arguments);
 
             this.on('deactivate', function (transition) {
-              assert.equal(++eventFired, 1, 'deactivate event is fired once');
+              assert.strictEqual(++eventFired, 1, 'deactivate event is fired once');
               assert.ok(transition, 'transition is passed');
             });
           },
@@ -1297,7 +1297,7 @@ moduleFor(
             assert.ok(true, 'foo');
           },
           bar(msg) {
-            assert.equal(msg, 'HELLO');
+            assert.strictEqual(msg, 'HELLO');
           },
         },
       });
@@ -1305,7 +1305,7 @@ moduleFor(
       let RouteMixin = Mixin.create({
         actions: {
           bar(msg) {
-            assert.equal(msg, 'HELLO');
+            assert.strictEqual(msg, 'HELLO');
             this._super(msg);
           },
         },
@@ -1350,7 +1350,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
         let transition = run(() => router.transitionTo('bar'));
-        assert.equal(transition instanceof Transition, true);
+        assert.strictEqual(transition instanceof Transition, true);
       });
     }
 
@@ -1367,7 +1367,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
         let transition = run(() => router.transitionTo('/bar/baz'));
-        assert.equal(transition instanceof Transition, true);
+        assert.strictEqual(transition instanceof Transition, true);
       });
     }
 
@@ -1397,8 +1397,8 @@ moduleFor(
             run(router, 'transitionTo', path);
           }
 
-          assert.equal(router.currentPath, expectedPath);
-          assert.equal(router.currentRouteName, expectedRouteName);
+          assert.strictEqual(router.currentPath, expectedPath);
+          assert.strictEqual(router.currentRouteName, expectedRouteName);
         }
 
         transitionAndCheck(null, 'index', 'index');
@@ -1451,7 +1451,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
-        assert.equal(router.get('location.path'), '/about/TreeklesMcGeekles');
+        assert.strictEqual(router.get('location.path'), '/about/TreeklesMcGeekles');
       });
     }
 
@@ -1468,17 +1468,21 @@ moduleFor(
       });
 
       console.error = function (initialMessage, errorMessage, errorStack) {
-        assert.equal(
+        assert.strictEqual(
           initialMessage,
           'Error while processing route: yippie',
           'a message with the current route name is printed'
         );
-        assert.equal(
+        assert.strictEqual(
           errorMessage,
           rejectedMessage,
           "the rejected reason's message property is logged"
         );
-        assert.equal(errorStack, rejectedStack, "the rejected reason's stack property is logged");
+        assert.strictEqual(
+          errorStack,
+          rejectedStack,
+          "the rejected reason's stack property is logged"
+        );
       };
 
       this.add(
@@ -1496,7 +1500,7 @@ moduleFor(
       await assert.rejects(
         this.visit('/'),
         function (err) {
-          assert.equal(err.message, rejectedMessage);
+          assert.strictEqual(err.message, rejectedMessage);
           return true;
         },
         'expected an exception'
@@ -1515,17 +1519,21 @@ moduleFor(
       });
 
       console.error = function (initialMessage, errorMessage, errorStack) {
-        assert.equal(
+        assert.strictEqual(
           initialMessage,
           'Error while processing route: yippie',
           'a message with the current route name is printed'
         );
-        assert.equal(
+        assert.strictEqual(
           errorMessage,
           rejectedMessage,
           "the rejected reason's message property is logged"
         );
-        assert.equal(errorStack, rejectedStack, "the rejected reason's stack property is logged");
+        assert.strictEqual(
+          errorStack,
+          rejectedStack,
+          "the rejected reason's stack property is logged"
+        );
       };
 
       this.add(
@@ -1542,7 +1550,7 @@ moduleFor(
       await assert.rejects(
         this.visit('/'),
         function ({ errorThrown: err }) {
-          assert.equal(err.message, rejectedMessage);
+          assert.strictEqual(err.message, rejectedMessage);
           return true;
         },
         'expected an exception'
@@ -1556,7 +1564,7 @@ moduleFor(
       });
 
       console.error = function (initialMessage) {
-        assert.equal(
+        assert.strictEqual(
           initialMessage,
           'Error while processing route: wowzers',
           'a message with the current route name is printed'
@@ -1584,12 +1592,12 @@ moduleFor(
       });
 
       console.error = function (initialMessage, errorMessage) {
-        assert.equal(
+        assert.strictEqual(
           initialMessage,
           'Error while processing route: yondo',
           'a message with the current route name is printed'
         );
-        assert.equal(
+        assert.strictEqual(
           errorMessage,
           rejectedMessage,
           "the rejected reason's message property is logged"
@@ -1671,8 +1679,12 @@ moduleFor(
 
       await assert.rejects(this.visit('/'), /More context objects were passed/);
 
-      assert.equal(actual.length, 1, 'the error is only logged once');
-      assert.equal(actual[0][0], 'Error while processing route: yondo', 'source route is printed');
+      assert.strictEqual(actual.length, 1, 'the error is only logged once');
+      assert.strictEqual(
+        actual[0][0],
+        'Error while processing route: yondo',
+        'source route is printed'
+      );
       assert.ok(
         actual[0][1].match(
           /More context objects were passed than there are dynamic segments for the route: stink-bomb/
@@ -1703,7 +1715,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let rootElement = document.querySelector('#qunit-fixture');
-        assert.equal(
+        assert.strictEqual(
           rootElement.querySelectorAll('#error').length,
           1,
           'Error template was rendered.'
@@ -1863,7 +1875,7 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let router = this.applicationInstance.lookup('router:main');
-        assert.equal(
+        assert.strictEqual(
           router._routerMicrolib.generate('blog.post', { id: '13' }),
           '/blog/post/13',
           'url is generated properly'
@@ -1945,13 +1957,13 @@ moduleFor(
           let router = this.applicationInstance.lookup('router:main');
 
           run(router, 'destroy');
-          assert.equal(router._toplevelView, null, 'the toplevelView was cleared');
+          assert.strictEqual(router._toplevelView, null, 'the toplevelView was cleared');
 
           run(route, 'destroy');
-          assert.equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
+          assert.strictEqual(router._toplevelView, null, 'the toplevelView was not reinitialized');
 
           run(this.applicationInstance, 'destroy');
-          assert.equal(router._toplevelView, null, 'the toplevelView was not reinitialized');
+          assert.strictEqual(router._toplevelView, null, 'the toplevelView was not reinitialized');
         });
     }
 

--- a/packages/ember/tests/routing/model_loading_test.js
+++ b/packages/ember/tests/routing/model_loading_test.js
@@ -87,7 +87,7 @@ moduleFor(
 
       return this.visit('/track/2')
         .then(() => {
-          assert.equal(
+          assert.strictEqual(
             document.querySelector('h3').innerText,
             '2',
             'the derived property matches the id'
@@ -95,7 +95,7 @@ moduleFor(
         })
         .then(() => {
           return this.visit('/track/3').then(() => {
-            assert.equal(
+            assert.strictEqual(
               document.querySelector('h3').innerText,
               '3',
               'the derived property matches the id'
@@ -129,7 +129,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let text = this.$('ul li:nth-child(3)').text();
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'Sunday: Noon to 6pm',
           'The template was rendered with the hours context'
@@ -154,7 +154,7 @@ moduleFor(
         let homeRoute = this.applicationInstance.lookup('route:home');
         let homeController = this.applicationInstance.lookup('controller:home');
 
-        assert.equal(
+        assert.strictEqual(
           homeRoute.controller,
           homeController,
           'route controller is the home controller'
@@ -182,12 +182,12 @@ moduleFor(
         let myController = this.applicationInstance.lookup('controller:myController');
         let text = this.$('p').text();
 
-        assert.equal(
+        assert.strictEqual(
           homeRoute.controller,
           myController,
           'route controller is set by controllerName'
         );
-        assert.equal(
+        assert.strictEqual(
           text,
           'foo',
           'The homepage template was rendered with data from the custom controller'
@@ -230,13 +230,13 @@ moduleFor(
         let myController = this.applicationInstance.lookup('controller:myController');
         let text = this.$('p').text();
 
-        assert.equal(
+        assert.strictEqual(
           homeRoute.controller,
           myController,
           'route controller is set by controllerName'
         );
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'home: myController',
           'The homepage template was rendered with data from the custom controller'
@@ -270,7 +270,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let text = this.$('ul li:nth-child(3)').text();
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'Sunday: Noon to 6pm',
           'The template was rendered with the hours context'
@@ -304,7 +304,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let text = this.$('ul li:nth-child(3)').text();
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'Sunday: Noon to 6pm',
           'The template was rendered with the context intact'
@@ -329,7 +329,7 @@ moduleFor(
           },
 
           setupController(controller, model) {
-            assert.equal(this.controllerFor('home'), controller);
+            assert.strictEqual(this.controllerFor('home'), controller);
 
             this.controllerFor('home').set('hours', model);
           },
@@ -344,7 +344,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let text = this.$('ul li:nth-child(3)').text();
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'Sunday: Noon to 6pm',
           'The template was rendered with the hours context'
@@ -374,7 +374,7 @@ moduleFor(
       return this.visit('/specials/1').then(() => {
         let text = this.$('p').text();
 
-        assert.equal(text, '1', 'The model was used to render the template');
+        assert.strictEqual(text, '1', 'The model was used to render the template');
       });
     }
 
@@ -427,7 +427,7 @@ moduleFor(
           return this.visit('/specials/1', promiseContext);
         })
         .then(() => {
-          assert.equal(this.currentURL, '/specials/1');
+          assert.strictEqual(this.currentURL, '/specials/1');
           this.assertText('1', 'The app is now transitioned');
         });
     }
@@ -496,27 +496,27 @@ moduleFor(
       return this.visit('/').then(() => {
         rootElement = document.getElementById('qunit-fixture');
 
-        assert.equal(
+        assert.strictEqual(
           getTextOf(rootElement.querySelector('h3')),
           'Home',
           'The app is now in the initial state'
         );
-        assert.equal(rootSetup, 1, 'The root setup was triggered');
-        assert.equal(rootSerialize, 0, 'The root serialize was not called');
-        assert.equal(rootModel, 1, 'The root model was called');
+        assert.strictEqual(rootSetup, 1, 'The root setup was triggered');
+        assert.strictEqual(rootSerialize, 0, 'The root serialize was not called');
+        assert.strictEqual(rootModel, 1, 'The root model was called');
 
         let router = this.applicationInstance.lookup('router:main');
         let menuItem = MenuItem.create({ id: 1 });
 
         return router.transitionTo('special', menuItem).then(function () {
-          assert.equal(rootSetup, 1, 'The root setup was not triggered again');
-          assert.equal(rootSerialize, 0, 'The root serialize was not called');
+          assert.strictEqual(rootSetup, 1, 'The root setup was not triggered again');
+          assert.strictEqual(rootSerialize, 0, 'The root serialize was not called');
 
           // TODO: Should this be changed?
-          assert.equal(rootModel, 1, 'The root model was called again');
+          assert.strictEqual(rootModel, 1, 'The root model was called again');
 
           assert.deepEqual(router.location.path, '/specials/1');
-          assert.equal(router.currentPath, 'root.special');
+          assert.strictEqual(router.currentPath, 'root.special');
         });
       });
     }
@@ -567,7 +567,7 @@ moduleFor(
           afterModel(post /*, transition */) {
             let parent_model = this.modelFor('the-post');
 
-            assert.equal(post, parent_model);
+            assert.strictEqual(post, parent_model);
           },
         })
       );
@@ -587,7 +587,7 @@ moduleFor(
           afterModel(share /*, transition */) {
             let parent_model = this.modelFor('shares');
 
-            assert.equal(share, parent_model);
+            assert.strictEqual(share, parent_model);
           },
         })
       );
@@ -652,7 +652,7 @@ moduleFor(
           afterModel(post /*, transition */) {
             let parent_model = this.modelFor('the-post');
 
-            assert.equal(post, parent_model);
+            assert.strictEqual(post, parent_model);
           },
         })
       );
@@ -704,7 +704,7 @@ moduleFor(
         'route:comments',
         Route.extend({
           model() {
-            assert.equal(this.modelFor('the-post'), currentPost);
+            assert.strictEqual(this.modelFor('the-post'), currentPost);
           },
         })
       );
@@ -799,7 +799,7 @@ moduleFor(
         run(() => router.send('editPost'));
         run(() => router.send('showPost', { id: '2' }));
         run(() => router.send('editPost'));
-        assert.equal(editCount, 2, 'set up the edit route twice without failure');
+        assert.strictEqual(editCount, 2, 'set up the edit route twice without failure');
         assert.deepEqual(
           editedPostIds,
           ['1', '2'],
@@ -827,8 +827,8 @@ moduleFor(
 
       return this.visit('/').then(() => {
         let routerService = this.applicationInstance.lookup('service:router');
-        assert.equal(routerService.currentRouteName, 'index', 'currentPath is index');
-        assert.equal(
+        assert.strictEqual(routerService.currentRouteName, 'index', 'currentPath is index');
+        assert.strictEqual(
           'currentPath' in model,
           false,
           'should have defined currentPath on controller'
@@ -852,7 +852,7 @@ moduleFor(
       });
 
       return this.visit('/post/1').then(() => {
-        assert.equal(Post, post);
+        assert.strictEqual(Post, post);
       });
     }
 
@@ -878,7 +878,7 @@ moduleFor(
         'route:parent',
         Route.extend({
           model(params) {
-            assert.equal(params.parent_id, '123');
+            assert.strictEqual(params.parent_id, '123');
             ++parentcount;
           },
           actions: {
@@ -903,21 +903,21 @@ moduleFor(
       return this.visit('/')
         .then(() => {
           router = this.applicationInstance.lookup('router:main');
-          assert.equal(appcount, 1);
-          assert.equal(parentcount, 0);
-          assert.equal(childcount, 0);
+          assert.strictEqual(appcount, 1);
+          assert.strictEqual(parentcount, 0);
+          assert.strictEqual(childcount, 0);
           return run(router, 'transitionTo', 'parent.child', '123');
         })
         .then(() => {
-          assert.equal(appcount, 1);
-          assert.equal(parentcount, 1);
-          assert.equal(childcount, 1);
+          assert.strictEqual(appcount, 1);
+          assert.strictEqual(parentcount, 1);
+          assert.strictEqual(childcount, 1);
           return run(router, 'send', 'refreshParent');
         })
         .then(() => {
-          assert.equal(appcount, 1);
-          assert.equal(parentcount, 2);
-          assert.equal(childcount, 2);
+          assert.strictEqual(appcount, 1);
+          assert.strictEqual(parentcount, 2);
+          assert.strictEqual(childcount, 2);
         });
     }
   }

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -73,24 +73,24 @@ moduleFor(
       );
 
       await this.visit('/');
-      assert.equal(appModelCount, 1, 'appModelCount is 1');
-      assert.equal(indexModelCount, 1);
+      assert.strictEqual(appModelCount, 1, 'appModelCount is 1');
+      assert.strictEqual(indexModelCount, 1);
 
       let indexController = this.getController('index');
       await this.setAndFlush(indexController, 'omg', 'lex');
 
-      assert.equal(appModelCount, 1, 'appModelCount is 1');
-      assert.equal(indexModelCount, 2);
+      assert.strictEqual(appModelCount, 1, 'appModelCount is 1');
+      assert.strictEqual(indexModelCount, 2);
 
       await this.setAndFlush(indexController, 'omg', 'hello');
-      assert.equal(appModelCount, 1, 'appModelCount is 1');
-      assert.equal(indexModelCount, 3);
+      assert.strictEqual(appModelCount, 1, 'appModelCount is 1');
+      assert.strictEqual(indexModelCount, 3);
 
       run(function () {
         promiseResolve();
       });
 
-      assert.equal(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
+      assert.strictEqual(get(indexController, 'omg'), 'hello', 'At the end last value prevails');
     }
 
     ["@test No replaceURL occurs on startup because default values don't show up in URL"](assert) {
@@ -131,7 +131,7 @@ moduleFor(
           '/parent/sibling?foo=lol',
           'redirected to the sibling route, instead of child route'
         );
-        assert.equal(
+        assert.strictEqual(
           this.getController('parent').get('foo'),
           'lol',
           'controller has value from the active transition'
@@ -177,7 +177,7 @@ moduleFor(
           '/parent/sibling?array=%5B%22one%22%2C2%5D&string=hello',
           'redirected to the sibling route, instead of child route'
         );
-        assert.equal(
+        assert.strictEqual(
           this.getController('parent').get('string'),
           'hello',
           'controller has value from the active transition'
@@ -235,7 +235,7 @@ moduleFor(
       this.assertCurrentPath('/?other_foo=WOO', "QP updated correctly without 'as'");
 
       await this.transitionTo('/?other_foo=NAW');
-      assert.equal(controller.get('foo'), 'NAW', 'QP managed correctly on URL transition');
+      assert.strictEqual(controller.get('foo'), 'NAW', 'QP managed correctly on URL transition');
 
       await this.setAndFlush(controller, 'bar', 'NERK');
       this.assertCurrentPath('/?other_bar=NERK&other_foo=NAW', "QP mapped correctly with 'as'");
@@ -386,7 +386,7 @@ moduleFor(
         'route:application',
         Route.extend({
           setupController(controller) {
-            assert.equal(
+            assert.strictEqual(
               controller.get('foo'),
               'YEAH',
               "controller's foo QP property set before setupController called"
@@ -407,7 +407,7 @@ moduleFor(
         'route:application',
         Route.extend({
           setupController(controller) {
-            assert.equal(
+            assert.strictEqual(
               controller.get('faz'),
               'YEAH',
               "controller's foo QP property set before setupController called"
@@ -621,14 +621,14 @@ moduleFor(
       );
 
       await this.visitAndAssert('/');
-      assert.equal(appModelCount, 1, 'app model hook ran');
-      assert.equal(indexModelCount, 1, 'index model hook ran');
+      assert.strictEqual(appModelCount, 1, 'app model hook ran');
+      assert.strictEqual(indexModelCount, 1, 'index model hook ran');
 
       let indexController = this.getController('index');
       await this.setAndFlush(indexController, 'omg', 'lex');
 
-      assert.equal(appModelCount, 1, 'app model hook did not run again');
-      assert.equal(indexModelCount, 2, 'index model hook ran again due to refreshModel');
+      assert.strictEqual(appModelCount, 1, 'app model hook did not run again');
+      assert.strictEqual(indexModelCount, 2, 'index model hook ran again due to refreshModel');
     }
 
     async ['@test refreshModel and replace work together'](assert) {
@@ -670,15 +670,15 @@ moduleFor(
       );
 
       await this.visitAndAssert('/');
-      assert.equal(appModelCount, 1, 'app model hook ran');
-      assert.equal(indexModelCount, 1, 'index model hook ran');
+      assert.strictEqual(appModelCount, 1, 'app model hook ran');
+      assert.strictEqual(indexModelCount, 1, 'index model hook ran');
 
       let indexController = this.getController('index');
       this.expectedReplaceURL = '/?omg=lex';
       await this.setAndFlush(indexController, 'omg', 'lex');
 
-      assert.equal(appModelCount, 1, 'app model hook did not run again');
-      assert.equal(indexModelCount, 2, 'index model hook ran again due to refreshModel');
+      assert.strictEqual(appModelCount, 1, 'app model hook did not run again');
+      assert.strictEqual(indexModelCount, 2, 'index model hook ran again due to refreshModel');
     }
 
     async ['@test multiple QP value changes only cause a single model refresh'](assert) {
@@ -713,7 +713,7 @@ moduleFor(
         steely: 'david',
       });
 
-      assert.equal(refreshCount, 1, 'index refresh hook only run once');
+      assert.strictEqual(refreshCount, 1, 'index refresh hook only run once');
     }
 
     ['@test refreshModel does not cause a second transition during app boot '](assert) {
@@ -768,18 +768,18 @@ moduleFor(
       );
 
       await this.visitAndAssert('/');
-      assert.equal(getTextOf(document.getElementById('test-value')), '1');
+      assert.strictEqual(getTextOf(document.getElementById('test-value')), '1');
 
       document.getElementById('test-button').click();
       await runLoopSettled();
 
-      assert.equal(getTextOf(document.getElementById('test-value')), '2');
+      assert.strictEqual(getTextOf(document.getElementById('test-value')), '2');
       this.assertCurrentPath('/?foo=2');
 
       document.getElementById('test-button').click();
       await runLoopSettled();
 
-      assert.equal(getTextOf(document.getElementById('test-value')), '3');
+      assert.strictEqual(getTextOf(document.getElementById('test-value')), '3');
       this.assertCurrentPath('/?foo=3');
     }
 
@@ -821,14 +821,14 @@ moduleFor(
       );
 
       await this.visitAndAssert('/');
-      assert.equal(appModelCount, 1);
-      assert.equal(indexModelCount, 1);
+      assert.strictEqual(appModelCount, 1);
+      assert.strictEqual(indexModelCount, 1);
 
       let indexController = this.getController('index');
       await this.setAndFlush(indexController, 'omg', 'lex');
 
-      assert.equal(appModelCount, 1);
-      assert.equal(indexModelCount, 2);
+      assert.strictEqual(appModelCount, 1);
+      assert.strictEqual(indexModelCount, 2);
     }
 
     async ['@test can use refreshModel even with URL changes that remove QPs from address bar'](
@@ -866,7 +866,7 @@ moduleFor(
       await this.transitionTo('/');
 
       let indexController = this.getController('index');
-      assert.equal(indexController.get('omg'), 'lol');
+      assert.strictEqual(indexController.get('omg'), 'lol');
     }
 
     async ['@test can opt into a replace query by specifying replace:true in the Route config hash'](
@@ -1000,10 +1000,10 @@ moduleFor(
 
       await this.visit('/parent/child?foo=lol');
 
-      assert.equal(parentModelCount, 1);
+      assert.strictEqual(parentModelCount, 1);
 
       run(document.getElementById('parent-link'), 'click');
-      assert.equal(parentModelCount, 2);
+      assert.strictEqual(parentModelCount, 2);
     }
 
     async ["@test Use Ember.get to retrieve query params 'replace' configuration"](assert) {
@@ -1098,10 +1098,10 @@ moduleFor(
 
       return this.visit('/?omg=borf').then(() => {
         let indexController = this.getController('index');
-        assert.equal(indexController.get('omg'), 'borf');
+        assert.strictEqual(indexController.get('omg'), 'borf');
 
         this.transitionTo('/');
-        assert.equal(indexController.get('omg'), 'lol');
+        assert.strictEqual(indexController.get('omg'), 'lol');
       });
     }
 
@@ -1126,8 +1126,8 @@ moduleFor(
 
       await this.visitAndAssert('/');
 
-      assert.equal(this.$('#one').attr('href'), '/abcdef?foo=123');
-      assert.equal(this.$('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
+      assert.strictEqual(this.$('#one').attr('href'), '/abcdef?foo=123');
+      assert.strictEqual(this.$('#two').attr('href'), '/abcdef/zoo?bar=456&foo=123');
 
       run(this.$('#one'), 'click');
       this.assertCurrentPath('/abcdef?foo=123');
@@ -1220,17 +1220,17 @@ moduleFor(
         'route:index',
         Route.extend({
           model(params) {
-            assert.equal(params.foo, true, 'model hook received foo as boolean true');
+            assert.strictEqual(params.foo, true, 'model hook received foo as boolean true');
           },
         })
       );
 
       return this.visit('/?foo=true').then(() => {
         let controller = this.getController('index');
-        assert.equal(controller.get('foo'), true);
+        assert.strictEqual(controller.get('foo'), true);
 
         this.transitionTo('/?foo=false');
-        assert.equal(controller.get('foo'), false);
+        assert.strictEqual(controller.get('foo'), false);
       });
     }
 
@@ -1247,7 +1247,7 @@ moduleFor(
 
       return this.visit('/?foo=').then(() => {
         let controller = this.getController('index');
-        assert.equal(controller.get('foo'), '');
+        assert.strictEqual(controller.get('foo'), '');
       });
     }
 
@@ -1370,12 +1370,12 @@ moduleFor(
       this.setSingleQPController('home', 'foo', emberA([1]));
 
       await this.visitAndAssert('/');
-      assert.equal(modelCount, 1);
+      assert.strictEqual(modelCount, 1);
 
       let controller = this.getController('home');
       await this.setAndFlush(controller, 'model', emberA([1]));
 
-      assert.equal(modelCount, 1);
+      assert.strictEqual(modelCount, 1);
       this.assertCurrentPath('/');
     }
 
@@ -1464,8 +1464,8 @@ moduleFor(
 
       await this.visitAndAssert('/home');
 
-      assert.equal(this.$('#null-link').attr('href'), '/home');
-      assert.equal(this.$('#undefined-link').attr('href'), '/home');
+      assert.strictEqual(this.$('#null-link').attr('href'), '/home');
+      assert.strictEqual(this.$('#undefined-link').attr('href'), '/home');
     }
 
     ["@test A child of a resource route still defaults to parent route's model even if the child route has a query param"](
@@ -1578,7 +1578,7 @@ moduleFor(
 
       await this.visitAndAssert('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#the-link').attr('href'),
         '/example',
         'renders without undefined qp serialized'
@@ -1588,7 +1588,7 @@ moduleFor(
         queryParams: { foo: undefined },
       });
 
-      assert.equal(entered, 1, 'Should have entered example route');
+      assert.strictEqual(entered, 1, 'Should have entered example route');
 
       this.assertCurrentPath('/example');
     }
@@ -1644,7 +1644,7 @@ moduleFor(
       await this.visit('/');
       await this.transitionTo('constructor', { queryParams: { foo: '999' } });
       let controller = this.getController('constructor');
-      assert.equal(get(controller, 'foo'), '999');
+      assert.strictEqual(get(controller, 'foo'), '999');
     }
 
     async ['@test Single query params defined with tracked properties can be on the controller and reflected in the url'](
@@ -1804,11 +1804,11 @@ moduleFor(
       let parentController = this.getController('grandparent.parent');
 
       await this.setAndFlush(parentController, 'foo', 'NEW_FOO');
-      assert.equal(parentController.foo, 'NEW_FOO');
+      assert.strictEqual(parentController.foo, 'NEW_FOO');
       this.assertCurrentPath('/grandparent/1/parent/child?foo=NEW_FOO');
 
       await this.setAndFlush(parentController, 'bar', 'NEW_BAR');
-      assert.equal(parentController.bar, 'NEW_BAR');
+      assert.strictEqual(parentController.bar, 'NEW_BAR');
       this.assertCurrentPath('/grandparent/1/parent/child?bar=NEW_BAR&foo=NEW_FOO');
     }
   }

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -39,19 +39,19 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
 
     await this.setAndFlush(this.controller, 'q', 'lol');
 
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
     this.$link2.click();
     await runLoopSettled();
 
-    assert.equal(this.controller.get('q'), 'wat');
-    assert.equal(this.controller.get('z'), 0);
+    assert.strictEqual(this.controller.get('q'), 'wat');
+    assert.strictEqual(this.controller.get('z'), 0);
     assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
   }
 
   async queryParamsStickyTest2(urlPrefix) {
@@ -65,11 +65,11 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
     await this.transitionTo(`${urlPrefix}/a-1?q=lol`);
 
     assert.deepEqual(this.controller.get('model'), { id: 'a-1' });
-    assert.equal(this.controller.get('q'), 'lol');
-    assert.equal(this.controller.get('z'), 0);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
+    assert.strictEqual(this.controller.get('q'), 'lol');
+    assert.strictEqual(this.controller.get('z'), 0);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
 
@@ -80,21 +80,21 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
       { id: 'a-2' },
       "controller's model changed to a-2"
     );
-    assert.equal(this.controller.get('q'), 'lol');
-    assert.equal(this.controller.get('z'), 0);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
+    assert.strictEqual(this.controller.get('q'), 'lol');
+    assert.strictEqual(this.controller.get('z'), 0);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-3', q: 'lol', z: 123 };
 
     await this.transitionTo(`${urlPrefix}/a-3?q=lol&z=123`);
 
-    assert.equal(this.controller.get('q'), 'lol');
-    assert.equal(this.controller.get('z'), 123);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol&z=123`);
+    assert.strictEqual(this.controller.get('q'), 'lol');
+    assert.strictEqual(this.controller.get('z'), 123);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol&z=123`);
   }
 
   async queryParamsStickyTest3(urlPrefix, articleLookup) {
@@ -116,41 +116,41 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
     await this.transitionTo(articleLookup, 'a-1');
 
     assert.deepEqual(this.controller.get('model'), { id: 'a-1' });
-    assert.equal(this.controller.get('q'), 'wat');
-    assert.equal(this.controller.get('z'), 0);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
+    assert.strictEqual(this.controller.get('q'), 'wat');
+    assert.strictEqual(this.controller.get('z'), 0);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
     await this.transitionTo(articleLookup, 'a-2', { queryParams: { q: 'lol' } });
 
     assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
-    assert.equal(this.controller.get('q'), 'lol');
-    assert.equal(this.controller.get('z'), 0);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
+    assert.strictEqual(this.controller.get('q'), 'lol');
+    assert.strictEqual(this.controller.get('z'), 0);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
     await this.transitionTo(articleLookup, 'a-3', { queryParams: { q: 'hay' } });
 
     assert.deepEqual(this.controller.get('model'), { id: 'a-3' });
-    assert.equal(this.controller.get('q'), 'hay');
-    assert.equal(this.controller.get('z'), 0);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=hay`);
+    assert.strictEqual(this.controller.get('q'), 'hay');
+    assert.strictEqual(this.controller.get('z'), 0);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=hay`);
 
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
     await this.transitionTo(articleLookup, 'a-2', { queryParams: { z: 1 } });
 
     assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
-    assert.equal(this.controller.get('q'), 'lol');
-    assert.equal(this.controller.get('z'), 1);
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol&z=1`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=hay`);
+    assert.strictEqual(this.controller.get('q'), 'lol');
+    assert.strictEqual(this.controller.get('z'), 1);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol&z=1`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=hay`);
   }
 
   async queryParamsStickyTest4(urlPrefix, articleLookup) {
@@ -172,37 +172,37 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
 
     await this.setAndFlush(this.controller, 'q', 'lol');
 
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol`);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol`);
 
     this.$link2.click();
     await runLoopSettled();
 
-    assert.equal(this.controller.get('q'), 'lol');
-    assert.equal(this.controller.get('z'), 0);
+    assert.strictEqual(this.controller.get('q'), 'lol');
+    assert.strictEqual(this.controller.get('z'), 0);
     assert.deepEqual(this.controller.get('model'), { id: 'a-2' });
 
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol`);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=lol`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=lol`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=lol`);
 
     this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
     await this.transitionTo(`${urlPrefix}/a-3?q=haha&z=123`);
 
     assert.deepEqual(this.controller.get('model'), { id: 'a-3' });
-    assert.equal(this.controller.get('q'), 'haha');
-    assert.equal(this.controller.get('z'), 123);
+    assert.strictEqual(this.controller.get('q'), 'haha');
+    assert.strictEqual(this.controller.get('z'), 123);
 
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=haha`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=haha`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=haha&z=123`);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=haha`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=haha`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=haha&z=123`);
 
     await this.setAndFlush(this.controller, 'q', 'woot');
 
-    assert.equal(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=woot`);
-    assert.equal(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=woot`);
-    assert.equal(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=woot&z=123`);
+    assert.strictEqual(this.$link1.getAttribute('href'), `${urlPrefix}/a-1?q=woot`);
+    assert.strictEqual(this.$link2.getAttribute('href'), `${urlPrefix}/a-2?q=woot`);
+    assert.strictEqual(this.$link3.getAttribute('href'), `${urlPrefix}/a-3?q=woot&z=123`);
   }
 
   async queryParamsStickyTest5(urlPrefix, commentsLookupKey) {
@@ -214,7 +214,7 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
     await this.transitionTo(commentsLookupKey, 'a-1');
 
     let commentsCtrl = this.getController(commentsLookupKey);
-    assert.equal(commentsCtrl.get('page'), 1);
+    assert.strictEqual(commentsCtrl.get('page'), 1);
     this.assertCurrentPath(`${urlPrefix}/a-1/comments`);
 
     await this.setAndFlush(commentsCtrl, 'page', 2);
@@ -224,11 +224,11 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
     this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=3`);
 
     await this.transitionTo(commentsLookupKey, 'a-2');
-    assert.equal(commentsCtrl.get('page'), 1);
+    assert.strictEqual(commentsCtrl.get('page'), 1);
     this.assertCurrentPath(`${urlPrefix}/a-2/comments`);
 
     await this.transitionTo(commentsLookupKey, 'a-1');
-    assert.equal(commentsCtrl.get('page'), 3);
+    assert.strictEqual(commentsCtrl.get('page'), 3);
     this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=3`);
   }
 
@@ -260,26 +260,29 @@ class ModelDependentQPTestCase extends QueryParamTestCase {
     await this.transitionTo(commentsLookup, 'a-1');
 
     let commentsCtrl = this.getController(commentsLookup);
-    assert.equal(commentsCtrl.get('page'), 1);
+    assert.strictEqual(commentsCtrl.get('page'), 1);
     this.assertCurrentPath(`${urlPrefix}/a-1/comments`);
 
     await this.setAndFlush(commentsCtrl, 'page', 2);
     this.assertCurrentPath(`${urlPrefix}/a-1/comments?page=2`);
 
     await this.transitionTo(commentsLookup, 'a-2');
-    assert.equal(commentsCtrl.get('page'), 1);
-    assert.equal(this.controller.get('q'), 'wat');
+    assert.strictEqual(commentsCtrl.get('page'), 1);
+    assert.strictEqual(this.controller.get('q'), 'wat');
 
     await this.transitionTo(commentsLookup, 'a-1');
     this.assertCurrentPath(`${urlPrefix}/a-1/comments`);
-    assert.equal(commentsCtrl.get('page'), 1);
+    assert.strictEqual(commentsCtrl.get('page'), 1);
 
     await this.transitionTo('about');
-    assert.equal(
+    assert.strictEqual(
       document.getElementById('one').getAttribute('href'),
       `${urlPrefix}/a-1/comments?q=imdone`
     );
-    assert.equal(document.getElementById('two').getAttribute('href'), `${urlPrefix}/a-2/comments`);
+    assert.strictEqual(
+      document.getElementById('two').getAttribute('href'),
+      `${urlPrefix}/a-2/comments`
+    );
   }
 }
 
@@ -358,9 +361,9 @@ moduleFor(
         this.$link2 = document.getElementById('a-2');
         this.$link3 = document.getElementById('a-3');
 
-        assert.equal(this.$link1.getAttribute('href'), '/a/a-1');
-        assert.equal(this.$link2.getAttribute('href'), '/a/a-2');
-        assert.equal(this.$link3.getAttribute('href'), '/a/a-3');
+        assert.strictEqual(this.$link1.getAttribute('href'), '/a/a-1');
+        assert.strictEqual(this.$link2.getAttribute('href'), '/a/a-2');
+        assert.strictEqual(this.$link3.getAttribute('href'), '/a/a-3');
 
         this.controller = this.getController('article');
       });
@@ -469,9 +472,9 @@ moduleFor(
         this.$link2 = document.getElementById('a-2');
         this.$link3 = document.getElementById('a-3');
 
-        assert.equal(this.$link1.getAttribute('href'), '/site/a/a-1');
-        assert.equal(this.$link2.getAttribute('href'), '/site/a/a-2');
-        assert.equal(this.$link3.getAttribute('href'), '/site/a/a-3');
+        assert.strictEqual(this.$link1.getAttribute('href'), '/site/a/a-1');
+        assert.strictEqual(this.$link2.getAttribute('href'), '/site/a/a-2');
+        assert.strictEqual(this.$link3.getAttribute('href'), '/site/a/a-3');
 
         this.controller = this.getController('site.article');
       });
@@ -634,15 +637,15 @@ moduleFor(
         this.links['s-3-a-2'] = document.getElementById('s-3-a-2');
         this.links['s-3-a-3'] = document.getElementById('s-3-a-3');
 
-        assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
-        assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
-        assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-        assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
-        assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-        assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-        assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
-        assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-        assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+        assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+        assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+        assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+        assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+        assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+        assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+        assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+        assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+        assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
         this.site_controller = this.getController('site');
         this.article_controller = this.getController('site.article');
@@ -661,63 +664,72 @@ moduleFor(
 
       await this.setAndFlush(this.article_controller, 'q', 'lol');
 
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       await this.setAndFlush(this.site_controller, 'country', 'us');
 
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(
+        this.links['s-1-a-1'].getAttribute('href'),
+        '/site/s-1/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.links['s-1-a-2'].click();
       await runLoopSettled();
 
-      assert.equal(this.site_controller.get('country'), 'us');
-      assert.equal(this.article_controller.get('q'), 'wat');
-      assert.equal(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.site_controller.get('country'), 'us');
+      assert.strictEqual(this.article_controller.get('q'), 'wat');
+      assert.strictEqual(this.article_controller.get('z'), 0);
       assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(
+        this.links['s-1-a-1'].getAttribute('href'),
+        '/site/s-1/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.links['s-2-a-2'].click();
       await runLoopSettled();
 
-      assert.equal(this.site_controller.get('country'), 'au');
-      assert.equal(this.article_controller.get('q'), 'wat');
-      assert.equal(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.site_controller.get('country'), 'au');
+      assert.strictEqual(this.article_controller.get('q'), 'wat');
+      assert.strictEqual(this.article_controller.get('z'), 0);
       assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(
+        this.links['s-1-a-1'].getAttribute('href'),
+        '/site/s-1/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?country=us');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?country=us');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
     }
 
     async ["@test query params have 'model' stickiness by default (url changes)"](assert) {
@@ -742,18 +754,18 @@ moduleFor(
         { id: 'a-1' },
         "article controller's model is a-1"
       );
-      assert.equal(this.site_controller.get('country'), 'au');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(this.site_controller.get('country'), 'au');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = {
@@ -773,18 +785,21 @@ moduleFor(
         { id: 'a-1' },
         "article controller's model is a-1"
       );
-      assert.equal(this.site_controller.get('country'), 'us');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(this.site_controller.get('country'), 'us');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.strictEqual(
+        this.links['s-2-a-1'].getAttribute('href'),
+        '/site/s-2/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = {
@@ -804,18 +819,24 @@ moduleFor(
         { id: 'a-2' },
         "article controller's model is a-2"
       );
-      assert.equal(this.site_controller.get('country'), 'us');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(this.site_controller.get('country'), 'us');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.strictEqual(
+        this.links['s-2-a-1'].getAttribute('href'),
+        '/site/s-2/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(
+        this.links['s-2-a-2'].getAttribute('href'),
+        '/site/s-2/a/a-2?country=us&q=lol'
+      );
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = {
@@ -835,21 +856,27 @@ moduleFor(
         { id: 'a-3' },
         "article controller's model is a-3"
       );
-      assert.equal(this.site_controller.get('country'), 'us');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 123);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=lol&z=123');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol');
-      assert.equal(
+      assert.strictEqual(this.site_controller.get('country'), 'us');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 123);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=lol&z=123');
+      assert.strictEqual(
+        this.links['s-2-a-1'].getAttribute('href'),
+        '/site/s-2/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(
+        this.links['s-2-a-2'].getAttribute('href'),
+        '/site/s-2/a/a-2?country=us&q=lol'
+      );
+      assert.strictEqual(
         this.links['s-2-a-3'].getAttribute('href'),
         '/site/s-2/a/a-3?country=us&q=lol&z=123'
       );
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=lol&z=123');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=lol&z=123');
 
       this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
       this.expectedArticleModelHookParams = {
@@ -869,21 +896,33 @@ moduleFor(
         { id: 'a-3' },
         "article controller's model is a-3"
       );
-      assert.equal(this.site_controller.get('country'), 'nz');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 123);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=lol&z=123');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=lol');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?country=us&q=lol');
-      assert.equal(
+      assert.strictEqual(this.site_controller.get('country'), 'nz');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 123);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=lol');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=lol&z=123');
+      assert.strictEqual(
+        this.links['s-2-a-1'].getAttribute('href'),
+        '/site/s-2/a/a-1?country=us&q=lol'
+      );
+      assert.strictEqual(
+        this.links['s-2-a-2'].getAttribute('href'),
+        '/site/s-2/a/a-2?country=us&q=lol'
+      );
+      assert.strictEqual(
         this.links['s-2-a-3'].getAttribute('href'),
         '/site/s-2/a/a-3?country=us&q=lol&z=123'
       );
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?country=nz&q=lol');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?country=nz&q=lol');
-      assert.equal(
+      assert.strictEqual(
+        this.links['s-3-a-1'].getAttribute('href'),
+        '/site/s-3/a/a-1?country=nz&q=lol'
+      );
+      assert.strictEqual(
+        this.links['s-3-a-2'].getAttribute('href'),
+        '/site/s-3/a/a-2?country=nz&q=lol'
+      );
+      assert.strictEqual(
         this.links['s-3-a-3'].getAttribute('href'),
         '/site/s-3/a/a-3?country=nz&q=lol&z=123'
       );
@@ -905,18 +944,18 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' });
-      assert.equal(this.site_controller.get('country'), 'au');
-      assert.equal(this.article_controller.get('q'), 'wat');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(this.site_controller.get('country'), 'au');
+      assert.strictEqual(this.article_controller.get('q'), 'wat');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
       this.expectedArticleModelHookParams = {
@@ -930,18 +969,18 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.site_controller.get('country'), 'au');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
+      assert.strictEqual(this.site_controller.get('country'), 'au');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3');
 
       this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
       this.expectedArticleModelHookParams = {
@@ -955,18 +994,18 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-3' });
-      assert.equal(this.site_controller.get('country'), 'au');
-      assert.equal(this.article_controller.get('q'), 'hay');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?q=hay');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
+      assert.strictEqual(this.site_controller.get('country'), 'au');
+      assert.strictEqual(this.article_controller.get('q'), 'hay');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?q=hay');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
       this.expectedArticleModelHookParams = {
@@ -980,18 +1019,18 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-1' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.site_controller.get('country'), 'au');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 1);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
-      assert.equal(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?q=hay');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
+      assert.strictEqual(this.site_controller.get('country'), 'au');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 1);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1');
+      assert.strictEqual(this.links['s-2-a-2'].getAttribute('href'), '/site/s-2/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?q=hay');
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = {
@@ -1005,21 +1044,24 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-2' });
-      assert.equal(this.site_controller.get('country'), 'us');
-      assert.equal(this.article_controller.get('q'), 'lol');
-      assert.equal(this.article_controller.get('z'), 1);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us');
-      assert.equal(
+      assert.strictEqual(this.site_controller.get('country'), 'us');
+      assert.strictEqual(this.article_controller.get('q'), 'lol');
+      assert.strictEqual(this.article_controller.get('z'), 1);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.strictEqual(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us');
+      assert.strictEqual(
         this.links['s-2-a-2'].getAttribute('href'),
         '/site/s-2/a/a-2?country=us&q=lol&z=1'
       );
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=hay');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
+      assert.strictEqual(
+        this.links['s-2-a-3'].getAttribute('href'),
+        '/site/s-2/a/a-3?country=us&q=hay'
+      );
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
       this.expectedArticleModelHookParams = {
@@ -1033,21 +1075,27 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-2' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-1' });
-      assert.equal(this.site_controller.get('country'), 'us');
-      assert.equal(this.article_controller.get('q'), 'yeah');
-      assert.equal(this.article_controller.get('z'), 0);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=yeah');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=yeah');
-      assert.equal(
+      assert.strictEqual(this.site_controller.get('country'), 'us');
+      assert.strictEqual(this.article_controller.get('q'), 'yeah');
+      assert.strictEqual(this.article_controller.get('z'), 0);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=yeah');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay');
+      assert.strictEqual(
+        this.links['s-2-a-1'].getAttribute('href'),
+        '/site/s-2/a/a-1?country=us&q=yeah'
+      );
+      assert.strictEqual(
         this.links['s-2-a-2'].getAttribute('href'),
         '/site/s-2/a/a-2?country=us&q=lol&z=1'
       );
-      assert.equal(this.links['s-2-a-3'].getAttribute('href'), '/site/s-2/a/a-3?country=us&q=hay');
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=yeah');
-      assert.equal(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
+      assert.strictEqual(
+        this.links['s-2-a-3'].getAttribute('href'),
+        '/site/s-2/a/a-3?country=us&q=hay'
+      );
+      assert.strictEqual(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?q=yeah');
+      assert.strictEqual(this.links['s-3-a-2'].getAttribute('href'), '/site/s-3/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-3-a-3'].getAttribute('href'), '/site/s-3/a/a-3?q=hay');
 
       this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
       this.expectedArticleModelHookParams = {
@@ -1061,27 +1109,33 @@ moduleFor(
 
       assert.deepEqual(this.site_controller.get('model'), { id: 's-3' });
       assert.deepEqual(this.article_controller.get('model'), { id: 'a-3' });
-      assert.equal(this.site_controller.get('country'), 'nz');
-      assert.equal(this.article_controller.get('q'), 'hay');
-      assert.equal(this.article_controller.get('z'), 3);
-      assert.equal(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=yeah');
-      assert.equal(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
-      assert.equal(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay&z=3');
-      assert.equal(this.links['s-2-a-1'].getAttribute('href'), '/site/s-2/a/a-1?country=us&q=yeah');
-      assert.equal(
+      assert.strictEqual(this.site_controller.get('country'), 'nz');
+      assert.strictEqual(this.article_controller.get('q'), 'hay');
+      assert.strictEqual(this.article_controller.get('z'), 3);
+      assert.strictEqual(this.links['s-1-a-1'].getAttribute('href'), '/site/s-1/a/a-1?q=yeah');
+      assert.strictEqual(this.links['s-1-a-2'].getAttribute('href'), '/site/s-1/a/a-2?q=lol&z=1');
+      assert.strictEqual(this.links['s-1-a-3'].getAttribute('href'), '/site/s-1/a/a-3?q=hay&z=3');
+      assert.strictEqual(
+        this.links['s-2-a-1'].getAttribute('href'),
+        '/site/s-2/a/a-1?country=us&q=yeah'
+      );
+      assert.strictEqual(
         this.links['s-2-a-2'].getAttribute('href'),
         '/site/s-2/a/a-2?country=us&q=lol&z=1'
       );
-      assert.equal(
+      assert.strictEqual(
         this.links['s-2-a-3'].getAttribute('href'),
         '/site/s-2/a/a-3?country=us&q=hay&z=3'
       );
-      assert.equal(this.links['s-3-a-1'].getAttribute('href'), '/site/s-3/a/a-1?country=nz&q=yeah');
-      assert.equal(
+      assert.strictEqual(
+        this.links['s-3-a-1'].getAttribute('href'),
+        '/site/s-3/a/a-1?country=nz&q=yeah'
+      );
+      assert.strictEqual(
         this.links['s-3-a-2'].getAttribute('href'),
         '/site/s-3/a/a-2?country=nz&q=lol&z=1'
       );
-      assert.equal(
+      assert.strictEqual(
         this.links['s-3-a-3'].getAttribute('href'),
         '/site/s-3/a/a-3?country=nz&q=hay&z=3'
       );

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -167,13 +167,13 @@ moduleFor(
 
       await this.setAndFlush(parentChildController, 'page', 2);
       this.assertCurrentPath('/parent/child?page=2');
-      assert.equal(parentController.get('page'), 1);
-      assert.equal(parentChildController.get('page'), 2);
+      assert.strictEqual(parentController.get('page'), 1);
+      assert.strictEqual(parentChildController.get('page'), 2);
 
       await this.setAndFlush(parentController, 'page', 2);
       this.assertCurrentPath('/parent/child?page=2&yespage=2');
-      assert.equal(parentController.get('page'), 2);
-      assert.equal(parentChildController.get('page'), 2);
+      assert.strictEqual(parentController.get('page'), 2);
+      assert.strictEqual(parentChildController.get('page'), 2);
     }
   }
 );

--- a/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_param_async_get_handler_test.js
@@ -81,12 +81,12 @@ moduleFor(
 
       await this.visitAndAssert('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('.post-link.is-1337').attr('href'),
         '/post/1337?foo=bar',
         'renders correctly with default QP value'
       );
-      assert.equal(
+      assert.strictEqual(
         this.$('.post-link.is-7331').attr('href'),
         '/post/7331?foo=boo',
         'renders correctly with non-default QP value'
@@ -121,7 +121,7 @@ moduleFor(
           return this.transitionTo('post', 1337, {
             queryParams: { foo: 'boo' },
           }).then(() => {
-            assert.equal(
+            assert.strictEqual(
               postController.get('foo'),
               'boo',
               'simple QP is correctly set on controller'
@@ -133,7 +133,7 @@ moduleFor(
           return this.transitionTo('post', 1337, {
             queryParams: { foo: 'bar' },
           }).then(() => {
-            assert.equal(
+            assert.strictEqual(
               postController.get('foo'),
               'bar',
               'simple QP is correctly set with default value'
@@ -202,12 +202,12 @@ moduleFor(
           return this.transitionTo('post.index', 1337, {
             queryParams: { note: 6, foo: 'boo' },
           }).then(() => {
-            assert.equal(
+            assert.strictEqual(
               postController.get('foo'),
               'boo',
               'simple QP is correctly set on controller'
             );
-            assert.equal(
+            assert.strictEqual(
               postIndexController.get('comment'),
               6,
               'mapped QP is correctly set on controller'
@@ -219,12 +219,12 @@ moduleFor(
           return this.transitionTo('post', 1337, {
             queryParams: { foo: 'bar' },
           }).then(() => {
-            assert.equal(
+            assert.strictEqual(
               postController.get('foo'),
               'bar',
               'simple QP is correctly set with default value'
             );
-            assert.equal(
+            assert.strictEqual(
               postIndexController.get('comment'),
               6,
               'mapped QP retains value scoped to model'
@@ -255,12 +255,12 @@ moduleFor(
           postIndexController = this.getController('post.index');
 
           return this.transitionTo('/post/1337?foo=boo&note=6').then(() => {
-            assert.equal(
+            assert.strictEqual(
               postController.get('foo'),
               'boo',
               'simple QP is correctly deserialized on controller'
             );
-            assert.equal(
+            assert.strictEqual(
               postIndexController.get('comment'),
               6,
               'mapped QP is correctly deserialized on controller'
@@ -270,12 +270,12 @@ moduleFor(
         })
         .then(() => {
           return this.transitionTo('/post/1337?note=6').then(() => {
-            assert.equal(
+            assert.strictEqual(
               postController.get('foo'),
               'bar',
               'simple QP is correctly deserialized with default value'
             );
-            assert.equal(
+            assert.strictEqual(
               postIndexController.get('comment'),
               6,
               'mapped QP retains value scoped to model'
@@ -311,7 +311,7 @@ moduleFor(
       );
 
       return this.visitAndAssert('/').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.$('#the-link').attr('href'),
           '/example',
           'renders without undefined qp serialized'

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -18,7 +18,10 @@ moduleFor(
       );
 
       return this.visit('/?foo=YEAH').then(() => {
-        assert.equal(document.getElementById('index-link').getAttribute('href'), '/?foo=YEAH');
+        assert.strictEqual(
+          document.getElementById('index-link').getAttribute('href'),
+          '/?foo=YEAH'
+        );
       });
     }
 

--- a/packages/ember/tests/routing/router_service_test/basic_test.js
+++ b/packages/ember/tests/routing/router_service_test/basic_test.js
@@ -12,13 +12,13 @@ moduleFor(
       return this.visit('/').then(() => {
         let currentRoute = this.routerService.currentRoute;
         let { name, localName, params, paramNames, queryParams } = currentRoute;
-        assert.equal(name, 'parent.index');
-        assert.equal(localName, 'index');
+        assert.strictEqual(name, 'parent.index');
+        assert.strictEqual(localName, 'index');
         assert.deepEqual(params, {});
         assert.deepEqual(queryParams, {});
         assert.deepEqual(paramNames, []);
 
-        assert.equal(this.routerService.get('currentRouteName'), 'parent.index');
+        assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.index');
       });
     }
 
@@ -28,13 +28,13 @@ moduleFor(
       return this.visit('/child').then(() => {
         let currentRoute = this.routerService.currentRoute;
         let { name, localName, params, paramNames, queryParams } = currentRoute;
-        assert.equal(name, 'parent.child');
-        assert.equal(localName, 'child');
+        assert.strictEqual(name, 'parent.child');
+        assert.strictEqual(localName, 'child');
         assert.deepEqual(params, {});
         assert.deepEqual(queryParams, {});
         assert.deepEqual(paramNames, []);
 
-        assert.equal(this.routerService.get('currentRouteName'), 'parent.child');
+        assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.child');
       });
     }
 
@@ -45,18 +45,18 @@ moduleFor(
         .then(() => {
           let currentRoute = this.routerService.currentRoute;
           let { name, localName } = currentRoute;
-          assert.equal(name, 'parent.child');
-          assert.equal(localName, 'child');
+          assert.strictEqual(name, 'parent.child');
+          assert.strictEqual(localName, 'child');
 
           return this.routerService.transitionTo('parent.sister');
         })
         .then(() => {
           let currentRoute = this.routerService.currentRoute;
           let { name, localName } = currentRoute;
-          assert.equal(name, 'parent.sister');
-          assert.equal(localName, 'sister');
+          assert.strictEqual(name, 'parent.sister');
+          assert.strictEqual(localName, 'sister');
 
-          assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+          assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.sister');
         });
     }
 
@@ -77,8 +77,8 @@ moduleFor(
           return this.routerService.transitionTo('/child');
         })
         .catch((e) => {
-          assert.equal(this.routerService.currentRouteName, 'parent.sister');
-          assert.equal(e.message, 'TransitionAborted');
+          assert.strictEqual(this.routerService.currentRouteName, 'parent.sister');
+          assert.strictEqual(e.message, 'TransitionAborted');
         });
     }
 
@@ -89,30 +89,30 @@ moduleFor(
         .then(() => {
           let currentRoute = this.routerService.currentRoute;
           let { name, localName } = currentRoute;
-          assert.equal(name, 'parent.child');
-          assert.equal(localName, 'child');
+          assert.strictEqual(name, 'parent.child');
+          assert.strictEqual(localName, 'child');
 
-          assert.equal(this.routerService.get('currentRouteName'), 'parent.child');
+          assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.child');
 
           return this.visit('/sister');
         })
         .then(() => {
           let currentRoute = this.routerService.currentRoute;
           let { name, localName } = currentRoute;
-          assert.equal(name, 'parent.sister');
-          assert.equal(localName, 'sister');
+          assert.strictEqual(name, 'parent.sister');
+          assert.strictEqual(localName, 'sister');
 
-          assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+          assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.sister');
 
           return this.visit('/brother');
         })
         .then(() => {
           let currentRoute = this.routerService.currentRoute;
           let { name, localName } = currentRoute;
-          assert.equal(name, 'parent.brother');
-          assert.equal(localName, 'brother');
+          assert.strictEqual(name, 'parent.brother');
+          assert.strictEqual(localName, 'brother');
 
-          assert.equal(this.routerService.get('currentRouteName'), 'parent.brother');
+          assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.brother');
         });
     }
 
@@ -120,7 +120,7 @@ moduleFor(
       assert.expect(1);
 
       return this.visit('/').then(() => {
-        assert.equal(this.routerService.get('rootURL'), '/');
+        assert.strictEqual(this.routerService.get('rootURL'), '/');
       });
     }
 
@@ -138,7 +138,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assert.equal(this.routerService.get('rootURL'), '/homepage');
+        assert.strictEqual(this.routerService.get('rootURL'), '/homepage');
       });
     }
 

--- a/packages/ember/tests/routing/router_service_test/build_routeinfo_metadata_test.js
+++ b/packages/ember/tests/routing/router_service_test/build_routeinfo_metadata_test.js
@@ -14,13 +14,13 @@ moduleFor(
           init() {
             this._super(...arguments);
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.metadata, 'parent-index-page');
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.metadata, 'parent-index-page');
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.metadata, 'parent-index-page');
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.metadata, 'parent-index-page');
             });
           },
         })
@@ -50,21 +50,21 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.metadata, 'parent-index-page');
-              assert.equal(transition.to.parent.name, 'parent');
-              assert.equal(transition.to.parent.metadata, 'parent-page');
-              assert.equal(transition.to.parent.parent.name, 'application');
-              assert.equal(transition.to.parent.parent.metadata, 'application-shell');
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.metadata, 'parent-index-page');
+              assert.strictEqual(transition.to.parent.name, 'parent');
+              assert.strictEqual(transition.to.parent.metadata, 'parent-page');
+              assert.strictEqual(transition.to.parent.parent.name, 'application');
+              assert.strictEqual(transition.to.parent.parent.metadata, 'application-shell');
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.metadata, 'parent-index-page');
-              assert.equal(transition.to.parent.name, 'parent');
-              assert.equal(transition.to.parent.metadata, 'parent-page');
-              assert.equal(transition.to.parent.parent.name, 'application');
-              assert.equal(transition.to.parent.parent.metadata, 'application-shell');
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.metadata, 'parent-index-page');
+              assert.strictEqual(transition.to.parent.name, 'parent');
+              assert.strictEqual(transition.to.parent.metadata, 'parent-page');
+              assert.strictEqual(transition.to.parent.parent.name, 'application');
+              assert.strictEqual(transition.to.parent.parent.metadata, 'application-shell');
             });
           },
         })
@@ -100,15 +100,15 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.metadata.name, 'parent-index-page');
-              assert.equal(transition.to.metadata.title('PARENT'), 'My Name is PARENT');
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.metadata.name, 'parent-index-page');
+              assert.strictEqual(transition.to.metadata.title('PARENT'), 'My Name is PARENT');
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.metadata.name, 'parent-index-page');
-              assert.equal(transition.to.metadata.title('PARENT'), 'My Name is PARENT');
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.metadata.name, 'parent-index-page');
+              assert.strictEqual(transition.to.metadata.title('PARENT'), 'My Name is PARENT');
             });
           },
         })
@@ -142,25 +142,25 @@ moduleFor(
 
             this.router.on('routeWillChange', (transition) => {
               if (transition.to.name === 'parent.index') {
-                assert.equal(transition.to.metadata.name, 'parent-index-page');
-                assert.equal(transition.to.metadata.title('INDEX'), 'My Name is INDEX');
+                assert.strictEqual(transition.to.metadata.name, 'parent-index-page');
+                assert.strictEqual(transition.to.metadata.title('INDEX'), 'My Name is INDEX');
               } else {
-                assert.equal(transition.from.metadata.name, 'parent-index-page');
-                assert.equal(transition.from.metadata.title('INDEX'), 'My Name is INDEX');
-                assert.equal(transition.to.metadata.name, 'parent-child-page');
-                assert.equal(transition.to.metadata.title('CHILD'), 'My Name is CHILD!!');
+                assert.strictEqual(transition.from.metadata.name, 'parent-index-page');
+                assert.strictEqual(transition.from.metadata.title('INDEX'), 'My Name is INDEX');
+                assert.strictEqual(transition.to.metadata.name, 'parent-child-page');
+                assert.strictEqual(transition.to.metadata.title('CHILD'), 'My Name is CHILD!!');
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
               if (transition.to.name === 'parent.index') {
-                assert.equal(transition.to.metadata.name, 'parent-index-page');
-                assert.equal(transition.to.metadata.title('INDEX'), 'My Name is INDEX');
+                assert.strictEqual(transition.to.metadata.name, 'parent-index-page');
+                assert.strictEqual(transition.to.metadata.title('INDEX'), 'My Name is INDEX');
               } else {
-                assert.equal(transition.from.metadata.name, 'parent-index-page');
-                assert.equal(transition.from.metadata.title('INDEX'), 'My Name is INDEX');
-                assert.equal(transition.to.metadata.name, 'parent-child-page');
-                assert.equal(transition.to.metadata.title('CHILD'), 'My Name is CHILD!!');
+                assert.strictEqual(transition.from.metadata.name, 'parent-index-page');
+                assert.strictEqual(transition.from.metadata.title('INDEX'), 'My Name is INDEX');
+                assert.strictEqual(transition.to.metadata.name, 'parent-child-page');
+                assert.strictEqual(transition.to.metadata.title('CHILD'), 'My Name is CHILD!!');
               }
             });
           },
@@ -209,19 +209,19 @@ moduleFor(
 
             this.router.on('routeDidChange', (transition) => {
               if (transition.to.name === 'parent.index') {
-                assert.equal(transition.to.metadata.name, 'parent-index-page');
-                assert.equal(
+                assert.strictEqual(transition.to.metadata.name, 'parent-index-page');
+                assert.strictEqual(
                   transition.to.metadata.title(transition.to.attributes),
                   'My Name is INDEX'
                 );
               } else {
-                assert.equal(transition.from.metadata.name, 'parent-index-page');
-                assert.equal(
+                assert.strictEqual(transition.from.metadata.name, 'parent-index-page');
+                assert.strictEqual(
                   transition.from.metadata.title(transition.from.attributes),
                   'My Name is INDEX'
                 );
-                assert.equal(transition.to.metadata.name, 'parent-child-page');
-                assert.equal(
+                assert.strictEqual(transition.to.metadata.name, 'parent-child-page');
+                assert.strictEqual(
                   transition.to.metadata.title(transition.to.attributes),
                   'My Name is CHILD!!'
                 );

--- a/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
+++ b/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
@@ -138,7 +138,7 @@ moduleFor(
       assert.expect(1);
 
       return this.visit('/').then(() => {
-        assert.equal(this.routerService.get('currentURL'), '/');
+        assert.strictEqual(this.routerService.get('currentURL'), '/');
       });
     }
 
@@ -146,7 +146,7 @@ moduleFor(
       assert.expect(1);
 
       return this.visit('/child').then(() => {
-        assert.equal(this.routerService.get('currentURL'), '/child');
+        assert.strictEqual(this.routerService.get('currentURL'), '/child');
       });
     }
 
@@ -158,7 +158,7 @@ moduleFor(
           return this.routerService.transitionTo('parent.sister');
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/sister');
+          assert.strictEqual(this.routerService.get('currentURL'), '/sister');
         });
     }
 
@@ -167,17 +167,17 @@ moduleFor(
 
       return this.visit('/child')
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child');
+          assert.strictEqual(this.routerService.get('currentURL'), '/child');
 
           return this.visit('/sister');
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/sister');
+          assert.strictEqual(this.routerService.get('currentURL'), '/sister');
 
           return this.visit('/brother');
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/brother');
+          assert.strictEqual(this.routerService.get('currentURL'), '/brother');
         });
     }
 

--- a/packages/ember/tests/routing/router_service_test/events_test.js
+++ b/packages/ember/tests/routing/router_service_test/events_test.js
@@ -16,23 +16,23 @@ moduleFor(
             this._super(...arguments);
             this.router.on('routeWillChange', (transition) => {
               assert.ok(transition);
-              assert.equal(transition.from, undefined);
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.localName, 'index');
+              assert.strictEqual(transition.from, undefined);
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.localName, 'index');
             });
 
             this.router.on('routeDidChange', (transition) => {
               assert.ok(transition);
               assert.ok(this.router.currentURL, `has URL ${this.router.currentURL}`);
-              assert.equal(this.router.currentURL, '/');
+              assert.strictEqual(this.router.currentURL, '/');
               assert.ok(
                 this.router.currentRouteName,
                 `has route name ${this.router.currentRouteName}`
               );
-              assert.equal(this.router.currentRouteName, 'parent.index');
-              assert.equal(transition.from, undefined);
-              assert.equal(transition.to.name, 'parent.index');
-              assert.equal(transition.to.localName, 'index');
+              assert.strictEqual(this.router.currentRouteName, 'parent.index');
+              assert.strictEqual(transition.from, undefined);
+              assert.strictEqual(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.localName, 'index');
             });
           },
         })
@@ -52,41 +52,45 @@ moduleFor(
             this._super(...arguments);
             this.router.on('routeWillChange', (transition) => {
               if (toParent) {
-                assert.equal(this.router.currentURL, null, 'starts as null');
-                assert.equal(transition.from, undefined);
-                assert.equal(transition.to.name, 'parent.child');
-                assert.equal(transition.to.localName, 'child');
-                assert.equal(transition.to.parent.name, 'parent', 'parent node');
-                assert.equal(
+                assert.strictEqual(this.router.currentURL, null, 'starts as null');
+                assert.strictEqual(transition.from, undefined);
+                assert.strictEqual(transition.to.name, 'parent.child');
+                assert.strictEqual(transition.to.localName, 'child');
+                assert.strictEqual(transition.to.parent.name, 'parent', 'parent node');
+                assert.strictEqual(
                   transition.to.parent.child,
                   transition.to,
                   'parents child node is the `to`'
                 );
-                assert.equal(transition.to.parent.parent.name, 'application', 'top level');
-                assert.equal(transition.to.parent.parent.parent, null, 'top level');
+                assert.strictEqual(transition.to.parent.parent.name, 'application', 'top level');
+                assert.strictEqual(transition.to.parent.parent.parent, null, 'top level');
               } else {
-                assert.equal(this.router.currentURL, '/child', 'not changed until transition');
+                assert.strictEqual(
+                  this.router.currentURL,
+                  '/child',
+                  'not changed until transition'
+                );
                 assert.notEqual(transition.from, undefined);
-                assert.equal(transition.from.name, 'parent.child');
-                assert.equal(transition.from.localName, 'child');
-                assert.equal(transition.to.localName, 'sister');
-                assert.equal(transition.to.name, 'parent.sister');
+                assert.strictEqual(transition.from.name, 'parent.child');
+                assert.strictEqual(transition.from.localName, 'child');
+                assert.strictEqual(transition.to.localName, 'sister');
+                assert.strictEqual(transition.to.name, 'parent.sister');
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
               if (toParent) {
-                assert.equal(this.router.currentURL, '/child');
-                assert.equal(transition.from, undefined);
-                assert.equal(transition.to.name, 'parent.child');
-                assert.equal(transition.to.localName, 'child');
+                assert.strictEqual(this.router.currentURL, '/child');
+                assert.strictEqual(transition.from, undefined);
+                assert.strictEqual(transition.to.name, 'parent.child');
+                assert.strictEqual(transition.to.localName, 'child');
               } else {
-                assert.equal(this.router.currentURL, '/sister');
+                assert.strictEqual(this.router.currentURL, '/sister');
                 assert.notEqual(transition.from, undefined);
-                assert.equal(transition.from.name, 'parent.child');
-                assert.equal(transition.from.localName, 'child');
-                assert.equal(transition.to.localName, 'sister');
-                assert.equal(transition.to.name, 'parent.sister');
+                assert.strictEqual(transition.from.name, 'parent.child');
+                assert.strictEqual(transition.from.localName, 'child');
+                assert.strictEqual(transition.to.localName, 'sister');
+                assert.strictEqual(transition.to.name, 'parent.sister');
               }
             });
           },
@@ -121,7 +125,7 @@ moduleFor(
           return this.visit('/');
         })
         .catch((e) => {
-          assert.equal(e.message, 'TransitionAborted');
+          assert.strictEqual(e.message, 'TransitionAborted');
         });
     }
 
@@ -160,24 +164,24 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.from, undefined, 'initial');
+              assert.strictEqual(transition.from, undefined, 'initial');
               if (toChild) {
                 if (toSister) {
-                  assert.equal(transition.to.name, 'parent.sister', 'going to /sister');
+                  assert.strictEqual(transition.to.name, 'parent.sister', 'going to /sister');
                 } else {
-                  assert.equal(transition.to.name, 'parent.child', 'going to /child');
+                  assert.strictEqual(transition.to.name, 'parent.child', 'going to /child');
                   toSister = true;
                 }
               } else {
                 // Going to `/`
-                assert.equal(transition.to.name, 'parent.index', 'going to /');
+                assert.strictEqual(transition.to.name, 'parent.index', 'going to /');
                 toChild = true;
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.from, undefined, 'initial');
-              assert.equal(transition.to.name, 'parent.sister', 'landed on /sister');
+              assert.strictEqual(transition.from, undefined, 'initial');
+              assert.strictEqual(transition.to.name, 'parent.sister', 'landed on /sister');
             });
           },
         })
@@ -220,24 +224,24 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.from, undefined, 'initial');
+              assert.strictEqual(transition.from, undefined, 'initial');
               if (toChild) {
                 if (toSister) {
-                  assert.equal(transition.to.name, 'parent.sister', 'going to /sister');
+                  assert.strictEqual(transition.to.name, 'parent.sister', 'going to /sister');
                 } else {
-                  assert.equal(transition.to.name, 'parent.child', 'going to /child');
+                  assert.strictEqual(transition.to.name, 'parent.child', 'going to /child');
                   toSister = true;
                 }
               } else {
                 // Going to `/`
-                assert.equal(transition.to.name, 'parent.index', 'going to /');
+                assert.strictEqual(transition.to.name, 'parent.index', 'going to /');
                 toChild = true;
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.from, undefined, 'initial');
-              assert.equal(transition.to.name, 'parent.sister', 'landed on /sister');
+              assert.strictEqual(transition.from, undefined, 'initial');
+              assert.strictEqual(transition.to.name, 'parent.sister', 'landed on /sister');
             });
           },
         })
@@ -270,27 +274,27 @@ moduleFor(
 
             this.router.on('routeWillChange', (transition) => {
               if (toChild) {
-                assert.equal(transition.from.name, 'parent.index');
+                assert.strictEqual(transition.from.name, 'parent.index');
                 if (toSister) {
-                  assert.equal(transition.to.name, 'parent.sister', 'going to /sister');
+                  assert.strictEqual(transition.to.name, 'parent.sister', 'going to /sister');
                 } else {
-                  assert.equal(transition.to.name, 'parent.child', 'going to /child');
+                  assert.strictEqual(transition.to.name, 'parent.child', 'going to /child');
                   toSister = true;
                 }
               } else {
                 // Going to `/`
-                assert.equal(transition.to.name, 'parent.index', 'going to /');
-                assert.equal(transition.from, undefined, 'initial');
+                assert.strictEqual(transition.to.name, 'parent.index', 'going to /');
+                assert.strictEqual(transition.from, undefined, 'initial');
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
               if (toSister) {
-                assert.equal(transition.from.name, 'parent.index', 'initial');
-                assert.equal(transition.to.name, 'parent.sister', 'landed on /sister');
+                assert.strictEqual(transition.from.name, 'parent.index', 'initial');
+                assert.strictEqual(transition.to.name, 'parent.sister', 'landed on /sister');
               } else {
-                assert.equal(transition.from, undefined, 'initial');
-                assert.equal(transition.to.name, 'parent.index', 'landed on /');
+                assert.strictEqual(transition.from, undefined, 'initial');
+                assert.strictEqual(transition.to.name, 'parent.index', 'landed on /');
               }
             });
           },
@@ -299,7 +303,7 @@ moduleFor(
       return this.visit('/').then(() => {
         toChild = true;
         return this.routerService.transitionTo('/child').catch((e) => {
-          assert.equal(e.name, 'TransitionAborted', 'Transition aborted');
+          assert.strictEqual(e.name, 'TransitionAborted', 'Transition aborted');
         });
       });
     }
@@ -329,27 +333,27 @@ moduleFor(
 
             this.router.on('routeWillChange', (transition) => {
               if (toChild) {
-                assert.equal(transition.from.name, 'parent.index');
+                assert.strictEqual(transition.from.name, 'parent.index');
                 if (toSister) {
-                  assert.equal(transition.to.name, 'parent.sister', 'going to /sister');
+                  assert.strictEqual(transition.to.name, 'parent.sister', 'going to /sister');
                 } else {
-                  assert.equal(transition.to.name, 'parent.child', 'going to /child');
+                  assert.strictEqual(transition.to.name, 'parent.child', 'going to /child');
                   toSister = true;
                 }
               } else {
                 // Going to `/`
-                assert.equal(transition.to.name, 'parent.index', 'going to /');
-                assert.equal(transition.from, undefined, 'initial');
+                assert.strictEqual(transition.to.name, 'parent.index', 'going to /');
+                assert.strictEqual(transition.from, undefined, 'initial');
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
               if (toSister) {
-                assert.equal(transition.from.name, 'parent.index', 'initial');
-                assert.equal(transition.to.name, 'parent.sister', 'landed on /sister');
+                assert.strictEqual(transition.from.name, 'parent.index', 'initial');
+                assert.strictEqual(transition.to.name, 'parent.sister', 'landed on /sister');
               } else {
-                assert.equal(transition.from, undefined, 'initial');
-                assert.equal(transition.to.name, 'parent.index', 'landed on /');
+                assert.strictEqual(transition.from, undefined, 'initial');
+                assert.strictEqual(transition.to.name, 'parent.index', 'landed on /');
               }
             });
           },
@@ -358,7 +362,7 @@ moduleFor(
       return this.visit('/').then(() => {
         toChild = true;
         return this.routerService.transitionTo('/child').catch((e) => {
-          assert.equal(e.name, 'TransitionAborted', 'Transition aborted');
+          assert.strictEqual(e.name, 'TransitionAborted', 'Transition aborted');
         });
       });
     }
@@ -387,24 +391,24 @@ moduleFor(
 
             this.router.on('routeWillChange', (transition) => {
               if (didAbort) {
-                assert.equal(transition.to.name, 'parent.index', 'transition aborted');
-                assert.equal(transition.from.name, 'parent.index', 'transition aborted');
+                assert.strictEqual(transition.to.name, 'parent.index', 'transition aborted');
+                assert.strictEqual(transition.from.name, 'parent.index', 'transition aborted');
               } else if (toChild) {
-                assert.equal(transition.from.name, 'parent.index', 'from /');
-                assert.equal(transition.to.name, 'parent.child', 'to /child');
+                assert.strictEqual(transition.from.name, 'parent.index', 'from /');
+                assert.strictEqual(transition.to.name, 'parent.child', 'to /child');
               } else {
-                assert.equal(transition.to.name, 'parent.index', 'going to /');
-                assert.equal(transition.from, undefined, 'initial');
+                assert.strictEqual(transition.to.name, 'parent.index', 'going to /');
+                assert.strictEqual(transition.from, undefined, 'initial');
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
               if (didAbort) {
-                assert.equal(transition.to.name, 'parent.index', 'landed on /');
-                assert.equal(transition.from.name, 'parent.index', 'initial');
+                assert.strictEqual(transition.to.name, 'parent.index', 'landed on /');
+                assert.strictEqual(transition.from.name, 'parent.index', 'initial');
               } else {
-                assert.equal(transition.to.name, 'parent.index', 'transition aborted');
-                assert.equal(transition.from, undefined, 'transition aborted');
+                assert.strictEqual(transition.to.name, 'parent.index', 'transition aborted');
+                assert.strictEqual(transition.from, undefined, 'transition aborted');
               }
             });
           },
@@ -413,7 +417,7 @@ moduleFor(
       return this.visit('/').then(() => {
         toChild = true;
         return this.routerService.transitionTo('/child').catch((e) => {
-          assert.equal(e.name, 'TransitionAborted', 'Transition aborted');
+          assert.strictEqual(e.name, 'TransitionAborted', 'Transition aborted');
         });
       });
     }
@@ -432,9 +436,9 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.index');
+              assert.strictEqual(transition.to.name, 'parent.index');
               if (initial) {
-                assert.equal(transition.from, null);
+                assert.strictEqual(transition.from, null);
                 assert.deepEqual(transition.to.queryParams, { a: 'true' });
               } else if (addQP) {
                 assert.deepEqual(transition.from.queryParams, { a: 'true' });
@@ -449,7 +453,7 @@ moduleFor(
 
             this.router.on('routeDidChange', (transition) => {
               if (initial) {
-                assert.equal(transition.from, null);
+                assert.strictEqual(transition.from, null);
                 assert.deepEqual(transition.to.queryParams, { a: 'true' });
               } else if (addQP) {
                 assert.deepEqual(transition.from.queryParams, { a: 'true' });
@@ -503,16 +507,16 @@ moduleFor(
 
             this.router.on('routeWillChange', (transition) => {
               if (toSister) {
-                assert.equal(transition.to.name, 'parent.sister');
+                assert.strictEqual(transition.to.name, 'parent.sister');
                 assert.deepEqual(transition.to.queryParams, { a: 'a' });
               } else {
-                assert.equal(transition.to.name, 'parent.child');
+                assert.strictEqual(transition.to.name, 'parent.child');
                 assert.deepEqual(transition.to.queryParams, {});
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.sister');
+              assert.strictEqual(transition.to.name, 'parent.sister');
               assert.deepEqual(transition.to.queryParams, { a: 'a' });
             });
           },
@@ -546,16 +550,16 @@ moduleFor(
 
             this.router.on('routeWillChange', (transition) => {
               if (toSister) {
-                assert.equal(transition.to.name, 'parent.sister');
+                assert.strictEqual(transition.to.name, 'parent.sister');
                 assert.deepEqual(transition.to.queryParams, { a: 'a' });
               } else {
-                assert.equal(transition.to.name, 'parent.child');
+                assert.strictEqual(transition.to.name, 'parent.child');
                 assert.deepEqual(transition.to.queryParams, {});
               }
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'parent.sister');
+              assert.strictEqual(transition.to.name, 'parent.sister');
               assert.deepEqual(transition.to.queryParams, { a: 'a' });
             });
           },
@@ -592,7 +596,7 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.to.name, 'dynamic');
+              assert.strictEqual(transition.to.name, 'dynamic');
               if (initial) {
                 assert.deepEqual(transition.to.paramNames, ['dynamic_id']);
                 assert.deepEqual(transition.to.params, { dynamic_id: '123' });
@@ -603,7 +607,7 @@ moduleFor(
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'dynamic');
+              assert.strictEqual(transition.to.name, 'dynamic');
               assert.deepEqual(transition.to.paramNames, ['dynamic_id']);
               if (initial) {
                 assert.deepEqual(transition.to.params, { dynamic_id: '123' });
@@ -657,7 +661,7 @@ moduleFor(
             this._super(...arguments);
 
             this.router.on('routeWillChange', (transition) => {
-              assert.equal(transition.to.name, 'dynamicWithChild.child');
+              assert.strictEqual(transition.to.name, 'dynamicWithChild.child');
               assert.deepEqual(transition.to.paramNames, ['child_id']);
               assert.deepEqual(transition.to.params, { child_id: '456' });
               assert.deepEqual(transition.to.parent.paramNames, ['dynamic_id']);
@@ -671,7 +675,7 @@ moduleFor(
             });
 
             this.router.on('routeDidChange', (transition) => {
-              assert.equal(transition.to.name, 'dynamicWithChild.child');
+              assert.strictEqual(transition.to.name, 'dynamicWithChild.child');
               assert.deepEqual(transition.to.paramNames, ['child_id']);
               assert.deepEqual(transition.to.params, { child_id: '456' });
               assert.deepEqual(transition.to.parent.paramNames, ['dynamic_id']);

--- a/packages/ember/tests/routing/router_service_test/isActive_test.js
+++ b/packages/ember/tests/routing/router_service_test/isActive_test.js
@@ -56,18 +56,18 @@ moduleFor(
 
       let fooService = this.applicationInstance.lookup('service:foo');
 
-      assert.equal(fooService.isChildActive, false);
-      assert.equal(fooService.isSisterActive, false);
+      assert.strictEqual(fooService.isChildActive, false);
+      assert.strictEqual(fooService.isSisterActive, false);
 
       await this.routerService.transitionTo('parent.child');
 
-      assert.equal(fooService.isChildActive, true);
-      assert.equal(fooService.isSisterActive, false);
+      assert.strictEqual(fooService.isChildActive, true);
+      assert.strictEqual(fooService.isSisterActive, false);
 
       await this.routerService.transitionTo('parent.sister');
 
-      assert.equal(fooService.isChildActive, false);
-      assert.equal(fooService.isSisterActive, true);
+      assert.strictEqual(fooService.isChildActive, false);
+      assert.strictEqual(fooService.isSisterActive, true);
     }
 
     ['@test RouterService#isActive does not eagerly instantiate controller for query params'](

--- a/packages/ember/tests/routing/router_service_test/non_application_test_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test_test.js
@@ -45,11 +45,11 @@ moduleFor(
 
     ['@test RouterService properties can be accessed with default'](assert) {
       assert.expect(5);
-      assert.equal(this.routerService.get('currentRouteName'), null);
-      assert.equal(this.routerService.get('currentURL'), null);
-      assert.equal(this.routerService.get('location'), 'none');
-      assert.equal(this.routerService.get('rootURL'), '/');
-      assert.equal(this.routerService.get('currentRoute'), null);
+      assert.strictEqual(this.routerService.get('currentRouteName'), null);
+      assert.strictEqual(this.routerService.get('currentURL'), null);
+      assert.strictEqual(this.routerService.get('location'), 'none');
+      assert.strictEqual(this.routerService.get('rootURL'), '/');
+      assert.strictEqual(this.routerService.get('currentRoute'), null);
     }
 
     ['@test RouterService properties of router can be accessed with default when router is present'](
@@ -58,15 +58,15 @@ moduleFor(
       assert.expect(5);
       let router = this.owner.lookup('router:main');
       router.setupRouter();
-      assert.equal(this.routerService.get('currentRouteName'), null);
-      assert.equal(this.routerService.get('currentURL'), null);
+      assert.strictEqual(this.routerService.get('currentRouteName'), null);
+      assert.strictEqual(this.routerService.get('currentURL'), null);
       assert.ok(this.routerService.get('location') instanceof NoneLocation);
-      assert.equal(this.routerService.get('rootURL'), '/');
-      assert.equal(this.routerService.get('currentRoute'), null);
+      assert.strictEqual(this.routerService.get('rootURL'), '/');
+      assert.strictEqual(this.routerService.get('currentRoute'), null);
     }
 
     ['@test RouterService#urlFor returns url'](assert) {
-      assert.equal(this.routerService.urlFor('parent.child'), '/child');
+      assert.strictEqual(this.routerService.urlFor('parent.child'), '/child');
     }
 
     ['@test RouterService#transitionTo with basic route'](assert) {
@@ -103,7 +103,7 @@ moduleFor(
         componentInstance.send('transitionToSister');
       });
 
-      assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+      assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.sister');
       assert.ok(this.routerService.isActive('parent.sister'));
     }
 
@@ -111,10 +111,10 @@ moduleFor(
       let routeInfo = this.routerService.recognize('/dynamic-with-child/123/1?a=b');
       assert.ok(routeInfo);
       let { name, localName, parent, child, params, queryParams, paramNames } = routeInfo;
-      assert.equal(name, 'dynamicWithChild.child');
-      assert.equal(localName, 'child');
+      assert.strictEqual(name, 'dynamicWithChild.child');
+      assert.strictEqual(localName, 'child');
       assert.ok(parent);
-      assert.equal(parent.name, 'dynamicWithChild');
+      assert.strictEqual(parent.name, 'dynamicWithChild');
       assert.notOk(child);
       assert.deepEqual(params, { child_id: '1' });
       assert.deepEqual(queryParams, { a: 'b' });

--- a/packages/ember/tests/routing/router_service_test/recognize_test.js
+++ b/packages/ember/tests/routing/router_service_test/recognize_test.js
@@ -9,10 +9,10 @@ moduleFor(
         let routeInfo = this.routerService.recognize('/dynamic-with-child/123/1?a=b');
         assert.ok(routeInfo);
         let { name, localName, parent, child, params, queryParams, paramNames } = routeInfo;
-        assert.equal(name, 'dynamicWithChild.child');
-        assert.equal(localName, 'child');
+        assert.strictEqual(name, 'dynamicWithChild.child');
+        assert.strictEqual(localName, 'child');
         assert.ok(parent);
-        assert.equal(parent.name, 'dynamicWithChild');
+        assert.strictEqual(parent.name, 'dynamicWithChild');
         assert.notOk(child);
         assert.deepEqual(params, { child_id: '1' });
         assert.deepEqual(queryParams, { a: 'b' });
@@ -27,7 +27,7 @@ moduleFor(
       return this.visit('/').then(() => {
         this.routerService.recognize('/dynamic-with-child/123/1?a=b');
         this.assertText('Parent', 'Did not transition and cause render');
-        assert.equal(this.routerService.currentURL, '/', 'Did not transition');
+        assert.strictEqual(this.routerService.currentURL, '/', 'Did not transition');
       });
     }
 
@@ -40,9 +40,9 @@ moduleFor(
         let routeInfo = this.routerService.recognize('/app/child/');
         assert.ok(routeInfo);
         let { name, localName, parent } = routeInfo;
-        assert.equal(name, 'parent.child');
-        assert.equal(localName, 'child');
-        assert.equal(parent.name, 'parent');
+        assert.strictEqual(name, 'parent.child');
+        assert.strictEqual(localName, 'child');
+        assert.strictEqual(parent.name, 'parent');
       });
     }
 
@@ -64,7 +64,7 @@ moduleFor(
     '@test returns `null` if URL is not recognized'(assert) {
       return this.visit('/').then(() => {
         let routeInfo = this.routerService.recognize('/foo');
-        assert.equal(routeInfo, null);
+        assert.strictEqual(routeInfo, null);
       });
     }
   }
@@ -106,9 +106,9 @@ moduleFor(
             params,
             queryParams,
           } = routeInfoWithAttributes;
-          assert.equal(name, 'dynamicWithChild.child');
-          assert.equal(localName, 'child');
-          assert.equal(parent.name, 'dynamicWithChild');
+          assert.strictEqual(name, 'dynamicWithChild.child');
+          assert.strictEqual(localName, 'child');
+          assert.strictEqual(parent.name, 'dynamicWithChild');
           assert.deepEqual(params, { child_id: '1' });
           assert.deepEqual(queryParams, { a: 'b' });
           assert.deepEqual(paramNames, ['child_id']);
@@ -138,7 +138,7 @@ moduleFor(
           return this.routerService.recognizeAndLoad('/child');
         })
         .then(() => {
-          assert.equal(this.routerService.currentURL, '/');
+          assert.strictEqual(this.routerService.currentURL, '/');
           this.assertText('Parent');
         });
     }
@@ -155,9 +155,9 @@ moduleFor(
         .then((routeInfoWithAttributes) => {
           assert.ok(routeInfoWithAttributes);
           let { name, localName, parent } = routeInfoWithAttributes;
-          assert.equal(name, 'parent.child');
-          assert.equal(localName, 'child');
-          assert.equal(parent.name, 'parent');
+          assert.strictEqual(name, 'parent.child');
+          assert.strictEqual(localName, 'child');
+          assert.strictEqual(parent.name, 'parent');
         });
     }
 
@@ -194,7 +194,7 @@ moduleFor(
             assert.ok(false, 'never');
           },
           (reason) => {
-            assert.equal(reason, 'URL /foo was not recognized');
+            assert.strictEqual(reason, 'URL /foo was not recognized');
           }
         );
     }
@@ -220,7 +220,7 @@ moduleFor(
             assert.ok(false, 'never');
           },
           (err) => {
-            assert.equal(err.message, 'Unhandled');
+            assert.strictEqual(err.message, 'Unhandled');
           }
         );
     }

--- a/packages/ember/tests/routing/router_service_test/refresh_test.js
+++ b/packages/ember/tests/routing/router_service_test/refresh_test.js
@@ -40,44 +40,44 @@ if (EMBER_ROUTING_ROUTER_SERVICE_REFRESH) {
         );
 
         await this.visit('/');
-        assert.equal(parentCounter, 1);
-        assert.equal(childCounter, 0);
-        assert.equal(sisterCounter, 0);
+        assert.strictEqual(parentCounter, 1);
+        assert.strictEqual(childCounter, 0);
+        assert.strictEqual(sisterCounter, 0);
 
         await this.routerService.refresh();
-        assert.equal(parentCounter, 2);
-        assert.equal(childCounter, 0);
-        assert.equal(sisterCounter, 0);
+        assert.strictEqual(parentCounter, 2);
+        assert.strictEqual(childCounter, 0);
+        assert.strictEqual(sisterCounter, 0);
 
         await this.routerService.refresh('application');
-        assert.equal(parentCounter, 3);
-        assert.equal(childCounter, 0);
-        assert.equal(sisterCounter, 0);
+        assert.strictEqual(parentCounter, 3);
+        assert.strictEqual(childCounter, 0);
+        assert.strictEqual(sisterCounter, 0);
 
         await this.routerService.transitionTo('parent.child');
-        assert.equal(parentCounter, 3);
-        assert.equal(childCounter, 1);
-        assert.equal(sisterCounter, 0);
+        assert.strictEqual(parentCounter, 3);
+        assert.strictEqual(childCounter, 1);
+        assert.strictEqual(sisterCounter, 0);
 
         await this.routerService.refresh('parent.child');
-        assert.equal(parentCounter, 3);
-        assert.equal(childCounter, 2);
-        assert.equal(sisterCounter, 0);
+        assert.strictEqual(parentCounter, 3);
+        assert.strictEqual(childCounter, 2);
+        assert.strictEqual(sisterCounter, 0);
 
         await this.routerService.refresh('parent');
-        assert.equal(parentCounter, 4);
-        assert.equal(childCounter, 3);
-        assert.equal(sisterCounter, 0);
+        assert.strictEqual(parentCounter, 4);
+        assert.strictEqual(childCounter, 3);
+        assert.strictEqual(sisterCounter, 0);
 
         await this.routerService.transitionTo('parent.sister');
-        assert.equal(parentCounter, 4);
-        assert.equal(childCounter, 3);
-        assert.equal(sisterCounter, 1);
+        assert.strictEqual(parentCounter, 4);
+        assert.strictEqual(childCounter, 3);
+        assert.strictEqual(sisterCounter, 1);
 
         await this.routerService.refresh();
-        assert.equal(parentCounter, 5);
-        assert.equal(childCounter, 3);
-        assert.equal(sisterCounter, 2);
+        assert.strictEqual(parentCounter, 5);
+        assert.strictEqual(childCounter, 3);
+        assert.strictEqual(sisterCounter, 2);
       }
 
       async ['@test RouterService#refresh verifies that the provided route exists']() {

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -121,7 +121,7 @@ moduleFor(
           componentInstance.send('transitionToSister');
         });
 
-        assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+        assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.sister');
       });
     }
 
@@ -153,7 +153,7 @@ moduleFor(
           componentInstance.send('transitionToSister');
         });
 
-        assert.equal(this.routerService.get('currentRouteName'), 'parent.sister');
+        assert.strictEqual(this.routerService.get('currentRouteName'), 'parent.sister');
       });
     }
 
@@ -188,8 +188,8 @@ moduleFor(
         componentInstance.send('transitionToDynamic');
       });
 
-      assert.equal(this.routerService.get('currentRouteName'), 'dynamic');
-      assert.equal(this.routerService.get('currentURL'), '/dynamic/1');
+      assert.strictEqual(this.routerService.get('currentRouteName'), 'dynamic');
+      assert.strictEqual(this.routerService.get('currentURL'), '/dynamic/1');
       this.assertText('much dynamicism');
     }
 
@@ -233,8 +233,8 @@ moduleFor(
         componentInstance.send('transitionToDynamic');
       });
 
-      assert.equal(this.routerService.get('currentRouteName'), 'dynamic');
-      assert.equal(this.routerService.get('currentURL'), '/dynamic/1');
+      assert.strictEqual(this.routerService.get('currentRouteName'), 'dynamic');
+      assert.strictEqual(this.routerService.get('currentURL'), '/dynamic/1');
       this.assertText('much dynamicism');
     }
 
@@ -258,7 +258,7 @@ moduleFor(
           return this.routerService.transitionTo('parent.child', queryParams);
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
+          assert.strictEqual(this.routerService.get('currentURL'), '/child?sort=ASC');
         });
     }
 
@@ -279,13 +279,13 @@ moduleFor(
           return this.routerService.transitionTo('parent.child');
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child');
+          assert.strictEqual(this.routerService.get('currentURL'), '/child');
         })
         .then(() => {
           return this.routerService.transitionTo(queryParams);
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child?sort=DESC');
+          assert.strictEqual(this.routerService.get('currentURL'), '/child?sort=DESC');
         });
     }
 
@@ -309,7 +309,7 @@ moduleFor(
           return this.routerService.transitionTo('parent.child', queryParams);
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child?sort=ASC');
+          assert.strictEqual(this.routerService.get('currentURL'), '/child?sort=ASC');
         });
     }
 
@@ -335,7 +335,7 @@ moduleFor(
           return this.routerService.transitionTo('parent.child', queryParams);
         })
         .then(() => {
-          assert.equal(this.routerService.get('currentURL'), '/child?url_sort=ASC');
+          assert.strictEqual(this.routerService.get('currentURL'), '/child?url_sort=ASC');
         });
     }
 
@@ -393,7 +393,7 @@ moduleFor(
       );
 
       return this.visit('/').then(() => {
-        assert.equal(this.routerService.get('currentURL'), '/child?url_sort=ASC');
+        assert.strictEqual(this.routerService.get('currentURL'), '/child?url_sort=ASC');
       });
     }
 
@@ -419,7 +419,7 @@ moduleFor(
       );
 
       return this.visit('/child?url_sort=a').then(() => {
-        assert.equal(this.routerService.get('currentURL'), '/?url_sort=a');
+        assert.strictEqual(this.routerService.get('currentURL'), '/?url_sort=a');
       });
     }
   }

--- a/packages/ember/tests/routing/router_service_test/urlFor_test.js
+++ b/packages/ember/tests/routing/router_service_test/urlFor_test.js
@@ -23,7 +23,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child');
 
-        assert.equal('/child', expectedURL);
+        assert.strictEqual('/child', expectedURL);
       });
     }
 
@@ -37,7 +37,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', dynamicModel);
 
-        assert.equal('/dynamic/1', expectedURL);
+        assert.strictEqual('/dynamic/1', expectedURL);
       });
     }
 
@@ -49,7 +49,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
 
-        assert.equal('/child?foo=bar', expectedURL);
+        assert.strictEqual('/child?foo=bar', expectedURL);
       });
     }
 
@@ -71,7 +71,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
 
-        assert.equal('/child?sort=ASC', expectedURL);
+        assert.strictEqual('/child?sort=ASC', expectedURL);
       });
     }
 
@@ -90,12 +90,12 @@ moduleFor(
 
       return this.visit('/child/?sort=DESC').then(() => {
         let controller = this.applicationInstance.lookup('controller:parent.child');
-        assert.equal(get(controller, 'sort'), 'DESC', 'sticky is set');
+        assert.strictEqual(get(controller, 'sort'), 'DESC', 'sticky is set');
 
         let queryParams = this.buildQueryParams({ foo: 'derp' });
         let actual = this.routerService.urlFor('parent.child', queryParams);
 
-        assert.equal(actual, '/child?foo=derp', 'does not use "stickiness"');
+        assert.strictEqual(actual, '/child?foo=derp', 'does not use "stickiness"');
       });
     }
 
@@ -109,7 +109,10 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
 
-        assert.equal('/child?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c', expectedURL);
+        assert.strictEqual(
+          '/child?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c',
+          expectedURL
+        );
       });
     }
 
@@ -121,7 +124,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
 
-        assert.equal('/child', expectedURL);
+        assert.strictEqual('/child', expectedURL);
       });
     }
 
@@ -135,7 +138,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('parent.child', queryParams);
 
-        assert.equal('/child', expectedURL);
+        assert.strictEqual('/child', expectedURL);
       });
     }
 
@@ -149,7 +152,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
 
-        assert.equal('/dynamic/1?foo=bar', expectedURL);
+        assert.strictEqual('/dynamic/1?foo=bar', expectedURL);
       });
     }
 
@@ -165,7 +168,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
 
-        assert.equal(
+        assert.strictEqual(
           '/dynamic/1?selectedItems[]=a&selectedItems[]=b&selectedItems[]=c',
           expectedURL
         );
@@ -182,7 +185,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
 
-        assert.equal('/dynamic/1', expectedURL);
+        assert.strictEqual('/dynamic/1', expectedURL);
       });
     }
 
@@ -196,7 +199,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let expectedURL = this.routerService.urlFor('dynamic', { id: 1 }, queryParams);
 
-        assert.equal('/dynamic/1', expectedURL);
+        assert.strictEqual('/dynamic/1', expectedURL);
       });
     }
 
@@ -212,7 +215,7 @@ moduleFor(
           return this.routerService.transitionTo(expectedURL);
         })
         .then(() => {
-          assert.equal(expectedURL, this.routerService.get('currentURL'));
+          assert.strictEqual(expectedURL, this.routerService.get('currentURL'));
         });
     }
 
@@ -240,7 +243,7 @@ moduleFor(
           return this.routerService.transitionTo(expectedURL);
         })
         .then(() => {
-          assert.equal(expectedURL, this.routerService.get('currentURL'));
+          assert.strictEqual(expectedURL, this.routerService.get('currentURL'));
         });
     }
 
@@ -262,7 +265,7 @@ moduleFor(
         .then(() => {
           actualURL = `${this.routerService.get('currentURL')}?foo=bar`;
 
-          assert.equal(expectedURL, actualURL);
+          assert.strictEqual(expectedURL, actualURL);
         });
     }
 
@@ -294,7 +297,7 @@ moduleFor(
         .then(() => {
           actualURL = `${this.routerService.get('currentURL')}?foo=bar`;
 
-          assert.equal(expectedURL, actualURL);
+          assert.strictEqual(expectedURL, actualURL);
         });
     }
   }

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -7,7 +7,7 @@ import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 let counter;
 
 function step(assert, expectedValue, description) {
-  assert.equal(counter, expectedValue, 'Step ' + expectedValue + ': ' + description);
+  assert.strictEqual(counter, expectedValue, 'Step ' + expectedValue + ': ' + description);
   counter++;
 }
 
@@ -68,7 +68,7 @@ moduleFor(
 
       let promise = this.visit('/turtle').then(() => {
         text = this.$('#app').text();
-        assert.equal(
+        assert.strictEqual(
           text,
           'TURTLE',
           `turtle template has loaded and replaced the loading template`
@@ -76,7 +76,7 @@ moduleFor(
       });
 
       let text = this.$('#app').text();
-      assert.equal(
+      assert.strictEqual(
         text,
         'LOADING',
         `The Loading template is nested in application template's outlet`
@@ -109,11 +109,11 @@ moduleFor(
       let promise = this.visit('/').then(() => {
         let text = this.$('#app').text();
 
-        assert.equal(text, 'INDEX', `index template has been rendered`);
+        assert.strictEqual(text, 'INDEX', `index template has been rendered`);
       });
 
       if (this.element) {
-        assert.equal(this.element.textContent, '');
+        assert.strictEqual(this.element.textContent, '');
       }
 
       appDeferred.resolve();
@@ -141,7 +141,7 @@ moduleFor(
         let promise = this.visit('/dummy').then(() => {
           let text = this.$('#app').text();
 
-          assert.equal(text, 'DUMMY', `dummy template has been rendered`);
+          assert.strictEqual(text, 'DUMMY', `dummy template has been rendered`);
         });
 
         assert.ok(
@@ -186,9 +186,9 @@ moduleFor(
         let promise = this.visit('/dummy').then(() => {
           let text = this.$('#app').text();
 
-          assert.equal(text, 'DUMMY', `dummy template has been rendered`);
+          assert.strictEqual(text, 'DUMMY', `dummy template has been rendered`);
         });
-        assert.equal(this.appRouter.currentPath, 'loading', `loading state entered`);
+        assert.strictEqual(this.appRouter.currentPath, 'loading', `loading state entered`);
         deferred.resolve();
 
         return promise;
@@ -232,7 +232,7 @@ moduleFor(
       this.addTemplate('dummy', 'DUMMY');
 
       return this.visit('/?qux=updated').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.getController('application').qux,
           'updated',
           'the application controller has the correct qp value'
@@ -241,21 +241,21 @@ moduleFor(
         let promise = this.visit('/dummy?qux=updated').then(() => {
           let text = this.$('#app').text();
 
-          assert.equal(text, 'DUMMY', `dummy template has been rendered`);
-          assert.equal(
+          assert.strictEqual(text, 'DUMMY', `dummy template has been rendered`);
+          assert.strictEqual(
             this.getController('application').qux,
             'updated',
             'the application controller has the correct qp value'
           );
         });
 
-        assert.equal(this.appRouter.currentPath, 'loading', `loading state entered`);
-        assert.equal(
+        assert.strictEqual(this.appRouter.currentPath, 'loading', `loading state entered`);
+        assert.strictEqual(
           this.currentURL,
           '/dummy?qux=updated',
           `during loading url reflect the correct state`
         );
-        assert.equal(
+        assert.strictEqual(
           this.getController('application').qux,
           'updated',
           'the application controller has the correct qp value'
@@ -309,7 +309,7 @@ moduleFor(
       this.addTemplate('parent.child', 'CHILD');
 
       return this.visit('/parent?qux=updated').then(() => {
-        assert.equal(
+        assert.strictEqual(
           this.getController('parent').qux,
           'updated',
           'in the parent route, the parent controller has the correct qp value'
@@ -318,27 +318,27 @@ moduleFor(
         let promise = this.visit('/parent/child?qux=updated').then(() => {
           let text = this.$('#app').text();
 
-          assert.equal(text, 'PARENT CHILD', `child template has been rendered`);
-          assert.equal(
+          assert.strictEqual(text, 'PARENT CHILD', `child template has been rendered`);
+          assert.strictEqual(
             this.getController('parent').qux,
             'updated',
             'after entered in the parent.child route, the parent controller has the correct qp value'
           );
         });
 
-        assert.equal(
+        assert.strictEqual(
           this.appRouter.currentPath,
           'parent.child_loading',
           `child loading state entered`
         );
 
-        assert.equal(
+        assert.strictEqual(
           this.currentURL,
           '/parent/child?qux=updated',
           `during child loading, url reflect the correct state`
         );
 
-        assert.equal(
+        assert.strictEqual(
           this.getController('parent').qux,
           'updated',
           'in the child_loading route, the parent controller has the correct qp value'
@@ -374,7 +374,7 @@ moduleFor(
       );
 
       let promise = this.visit('/').then(() => {
-        assert.equal(this.$('#app').text(), 'INDEX', 'index route loaded');
+        assert.strictEqual(this.$('#app').text(), 'INDEX', 'index route loaded');
       });
       assert.ok(loadingRouteEntered, 'ApplicationLoadingRoute was entered');
       appDeferred.resolve();
@@ -406,12 +406,16 @@ moduleFor(
         let length = this.$('#toplevel-loading').length;
         text = this.$('#app').text();
 
-        assert.equal(length, 0, `top-level loading view has been entirely removed from the DOM`);
-        assert.equal(text, 'INDEX', 'index has fully rendered');
+        assert.strictEqual(
+          length,
+          0,
+          `top-level loading view has been entirely removed from the DOM`
+        );
+        assert.strictEqual(text, 'INDEX', 'index has fully rendered');
       });
       let text = this.$('#toplevel-loading').text();
 
-      assert.equal(text, 'TOPLEVEL LOADING', 'still loading the top level');
+      assert.strictEqual(text, 'TOPLEVEL LOADING', 'still loading the top level');
       appDeferred.resolve();
 
       return promise;
@@ -442,11 +446,11 @@ moduleFor(
         let promise = this.visit('/foo/bar').then(() => {
           text = this.$('#app').text();
 
-          assert.equal(text, 'YAY', 'foo.bar.index fully loaded');
+          assert.strictEqual(text, 'YAY', 'foo.bar.index fully loaded');
         });
         let text = this.$('#app').text();
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'FOOBAR LOADING',
           `foo.bar_loading was entered (as opposed to something like foo/foo/bar_loading)`
@@ -482,12 +486,12 @@ moduleFor(
         let promise = this.visit('/foo/bar').then(() => {
           text = this.$('#app').text();
 
-          assert.equal(text, 'YAY', 'bar.index fully loaded');
+          assert.strictEqual(text, 'YAY', 'bar.index fully loaded');
         });
 
         let text = this.$('#app').text();
 
-        assert.equal(
+        assert.strictEqual(
           text,
           'BAR LOADING',
           `foo.bar_loading was entered (as opposed to something likefoo/foo/bar_loading)`
@@ -524,11 +528,11 @@ moduleFor(
       let promise = this.visit('/foo/bar').then(() => {
         text = this.$('#app').text();
 
-        assert.equal(text, 'YAY', 'foo.bar has rendered');
+        assert.strictEqual(text, 'YAY', 'foo.bar has rendered');
       });
       let text = this.$('#app').text();
 
-      assert.equal(
+      assert.strictEqual(
         text,
         'FOOBAR LOADING',
         `foo.bar_loading was entered (as opposed to something like foo/foo/bar_loading)`
@@ -565,7 +569,7 @@ moduleFor(
 
       await this.visit('/foo/bar');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#app').text(),
         'FOOBAR ERROR: did it broke?',
         `foo.bar_error was entered (as opposed to something like foo/foo/bar_error)`
@@ -604,10 +608,10 @@ moduleFor(
       let promise = this.visit('/foo').then(() => {
         text = this.$('#app').text();
 
-        assert.equal(text, 'YAY', 'foo.index was rendered');
+        assert.strictEqual(text, 'YAY', 'foo.index was rendered');
       });
       let text = this.$('#app').text();
-      assert.equal(text, 'FOO LOADING', 'foo.index_loading was entered');
+      assert.strictEqual(text, 'FOO LOADING', 'foo.index_loading was entered');
 
       deferred.resolve();
 
@@ -650,7 +654,7 @@ moduleFor(
 
       await this.visit('/foo');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#app').text(),
         'FOO ERROR: did it broke?',
         'foo.index_error was entered'
@@ -686,7 +690,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#toplevel-error').text(),
         'TOPLEVEL ERROR: BAD NEWS BEARS',
         'toplevel error rendered'
@@ -696,7 +700,7 @@ moduleFor(
 
       await this.visit('/');
 
-      assert.equal(this.$('#index').text(), 'INDEX', 'the index route resolved');
+      assert.strictEqual(this.$('#index').text(), 'INDEX', 'the index route resolved');
     }
   }
 );
@@ -749,8 +753,8 @@ moduleFor(
       let promise = runTask(() => this.visit('/grandma/mom')).then(() => {
         text = this.$('#app').text();
 
-        assert.equal(text, 'GRANDMA MOM', `Grandma.mom loaded text is displayed`);
-        assert.equal(
+        assert.strictEqual(text, 'GRANDMA MOM', `Grandma.mom loaded text is displayed`);
+        assert.strictEqual(
           this.appRouter.currentPath,
           'grandma.mom.index',
           `currentPath reflects final state`
@@ -758,9 +762,9 @@ moduleFor(
       });
       let text = this.$('#app').text();
 
-      assert.equal(text, 'GRANDMA GRANDMALOADING', `Grandma.mom loading text displayed`);
+      assert.strictEqual(text, 'GRANDMA GRANDMALOADING', `Grandma.mom loading text displayed`);
 
-      assert.equal(
+      assert.strictEqual(
         this.appRouter.currentPath,
         'grandma.loading',
         `currentPath reflects loading state`
@@ -807,16 +811,20 @@ moduleFor(
       );
 
       let promise = this.visit('/grandma/mom/sally');
-      assert.equal(this.appRouter.currentPath, 'index', 'Initial route fully loaded');
+      assert.strictEqual(this.appRouter.currentPath, 'index', 'Initial route fully loaded');
 
       sallyDeferred.resolve();
 
       promise
         .then(() => {
-          assert.equal(this.appRouter.currentPath, 'grandma.mom.sally', 'transition completed');
+          assert.strictEqual(
+            this.appRouter.currentPath,
+            'grandma.mom.sally',
+            'transition completed'
+          );
 
           let visit = this.visit('/grandma/puppies');
-          assert.equal(
+          assert.strictEqual(
             this.appRouter.currentPath,
             'grandma.mom.sally',
             'still in initial state because the only loading state is above the pivot route'
@@ -827,7 +835,7 @@ moduleFor(
         .then(() => {
           runTask(() => puppiesDeferred.resolve());
 
-          assert.equal(this.appRouter.currentPath, 'grandma.puppies', 'Finished transition');
+          assert.strictEqual(this.appRouter.currentPath, 'grandma.puppies', 'Finished transition');
         });
 
       return promise;
@@ -860,8 +868,8 @@ moduleFor(
 
       step(assert, 3, 'App finished loading');
 
-      assert.equal(this.$('#app').text(), 'GRANDMA ERROR: did it broke?', 'error bubbles');
-      assert.equal(this.appRouter.currentPath, 'grandma.error', 'Initial route fully loaded');
+      assert.strictEqual(this.$('#app').text(), 'GRANDMA ERROR: did it broke?', 'error bubbles');
+      assert.strictEqual(this.appRouter.currentPath, 'grandma.error', 'Initial route fully loaded');
     }
 
     async [`@test Non-bubbled errors that re-throw aren't swallowed`](assert) {
@@ -1047,13 +1055,17 @@ moduleFor(
 
       step(assert, 3, 'Application finished booting');
 
-      assert.equal(
+      assert.strictEqual(
         this.$('#app').text(),
         'GRANDMA MOM ERROR: did it broke?',
         'the more specifically named mome error substate was entered over the other error route'
       );
 
-      assert.equal(this.appRouter.currentPath, 'grandma.mom_error', 'Initial route fully loaded');
+      assert.strictEqual(
+        this.appRouter.currentPath,
+        'grandma.mom_error',
+        'Initial route fully loaded'
+      );
     }
 
     async ['@test Slow promises waterfall on startup'](assert) {
@@ -1103,11 +1115,11 @@ moduleFor(
       let promise = runTask(() => this.visit('/grandma/mom/sally')).then(() => {
         text = this.$('#app').text();
 
-        assert.equal(text, 'GRANDMA MOM SALLY', `Sally template displayed`);
+        assert.strictEqual(text, 'GRANDMA MOM SALLY', `Sally template displayed`);
       });
       let text = this.$('#app').text();
 
-      assert.equal(
+      assert.strictEqual(
         text,
         'LOADING',
         `The loading template is nested in application template's outlet`
@@ -1116,7 +1128,7 @@ moduleFor(
       runTask(() => grandmaDeferred.resolve());
       text = this.$('#app').text();
 
-      assert.equal(
+      assert.strictEqual(
         text,
         'GRANDMA MOM MOMLOADING',
         `Mom's child loading route is displayed due to sally's slow promise`
@@ -1152,13 +1164,17 @@ moduleFor(
       );
 
       await this.visit('/grandma/mom/sally');
-      assert.equal(this.appRouter.currentPath, 'grandma.mom.sally', 'Initial route fully loaded');
+      assert.strictEqual(
+        this.appRouter.currentPath,
+        'grandma.mom.sally',
+        'Initial route fully loaded'
+      );
 
       let promise = runTask(() => this.visit('/grandma/puppies')).then(() => {
-        assert.equal(this.appRouter.currentPath, 'grandma.puppies', 'Finished transition');
+        assert.strictEqual(this.appRouter.currentPath, 'grandma.puppies', 'Finished transition');
       });
 
-      assert.equal(
+      assert.strictEqual(
         this.appRouter.currentPath,
         'grandma.loading',
         `in pivot route's child loading state`
@@ -1184,7 +1200,7 @@ moduleFor(
           actions: {
             error(err) {
               step(assert, 2, 'MomSallyRoute#actions.error');
-              assert.equal(err.msg, 'did it broke?', `it didn't break`);
+              assert.strictEqual(err.msg, 'did it broke?', `it didn't break`);
               return false;
             },
           },
@@ -1203,7 +1219,7 @@ moduleFor(
           actions: {
             error(err) {
               step(assert, 3, 'MomRoute#actions.error');
-              assert.equal(
+              assert.strictEqual(
                 err,
                 handledError,
                 `error handled and rebubbled is handleable at higher route`
@@ -1272,21 +1288,29 @@ moduleFor(
       );
 
       let promise = runTask(() => this.visit('/grandma')).then(() => {
-        assert.equal(this.appRouter.currentPath, 'memere.index', 'Transition should be complete');
+        assert.strictEqual(
+          this.appRouter.currentPath,
+          'memere.index',
+          'Transition should be complete'
+        );
       });
       let memereController = this.getController('memere');
 
-      assert.equal(this.appRouter.currentPath, 'memere.loading', 'Initial route should be loading');
+      assert.strictEqual(
+        this.appRouter.currentPath,
+        'memere.loading',
+        'Initial route should be loading'
+      );
 
       memereController.set('test', 3);
 
-      assert.equal(
+      assert.strictEqual(
         this.appRouter.currentPath,
         'memere.loading',
         'Initial route should still be loading'
       );
 
-      assert.equal(
+      assert.strictEqual(
         memereController.get('test'),
         3,
         'Controller query param value should have changed'

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -82,7 +82,7 @@ moduleFor(
       return this.visit('/').then(() => {
         let text = this.$('p').text();
 
-        assert.equal(text, 'THIS IS THE REAL HOME', 'the homepage template was rendered');
+        assert.strictEqual(text, 'THIS IS THE REAL HOME', 'the homepage template was rendered');
       });
     }
 
@@ -140,7 +140,7 @@ moduleFor(
       return this.visit('/top/middle/bottom').then(() => {
         assert.ok(true, '/top/middle/bottom has been handled');
         let rootElement = document.getElementById('qunit-fixture');
-        assert.equal(
+        assert.strictEqual(
           getTextOf(rootElement.querySelector('.main .middle .bottom p')),
           'BarBazBottom!',
           'The templates were rendered into their appropriate parents'
@@ -166,7 +166,7 @@ moduleFor(
       return this.visit('/top/middle/bottom').then(() => {
         assert.ok(true, '/top/middle/bottom has been handled');
         let rootElement = document.getElementById('qunit-fixture');
-        assert.equal(
+        assert.strictEqual(
           getTextOf(rootElement.querySelector('.main .middle .bottom p')),
           'Bottom!',
           'The templates were rendered into their appropriate parents'
@@ -193,7 +193,7 @@ moduleFor(
       return this.visit('/posts').then(() => {
         assert.ok(true, '/posts has been handled');
         let rootElement = document.getElementById('qunit-fixture');
-        assert.equal(getTextOf(rootElement.querySelector('h3.render-once')), 'I render once');
+        assert.strictEqual(getTextOf(rootElement.querySelector('h3.render-once')), 'I render once');
       });
     }
 
@@ -221,7 +221,7 @@ moduleFor(
 
       return this.visit('/posts').then(() => {
         let rootElement = document.getElementById('qunit-fixture');
-        assert.equal(rootElement.textContent.trim(), 'App posts');
+        assert.strictEqual(rootElement.textContent.trim(), 'App posts');
       });
     }
 
@@ -256,20 +256,20 @@ moduleFor(
       await this.visit('/page/first');
 
       assert.ok(true, '/page/first has been handled');
-      assert.equal(getTextOf(rootElement.querySelector('p')), 'first');
-      assert.equal(insertionCount, 1);
+      assert.strictEqual(getTextOf(rootElement.querySelector('p')), 'first');
+      assert.strictEqual(insertionCount, 1);
 
       await this.visit('/page/second');
 
       assert.ok(true, '/page/second has been handled');
-      assert.equal(getTextOf(rootElement.querySelector('p')), 'second');
-      assert.equal(insertionCount, 1, 'view should have inserted only once');
+      assert.strictEqual(getTextOf(rootElement.querySelector('p')), 'second');
+      assert.strictEqual(insertionCount, 1, 'view should have inserted only once');
       let router = this.applicationInstance.lookup('router:main');
 
       await run(() => router.transitionTo('page', EmberObject.create({ name: 'third' })));
 
-      assert.equal(getTextOf(rootElement.querySelector('p')), 'third');
-      assert.equal(insertionCount, 1, 'view should still have inserted only once');
+      assert.strictEqual(getTextOf(rootElement.querySelector('p')), 'third');
+      assert.strictEqual(insertionCount, 1, 'view should still have inserted only once');
     }
 
     ['@test {{outlet}} works when created after initial render'](assert) {
@@ -287,15 +287,15 @@ moduleFor(
       return this.visit('/')
         .then(() => {
           rootElement = document.getElementById('qunit-fixture');
-          assert.equal(rootElement.textContent.trim(), 'HiBye', 'initial render');
+          assert.strictEqual(rootElement.textContent.trim(), 'HiBye', 'initial render');
 
           run(() => this.applicationInstance.lookup('controller:sample').set('showTheThing', true));
 
-          assert.equal(rootElement.textContent.trim(), 'HiYayBye', 'second render');
+          assert.strictEqual(rootElement.textContent.trim(), 'HiYayBye', 'second render');
           return this.visit('/2');
         })
         .then(() => {
-          assert.equal(rootElement.textContent.trim(), 'HiBooBye', 'third render');
+          assert.strictEqual(rootElement.textContent.trim(), 'HiBooBye', 'third render');
         });
     }
 

--- a/packages/ember/tests/service_injection_test.js
+++ b/packages/ember/tests/service_injection_test.js
@@ -48,7 +48,7 @@ moduleFor(
 
       let controller = this.applicationInstance.lookup('controller:application');
       assert.ok(controller.get('myService') instanceof MyService);
-      assert.equal(serviceOwner, instance, 'should be able to `getOwner` in init');
+      assert.strictEqual(serviceOwner, instance, 'should be able to `getOwner` in init');
     }
   }
 );
@@ -75,7 +75,11 @@ moduleFor(
 
       let controller = this.applicationInstance.lookup('controller:application');
       assert.ok(controller.myService instanceof MyService);
-      assert.equal(controller.myService.name, 'The service name', 'service property accessible');
+      assert.strictEqual(
+        controller.myService.name,
+        'The service name',
+        'service property accessible'
+      );
     }
   }
 );

--- a/packages/ember/tests/view_instrumentation_test.js
+++ b/packages/ember/tests/view_instrumentation_test.js
@@ -31,7 +31,7 @@ moduleFor(
 
       return this.visit('/')
         .then(() => {
-          assert.equal(this.textValue(), 'Index', 'It rendered the correct template');
+          assert.strictEqual(this.textValue(), 'Index', 'It rendered the correct template');
 
           assert.ok(called, 'Instrumentation called on first render');
           called = false;
@@ -39,7 +39,7 @@ moduleFor(
           return this.visit('/posts');
         })
         .then(() => {
-          assert.equal(this.textValue(), 'Posts', 'It rendered the correct template');
+          assert.strictEqual(this.textValue(), 'Posts', 'It rendered the correct template');
           assert.ok(called, 'Instrumentation called on transition to non-view backed route');
         });
     }

--- a/packages/internal-test-helpers/lib/confirm-export.js
+++ b/packages/internal-test-helpers/lib/confirm-export.js
@@ -31,17 +31,25 @@ export default function confirmExport(Ember, assert, path, moduleId, exportName)
     } else if (typeof exportName === 'string') {
       let mod = require(moduleId);
       let value = 'value' in desc ? desc.value : desc.get.call(Ember);
-      assert.equal(value, mod[exportName], `Ember.${path} is exported correctly`);
+      assert.strictEqual(value, mod[exportName], `Ember.${path} is exported correctly`);
       assert.notEqual(mod[exportName], undefined, `Ember.${path} is not \`undefined\``);
     } else if ('value' in desc) {
-      assert.equal(desc.value, exportName.value, `Ember.${path} is exported correctly`);
+      assert.strictEqual(desc.value, exportName.value, `Ember.${path} is exported correctly`);
     } else {
       let mod = require(moduleId);
-      assert.equal(desc.get, mod[exportName.get], `Ember.${path} getter is exported correctly`);
+      assert.strictEqual(
+        desc.get,
+        mod[exportName.get],
+        `Ember.${path} getter is exported correctly`
+      );
       assert.notEqual(desc.get, undefined, `Ember.${path} getter is not undefined`);
 
       if (exportName.set) {
-        assert.equal(desc.set, mod[exportName.set], `Ember.${path} setter is exported correctly`);
+        assert.strictEqual(
+          desc.set,
+          mod[exportName.set],
+          `Ember.${path} setter is exported correctly`
+        );
         assert.notEqual(desc.set, undefined, `Ember.${path} setter is not undefined`);
       }
     }

--- a/packages/internal-test-helpers/lib/ember-dev/assertion.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/assertion.ts
@@ -103,7 +103,7 @@ function check(
           `Expected failing Ember.assert: '${expectedMessage}', but got '${actualMessage}'.`
         );
       } else {
-        assert.equal(
+        assert.strictEqual(
           actualMessage,
           expectedMessage,
           `Expected failing Ember.assert: '${expectedMessage}', but got '${actualMessage}'.`

--- a/packages/internal-test-helpers/lib/test-cases/query-param.js
+++ b/packages/internal-test-helpers/lib/test-cases/query-param.js
@@ -21,7 +21,11 @@ export default class QueryParamTestCase extends ApplicationTestCase {
           }
 
           if (testCase.expectedPushURL) {
-            testCase.assert.equal(path, testCase.expectedPushURL, 'an expected pushState occurred');
+            testCase.assert.strictEqual(
+              path,
+              testCase.expectedPushURL,
+              'an expected pushState occurred'
+            );
             testCase.expectedPushURL = null;
           }
 
@@ -34,7 +38,7 @@ export default class QueryParamTestCase extends ApplicationTestCase {
           }
 
           if (testCase.expectedReplaceURL) {
-            testCase.assert.equal(
+            testCase.assert.strictEqual(
               path,
               testCase.expectedReplaceURL,
               'an expected replaceState occurred'
@@ -79,7 +83,7 @@ export default class QueryParamTestCase extends ApplicationTestCase {
   }
 
   assertCurrentPath(path, message = `current path equals '${path}'`) {
-    this.assert.equal(this.appRouter.get('location.path'), path, message);
+    this.assert.strictEqual(this.appRouter.get('location.path'), path, message);
   }
 
   /**

--- a/tests/node/build-info-test.js
+++ b/tests/node/build-info-test.js
@@ -33,7 +33,7 @@ QUnit.module('buildVersion', () => {
     padEmptyArgs(3, [null, ''])
   ).forEach(({ args, expected }) => {
     QUnit.test(JSON.stringify(args), function (assert) {
-      assert.equal(buildVersion(...args), expected);
+      assert.strictEqual(buildVersion(...args), expected);
     });
   });
 });
@@ -50,7 +50,7 @@ QUnit.module('parseTagVersion', () => {
     },
   ].forEach(({ tag, expected }) => {
     QUnit.test(JSON.stringify(tag), function (assert) {
-      assert.equal(parseTagVersion(tag), expected);
+      assert.strictEqual(parseTagVersion(tag), expected);
     });
   });
 

--- a/tests/node/fastboot-sandbox-test.js
+++ b/tests/node/fastboot-sandbox-test.js
@@ -112,8 +112,8 @@ QUnit.module('Ember.Application - visit() Integration Tests', function (hooks) {
   QUnit.test('FastBoot: basic', async function (assert) {
     let result = await fastbootVisit(this.context, '/');
 
-    assert.equal(result.url, '/', 'landed on correct url');
-    assert.equal(
+    assert.strictEqual(result.url, '/', 'landed on correct url');
+    assert.strictEqual(
       result.body,
       '<body><h1>Hello world!</h1>\n<!----></body>',
       'results in expected HTML'

--- a/tests/node/instrumentation-test.js
+++ b/tests/node/instrumentation-test.js
@@ -18,7 +18,7 @@ QUnit.module('instrumentation', function (hooks) {
       return 'hello';
     });
 
-    assert.equal(result, 'hello', 'called block');
+    assert.strictEqual(result, 'hello', 'called block');
 
     global.window = _originalWindow;
   });

--- a/tests/node/overrides-test.js
+++ b/tests/node/overrides-test.js
@@ -518,7 +518,7 @@ QUnit.module('Overrides', function () {
 
   QUnit.module('.printList', function () {
     QUnit.test('it can print a flat list', function (assert) {
-      assert.equal(
+      assert.strictEqual(
         Overrides.printList(['first', 'second', 'third'], '        '),
         `\
         * first
@@ -529,7 +529,7 @@ QUnit.module('Overrides', function () {
     });
 
     QUnit.test('it can print a nested list', function (assert) {
-      assert.equal(
+      assert.strictEqual(
         Overrides.printList(
           [
             'first',

--- a/tests/node/sourcemap-test.js
+++ b/tests/node/sourcemap-test.js
@@ -7,7 +7,7 @@ QUnit.module('sourcemap validation', function () {
 
     let contents = fs.readFileSync(jsPath, 'utf-8');
     let num = count(contents, '//# sourceMappingURL=');
-    assert.equal(num, 1);
+    assert.strictEqual(num, 1);
   });
 });
 

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -30,21 +30,29 @@ QUnit.module('ember-template-compiler.js', function () {
     });
 
     QUnit.test('can access _Ember.ENV (private API used by ember-cli-htmlbars)', function (assert) {
-      assert.equal(typeof templateCompiler._Ember.ENV, 'object', '_Ember.ENV is present');
+      assert.strictEqual(typeof templateCompiler._Ember.ENV, 'object', '_Ember.ENV is present');
       assert.notEqual(typeof templateCompiler._Ember.ENV, null, '_Ember.ENV is not null');
     });
 
     QUnit.test('can access _Ember.FEATURES (private API used by ember-cli-htmlbars)', function (
       assert
     ) {
-      assert.equal(typeof templateCompiler._Ember.FEATURES, 'object', '_Ember.FEATURES is present');
+      assert.strictEqual(
+        typeof templateCompiler._Ember.FEATURES,
+        'object',
+        '_Ember.FEATURES is present'
+      );
       assert.notEqual(typeof templateCompiler._Ember.FEATURES, null, '_Ember.FEATURES is not null');
     });
 
     QUnit.test('can access _Ember.VERSION (private API used by ember-cli-htmlbars)', function (
       assert
     ) {
-      assert.equal(typeof templateCompiler._Ember.VERSION, 'string', '_Ember.VERSION is present');
+      assert.strictEqual(
+        typeof templateCompiler._Ember.VERSION,
+        'string',
+        '_Ember.VERSION is present'
+      );
     });
   });
 });

--- a/tests/node/visit-test.js
+++ b/tests/node/visit-test.js
@@ -34,7 +34,7 @@ function fastbootVisit(App, url) {
 
 function assertFastbootResult(assert, expected) {
   return function (actual) {
-    assert.equal(actual.url, expected.url);
+    assert.strictEqual(actual.url, expected.url);
     assertHTMLMatches(assert, actual.body, expected.body);
   };
 }
@@ -184,7 +184,7 @@ QUnit.module('Ember.Application - visit() Integration Tests', function (hooks) {
           instance.destroy();
         },
         function (error) {
-          assert.equal(error.message, 'Error from A');
+          assert.strictEqual(error.message, 'Error from A');
         }
       ),
       fastbootVisit(App, '/b').then(
@@ -193,7 +193,7 @@ QUnit.module('Ember.Application - visit() Integration Tests', function (hooks) {
           instance.destroy();
         },
         function (error) {
-          assert.equal(error.message, 'Error from B');
+          assert.strictEqual(error.message, 'Error from B');
         }
       ),
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5824,10 +5824,10 @@ eslint-plugin-prettier@^3.4.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-qunit@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz#f4efda29da99523e560848d9592c39c0590c308d"
-  integrity sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==
+eslint-plugin-qunit@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-qunit/-/eslint-plugin-qunit-7.0.0.tgz#a782fafe930820f6b62880958ebc3e93de462f02"
+  integrity sha512-yPh02tbQoZK43voIfJFO9CUN5Q6j8ebfrnxEqPr7I4UiYln4RWKDQ4ajaHgV3gJKSAUZwymJ0DsB/YH6btRxIQ==
   dependencies:
     eslint-utils "^3.0.0"
     requireindex "^1.2.0"


### PR DESCRIPTION
[no-assert-equal](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md) is now a recommended rule in [eslint-plugin-qunit v7](https://github.com/platinumazure/eslint-plugin-qunit/blob/master/CHANGELOG.md#700). In JavaScript, we should generally use strict equality checks like [assert.strictEqual](https://api.qunitjs.com/assert/strictEqual/).

This PR updates all references in the codebase including internal tests and blueprints used for code generation.

Related to how we are upgrading ember-cli to use eslint-plugin-qunit v7:
* https://github.com/ember-cli/ember-cli/pull/9671
* https://github.com/ember-cli/ember-cli/pull/9667
* https://github.com/emberjs/data/pull/7726