### PR TITLE
[DOC beta] Remove some jQuery examples from comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,10 +141,6 @@ example:
 
 To test multiple packages, you can separate them with commas.
 
-You can also pass `jquery=VERSION` in the test URL to test different
-versions of jQuery. You can also pass `jquery=none` to run tests without jQuery
-integration.
-
 ## From the CLI
 
 Run `yarn test` to run a basic test suite or run `TEST_SUITE=all yarn test` to

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1001,23 +1001,6 @@ const Component = CoreView.extend(
     */
 
     /**
-      Returns a jQuery object for this component's element. If you pass in a selector
-      string, this method will return a jQuery object, using the current element
-      as its buffer.
-
-      For example, calling `component.$('li')` will return a jQuery object containing
-      all of the `li` elements inside the DOM element of this component.
-
-      Please note that jQuery integration is off by default and this feature will
-      not work properly. To enable this feature, you can read the instructions in
-      the [jquery-integration optional feature guide](https://guides.emberjs.com/release/configuring-ember/optional-features/#toc_jquery-integration).
-      @method $
-      @param {String} [selector] a jQuery-compatible selector string
-      @return {jQuery} the jQuery object for the DOM node
-      @public
-    */
-
-    /**
       The HTML `id` of the component's element in the DOM. You can provide this
       value yourself but it must be unique (just as in HTML):
 

--- a/packages/@ember/-internals/glimmer/lib/components/checkbox.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/checkbox.ts
@@ -21,7 +21,7 @@ import layout from '../templates/empty';
   The `checked` attribute of an `Checkbox` object should always be set
   through the Ember object or by interacting with its rendered element
   representation via the mouse, keyboard, or touch. Updating the value of the
-  checkbox via jQuery will result in the checked value of the object and its
+  checkbox programmatically will result in the checked value of the object and its
   element losing synchronization.
 
   ## Layout and LayoutName properties

--- a/packages/@ember/-internals/utils/lib/guid.ts
+++ b/packages/@ember/-internals/utils/lib/guid.ts
@@ -6,9 +6,6 @@ import { isObject } from './spec';
 */
 
 /**
- Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from
- jQuery master. We'll just bootstrap our own uuid now.
-
  @private
  @return {Number} the uuid
  */
@@ -22,7 +19,7 @@ let _uuid = 0;
  @public
  @return {Number} [description]
  */
-export function uuid() {
+export function uuid(): number {
   return ++_uuid;
 }
 
@@ -73,7 +70,7 @@ export const GUID_KEY = intern(`__ember${Date.now()}`);
     separate the guid into separate namespaces.
   @return {String} the guid
 */
-export function generateGuid(obj: object, prefix = GUID_PREFIX) {
+export function generateGuid(obj: object, prefix = GUID_PREFIX): String {
   let guid = prefix + uuid();
 
   if (isObject(obj)) {
@@ -97,7 +94,7 @@ export function generateGuid(obj: object, prefix = GUID_PREFIX) {
   @param {Object} obj any object, string, number, Element, or primitive
   @return {String} the unique guid for this instance.
 */
-export function guidFor(value: any | null | undefined) {
+export function guidFor(value: any | null | undefined): string {
   let guid;
 
   if (isObject(value)) {

--- a/packages/@ember/-internals/views/lib/mixins/view_support.js
+++ b/packages/@ember/-internals/views/lib/mixins/view_support.js
@@ -166,7 +166,7 @@ let mixin = {
    and does not have an ancestor element that is associated with an Ember view.
 
    @method appendTo
-   @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+   @param {String|DOMElement} A selector, element, HTML string
    @return {Ember.View} receiver
    @private
    */
@@ -197,11 +197,11 @@ let mixin = {
       target = selector;
 
       assert(
-        `You tried to append to a selector string (${selector}) in an environment without jQuery`,
+        `You tried to append to a selector string (${selector}) in an environment without a DOM`,
         typeof target !== 'string'
       );
       assert(
-        `You tried to append to a non-Element (${selector}) in an environment without jQuery`,
+        `You tried to append to a non-Element (${selector}) in an environment without a DOM`,
         typeof selector.appendChild === 'function'
       );
     }
@@ -354,7 +354,7 @@ let mixin = {
    Component properties that depend on the presence of an outer element, such
    as `classNameBindings` and `attributeBindings`, do not work with tagless
    components. Tagless components cannot implement methods to handle events,
-   and have no associated jQuery object to return with `$()`.
+   and their `element` property has a `null` value.
 
    @property tagName
    @type String

--- a/packages/@ember/application/lib/application.js
+++ b/packages/@ember/application/lib/application.js
@@ -120,7 +120,7 @@ import { RouterService } from '@ember/-internals/routing';
   });
   ```
 
-  The `rootElement` can be either a DOM element or a jQuery-compatible selector
+  The `rootElement` can be either a DOM element or a CSS selector
   string. Note that *views appended to the DOM outside the root element will
   not receive events.* If you specify a custom root element, make sure you only
   append views inside it!
@@ -184,8 +184,7 @@ import { RouterService } from '@ember/-internals/routing';
 const Application = Engine.extend({
   /**
     The root DOM element of the Application. This can be specified as an
-    element or a
-    [jQuery-compatible selector string](http://api.jquery.com/category/selectors/).
+    element or a [selector string](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors#reference_table_of_selectors).
 
     This is the element that will be passed to the Application's,
     `eventDispatcher`, which sets up the listeners for event delegation. Every
@@ -548,11 +547,10 @@ const Application = Engine.extend({
 
     App.deferReadiness();
 
-    // $ is a reference to the jQuery object/function
-    import $ from 'jquery;
-
-    $.getJSON('/auth-token', function(token) {
-      App.token = token;
+    fetch('/auth-token')
+    .then(response => response.json())
+    .then(data => {
+      App.token = data.token;
       App.advanceReadiness();
     });
     ```
@@ -1000,7 +998,7 @@ const Application = Engine.extend({
     implement a limited subset of the full DOM API. The `SimpleDOM` library is known
     to work.
 
-    Since there is no access to jQuery in the non-browser environment, you must also
+    Since there is no DOM access in the non-browser environment, you must also
     specify a DOM `Element` object in the same `document` for the `rootElement` option
     (as opposed to a selector string like `"body"`).
 

--- a/packages/@ember/engine/index.js
+++ b/packages/@ember/engine/index.js
@@ -339,7 +339,6 @@ Engine.reopenClass({
     Example instanceInitializer to preload data into the store.
 
     ```app/initializer/preload-data.js
-    import $ from 'jquery';
 
     export function initialize(application) {
         var userConfig, userConfigEncoded, store;
@@ -352,7 +351,7 @@ Engine.reopenClass({
         // should not be relied upon for security or authorization.
 
         // Grab the encoded data from the meta tag
-        userConfigEncoded = $('head meta[name=app-user-config]').attr('content');
+        userConfigEncoded = document.querySelector('head meta[name=app-user-config]').attr('content');
 
         // Unescape the text, then parse the resulting JSON into a real object
         userConfig = JSON.parse(unescape(userConfigEncoded));

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -272,12 +272,16 @@ Ember._isDestroyed = isDestroyed;
   and reporting code.
 
   ```javascript
-  import $ from 'jquery';
 
   Ember.onerror = function(error) {
-    $.ajax('/report-error', 'POST', {
+    const payload = {
       stack: error.stack,
       otherInformation: 'whatever app state you want to provide'
+    };
+
+    fetch('/report-error', {
+      method: 'POST',
+      body: JSON.stringify(payload)
     });
   };
   ```
@@ -675,14 +679,3 @@ Ember.__loader = {
 };
 
 export default Ember;
-
-/**
- @module jquery
- @public
- */
-
-/**
- @class jquery
- @public
- @static
- */

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -1,6 +1,5 @@
 module.exports = {
   classitems: [
-    '$',
     'A',
     'EXTEND_PROTOTYPES',
     'GUID_KEY',

--- a/tests/index.html
+++ b/tests/index.html
@@ -20,15 +20,6 @@
       };
     </script>
 
-    <script type="text/javascript">
-      // Load custom version of jQuery if possible
-      var jQueryVersion = QUnit.urlParams.jquery;
-      if (jQueryVersion && jQueryVersion !== 'none') {
-        loadScript('https://code.jquery.com/jquery-'+jQueryVersion+'.js');
-      }
-      // Close the script tag to make sure document.write happens
-    </script>
-
     <script>
       (function() {
         window.EmberENV = window.EmberENV || {};


### PR DESCRIPTION
Removes some jQuery mentions from docs/code examples, and removes the `jquery` QUnit query param.

Raised as an issue by @simonihmig [here](https://github.com/emberjs/ember.js/pull/19677#issuecomment-953711044).