### PR TITLE
Fix memory leak when looking up non-instantiable objects from the owner

### DIFF
--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -485,7 +485,7 @@ class FactoryManager<T, C> {
     this.injections = undefined;
     setFactoryFor(this, this);
 
-    if (factory) {
+    if (isInstantiatable(container, fullName)) {
       setFactoryFor(factory, this);
     }
   }


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/emberjs/ember.js/pull/19467 which was merged into https://github.com/emberjs/ember.js/releases/tag/v3.27.0-beta.1

Before that PR moved where the back ref to the factory was created, it was only set if instantiate flag was true. After that PR moved where this was done, it would set the back ref on instantiate false, leaking the owner onto things like static template imports.

This isn't a big deal when there is only one app instance, but it is a problem in Fastboot and Acceptance tests.