### PR TITLE
[DOC release beta 3.28] Fix deprecation info

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1084,10 +1084,10 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
             id: 'ember.component.reopen',
             for: 'ember-source',
             since: {
-              enabled: '4.0.0',
+              enabled: '3.27.0',
             },
-            url: 'https://deprecations.emberjs.com/v4.x#toc_ember-component-reopen',
-            until: '5.0.0',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-reopen',
+            until: '4.0.0',
           }
         );
 


### PR DESCRIPTION
This deprecation documentation change needs to go into `master`, `beta`, and backported to `3.28`.

The intent was to remove this API in 4.0.
When we backfilled the missing info in previous work, this was unclear.

I got the "since" from looking at tags in https://github.com/emberjs/ember.js/commit/98b70da5c8efd7807e1f640ada5035e8097b28ae

Addresses https://github.com/emberjs/ember.js/pull/19744#issuecomment-954956205