### PR TITLE
[BUGFIX beta] Replace `assert.equal` in blueprints with `assert.strictEqual` to appease eslint-plugin-qunit on generation

### DIFF
--- a/blueprints/acceptance-test/qunit-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/qunit-files/tests/acceptance/__name__-test.js
@@ -7,6 +7,6 @@ test('visiting /<%= dasherizedModuleName %>', function(assert) {
   visit('/<%= dasherizedModuleName %>');
 
   andThen(function() {
-    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+    assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });

--- a/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
@@ -8,6 +8,6 @@ module('<%= friendlyTestName %>', function(hooks) {
   test('visiting /<%= dasherizedModuleName %>', async function(assert) {
     await visit('/<%= dasherizedModuleName %>');
 
-    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+    assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });

--- a/blueprints/component-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -13,7 +13,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`<%= selfCloseComponent(componentName) %>`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.strictEqual(this.$().text().trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -22,10 +22,10 @@ test('it renders', function(assert) {
     <%= closeComponent(componentName) %>
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>
+  assert.strictEqual(this.$().text().trim(), 'template block text');<% } else if(testType === 'unit') { %>
   // Creates the component instance
   /*let component =*/ this.subject();
   // Renders the component to the page
   this.render();
-  assert.equal(this.$().text().trim(), '');<% } %>
+  assert.strictEqual(this.$().text().trim(), '');<% } %>
 });

--- a/blueprints/helper-test/qunit-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/qunit-files/__root__/__testType__/__collection__/__name__-test.js
@@ -11,5 +11,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);
 
-  assert.equal(this.$().text().trim(), '1234');
+  assert.strictEqual(this.$().text().trim(), '1234');
 });

--- a/node-tests/fixtures/acceptance-test/addon-default.js
+++ b/node-tests/fixtures/acceptance-test/addon-default.js
@@ -7,6 +7,6 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), '/foo');
+    assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/node-tests/fixtures/acceptance-test/addon-nested.js
+++ b/node-tests/fixtures/acceptance-test/addon-nested.js
@@ -7,6 +7,6 @@ test('visiting /foo/bar', function(assert) {
   visit('/foo/bar');
 
   andThen(function() {
-    assert.equal(currentURL(), '/foo/bar');
+    assert.strictEqual(currentURL(), '/foo/bar');
   });
 });

--- a/node-tests/fixtures/acceptance-test/default.js
+++ b/node-tests/fixtures/acceptance-test/default.js
@@ -7,6 +7,6 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   andThen(function() {
-    assert.equal(currentURL(), '/foo');
+    assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/node-tests/fixtures/acceptance-test/qunit-rfc268.js
+++ b/node-tests/fixtures/acceptance-test/qunit-rfc268.js
@@ -8,6 +8,6 @@ module('Acceptance | foo', function(hooks) {
   test('visiting /foo', async function(assert) {
     await visit('/foo');
 
-    assert.equal(currentURL(), '/foo');
+    assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/node-tests/fixtures/component-test/default-template.js
+++ b/node-tests/fixtures/component-test/default-template.js
@@ -11,7 +11,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`<<%= componentInvocation =%> />`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.strictEqual(this.$().text().trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -20,5 +20,5 @@ test('it renders', function(assert) {
     </<%= componentInvocation =%>>
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.strictEqual(this.$().text().trim(), 'template block text');
 });

--- a/node-tests/fixtures/component-test/default.js
+++ b/node-tests/fixtures/component-test/default.js
@@ -11,7 +11,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`<XFoo />`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.strictEqual(this.$().text().trim(), '');
 
   // Template block usage:
   this.render(hbs`
@@ -20,5 +20,5 @@ test('it renders', function(assert) {
     </XFoo>
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.strictEqual(this.$().text().trim(), 'template block text');
 });

--- a/node-tests/fixtures/component-test/unit.js
+++ b/node-tests/fixtures/component-test/unit.js
@@ -12,5 +12,5 @@ test('it renders', function(assert) {
   /*let component =*/ this.subject();
   // Renders the component to the page
   this.render();
-  assert.equal(this.$().text().trim(), '');
+  assert.strictEqual(this.$().text().trim(), '');
 });

--- a/node-tests/fixtures/helper-test/integration.js
+++ b/node-tests/fixtures/helper-test/integration.js
@@ -11,5 +11,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{foo/bar-baz this.inputValue}}`);
 
-  assert.equal(this.$().text().trim(), '1234');
+  assert.strictEqual(this.$().text().trim(), '1234');
 });


### PR DESCRIPTION
Co-authored-by: Bryan Mishkin <698306+bmish@users.noreply.github.com>

Required for 4.0