### PR TITLE
[BUGFIX release] Fix deprecation `until` and link for Component.reopenClass

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -1095,11 +1095,11 @@ if (EMBER_MODERNIZED_BUILT_IN_COMPONENTS) {
           {
             id: 'ember.component.reopen',
             for: 'ember-source',
-            url: 'https://deprecations.emberjs.com/v4.x#toc_ember-component-reopen',
+            url: 'https://deprecations.emberjs.com/v3.x#toc_ember-component-reopen',
             since: {
-              enabled: '4.0.0',
+              enabled: '3.27.0',
             },
-            until: '5.0.0',
+            until: '4.0.0',
           }
         );
 


### PR DESCRIPTION
The same work as in 
https://github.com/emberjs/ember.js/pull/19823 for the second deprecation that was erroneously updated in https://github.com/emberjs/ember.js/pull/19744#issuecomment-954956205