### PR TITLE
Fix missing `deprecate` import in router

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -6,7 +6,7 @@ import { BucketCache } from '@ember/-internals/routing';
 import RouterService from '@ember/-internals/routing/lib/services/router';
 import { A as emberA, Evented, Object as EmberObject, typeOf } from '@ember/-internals/runtime';
 import Controller from '@ember/controller';
-import { assert, info } from '@ember/debug';
+import { assert, deprecate, info } from '@ember/debug';
 import EmberError from '@ember/error';
 import { cancel, once, run, scheduleOnce } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';


### PR DESCRIPTION
Two PR's "crossed in the mail" and left things a bit broken (deprecate was removed when deprecations were cleaned up, then we landed a new deprecation).
