### PR TITLE
[CLEANUP beta] Turn `template-only-glimmer-components` deprecation into an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const injectBabelHelpers = require('./transforms/inject-babel-helpers').injectBa
 const debugTree = require('broccoli-debug').buildDebugCallback('ember-source:addon');
 const vmBabelPlugins = require('@glimmer/vm-babel-plugins');
 const Overrides = require('./overrides');
+const SilentError = require('silent-error');
 
 const PRE_BUILT_TARGETS = [
   'last 1 Chrome versions',
@@ -115,7 +116,6 @@ module.exports = {
           `You have configured your application to indicate that it is using the 'octane' edition (via \`setEdition('octane')\`), but the appropriate Octane features were not enabled:\n`
         );
 
-        const SilentError = require('silent-error');
         throw new SilentError(message.join('\n\t'));
       }
     } else {
@@ -136,8 +136,8 @@ module.exports = {
         optionalFeaturesMissing ||
         !optionalFeatures.isFeatureEnabled('template-only-glimmer-components')
       ) {
-        this.ui.writeWarnLine(
-          'Setting the `template-only-glimmer-components` optional feature flag to `false`, or not providing a setting at all, has been deprecated. You must add the `@ember/optional-features` addon and set this feature to `true`. You can also run `npx @ember/octanify` to do this. This warning will become an error in Ember 4.0.0.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-template-only-glimmer-components'
+        throw new SilentError(
+          'Setting the `template-only-glimmer-components` optional feature flag to `false`, or not providing a setting at all, was deprecated in Ember 3.x and removed in Ember 4.0.0. You must add the `@ember/optional-features` addon and set this feature to `true`.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-template-only-glimmer-components'
         );
       }
     }
@@ -148,7 +148,6 @@ module.exports = {
       typeof optionalFeatures.isFeatureExplicitlySet === 'function' &&
       optionalFeatures.isFeatureExplicitlySet('jquery-integration')
     ) {
-      const SilentError = require('silent-error');
       throw new SilentError(
         'Setting the `jquery-integration` optional feature flag to `true` was deprecated in Ember 3.x and removed in Ember 4.0.0. You must add the `@ember/optional-features` addon and set this feature to `false`.\n\nFor more information, see the deprecation guide: https://deprecations.emberjs.com/v3.x/#toc_optional-feature-jquery-integration'
       );


### PR DESCRIPTION
Part of #19617.