### PR TITLE
[bug]: Check if modelClass has a find method

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1742,7 +1742,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
           Boolean(modelClass)
         );
 
-        if (!modelClass) {
+        if (!modelClass || !modelClass.find) {
           return;
         }
 


### PR DESCRIPTION
https://github.com/emberjs/ember.js/issues/19545
https://github.com/emberjs/data/pull/7744#issuecomment-966832106

There is no `find` method on model class instances.