### PR TITLE
Remove assertion if model has no `find` method in implicit record loading

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1749,7 +1749,10 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
         modelClass = modelClass.class;
 
         if (!modelClass.find) {
-          assert(`${classify(name)} has no method \`find\`.`, typeof modelClass.find === 'function');
+          assert(
+            `${classify(name)} has no method \`find\`.`,
+            typeof modelClass.find === 'function'
+          );
           return;
         }
 

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1748,7 +1748,10 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
 
         modelClass = modelClass.class;
 
-        assert(`${classify(name)} has no method \`find\`.`, typeof modelClass.find === 'function');
+        if (!modelClass.find) {
+          assert(`${classify(name)} has no method \`find\`.`, typeof modelClass.find === 'function');
+          return;
+        }
 
         return modelClass.find(value);
       },

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1749,10 +1749,6 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
         modelClass = modelClass.class;
 
         if (!modelClass.find) {
-          assert(
-            `${classify(name)} has no method \`find\`.`,
-            typeof modelClass.find === 'function'
-          );
           return;
         }
 

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -64,7 +64,7 @@ moduleFor(
       runDestroy(owner);
     }
 
-    ["@test assert if 'store.find' method is not found"]() {
+    ["@test assert if 'store.find' method is not found"](assert) {
       runDestroy(route);
 
       let owner = buildOwner();
@@ -75,10 +75,9 @@ moduleFor(
 
       route = owner.lookup('route:index');
 
-      expectAssertion(function () {
-        route.findModel('post', 1);
-      }, 'Post has no method `find`.');
+      let result = route.findModel('post', 1);
 
+      assert.equal(result, undefined);
       runDestroy(owner);
     }
 


### PR DESCRIPTION
https://github.com/emberjs/ember.js/issues/19545
https://github.com/emberjs/data/pull/7744#issuecomment-966832106

There is no `find` method on model class instances.  Ideally this change to early return was made when ember-data removed the `find` method from model instances - see [here](https://github.com/emberjs/data/blob/v0.13/packages/ember-data/lib/system/model/model.js#L510) for old definition.