### PR TITLE
[CLEANUP beta] Inelegant throw for arg-less-paren-less helper

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -66,6 +66,15 @@ setGlobalContext({
     if (DEBUG) {
       let { id } = options;
 
+      if (id === 'argument-less-helper-paren-less-invocation') {
+        throw new Error(
+          `A resolved helper cannot be passed as a named argument as the syntax is ` +
+            `ambiguously a pass-by-reference or invocation. Use the ` +
+            `\`{{helper 'foo-helper}}\` helper to pass by reference or explicitly ` +
+            `invoke the helper with parens: \`{{(fooHelper)}}\`.`
+        );
+      }
+
       let override = VM_DEPRECATION_OVERRIDES.filter((o) => o.id === id)[0];
 
       if (!override) throw new Error(`deprecation override for ${id} not found`);
@@ -98,15 +107,6 @@ const VM_DEPRECATION_OVERRIDES: (DeprecationOptions & {
   disabled?: boolean;
   message?: string;
 })[] = [
-  {
-    id: 'argument-less-helper-paren-less-invocation',
-    url: 'https://deprecations.emberjs.com/v3.x#toc_argument-less-helper-paren-less-invocation',
-    until: '4.0.0',
-    for: 'ember-source',
-    since: {
-      enabled: '3.27.0',
-    },
-  },
   {
     id: 'setting-on-hash',
     until: '4.4.0',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -870,25 +870,21 @@ if (DEBUG) {
         this.registerHelper('is-string', ([value]) => typeof value === 'string');
       }
 
-      ['@test invoking an argument-less helper without parens in named argument position is deprecated']() {
+      ['@test invoking an argument-less helper without parens in named argument position throws'](
+        assert
+      ) {
         this.registerHelper('foo', () => 'Hello, world!');
 
-        expectDeprecation(
+        assert.throws(
           () => this.render('<Bar @content={{foo}} />', { foo: 'Not it!' }),
-          new RegExp(
-            /The `foo` helper was used in the `-top-level` template as /.source +
-              /`@content={{foo}}`\. This is ambigious between wanting the `@content` /.source +
-              /argument to be the `foo` helper itself, or the result of invoking the /.source +
-              /`foo` helper \(current behavior\)\. This implicit invocation behavior /.source +
-              /has been deprecated\./.source
-          )
+          `A resolved helper cannot be passed as a named argument as the syntax is ` +
+            `ambiguously a pass-by-reference or invocation. Use the ` +
+            `\`{{helper 'foo-helper}}\` helper to pass by reference or explicitly ` +
+            `invoke the helper with parens: \`{{(fooHelper)}}\`.`
         );
-
-        this.assertText('[true][Hello, world!]');
-        this.assertStableRerender();
       }
 
-      ['@test invoking an argument-less helper with parens in named argument position is not deprecated']() {
+      ['@test invoking an argument-less helper with parens in named argument position']() {
         this.registerHelper('foo', () => 'Hello, world!');
 
         expectNoDeprecation(() => this.render('<Bar @content={{(foo)}} />', { foo: 'Not it!' }));
@@ -897,7 +893,7 @@ if (DEBUG) {
         this.assertStableRerender();
       }
 
-      ['@test invoking an argument-less helper with quotes in named argument position is not deprecated']() {
+      ['@test invoking an argument-less helper with quotes in named argument position']() {
         this.registerHelper('foo', () => 'Hello, world!');
 
         expectNoDeprecation(() => this.render('<Bar @content="{{foo}}" />', { foo: 'Not it!' }));
@@ -906,7 +902,7 @@ if (DEBUG) {
         this.assertStableRerender();
       }
 
-      ['@test passing a local helper in named argument position is not deprecated']() {
+      ['@test passing a local helper in named argument position']() {
         let foo = defineSimpleHelper(() => 'Hello, world!');
 
         expectNoDeprecation(() =>
@@ -922,7 +918,7 @@ if (DEBUG) {
       // is trying to call `block.compile()` but `block` is the reference for `this.foo`.
       // So the execution stack is probably off-by-one or something.
 
-      ['@test invoking a local helper with parens in named argument position is not deprecated']() {
+      ['@test invoking a local helper with parens in named argument position']() {
         let foo = defineSimpleHelper(() => 'Hello, world!');
 
         expectNoDeprecation(() =>
@@ -933,9 +929,7 @@ if (DEBUG) {
         this.assertStableRerender();
       }
 
-      // TODO: this one doesn't work yet, and there is a failing test in glimmer-vm
-
-      ['@skip invoking a helper with quotes in named argument position is not deprecated']() {
+      ['@skip invoking a helper with quotes in named argument position']() {
         let foo = defineSimpleHelper(() => 'Hello, world!');
 
         expectNoDeprecation(() =>


### PR DESCRIPTION
Part of https://github.com/emberjs/ember.js/issues/19617

Convert the deprecation for `argument-less-helper-paren-less-invocation` into a `throw`. A more elegant version of this fix would convert the deprecation upstream in Glimmer VM into an assert, or would update the syntax to match a more desired functionality. I've taken a quick stab at that, but wasn't able to come up with something I was happy with quickly.

I suggest we land this for 4.0, and we can continue to improve the message in the `throw`, or remove the `throw`, or add an `assert` instead at the Glimmer VM level, in followup patches.