### PR TITLE
Re-enable `ember-string.htmlsafe-ishtmlsafe` deprecations

### DIFF
--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -239,15 +239,13 @@ function deprecateImportFromString(
   name: string,
   message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
 ) {
-  // Disabling this deprecation due to unintended errors in 3.25
-  // See https://github.com/emberjs/ember.js/issues/19393 fo more information.
-  deprecate(message, true, {
+  deprecate(message, false, {
     id: 'ember-string.htmlsafe-ishtmlsafe',
     for: 'ember-source',
     since: {
       enabled: '3.25',
     },
-    until: '4.0.0',
+    until: '5.0.0',
     url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
   });
 }

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -440,15 +440,13 @@ const deprecateImportFromString = function (
   name,
   message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
 ) {
-  // Disabling this deprecation due to unintended errors in 3.25
-  // See https://github.com/emberjs/ember.js/issues/19393 fo more information.
-  deprecate(message, true, {
+  deprecate(message, false, {
     id: 'ember-string.htmlsafe-ishtmlsafe',
     for: 'ember-source',
     since: {
       enabled: '3.25',
     },
-    until: '4.0.0',
+    until: '5.0.0',
     url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
   });
 };

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -20,7 +20,7 @@ moduleFor(
       });
     }
 
-    ['@skip Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
+    ['@test Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
         assert.equal(
@@ -32,7 +32,7 @@ moduleFor(
       assert.notEqual(glimmer.htmlSafe, undefined, 'Ember.String.htmlSafe is not `undefined`');
     }
 
-    ['@skip Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
+    ['@test Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
         assert.equal(
@@ -259,8 +259,6 @@ let allExports = [
   ['String.classify', '@ember/string', 'classify'],
   ['String.dasherize', '@ember/string', 'dasherize'],
   ['String.decamelize', '@ember/string', 'decamelize'],
-  ['String.htmlSafe', '@ember/-internals/glimmer', 'htmlSafe'],
-  ['String.isHTMLSafe', '@ember/-internals/glimmer', 'isHTMLSafe'],
   ['String.underscore', '@ember/string', 'underscore'],
   ['String.w', '@ember/string', 'w'],
   ['STRINGS', '@ember/string', { get: '_getStrings', set: '_setStrings' }],


### PR DESCRIPTION
Due to an [issue](https://github.com/emberjs/ember.js/issues/19393), these deprecations were disabled and therefore will not be removed for the v4 release.

I will issue a PR for the corresponding deprecation guide if this gets merged.