### PR TITLE
[BUGFIX 3.28] Improve implicit injections deprecation for routes

### DIFF
--- a/packages/@ember/-internals/container/index.ts
+++ b/packages/@ember/-internals/container/index.ts
@@ -6,4 +6,10 @@ The public API, specified on the application namespace should be considered the 
 */
 
 export { default as Registry, privatize } from './lib/registry';
-export { default as Container, getFactoryFor, setFactoryFor, INIT_FACTORY } from './lib/container';
+export {
+  default as Container,
+  getFactoryFor,
+  setFactoryFor,
+  INIT_FACTORY,
+  DeprecatedStoreInjection,
+} from './lib/container';

--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -49,6 +49,13 @@ if (DEBUG) {
   }
 }
 
+export class DeprecatedStoreInjection {
+  store: unknown;
+  constructor(store: unknown) {
+    this.store = store;
+  }
+}
+
 export interface ContainerOptions {
   owner?: Owner;
   cache?: { [key: string]: CacheMember };
@@ -470,7 +477,12 @@ function injectionsFor(container: Container, fullName: string) {
   let typeInjections = registry.getTypeInjections(type);
   let injections = registry.getInjections(fullName);
 
-  return buildInjections(container, typeInjections, injections);
+  let result = buildInjections(container, typeInjections, injections);
+
+  if (DEBUG && type === 'route' && result.injections.store) {
+    result.injections.store = new DeprecatedStoreInjection(result.injections.store);
+  }
+  return result;
 }
 
 function destroyDestroyables(container: Container): void {

--- a/packages/@ember/-internals/routing/tests/system/route_test.js
+++ b/packages/@ember/-internals/routing/tests/system/route_test.js
@@ -23,7 +23,9 @@ moduleFor(
     }
 
     ['@test default store utilizes the container to acquire the model factory'](assert) {
-      assert.expect(4);
+      assert.expect(5);
+
+      expectNoDeprecation();
 
       let Post = EmberObject.extend();
       let post = {};
@@ -64,8 +66,9 @@ moduleFor(
       runDestroy(owner);
     }
 
-    ["@test 'store' can be injected by data persistence frameworks"](assert) {
-      assert.expect(8);
+    ["@test 'store' can be injected by data persistence frameworks [DEPRECATED]"](assert) {
+      assert.expect(9);
+      expectDeprecation();
       runDestroy(route);
 
       let owner = buildOwner();
@@ -96,8 +99,110 @@ moduleFor(
       runDestroy(owner);
     }
 
+    ["@test 'store' can be set via assignment by data persistence frameworks"](assert) {
+      assert.expect(9);
+      expectNoDeprecation();
+      runDestroy(route);
+
+      let owner = buildOwner();
+
+      let post = {
+        id: 1,
+      };
+
+      let store = {
+        find(type, value) {
+          assert.ok(true, 'injected model was called');
+          assert.equal(type, 'post', 'correct type was called');
+          assert.equal(value, 1, 'correct value was called');
+          return post;
+        },
+      };
+
+      owner.register('route:index', EmberRoute);
+
+      route = owner.lookup('route:index');
+      route.store = store;
+
+      assert.equal(route.model({ post_id: 1 }), post, '#model returns the correct post');
+      assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+
+      runDestroy(owner);
+    }
+
+    ["@test 'store' can be set on subclass by data persistence frameworks"](assert) {
+      assert.expect(9);
+      expectNoDeprecation();
+      runDestroy(route);
+
+      let owner = buildOwner();
+
+      let post = {
+        id: 1,
+      };
+
+      let store = {
+        find(type, value) {
+          assert.ok(true, 'injected model was called');
+          assert.equal(type, 'post', 'correct type was called');
+          assert.equal(value, 1, 'correct value was called');
+          return post;
+        },
+      };
+
+      owner.register(
+        'route:index',
+        EmberRoute.extend({
+          store,
+        })
+      );
+
+      route = owner.lookup('route:index');
+
+      assert.equal(route.model({ post_id: 1 }), post, '#model returns the correct post');
+      assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+
+      runDestroy(owner);
+    }
+
+    ["@test 'store' can be set via reopen by data persistence frameworks"](assert) {
+      assert.expect(9);
+      expectNoDeprecation();
+      runDestroy(route);
+
+      let owner = buildOwner();
+
+      let post = {
+        id: 1,
+      };
+
+      let store = {
+        find(type, value) {
+          assert.ok(true, 'injected model was called');
+          assert.equal(type, 'post', 'correct type was called');
+          assert.equal(value, 1, 'correct value was called');
+          return post;
+        },
+      };
+
+      let EmberRouteSubclassForReopen = EmberRoute.extend();
+      EmberRouteSubclassForReopen.reopen({
+        store,
+      });
+
+      owner.register('route:index', EmberRouteSubclassForReopen);
+
+      route = owner.lookup('route:index');
+
+      assert.equal(route.model({ post_id: 1 }), post, '#model returns the correct post');
+      assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+
+      runDestroy(owner);
+    }
+
     ["@test assert if 'store.find' method is not found"]() {
       runDestroy(route);
+      expectNoDeprecation();
 
       let owner = buildOwner();
       let Post = EmberObject.extend();


### PR DESCRIPTION
The store property on routes uses a setter, and so was not impacted by the implicit-injections deprecation issued elsewhere. This may lead app or addon authors to miss usage of a deprecated store injection on the road to 4.0.

This improvement of the deprecation fidelity means libraries which use the type injection system to define a store, like Ember Data, should consider another approach to maintain any undeprecated API (for example reopening the route class).

Practically, we're not going to change the use of the injection API in Ember Data 3.28 this late, so this deprecation will log until Ember Data 4.0 is adopted by an app or all codepaths touching the injected store are avoided. With Ember and Ember Data 3.28, that would mean adding explicit model hooks on all routes with dynamic segments.