### PR TITLE
[BUGFIX release-3-28] Fix #19867

### DIFF
--- a/packages/@ember/-internals/container/index.ts
+++ b/packages/@ember/-internals/container/index.ts
@@ -11,5 +11,5 @@ export {
   getFactoryFor,
   setFactoryFor,
   INIT_FACTORY,
-  DeprecatedStoreInjection,
+  deprecatedStoreInjections,
 } from './lib/container';

--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -49,12 +49,8 @@ if (DEBUG) {
   }
 }
 
-export class DeprecatedStoreInjection {
-  store: unknown;
-  constructor(store: unknown) {
-    this.store = store;
-  }
-}
+export const deprecatedStoreInjections =
+  DEBUG && window.WeakSet ? new window.WeakSet<object>() : undefined;
 
 export interface ContainerOptions {
   owner?: Owner;
@@ -479,8 +475,8 @@ function injectionsFor(container: Container, fullName: string) {
 
   let result = buildInjections(container, typeInjections, injections);
 
-  if (DEBUG && type === 'route' && result.injections.store) {
-    result.injections.store = new DeprecatedStoreInjection(result.injections.store);
+  if (DEBUG && deprecatedStoreInjections && type === 'route' && result.injections.store) {
+    deprecatedStoreInjections.add(result.injections.store as object);
   }
   return result;
 }

--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -1,4 +1,4 @@
-import { DeprecatedStoreInjection, privatize as P } from '@ember/-internals/container';
+import { deprecatedStoreInjections, privatize as P } from '@ember/-internals/container';
 import {
   addObserver,
   computed,
@@ -2377,7 +2377,7 @@ Route.reopen(ActionHandler, Evented, {
     },
 
     set(key, value) {
-      if (DEBUG && value instanceof DeprecatedStoreInjection) {
+      if (DEBUG && deprecatedStoreInjections?.has(value)) {
         Object.defineProperty(this, key, {
           configurable: true,
           enumerable: false,
@@ -2395,7 +2395,7 @@ Route.reopen(ActionHandler, Evented, {
                 },
               }
             );
-            return value.store;
+            return value;
           },
         });
       } else {


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/19867. Confirmed fix on the reproductions at https://github.com/jherdman/ember-data-store-sadness/pull/1 and https://github.com/empress/empress-blog/pull/148.

A build of this branch can be downloaded at https://gist.github.com/mixonic/fe502b7f84eba571b9bde80e78f1b720. You can try out the branch in your application with that build.

The way most Ember apps are setup in late 3.28 (an implicit injection of `store` but also an explicit injection) was not under test. This patch adds a test, and fixes a bug when applications use that pattern.

The prior implementation of the `store` injection deprecation on routes (added in #19854) used a wrapper `DeprecatedStoreInjection` in some cases which was unwrapped by the store getter. A deprecation implemented on `CoreObject` for when a explicit and implicit deprecation mis-match conflicted with that logic.

Here, refactor away from the `DeprecatedStoreInjection` wrapper to instead use a WeakSet to track injected instances. This does mean the deprecation is only going to fire in newer browsers (not in IE11), but I think that is acceptable.

