### PR TITLE
[DOC] Document get helper array element access with second arg of type number

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -3,8 +3,9 @@
 */
 
 /**
-  Dynamically look up a property on an object. The second argument to `{{get}}`
-  should have a string value, although it can be bound.
+  Dynamically look up a property on an object or an element in an array.
+  The second argument to `{{get}}` should have a string or number value,
+  although it can be bound.
 
   For example, these two usages are equivalent:
 
@@ -76,6 +77,19 @@
 
   Would allow the user to swap what fact is being displayed, and also edit
   that fact via a two-way mutable binding.
+
+  The `{{get}}` helper can also be used for array element access via index.
+  This would display the value of the first element in the array `this.names`:
+
+  ```handlebars
+  {{get this.names 0}}
+  ```
+
+  Array element access also works with a dynamic second argument:
+
+  ```handlebars
+  {{get this.names @index}}
+  ```
 
   @public
   @method get


### PR DESCRIPTION
I've updated the docs for the `get` helper to indicate that the 2nd argument can be a number. This has been supported since Ember 2.14 and was added in #15366 (along with a test to make sure it continues to work). This test [still exists in Ember 4](https://github.com/emberjs/ember.js/blob/v4.0.1/packages/%40ember/-internals/glimmer/tests/integration/helpers/get-test.js#L62-L85).

I've also updated the docs to indicate that the `get` helper can be used for array element access via index with a second dynamic arg that has a numeric value. #15667 fixed and added a test specifically for array element access via numeric index, which is [still present](https://github.com/emberjs/ember.js/blob/v4.0.1/packages/%40ember/-internals/glimmer/tests/integration/helpers/get-test.js#L132-L146), and #16218 fixed this for a _const_ number second arg and added a test specifically for array index access via a const number, which is [also still present](https://github.com/emberjs/ember.js/blob/v4.0.1/packages/%40ember/-internals/glimmer/tests/integration/helpers/get-test.js#L87-L105).