### PR TITLE
[BUGFIX release] Explicitly list and expose the currently supported browsers on the `ember-source` module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,11 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Setup firefox
+        uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: 91
+      - run: firefox --version
       - name: test
         run: yarn ember test -c testem.ci-browsers.js
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Setup firefox
         uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: 91
+          firefox-version: 91.0.1
       - run: firefox --version
       - name: test
         run: yarn ember test -c testem.ci-browsers.js

--- a/config/browserlists.js
+++ b/config/browserlists.js
@@ -1,9 +1,4 @@
-const allSupportedBrowsers = [
-  'last 2 Chrome versions',
-  'last 2 Firefox versions',
-  'Safari 12',
-  'last 2 Edge versions',
-];
+const allSupportedBrowsers = require('../lib/browsers');
 
 const modernBrowsers = [
   'last 1 Chrome versions',

--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -1,0 +1,50 @@
+module.exports = [
+  'Chrome >= 92',
+  'Edge >= 93',
+  'Firefox >= 91',
+  'iOS >= 12',
+  'Safari >= 12',
+  'ChromeAndroid >= 96',
+  'FirefoxAndroid >= 94',
+];
+
+/*
+  As of the release of 4.0.0, the above query expands to:
+
+  and_chr 96
+  and_ff 94
+  chrome 96
+  chrome 95
+  chrome 94
+  chrome 93
+  chrome 92
+  chrome 91
+  chrome 87
+  edge 96
+  edge 95
+  firefox 95
+  firefox 94
+  firefox 93
+  firefox 60
+  firefox 52
+  ios_saf 15.2
+  ios_saf 15.0-15.1
+  ios_saf 14.5-14.8
+  ios_saf 14.0-14.4
+  ios_saf 13.4-13.7
+  ios_saf 13.3
+  ios_saf 13.2
+  ios_saf 13.0-13.1
+  ios_saf 12.2-12.5
+  ios_saf 12.0-12.1
+  safari 15.2
+  safari 15.1
+  safari 15
+  safari 14.1
+  safari 14
+  safari 13.1
+  safari 13
+  safari 12.1
+  safari 12
+
+*/

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const debugTree = require('broccoli-debug').buildDebugCallback('ember-source:add
 const vmBabelPlugins = require('@glimmer/vm-babel-plugins');
 const Overrides = require('./overrides');
 const SilentError = require('silent-error');
+const SupportedBrowsers = require('./browsers');
 
 const PRE_BUILT_TARGETS = [
   'last 1 Chrome versions',
@@ -58,6 +59,9 @@ module.exports = {
   paths,
   absolutePaths,
   _overrideTree: undefined,
+
+  // Expose supported list of browsers for reference by other packages
+  supportedBrowsers: SupportedBrowsers,
 
   included() {
     this._super.included.apply(this, arguments);

--- a/testem.browserstack.js
+++ b/testem.browserstack.js
@@ -1,7 +1,7 @@
 const FailureOnlyPerBrowserReporter = require('testem-failure-only-reporter/grouped-by-browser');
 
 const BrowserStackLaunchers = {
-  BS_Safari_Current: {
+  BS_Safari_12: {
     exe: 'node_modules/.bin/browserstack-launch',
     args: [
       '--os',
@@ -11,7 +11,7 @@ const BrowserStackLaunchers = {
       '--b',
       'safari',
       '--bv',
-      'latest',
+      'latest', // Will always be 12.x on Mojave
       '-t',
       '1200',
       '--u',
@@ -29,7 +29,25 @@ const BrowserStackLaunchers = {
       '--b',
       'edge',
       '--bv',
-      'latest',
+      '93',
+      '-t',
+      '1200',
+      '--u',
+      '<url>',
+    ],
+    protocol: 'browser',
+  },
+  BS_MS_Chrome: {
+    exe: 'node_modules/.bin/browserstack-launch',
+    args: [
+      '--os',
+      'Windows',
+      '--osv',
+      '11',
+      '--b',
+      'Chrome',
+      '--bv',
+      '92',
       '-t',
       '1200',
       '--u',


### PR DESCRIPTION
- Test against the lowest supported browsers for Firefox, Safari and
  Chrome

In a future PR will automate creating and updating this list. Will also have a future PR to test against the mobile browsers we support. 