### PR TITLE
Improve types for DeprecationOptions

### DIFF
--- a/packages/@ember/-internals/container/lib/registry.ts
+++ b/packages/@ember/-internals/container/lib/registry.ts
@@ -159,7 +159,7 @@ export default class Registry implements IRegistry {
    @param {Object} options
    @return {Container} created container
    */
-  container(options?: ContainerOptions) {
+  container(options?: ContainerOptions): Container {
     return new Container(this, options);
   }
 
@@ -355,7 +355,7 @@ export default class Registry implements IRegistry {
    @param {String} [options.source] the fullname of the request source (used for local lookups)
    @return {Boolean}
    */
-  has(fullName: string) {
+  has(fullName: string): boolean {
     if (!this.isValidFullName(fullName)) {
       return false;
     }
@@ -392,7 +392,7 @@ export default class Registry implements IRegistry {
    @param {String} type
    @param {Object} options
    */
-  optionsForType(type: string, options: TypeOptions) {
+  optionsForType(type: string, options: TypeOptions): void {
     this._typeOptions[type] = options;
   }
 
@@ -410,7 +410,7 @@ export default class Registry implements IRegistry {
    @param {String} fullName
    @param {Object} options
    */
-  options(fullName: string, options: TypeOptions) {
+  options(fullName: string, options: TypeOptions): void {
     let normalizedName = this.normalize(fullName);
     this._options[normalizedName] = options;
   }
@@ -459,7 +459,7 @@ export default class Registry implements IRegistry {
    @param {String} injectionName
    @deprecated
    */
-  injection(fullName: string, property: string) {
+  injection(fullName: string, property: string): void {
     deprecate(
       `As of Ember 4.0.0, owner.inject no longer injects values into resolved instances, and calling the method has been deprecated. Since this method no longer does anything, it is fully safe to remove this injection. As an alternative to this API, you can refactor to explicitly inject \`${property}\` on \`${fullName}\`, or look it up directly using the \`getOwner\` API.`,
       false,
@@ -469,6 +469,7 @@ export default class Registry implements IRegistry {
         url: 'https://deprecations.emberjs.com/v4.x#toc_implicit-injections',
         for: 'ember-source',
         since: {
+          available: '4.0.0',
           enabled: '4.0.0',
         },
       }

--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -112,6 +112,7 @@ const VM_DEPRECATION_OVERRIDES: (DeprecationOptions & {
     until: '4.4.0',
     for: 'ember-source',
     since: {
+      available: '3.28.0',
       enabled: '3.28.0',
     },
   },

--- a/packages/@ember/-internals/routing/lib/location/api.ts
+++ b/packages/@ember/-internals/routing/lib/location/api.ts
@@ -120,6 +120,7 @@ export default {
         url: 'https://emberjs.com/deprecations/v4.x#toc_deprecate-auto-location',
         for: 'ember-source',
         since: {
+          available: '4.1.0',
           enabled: '4.1.0',
         },
       }

--- a/packages/@ember/-internals/routing/lib/system/router.ts
+++ b/packages/@ember/-internals/routing/lib/system/router.ts
@@ -832,6 +832,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
             url: 'https://emberjs.com/deprecations/v4.x#toc_deprecate-auto-location',
             for: 'ember-source',
             since: {
+              available: '4.1.0',
               enabled: '4.1.0',
             },
           }
@@ -869,6 +870,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
               url: 'https://emberjs.com/deprecations/v4.x#toc_deprecate-auto-location',
               for: 'ember-source',
               since: {
+                available: '4.1.0',
                 enabled: '4.1.0',
               },
             }

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -8,7 +8,9 @@ import EmberRouter, { PrivateRouteInfo, QueryParam } from './system/router';
 
 const ALL_PERIODS_REGEX = /\./g;
 
-export function extractRouteArgs(args: unknown[]) {
+export function extractRouteArgs(
+  args: unknown[]
+): { routeName: string | undefined; models: {}[]; queryParams: object } {
   args = args.slice();
   let possibleQueryParams = args[args.length - 1];
 
@@ -35,14 +37,14 @@ export function extractRouteArgs(args: unknown[]) {
   return { routeName, models, queryParams };
 }
 
-export function getActiveTargetName(router: Router<Route>) {
+export function getActiveTargetName(router: Router<Route>): string {
   let routeInfos = router.activeTransition
     ? router.activeTransition[STATE_SYMBOL]!.routeInfos
     : router.state!.routeInfos;
   return routeInfos[routeInfos.length - 1].name;
 }
 
-export function stashParamNames(router: EmberRouter, routeInfos: PrivateRouteInfo[]) {
+export function stashParamNames(router: EmberRouter, routeInfos: PrivateRouteInfo[]): void {
   if (routeInfos['_namesStashed']) {
     return;
   }
@@ -99,7 +101,7 @@ function _calculateCacheValuePrefix(prefix: string, part: string) {
 /*
   Stolen from Controller
 */
-export function calculateCacheKey(prefix: string, parts: string[] = [], values: {}) {
+export function calculateCacheKey(prefix: string, parts: string[] = [], values: {}): string {
   let suffixes = '';
   for (let i = 0; i < parts.length; ++i) {
     let part = parts[i];
@@ -221,7 +223,7 @@ export function prefixRouteNameArg(route: Route, args: any[]) {
   return args;
 }
 
-export function shallowEqual(a: {}, b: {}) {
+export function shallowEqual(a: {}, b: {}): boolean {
   let k;
   let aCount = 0;
   let bCount = 0;
@@ -243,7 +245,7 @@ export function shallowEqual(a: {}, b: {}) {
   return aCount === bCount;
 }
 
-export function deprecateTransitionMethods(frameworkClass: string, methodName: string) {
+export function deprecateTransitionMethods(frameworkClass: string, methodName: string): void {
   deprecate(
     `Calling ${methodName} on a ${frameworkClass} is deprecated. Use the RouterService instead.`,
     false,
@@ -251,6 +253,7 @@ export function deprecateTransitionMethods(frameworkClass: string, methodName: s
       id: 'routing.transition-methods',
       for: 'ember-source',
       since: {
+        available: '3.26.0',
         enabled: '3.26.0',
       },
       until: '5.0.0',

--- a/packages/@ember/polyfills/lib/assign.ts
+++ b/packages/@ember/polyfills/lib/assign.ts
@@ -39,6 +39,7 @@ export function assign(target: object, ...rest: object[]): object {
       url: 'https://deprecations.emberjs.com/v4.x/#toc_ember-polyfills-deprecate-assign',
       for: 'ember-source',
       since: {
+        available: '4.0.0',
         enabled: '4.0.0',
       },
     }

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -245,6 +245,7 @@ function deprecateImportFromString(
     id: 'ember-string.htmlsafe-ishtmlsafe',
     for: 'ember-source',
     since: {
+      available: '3.25',
       enabled: '3.25',
     },
     until: '4.0.0',


### PR DESCRIPTION
The previous design allowed invalid values for `DeprecationOptions`:

- `{}` (that is, an empty object)
- `{ enabled: 'v4.1.0' }` (that is, without `available`)

Both of these violate [the text of the RFC](https://emberjs.github.io/rfcs/0649-deprecation-staging.html#deprecate)! The new design *requires* that at least `available` be present, and that `enabled` cannot be present *without* `available`:

> If a value for a stage if present, the value of all previous stages must also be present.

This PR also removes the exported key names for the stages, which are implicit in the interface-based API and which are currently unused outside this module.

---

(Noticed this while working on the Ember v4 types on DefinitelyTyped, and made this change there as well.)