### PR TITLE
[Bugfix release] make setOwner check its shape, so that we can be cer…

### DIFF
--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -1,6 +1,6 @@
-import {getOwner as glimmerGetOwner, setOwner as glimmerSetOwner} from '@glimmer/owner';
-import {assert} from '@ember/debug';
-import {DEBUG} from '@glimmer/env';
+import { getOwner as glimmerGetOwner, setOwner as glimmerSetOwner } from '@glimmer/owner';
+import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
 
 /**
 @module @ember/application
@@ -20,7 +20,7 @@ export interface Factory<T, C extends FactoryClass | object = FactoryClass> {
   name?: string;
   fullName?: string;
   normalizedName?: string;
-  create(props?: {[prop: string]: any}): T;
+  create(props?: { [prop: string]: any }): T;
 }
 
 export interface EngineInstanceOptions {
@@ -105,11 +105,22 @@ export function setOwner(object: any, owner: Owner): void {
     let publicApiType = owner as any;
 
     assert(`Expected owner to be truthy`, publicApiType);
-    assert('Passed owner must have a function, `lookup`', typeof publicApiType.lookup === 'function');
-    assert('Passed owner must have a function, `factoryFor`', typeof publicApiType.factoryFor === 'function');
-    assert('Passed owner must have a function, `register`', typeof publicApiType.register === 'function');
-    assert('Passed owner must have a function, `hasRegistration`', typeof publicApiType.hasRegistration === 'function');
-    assert(`Expected owner to match the Owner's buildChildEngineInstance`, typeof publicApiType.buildChildEngineInstance === 'function');
+    assert(
+      'Passed owner must have a function, `lookup`',
+      typeof publicApiType.lookup === 'function'
+    );
+    assert(
+      'Passed owner must have a function, `factoryFor`',
+      typeof publicApiType.factoryFor === 'function'
+    );
+    assert(
+      'Passed owner must have a function, `register`',
+      typeof publicApiType.register === 'function'
+    );
+    assert(
+      'Passed owner must have a function, `hasRegistration`',
+      typeof publicApiType.hasRegistration === 'function'
+    );
   }
 
   glimmerSetOwner(object, owner);

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -1,4 +1,6 @@
-import { getOwner as glimmerGetOwner, setOwner as glimmerSetOwner } from '@glimmer/owner';
+import {getOwner as glimmerGetOwner, setOwner as glimmerSetOwner} from '@glimmer/owner';
+import {assert} from '@ember/debug';
+import {DEBUG} from '@glimmer/env';
 
 /**
 @module @ember/application
@@ -18,7 +20,7 @@ export interface Factory<T, C extends FactoryClass | object = FactoryClass> {
   name?: string;
   fullName?: string;
   normalizedName?: string;
-  create(props?: { [prop: string]: any }): T;
+  create(props?: {[prop: string]: any}): T;
 }
 
 export interface EngineInstanceOptions {
@@ -78,7 +80,7 @@ export interface Owner {
   @static
   @for @ember/application
   @param {Object} object An object with an owner.
-  @return {Object} An owner object.
+  @return {Owner} An owner object.
   @since 2.3.0
   @public
 */
@@ -99,5 +101,16 @@ export function getOwner(object: any): Owner {
   @public
 */
 export function setOwner(object: any, owner: Owner): void {
+  if (DEBUG) {
+    let publicApiType = owner as any;
+
+    assert(`Expected owner to be truthy`, publicApiType);
+    assert('Passed owner must have a function, `lookup`', typeof publicApiType.lookup === 'function');
+    assert('Passed owner must have a function, `factoryFor`', typeof publicApiType.factoryFor === 'function');
+    assert('Passed owner must have a function, `register`', typeof publicApiType.register === 'function');
+    assert('Passed owner must have a function, `hasRegistration`', typeof publicApiType.hasRegistration === 'function');
+    assert(`Expected owner to match the Owner's buildChildEngineInstance`, typeof publicApiType.buildChildEngineInstance === 'function');
+  }
+
   glimmerSetOwner(object, owner);
 }


### PR DESCRIPTION
…tain people arent mis-using it

The motivation from this comes from a couple places (in TypeScript):
 - in practical usage, `getOwner` _needs_ casting in order to be used (annoying for consumers of `getOwner`)
 - typed-ember will only document "what is correct" (which makes sense), so in order for `getOwner` to have a useful return type, we need to ensure an owner with _incorrect_ shape cannot be set in the first place.