### PR TITLE
[DOC] Remove `name` param from `outlet` docs

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -38,7 +38,6 @@ import { OutletState } from '../utils/outlet';
   Note: Your content __will not render__ if there isn't an `{{outlet}}` for it.
 
   @method outlet
-  @param {String} [name]
   @for Ember.Templates.helpers
   @public
 */


### PR DESCRIPTION
Named outlets are not supported anymore.