### PR TITLE
Pre-format blueprints to match Prettier rules.

### DIFF
--- a/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
@@ -3,18 +3,18 @@ import { expect } from 'chai';
 import startApp from '<%= dasherizedPackageName %>/tests/helpers/start-app';
 <% if (destroyAppExists) { %>import destroyApp from '<%= dasherizedPackageName %>/tests/helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   let application;
 
-  beforeEach(function() {
+  beforeEach(function () {
     application = startApp();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>run(application, 'destroy');<% } %>
   });
 
-  it('can visit /<%= dasherizedModuleName %>', function() {
+  it('can visit /<%= dasherizedModuleName %>', function () {
     visit('/<%= dasherizedModuleName %>');
 
     return andThen(() => {

--- a/blueprints/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.js
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { visit, currentURL } from '@ember/test-helpers';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   setupApplicationTest();
 
-  it('can visit /<%= dasherizedModuleName %>', async function() {
+  it('can visit /<%= dasherizedModuleName %>', async function () {
     await visit('/<%= dasherizedModuleName %>');
     expect(currentURL()).to.equal('/<%= dasherizedModuleName %>');
   });

--- a/blueprints/acceptance-test/qunit-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/qunit-files/tests/acceptance/__name__-test.js
@@ -3,10 +3,10 @@ import moduleForAcceptance from '<%= testFolderRoot %>/tests/helpers/module-for-
 
 moduleForAcceptance('<%= friendlyTestName %>');
 
-test('visiting /<%= dasherizedModuleName %>', function(assert) {
+test('visiting /<%= dasherizedModuleName %>', function (assert) {
   visit('/<%= dasherizedModuleName %>');
 
-  andThen(function() {
+  andThen(function () {
     assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });

--- a/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
-module('<%= friendlyTestName %>', function(hooks) {
+module('<%= friendlyTestName %>', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('visiting /<%= dasherizedModuleName %>', async function(assert) {
+  test('visiting /<%= dasherizedModuleName %>', async function (assert) {
     await visit('/<%= dasherizedModuleName %>');
 
     assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');

--- a/blueprints/component-class/index.js
+++ b/blueprints/component-class/index.js
@@ -151,12 +151,12 @@ module.exports = {
           importTemplate = `import layout from '${templatePath}';${EOL}`;
           defaultExport = `Component.extend({${EOL}  layout${EOL}});`;
         } else {
-          defaultExport = `Component.extend({${EOL}});`;
+          defaultExport = `Component.extend({});`;
         }
         break;
       case '@glimmer/component':
         importComponent = `import Component from '@glimmer/component';`;
-        defaultExport = `class ${classifiedModuleName}Component extends Component {\n}`;
+        defaultExport = `class ${classifiedModuleName}Component extends Component {}`;
         break;
       case '@ember/component/template-only':
         importComponent = `import templateOnly from '@ember/component/template-only';`;

--- a/blueprints/component-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -3,14 +3,14 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';<% if (testType === 'integration') { %>
 import hbs from 'htmlbars-inline-precompile';<% } %>
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupComponentTest('<%= componentPathName %>', {
-    <% if (testType === 'integration' ) { %>integration: true<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
+    <% if (testType === 'integration' ) { %>integration: true,<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
     // needs: ['component:foo', 'helper:bar'],
-    unit: true<% } %>
+    unit: true,<% } %>
   });
 
-  it('renders', function() {
+  it('renders', function () {
     <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/blueprints/component-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -2,14 +2,16 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';<% if (testType === 'integration') { %>
 import hbs from 'htmlbars-inline-precompile';<% } %>
 
-describeComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
+describeComponent(
+  '<%= componentPathName %>',
+  '<%= friendlyTestDescription %>',
   {
-    <% if (testType === 'integration' ) { %>integration: true<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
+    <% if (testType === 'integration' ) { %>integration: true,<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
     // needs: ['component:foo', 'helper:bar'],
-    unit: true<% } %>
+    unit: true,<% } %>
   },
-  function() {
-    it('renders', function() {
+  function () {
+    it('renders', function () {
       <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -4,10 +4,10 @@ import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupRenderingTest();
 
-  it('renders', async function() {
+  it('renders', async function () {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
@@ -28,10 +28,10 @@ describe('<%= friendlyTestDescription %>', function() {
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest();
 
-  it('exists', function() {
+  it('exists', function () {
     let component = this.owner.factoryFor('component:<%= componentPathName %>').create();
     expect(component).to.be.ok;
   });

--- a/blueprints/component-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -2,13 +2,13 @@ import { moduleForComponent, test } from 'ember-qunit';<% if (testType === 'inte
 import hbs from 'htmlbars-inline-precompile';<% } %>
 
 moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>', {
-  <% if (testType === 'integration' ) { %>integration: true<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
+  <% if (testType === 'integration' ) { %>integration: true,<% } else if(testType === 'unit') { %>// Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar'],
-  unit: true<% } %>
+  unit: true,<% } %>
 });
 
-test('it renders', function(assert) {
-  <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
+test('it renders', function (assert) {<% if (testType === 'integration' ) { %>
+  // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`<%= selfCloseComponent(componentName) %>`);

--- a/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
-module('<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
@@ -26,10 +26,10 @@ module('<%= friendlyTestDescription %>', function(hooks) {
 });<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let component = this.owner.factoryFor('component:<%= componentPathName %>').create();
     assert.ok(component);
   });

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -253,12 +253,12 @@ module.exports = {
           importTemplate = `import layout from '${templatePath}';${EOL}`;
           defaultExport = `Component.extend({${EOL}  layout${EOL}});`;
         } else {
-          defaultExport = `Component.extend({${EOL}});`;
+          defaultExport = `Component.extend({});`;
         }
         break;
       case '@glimmer/component':
         importComponent = `import Component from '@glimmer/component';`;
-        defaultExport = `class ${classifiedModuleName}Component extends Component {${EOL}}`;
+        defaultExport = `class ${classifiedModuleName}Component extends Component {}`;
         break;
       case '@ember/component/template-only':
         importComponent = `import templateOnly from '@ember/component/template-only';`;

--- a/blueprints/controller-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest('controller:<%= dasherizedModuleName %>', {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   });
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let controller = this.subject();
     expect(controller).to.be.ok;
   });

--- a/blueprints/controller-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
+describeModule(
+  'controller:<%= dasherizedModuleName %>',
+  '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   },
-  function() {
+  function () {
     // TODO: Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function () {
       let controller = this.subject();
       expect(controller).to.be.ok;
     });

--- a/blueprints/controller-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let controller = this.owner.lookup('controller:<%= controllerPathName %>');
     expect(controller).to.be.ok;
   });

--- a/blueprints/controller-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -6,7 +6,7 @@ moduleFor('controller:<%= dasherizedModuleName %>', '<%= friendlyTestDescription
 });
 
 // TODO: Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let controller = this.subject();
   assert.ok(controller);
 });

--- a/blueprints/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:<%= controllerPathName %>');
     assert.ok(controller);
   });

--- a/blueprints/controller/files/__root__/__path__/__name__.js
+++ b/blueprints/controller/files/__root__/__path__/__name__.js
@@ -1,4 +1,3 @@
 import Controller from '@ember/controller';
 
-export default class <%= classifiedModuleName %>Controller extends Controller {
-}
+export default class <%= classifiedModuleName %>Controller extends Controller {}

--- a/blueprints/helper-test/mocha-0.12-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-0.12-files/__root__/__testType__/__collection__/__name__-test.js
@@ -3,12 +3,12 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   setupComponentTest('<%= dasherizedModuleName %>', {
-    integration: true
+    integration: true,
   });
 
-  it('renders', function() {
+  it('renders', function () {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/blueprints/helper-test/mocha-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-files/__root__/__testType__/__collection__/__name__-test.js
@@ -2,12 +2,14 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describeComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleName %>',
+describeComponent(
+  '<%= dasherizedModuleName %>',
+  'helper:<%= dasherizedModuleName %>',
   {
-    integration: true
+    integration: true,
   },
-  function() {
-    it('renders', function() {
+  function () {
+    it('renders', function () {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
       // Template block usage:

--- a/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
@@ -4,11 +4,11 @@ import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   setupRenderingTest();
 
   // TODO: Replace this with your real tests.
-  it('renders', async function() {
+  it('renders', async function () {
     this.set('inputValue', '1234');
 
     await render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);

--- a/blueprints/helper-test/qunit-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/qunit-files/__root__/__testType__/__collection__/__name__-test.js
@@ -2,11 +2,11 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('<%= dasherizedModuleName %>', 'helper:<%= dasherizedModuleName %>', {
-  integration: true
+  integration: true,
 });
 
 // TODO: Replace this with your real tests.
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   this.set('inputValue', '1234');
 
   this.render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);

--- a/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
+++ b/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.js
@@ -3,11 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
-module('<%= friendlyTestName %>', function(hooks) {
+module('<%= friendlyTestName %>', function (hooks) {
   setupRenderingTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     this.set('inputValue', '1234');
 
     await render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);

--- a/blueprints/helper/files/__root__/__collection__/__name__.js
+++ b/blueprints/helper/files/__root__/__collection__/__name__.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function <%= camelizedModuleName %>(positional/*, named*/) {
+export default helper(function <%= camelizedModuleName %>(positional /*, named*/) {
   return positional;
 });

--- a/blueprints/helper/mu-files/__root__/__collection__/__name__.js
+++ b/blueprints/helper/mu-files/__root__/__collection__/__name__.js
@@ -1,6 +1,6 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
-export function <%= camelizedModuleName %>(positional/*, named*/) {
+export function <%= camelizedModuleName %>(positional /*, named*/) {
   return positional;
 }
 

--- a/blueprints/initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
@@ -3,24 +3,23 @@ import { describe, it, beforeEach, afterEach } from 'mocha';
 import { run } from '@ember/runloop';
 import Application from '@ember/application';
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
-<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } %>
-
-describe('<%= friendlyTestName %>', function() {
+<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';\n<% } %>
+describe('<%= friendlyTestName %>', function () {
   let application;
 
-  beforeEach(function() {
-    run(function() {
+  beforeEach(function () {
+    run(function () {
       application = Application.create();
       application.deferReadiness();
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>run(application, 'destroy');<% } %>
   });
 
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     initialize(application);
 
     // you would normally confirm the results of the initializer here

--- a/blueprints/initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -4,23 +4,23 @@ import Application from '@ember/application';
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
-describe('<%= friendlyTestName %>', function() {
-  beforeEach(function() {
+describe('<%= friendlyTestName %>', function () {
+  beforeEach(function () {
     this.TestApplication = Application.extend();
     this.TestApplication.initializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
 
     this.application = this.TestApplication.create({ autoboot: false });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
   // TODO: Replace this with your real tests.
-  it('works', async function() {
+  it('works', async function () {
     await this.application.boot();
 
     // you would normally confirm the results of the initializer here

--- a/blueprints/initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
@@ -3,8 +3,7 @@ import { run } from '@ember/runloop';
 
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
-<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } %>
-
+<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';\n<% } %>
 module('<%= friendlyTestName %>', {
   beforeEach() {
     run(() => {
@@ -14,11 +13,11 @@ module('<%= friendlyTestName %>', {
   },
   afterEach() {
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
-  }
+  },
 });
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   initialize(this.application);
 
   // you would normally confirm the results of the initializer here

--- a/blueprints/initializer/files/__root__/initializers/__name__.js
+++ b/blueprints/initializer/files/__root__/initializers/__name__.js
@@ -1,6 +1,5 @@
-export function initialize(/* application */) {
-}
+export function initialize(/* application */) {}
 
 export default {
-  initialize
+  initialize,
 };

--- a/blueprints/instance-initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-files/__root__/__testType__/__path__/__name__-test.js
@@ -5,23 +5,23 @@ import { run } from '@ember/runloop';
 import { initialize } from '<%= modulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import destroyApp from '../../helpers/destroy-app';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   let application, appInstance;
 
-  beforeEach(function() {
-    run(function() {
+  beforeEach(function () {
+    run(function () {
       application = Application.create();
       appInstance = application.buildInstance();
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     run(appInstance, 'destroy');
     destroyApp(application);
   });
 
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     initialize(appInstance);
 
     // you would normally confirm the results of the initializer here

--- a/blueprints/instance-initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-rfc-232-files/__root__/__testType__/__path__/__name__-test.js
@@ -4,23 +4,23 @@ import Application from '@ember/application';
 import { initialize } from '<%= modulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 <% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
 
-describe('<%= friendlyTestName %>', function() {
-  beforeEach(function() {
+describe('<%= friendlyTestName %>', function () {
+  beforeEach(function () {
     this.TestApplication = Application.extend();
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
     this.application = this.TestApplication.create({ autoboot: false });
     this.instance = this.application.buildInstance();
   });
-  afterEach(function() {
+  afterEach(function () {
     <% if (destroyAppExists) { %>destroyApp(this.instance);<% } else { %>run(this.instance, 'destroy');<% } %>
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
   });
 
   // TODO: Replace this with your real tests.
-  it('works', async function() {
+  it('works', async function () {
     await this.instance.boot();
 
     expect(true).to.be.ok;

--- a/blueprints/instance-initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-files/__root__/__testType__/__path__/__name__-test.js
@@ -14,11 +14,11 @@ module('<%= friendlyTestName %>', {
   afterEach() {
     run(this.appInstance, 'destroy');
     <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
-  }
+  },
 });
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   initialize(this.appInstance);
 
   // you would normally confirm the results of the initializer here

--- a/blueprints/instance-initializer/files/__root__/instance-initializers/__name__.js
+++ b/blueprints/instance-initializer/files/__root__/instance-initializers/__name__.js
@@ -1,6 +1,5 @@
-export function initialize(/* appInstance */) {
-}
+export function initialize(/* appInstance */) {}
 
 export default {
-  initialize
+  initialize,
 };

--- a/blueprints/mixin-test/mocha-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/mocha-files/__root__/__testType__/__name__-test.js
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();
     expect(subject).to.be.ok;

--- a/blueprints/mixin-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();
     expect(subject).to.be.ok;

--- a/blueprints/mixin-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 module('<%= friendlyTestName %>');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
   let subject = <%= classifiedModuleName %>Object.create();
   assert.ok(subject);

--- a/blueprints/mixin-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/mixin-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-module('<%= friendlyTestName %>', function() {
+module('<%= friendlyTestName %>', function () {
   // TODO: Replace this with your real tests.
   test('it works', function (assert) {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);

--- a/blueprints/mixin/files/__root__/mixins/__name__.js
+++ b/blueprints/mixin/files/__root__/mixins/__name__.js
@@ -1,4 +1,3 @@
 import Mixin from '@ember/object/mixin';
 
-export default Mixin.create({
-});
+export default Mixin.create({});

--- a/blueprints/route-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/route-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest('route:<%= moduleName %>', {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   });
 
-  it('exists', function() {
+  it('exists', function () {
     let route = this.subject();
     expect(route).to.be.ok;
   });

--- a/blueprints/route-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/route-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('route:<%= moduleName %>', '<%= friendlyTestDescription %>',
+describeModule(
+  'route:<%= moduleName %>',
+  '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   },
-  function() {
-    it('exists', function() {
+  function () {
+    it('exists', function () {
       let route = this.subject();
       expect(route).to.be.ok;
     });

--- a/blueprints/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest();
 
-  it('exists', function() {
+  it('exists', function () {
     let route = this.owner.lookup('route:<%= dasherizedModuleName %>');
     expect(route).to.be.ok;
   });

--- a/blueprints/route-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/route-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -5,7 +5,7 @@ moduleFor('route:<%= moduleName %>', '<%= friendlyTestDescription %>', {
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let route = this.subject();
   assert.ok(route);
 });

--- a/blueprints/route-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/route-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let route = this.owner.lookup('route:<%= moduleName %>');
     assert.ok(route);
   });

--- a/blueprints/route/files/__root__/__path__/__name__.js
+++ b/blueprints/route/files/__root__/__path__/__name__.js
@@ -7,5 +7,5 @@ export default class <%= classifiedModuleName %>Route extends Route {<% if (hasD
      * based on that dynamic segment here in the model hook.
      */
     return params;
-  }<%}%>
-}
+  }
+<%}%>}

--- a/blueprints/service-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-0.12-files/__root__/__testType__/__path__/__test__.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest('service:<%= dasherizedModuleName %>', {
     // Specify the other units that are required for this test.
     // needs: ['service:foo']
   });
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let service = this.subject();
     expect(service).to.be.ok;
   });

--- a/blueprints/service-test/mocha-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-files/__root__/__testType__/__path__/__test__.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>',
+describeModule(
+  'service:<%= dasherizedModuleName %>',
+  '<%= friendlyTestDescription %>',
   {
     // Specify the other units that are required for this test.
     // needs: ['service:foo']
   },
-  function() {
+  function () {
     // TODO: Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function () {
       let service = this.subject();
       expect(service).to.be.ok;
     });

--- a/blueprints/service-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('<%= friendlyTestDescription %>', function() {
+describe('<%= friendlyTestDescription %>', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let service = this.owner.lookup('service:<%= dasherizedModuleName %>');
     expect(service).to.be.ok;
   });

--- a/blueprints/service-test/qunit-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/qunit-files/__root__/__testType__/__path__/__test__.js
@@ -6,7 +6,7 @@ moduleFor('service:<%= dasherizedModuleName %>', '<%= friendlyTestDescription %>
 });
 
 // TODO: Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let service = this.subject();
   assert.ok(service);
 });

--- a/blueprints/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('<%= friendlyTestDescription %>', function(hooks) {
+module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let service = this.owner.lookup('service:<%= dasherizedModuleName %>');
     assert.ok(service);
   });

--- a/blueprints/service/files/__root__/__path__/__name__.js
+++ b/blueprints/service/files/__root__/__path__/__name__.js
@@ -1,4 +1,3 @@
 import Service from '@ember/service';
 
-export default class <%= classifiedModuleName %>Service extends Service {
-}
+export default class <%= classifiedModuleName %>Service extends Service {}

--- a/blueprints/util-test/mocha-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/mocha-files/__root__/__testType__/__name__-test.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let result = <%= camelizedModuleName %>();
     expect(result).to.be.ok;
   });

--- a/blueprints/util-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/mocha-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import <%= camelizedModuleName %> from '<%= dasherizedPackageName %>/utils/<%= dasherizedModuleName %>';
 
-describe('<%= friendlyTestName %>', function() {
+describe('<%= friendlyTestName %>', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let result = <%= camelizedModuleName %>();
     expect(result).to.be.ok;
   });

--- a/blueprints/util-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('<%= friendlyTestName %>');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let result = <%= camelizedModuleName %>();
   assert.ok(result);
 });

--- a/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -1,10 +1,9 @@
 import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
-module('<%= friendlyTestName %>', function() {
-
+module('<%= friendlyTestName %>', function () {
   // TODO: Replace this with your real tests.
-  test('it works', function(assert) {
+  test('it works', function (assert) {
     let result = <%= camelizedModuleName %>();
     assert.ok(result);
   });

--- a/node-tests/blueprints/component-class-test.js
+++ b/node-tests/blueprints/component-class-test.js
@@ -18,14 +18,12 @@ const enableOctane = setupTestEnvironment.enableOctane;
 
 const glimmerComponentContents = `import Component from '@glimmer/component';
 
-export default class FooComponent extends Component {
-}
+export default class FooComponent extends Component {}
 `;
 
 const emberComponentContents = `import Component from '@ember/component';
 
-export default Component.extend({
-});
+export default Component.extend({});
 `;
 
 const templateOnlyContents = `import templateOnly from '@ember/component/template-only';

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -18,14 +18,12 @@ const enableOctane = setupTestEnvironment.enableOctane;
 
 const glimmerComponentContents = `import Component from '@glimmer/component';
 
-export default class FooComponent extends Component {
-}
+export default class FooComponent extends Component {}
 `;
 
 const emberComponentContents = `import Component from '@ember/component';
 
-export default Component.extend({
-});
+export default Component.extend({});
 `;
 
 const templateOnlyContents = `import templateOnly from '@ember/component/template-only';

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -22,7 +22,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo'], (_file) => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -37,7 +37,7 @@ describe('Blueprint: mixin', function () {
 
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -49,7 +49,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo/bar'], (_file) => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -69,7 +69,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo', '--pod'], (_file) => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -84,7 +84,7 @@ describe('Blueprint: mixin', function () {
 
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-app/mixins/foo';"
@@ -96,7 +96,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo/bar', '--pod'], (_file) => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -121,7 +121,7 @@ describe('Blueprint: mixin', function () {
         return emberGenerateDestroy(['mixin', 'foo', '--pod'], (_file) => {
           expect(_file('app/mixins/foo.js'))
             .to.contain("import Mixin from '@ember/object/mixin';")
-            .to.contain(`export default Mixin.create({${EOL}});`);
+            .to.contain(`export default Mixin.create({});`);
 
           expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
             "import FooMixin from 'my-app/mixins/foo';"
@@ -136,7 +136,7 @@ describe('Blueprint: mixin', function () {
 
           expect(_file('app/mixins/foo.js'))
             .to.contain("import Mixin from '@ember/object/mixin';")
-            .to.contain(`export default Mixin.create({${EOL}});`);
+            .to.contain(`export default Mixin.create({});`);
 
           expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
             "import FooMixin from 'my-app/mixins/foo';"
@@ -148,7 +148,7 @@ describe('Blueprint: mixin', function () {
         return emberGenerateDestroy(['mixin', 'foo/bar', '--pod'], (_file) => {
           expect(_file('app/mixins/foo/bar.js'))
             .to.contain("import Mixin from '@ember/object/mixin';")
-            .to.contain(`export default Mixin.create({${EOL}});`);
+            .to.contain(`export default Mixin.create({});`);
 
           expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
             "import FooBarMixin from 'my-app/mixins/foo/bar';"
@@ -167,7 +167,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo'], (_file) => {
         expect(_file('addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -184,7 +184,7 @@ describe('Blueprint: mixin', function () {
 
         expect(_file('addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -198,7 +198,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo/bar'], (_file) => {
         expect(_file('addon/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-addon/mixins/foo/bar';"
@@ -212,7 +212,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz'], (_file) => {
         expect(_file('addon/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo/bar/baz-test.js')).to.contain(
           "import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';"
@@ -226,7 +226,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo/bar/baz', '--dummy'], (_file) => {
         expect(_file('tests/dummy/app/mixins/foo/bar/baz.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('addon/mixins/foo/bar/baz.js')).to.not.exist;
       });
@@ -238,7 +238,7 @@ describe('Blueprint: mixin', function () {
 
         expect(_file('tests/dummy/app/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('addon/mixins/foo.js')).to.not.exist;
       });
@@ -254,7 +254,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo', '--in-repo-addon=my-addon'], (_file) => {
         expect(_file('lib/my-addon/addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -269,7 +269,7 @@ describe('Blueprint: mixin', function () {
 
         expect(_file('lib/my-addon/addon/mixins/foo.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo-test.js')).to.contain(
           "import FooMixin from 'my-addon/mixins/foo';"
@@ -281,7 +281,7 @@ describe('Blueprint: mixin', function () {
       return emberGenerateDestroy(['mixin', 'foo/bar', '--in-repo-addon=my-addon'], (_file) => {
         expect(_file('lib/my-addon/addon/mixins/foo/bar.js'))
           .to.contain("import Mixin from '@ember/object/mixin';")
-          .to.contain(`export default Mixin.create({${EOL}});`);
+          .to.contain(`export default Mixin.create({});`);
 
         expect(_file('tests/unit/mixins/foo/bar-test.js')).to.contain(
           "import FooBarMixin from 'my-addon/mixins/foo/bar';"

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -5,7 +5,6 @@ const setupTestHooks = blueprintHelpers.setupTestHooks;
 const emberNew = blueprintHelpers.emberNew;
 const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
 const setupPodConfig = blueprintHelpers.setupPodConfig;
-const EOL = require('os').EOL;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;

--- a/node-tests/fixtures/acceptance-test/addon-default.js
+++ b/node-tests/fixtures/acceptance-test/addon-default.js
@@ -3,10 +3,10 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | foo');
 
-test('visiting /foo', function(assert) {
+test('visiting /foo', function (assert) {
   visit('/foo');
 
-  andThen(function() {
+  andThen(function () {
     assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/node-tests/fixtures/acceptance-test/addon-nested.js
+++ b/node-tests/fixtures/acceptance-test/addon-nested.js
@@ -3,10 +3,10 @@ import moduleForAcceptance from '../../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | foo/bar');
 
-test('visiting /foo/bar', function(assert) {
+test('visiting /foo/bar', function (assert) {
   visit('/foo/bar');
 
-  andThen(function() {
+  andThen(function () {
     assert.strictEqual(currentURL(), '/foo/bar');
   });
 });

--- a/node-tests/fixtures/acceptance-test/default.js
+++ b/node-tests/fixtures/acceptance-test/default.js
@@ -3,10 +3,10 @@ import moduleForAcceptance from 'my-app/tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | foo');
 
-test('visiting /foo', function(assert) {
+test('visiting /foo', function (assert) {
   visit('/foo');
 
-  andThen(function() {
+  andThen(function () {
     assert.strictEqual(currentURL(), '/foo');
   });
 });

--- a/node-tests/fixtures/acceptance-test/mocha-rfc268.js
+++ b/node-tests/fixtures/acceptance-test/mocha-rfc268.js
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { visit, currentURL } from '@ember/test-helpers';
 
-describe('Acceptance | foo', function() {
+describe('Acceptance | foo', function () {
   setupApplicationTest();
 
-  it('can visit /foo', async function() {
+  it('can visit /foo', async function () {
     await visit('/foo');
     expect(currentURL()).to.equal('/foo');
   });

--- a/node-tests/fixtures/acceptance-test/mocha.js
+++ b/node-tests/fixtures/acceptance-test/mocha.js
@@ -3,18 +3,18 @@ import { expect } from 'chai';
 import startApp from 'my-app/tests/helpers/start-app';
 import { run } from '@ember/runloop';
 
-describe('Acceptance | foo', function() {
+describe('Acceptance | foo', function () {
   let application;
 
-  beforeEach(function() {
+  beforeEach(function () {
     application = startApp();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     run(application, 'destroy');
   });
 
-  it('can visit /foo', function() {
+  it('can visit /foo', function () {
     visit('/foo');
 
     return andThen(() => {

--- a/node-tests/fixtures/acceptance-test/qunit-rfc268.js
+++ b/node-tests/fixtures/acceptance-test/qunit-rfc268.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
-module('Acceptance | foo', function(hooks) {
+module('Acceptance | foo', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('visiting /foo', async function(assert) {
+  test('visiting /foo', async function (assert) {
     await visit('/foo');
 
     assert.strictEqual(currentURL(), '/foo');

--- a/node-tests/fixtures/component-test/default-template.js
+++ b/node-tests/fixtures/component-test/default-template.js
@@ -2,10 +2,10 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('<%= path =%><%= component =%>', 'Integration | Component | <%= component =%>', {
-  integration: true
+  integration: true,
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/default.js
+++ b/node-tests/fixtures/component-test/default.js
@@ -2,10 +2,10 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('x-foo', 'Integration | Component | x-foo', {
-  integration: true
+  integration: true,
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/mocha-0.12-unit.js
+++ b/node-tests/fixtures/component-test/mocha-0.12-unit.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 
-describe('Unit | Component | x-foo', function() {
+describe('Unit | Component | x-foo', function () {
   setupComponentTest('x-foo', {
     // Specify the other units that are required for this test
     // needs: ['component:foo', 'helper:bar'],
-    unit: true
+    unit: true,
   });
 
-  it('renders', function() {
+  it('renders', function () {
     // creates the component instance
     let component = this.subject();
     // renders the component on the page

--- a/node-tests/fixtures/component-test/mocha-0.12.js
+++ b/node-tests/fixtures/component-test/mocha-0.12.js
@@ -3,12 +3,12 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | x-foo', function() {
+describe('Integration | Component | x-foo', function () {
   setupComponentTest('x-foo', {
-    integration: true
+    integration: true,
   });
 
-  it('renders', function() {
+  it('renders', function () {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/mocha-rfc232-unit.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232-unit.js
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Component | x-foo', function() {
+describe('Unit | Component | x-foo', function () {
   setupTest();
 
-  it('exists', function() {
+  it('exists', function () {
     let component = this.owner.factoryFor('component:x-foo').create();
     expect(component).to.be.ok;
   });

--- a/node-tests/fixtures/component-test/mocha-rfc232.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232.js
@@ -4,10 +4,10 @@ import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Component | x-foo', function() {
+describe('Integration | Component | x-foo', function () {
   setupRenderingTest();
 
-  it('renders', async function() {
+  it('renders', async function () {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/mocha-unit.js
+++ b/node-tests/fixtures/component-test/mocha-unit.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 
-describeComponent('x-foo', 'Unit | Component | x-foo',
+describeComponent(
+  'x-foo',
+  'Unit | Component | x-foo',
   {
     // Specify the other units that are required for this test
     // needs: ['component:foo', 'helper:bar'],
-    unit: true
+    unit: true,
   },
-  function() {
-    it('renders', function() {
+  function () {
+    it('renders', function () {
       // creates the component instance
       let component = this.subject();
       // renders the component on the page

--- a/node-tests/fixtures/component-test/mocha.js
+++ b/node-tests/fixtures/component-test/mocha.js
@@ -2,12 +2,14 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describeComponent('x-foo', 'Integration | Component | x-foo',
+describeComponent(
+  'x-foo',
+  'Integration | Component | x-foo',
   {
-    integration: true
+    integration: true,
   },
-  function() {
-    it('renders', function() {
+  function () {
+    it('renders', function () {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/rfc232-unit.js
+++ b/node-tests/fixtures/component-test/rfc232-unit.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Component | x-foo', function(hooks) {
+module('Unit | Component | x-foo', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let component = this.owner.factoryFor('component:x-foo').create();
     assert.ok(component);
   });

--- a/node-tests/fixtures/component-test/rfc232.js
+++ b/node-tests/fixtures/component-test/rfc232.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | x-foo', function(hooks) {
+module('Integration | Component | x-foo', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/node-tests/fixtures/component-test/unit.js
+++ b/node-tests/fixtures/component-test/unit.js
@@ -3,11 +3,10 @@ import { moduleForComponent, test } from 'ember-qunit';
 moduleForComponent('x-foo', 'Unit | Component | x-foo', {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar'],
-  unit: true
+  unit: true,
 });
 
-test('it renders', function(assert) {
-  
+test('it renders', function (assert) {
   // Creates the component instance
   /*let component =*/ this.subject();
   // Renders the component to the page

--- a/node-tests/fixtures/component/component-dash.js
+++ b/node-tests/fixtures/component/component-dash.js
@@ -1,4 +1,3 @@
 import Component from '@glimmer/component';
 
-export default class XFooComponent extends Component {
-}
+export default class XFooComponent extends Component {}

--- a/node-tests/fixtures/component/component-nested.js
+++ b/node-tests/fixtures/component/component-nested.js
@@ -1,4 +1,3 @@
 import Component from '@glimmer/component';
 
-export default class FooXFooComponent extends Component {
-}
+export default class FooXFooComponent extends Component {}

--- a/node-tests/fixtures/component/component.js
+++ b/node-tests/fixtures/component/component.js
@@ -1,4 +1,3 @@
 import Component from '@glimmer/component';
 
-export default class FooComponent extends Component {
-}
+export default class FooComponent extends Component {}

--- a/node-tests/fixtures/controller-test/default-nested.js
+++ b/node-tests/fixtures/controller-test/default-nested.js
@@ -6,7 +6,7 @@ moduleFor('controller:foo/bar', 'Unit | Controller | foo/bar', {
 });
 
 // TODO: Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let controller = this.subject();
   assert.ok(controller);
 });

--- a/node-tests/fixtures/controller-test/default.js
+++ b/node-tests/fixtures/controller-test/default.js
@@ -6,7 +6,7 @@ moduleFor('controller:foo', 'Unit | Controller | foo', {
 });
 
 // TODO: Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let controller = this.subject();
   assert.ok(controller);
 });

--- a/node-tests/fixtures/controller-test/mocha-0.12-nested.js
+++ b/node-tests/fixtures/controller-test/mocha-0.12-nested.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Controller | foo/bar', function() {
+describe('Unit | Controller | foo/bar', function () {
   setupTest('controller:foo/bar', {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   });
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let controller = this.subject();
     expect(controller).to.be.ok;
   });

--- a/node-tests/fixtures/controller-test/mocha-0.12.js
+++ b/node-tests/fixtures/controller-test/mocha-0.12.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Controller | foo', function() {
+describe('Unit | Controller | foo', function () {
   setupTest('controller:foo', {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   });
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let controller = this.subject();
     expect(controller).to.be.ok;
   });

--- a/node-tests/fixtures/controller-test/mocha-nested.js
+++ b/node-tests/fixtures/controller-test/mocha-nested.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('controller:foo/bar', 'Unit | Controller | foo/bar',
+describeModule(
+  'controller:foo/bar',
+  'Unit | Controller | foo/bar',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   },
-  function() {
+  function () {
     // TODO: Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function () {
       let controller = this.subject();
       expect(controller).to.be.ok;
     });

--- a/node-tests/fixtures/controller-test/mocha-rfc232-nested.js
+++ b/node-tests/fixtures/controller-test/mocha-rfc232-nested.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Controller | foo/bar', function() {
+describe('Unit | Controller | foo/bar', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let controller = this.owner.lookup('controller:foo/bar');
     expect(controller).to.be.ok;
   });

--- a/node-tests/fixtures/controller-test/mocha-rfc232.js
+++ b/node-tests/fixtures/controller-test/mocha-rfc232.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Controller | foo', function() {
+describe('Unit | Controller | foo', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let controller = this.owner.lookup('controller:foo');
     expect(controller).to.be.ok;
   });

--- a/node-tests/fixtures/controller-test/mocha.js
+++ b/node-tests/fixtures/controller-test/mocha.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('controller:foo', 'Unit | Controller | foo',
+describeModule(
+  'controller:foo',
+  'Unit | Controller | foo',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   },
-  function() {
+  function () {
     // TODO: Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function () {
       let controller = this.subject();
       expect(controller).to.be.ok;
     });

--- a/node-tests/fixtures/controller-test/rfc232-nested.js
+++ b/node-tests/fixtures/controller-test/rfc232-nested.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | foo/bar', function(hooks) {
+module('Unit | Controller | foo/bar', function (hooks) {
   setupTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:foo/bar');
     assert.ok(controller);
   });

--- a/node-tests/fixtures/controller-test/rfc232.js
+++ b/node-tests/fixtures/controller-test/rfc232.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | foo', function(hooks) {
+module('Unit | Controller | foo', function (hooks) {
   setupTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:foo');
     assert.ok(controller);
   });

--- a/node-tests/fixtures/controller/controller-nested.js
+++ b/node-tests/fixtures/controller/controller-nested.js
@@ -1,4 +1,3 @@
 import Controller from '@ember/controller';
 
-export default class FooBarController extends Controller {
-}
+export default class FooBarController extends Controller {}

--- a/node-tests/fixtures/controller/controller.js
+++ b/node-tests/fixtures/controller/controller.js
@@ -1,4 +1,3 @@
 import Controller from '@ember/controller';
 
-export default class FooController extends Controller {
-}
+export default class FooController extends Controller {}

--- a/node-tests/fixtures/helper-test/integration.js
+++ b/node-tests/fixtures/helper-test/integration.js
@@ -2,11 +2,11 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('foo/bar-baz', 'helper:foo/bar-baz', {
-  integration: true
+  integration: true,
 });
 
 // TODO: Replace this with your real tests.
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   this.set('inputValue', '1234');
 
   this.render(hbs`{{foo/bar-baz this.inputValue}}`);

--- a/node-tests/fixtures/helper-test/mocha-0.12.js
+++ b/node-tests/fixtures/helper-test/mocha-0.12.js
@@ -3,12 +3,12 @@ import { describe, it } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Helper | foo/bar-baz', function() {
+describe('Integration | Helper | foo/bar-baz', function () {
   setupComponentTest('foo/bar-baz', {
-    integration: true
+    integration: true,
   });
 
-  it('renders', function() {
+  it('renders', function () {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/node-tests/fixtures/helper-test/mocha-rfc232.js
+++ b/node-tests/fixtures/helper-test/mocha-rfc232.js
@@ -4,11 +4,11 @@ import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Helper | foo/bar-baz', function() {
+describe('Integration | Helper | foo/bar-baz', function () {
   setupRenderingTest();
 
   // TODO: Replace this with your real tests.
-  it('renders', async function() {
+  it('renders', async function () {
     this.set('inputValue', '1234');
 
     await render(hbs`{{foo/bar-baz this.inputValue}}`);

--- a/node-tests/fixtures/helper-test/mocha.js
+++ b/node-tests/fixtures/helper-test/mocha.js
@@ -2,12 +2,14 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
-describeComponent('foo/bar-baz', 'helper:foo/bar-baz',
+describeComponent(
+  'foo/bar-baz',
+  'helper:foo/bar-baz',
   {
-    integration: true
+    integration: true,
   },
-  function() {
-    it('renders', function() {
+  function () {
+    it('renders', function () {
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.on('myAction', function(val) { ... });
       // Template block usage:

--- a/node-tests/fixtures/helper-test/rfc232.js
+++ b/node-tests/fixtures/helper-test/rfc232.js
@@ -3,11 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | foo/bar-baz', function(hooks) {
+module('Integration | Helper | foo/bar-baz', function (hooks) {
   setupRenderingTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     this.set('inputValue', '1234');
 
     await render(hbs`{{foo/bar-baz this.inputValue}}`);

--- a/node-tests/fixtures/helper/helper.js
+++ b/node-tests/fixtures/helper/helper.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
 
-export default helper(function fooBarBaz(positional/*, named*/) {
+export default helper(function fooBarBaz(positional /*, named*/) {
   return positional;
 });

--- a/node-tests/fixtures/helper/mu-helper.js
+++ b/node-tests/fixtures/helper/mu-helper.js
@@ -1,6 +1,6 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
-export function fooBarBaz(positional/*, named*/) {
+export function fooBarBaz(positional /*, named*/) {
   return positional;
 }
 

--- a/node-tests/fixtures/initializer-test/default.js
+++ b/node-tests/fixtures/initializer-test/default.js
@@ -4,7 +4,6 @@ import { run } from '@ember/runloop';
 import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
 
-
 module('Unit | Initializer | foo', {
   beforeEach() {
     run(() => {
@@ -14,11 +13,11 @@ module('Unit | Initializer | foo', {
   },
   afterEach() {
     run(this.application, 'destroy');
-  }
+  },
 });
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   initialize(this.application);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/initializer-test/dummy.js
+++ b/node-tests/fixtures/initializer-test/dummy.js
@@ -4,7 +4,6 @@ import { run } from '@ember/runloop';
 import { initialize } from 'dummy/initializers/foo';
 import { module, test } from 'qunit';
 
-
 module('Unit | Initializer | foo', {
   beforeEach() {
     run(() => {
@@ -14,11 +13,11 @@ module('Unit | Initializer | foo', {
   },
   afterEach() {
     run(this.application, 'destroy');
-  }
+  },
 });
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   initialize(this.application);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/initializer-test/mocha-rfc232.js
+++ b/node-tests/fixtures/initializer-test/mocha-rfc232.js
@@ -4,23 +4,23 @@ import Application from '@ember/application';
 import { initialize } from 'my-app/initializers/foo';
 import { run } from '@ember/runloop';
 
-describe('Unit | Initializer | foo', function() {
-  beforeEach(function() {
+describe('Unit | Initializer | foo', function () {
+  beforeEach(function () {
     this.TestApplication = Application.extend();
     this.TestApplication.initializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
 
     this.application = this.TestApplication.create({ autoboot: false });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     run(this.application, 'destroy');
   });
 
   // TODO: Replace this with your real tests.
-  it('works', async function() {
+  it('works', async function () {
     await this.application.boot();
 
     // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/initializer-test/mocha.js
+++ b/node-tests/fixtures/initializer-test/mocha.js
@@ -4,23 +4,22 @@ import { run } from '@ember/runloop';
 import Application from '@ember/application';
 import { initialize } from 'my-app/initializers/foo';
 
-
-describe('Unit | Initializer | foo', function() {
+describe('Unit | Initializer | foo', function () {
   let application;
 
-  beforeEach(function() {
-    run(function() {
+  beforeEach(function () {
+    run(function () {
       application = Application.create();
       application.deferReadiness();
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     run(application, 'destroy');
   });
 
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     initialize(application);
 
     // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/initializer/initializer-nested.js
+++ b/node-tests/fixtures/initializer/initializer-nested.js
@@ -1,6 +1,5 @@
-export function initialize(/* application */) {
-}
+export function initialize(/* application */) {}
 
 export default {
-  initialize
+  initialize,
 };

--- a/node-tests/fixtures/initializer/initializer.js
+++ b/node-tests/fixtures/initializer/initializer.js
@@ -1,6 +1,5 @@
-export function initialize(/* application */) {
-}
+export function initialize(/* application */) {}
 
 export default {
-  initialize
+  initialize,
 };

--- a/node-tests/fixtures/instance-initializer-test/default.js
+++ b/node-tests/fixtures/instance-initializer-test/default.js
@@ -13,11 +13,11 @@ module('Unit | Instance Initializer | foo', {
   afterEach() {
     run(this.appInstance, 'destroy');
     run(this.application, 'destroy');
-  }
+  },
 });
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   initialize(this.appInstance);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/instance-initializer-test/dummy.js
+++ b/node-tests/fixtures/instance-initializer-test/dummy.js
@@ -13,11 +13,11 @@ module('Unit | Instance Initializer | foo', {
   afterEach() {
     run(this.appInstance, 'destroy');
     run(this.application, 'destroy');
-  }
+  },
 });
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   initialize(this.appInstance);
 
   // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/instance-initializer-test/mocha-rfc232.js
+++ b/node-tests/fixtures/instance-initializer-test/mocha-rfc232.js
@@ -4,23 +4,23 @@ import Application from '@ember/application';
 import { initialize } from 'my-app/instance-initializers/foo';
 import { run } from '@ember/runloop';
 
-describe('Unit | Instance Initializer | foo', function() {
-  beforeEach(function() {
+describe('Unit | Instance Initializer | foo', function () {
+  beforeEach(function () {
     this.TestApplication = Application.extend();
     this.TestApplication.instanceInitializer({
       name: 'initializer under test',
-      initialize
+      initialize,
     });
     this.application = this.TestApplication.create({ autoboot: false });
     this.instance = this.application.buildInstance();
   });
-  afterEach(function() {
+  afterEach(function () {
     run(this.instance, 'destroy');
     run(this.application, 'destroy');
   });
 
   // TODO: Replace this with your real tests.
-  it('works', async function() {
+  it('works', async function () {
     await this.instance.boot();
 
     expect(true).to.be.ok;

--- a/node-tests/fixtures/instance-initializer-test/mocha.js
+++ b/node-tests/fixtures/instance-initializer-test/mocha.js
@@ -5,23 +5,23 @@ import { run } from '@ember/runloop';
 import { initialize } from 'my-app/instance-initializers/foo';
 import destroyApp from '../../helpers/destroy-app';
 
-describe('Unit | Instance Initializer | foo', function() {
+describe('Unit | Instance Initializer | foo', function () {
   let application, appInstance;
 
-  beforeEach(function() {
-    run(function() {
+  beforeEach(function () {
+    run(function () {
       application = Application.create();
       appInstance = application.buildInstance();
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     run(appInstance, 'destroy');
     destroyApp(application);
   });
 
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     initialize(appInstance);
 
     // you would normally confirm the results of the initializer here

--- a/node-tests/fixtures/instance-initializer/instance-initializer-nested.js
+++ b/node-tests/fixtures/instance-initializer/instance-initializer-nested.js
@@ -1,6 +1,5 @@
-export function initialize(/* appInstance */) {
-}
+export function initialize(/* appInstance */) {}
 
 export default {
-  initialize
+  initialize,
 };

--- a/node-tests/fixtures/instance-initializer/instance-initializer.js
+++ b/node-tests/fixtures/instance-initializer/instance-initializer.js
@@ -1,6 +1,5 @@
-export function initialize(/* appInstance */) {
-}
+export function initialize(/* appInstance */) {}
 
 export default {
-  initialize
+  initialize,
 };

--- a/node-tests/fixtures/mixin-test/addon.js
+++ b/node-tests/fixtures/mixin-test/addon.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 module('Unit | Mixin | foo');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let FooObject = EmberObject.extend(FooMixin);
   let subject = FooObject.create();
   assert.ok(subject);

--- a/node-tests/fixtures/mixin-test/default.js
+++ b/node-tests/fixtures/mixin-test/default.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 module('Unit | Mixin | foo');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let FooObject = EmberObject.extend(FooMixin);
   let subject = FooObject.create();
   assert.ok(subject);

--- a/node-tests/fixtures/mixin-test/mocha-rfc232.js
+++ b/node-tests/fixtures/mixin-test/mocha-rfc232.js
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 import EmberObject from '@ember/object';
 import FooMixin from 'my-app/mixins/foo';
 
-describe('Unit | Mixin | foo', function() {
+describe('Unit | Mixin | foo', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let FooObject = EmberObject.extend(FooMixin);
     let subject = FooObject.create();
     expect(subject).to.be.ok;

--- a/node-tests/fixtures/mixin-test/mocha.js
+++ b/node-tests/fixtures/mixin-test/mocha.js
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 import EmberObject from '@ember/object';
 import FooMixin from 'my-app/mixins/foo';
 
-describe('Unit | Mixin | foo', function() {
+describe('Unit | Mixin | foo', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let FooObject = EmberObject.extend(FooMixin);
     let subject = FooObject.create();
     expect(subject).to.be.ok;

--- a/node-tests/fixtures/mixin-test/rfc232.js
+++ b/node-tests/fixtures/mixin-test/rfc232.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import FooMixin from 'my-app/mixins/foo';
 import { module, test } from 'qunit';
 
-module('Unit | Mixin | foo', function() {
+module('Unit | Mixin | foo', function () {
   // TODO: Replace this with your real tests.
   test('it works', function (assert) {
     let FooObject = EmberObject.extend(FooMixin);

--- a/node-tests/fixtures/route-test/default-child.js
+++ b/node-tests/fixtures/route-test/default-child.js
@@ -5,7 +5,7 @@ moduleFor('route:child', 'Unit | Route | parent/child', {
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let route = this.subject();
   assert.ok(route);
 });

--- a/node-tests/fixtures/route-test/default-nested.js
+++ b/node-tests/fixtures/route-test/default-nested.js
@@ -5,7 +5,7 @@ moduleFor('route:foo/bar', 'Unit | Route | foo/bar', {
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let route = this.subject();
   assert.ok(route);
 });

--- a/node-tests/fixtures/route-test/default.js
+++ b/node-tests/fixtures/route-test/default.js
@@ -5,7 +5,7 @@ moduleFor('route:foo', 'Unit | Route | foo', {
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let route = this.subject();
   assert.ok(route);
 });

--- a/node-tests/fixtures/route-test/mocha-0.12.js
+++ b/node-tests/fixtures/route-test/mocha-0.12.js
@@ -2,13 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Route | foo', function() {
+describe('Unit | Route | foo', function () {
   setupTest('route:foo', {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   });
 
-  it('exists', function() {
+  it('exists', function () {
     let route = this.subject();
     expect(route).to.be.ok;
   });

--- a/node-tests/fixtures/route-test/mocha-rfc232.js
+++ b/node-tests/fixtures/route-test/mocha-rfc232.js
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Route | foo', function() {
+describe('Unit | Route | foo', function () {
   setupTest();
 
-  it('exists', function() {
+  it('exists', function () {
     let route = this.owner.lookup('route:foo');
     expect(route).to.be.ok;
   });

--- a/node-tests/fixtures/route-test/mocha.js
+++ b/node-tests/fixtures/route-test/mocha.js
@@ -1,13 +1,15 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('route:foo', 'Unit | Route | foo',
+describeModule(
+  'route:foo',
+  'Unit | Route | foo',
   {
     // Specify the other units that are required for this test.
     // needs: ['controller:foo']
   },
-  function() {
-    it('exists', function() {
+  function () {
+    it('exists', function () {
       let route = this.subject();
       expect(route).to.be.ok;
     });

--- a/node-tests/fixtures/route-test/rfc232.js
+++ b/node-tests/fixtures/route-test/rfc232.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | foo', function(hooks) {
+module('Unit | Route | foo', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let route = this.owner.lookup('route:foo');
     assert.ok(route);
   });

--- a/node-tests/fixtures/route/route-child.js
+++ b/node-tests/fixtures/route/route-child.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class ParentChildRoute extends Route {
-}
+export default class ParentChildRoute extends Route {}

--- a/node-tests/fixtures/route/route-nested.js
+++ b/node-tests/fixtures/route/route-nested.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class FooBarRoute extends Route {
-}
+export default class FooBarRoute extends Route {}

--- a/node-tests/fixtures/route/route.js
+++ b/node-tests/fixtures/route/route.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default class FooRoute extends Route {
-}
+export default class FooRoute extends Route {}

--- a/node-tests/fixtures/service-test/default-nested.js
+++ b/node-tests/fixtures/service-test/default-nested.js
@@ -6,7 +6,7 @@ moduleFor('service:foo/bar', 'Unit | Service | foo/bar', {
 });
 
 // TODO: Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let service = this.subject();
   assert.ok(service);
 });

--- a/node-tests/fixtures/service-test/default.js
+++ b/node-tests/fixtures/service-test/default.js
@@ -6,7 +6,7 @@ moduleFor('service:foo', 'Unit | Service | foo', {
 });
 
 // TODO: Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let service = this.subject();
   assert.ok(service);
 });

--- a/node-tests/fixtures/service-test/mocha-0.12.js
+++ b/node-tests/fixtures/service-test/mocha-0.12.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Service | foo', function() {
+describe('Unit | Service | foo', function () {
   setupTest('service:foo', {
     // Specify the other units that are required for this test.
     // needs: ['service:foo']
   });
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let service = this.subject();
     expect(service).to.be.ok;
   });

--- a/node-tests/fixtures/service-test/mocha-rfc232.js
+++ b/node-tests/fixtures/service-test/mocha-rfc232.js
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Service | foo', function() {
+describe('Unit | Service | foo', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
-  it('exists', function() {
+  it('exists', function () {
     let service = this.owner.lookup('service:foo');
     expect(service).to.be.ok;
   });

--- a/node-tests/fixtures/service-test/mocha.js
+++ b/node-tests/fixtures/service-test/mocha.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { describeModule, it } from 'ember-mocha';
 
-describeModule('service:foo', 'Unit | Service | foo',
+describeModule(
+  'service:foo',
+  'Unit | Service | foo',
   {
     // Specify the other units that are required for this test.
     // needs: ['service:foo']
   },
-  function() {
+  function () {
     // TODO: Replace this with your real tests.
-    it('exists', function() {
+    it('exists', function () {
       let service = this.subject();
       expect(service).to.be.ok;
     });

--- a/node-tests/fixtures/service-test/rfc232.js
+++ b/node-tests/fixtures/service-test/rfc232.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Service | foo', function(hooks) {
+module('Unit | Service | foo', function (hooks) {
   setupTest(hooks);
 
   // TODO: Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let service = this.owner.lookup('service:foo');
     assert.ok(service);
   });

--- a/node-tests/fixtures/service/service-nested.js
+++ b/node-tests/fixtures/service/service-nested.js
@@ -1,4 +1,3 @@
 import Service from '@ember/service';
 
-export default class FooBarService extends Service {
-}
+export default class FooBarService extends Service {}

--- a/node-tests/fixtures/service/service.js
+++ b/node-tests/fixtures/service/service.js
@@ -1,4 +1,3 @@
 import Service from '@ember/service';
 
-export default class FooService extends Service {
-}
+export default class FooService extends Service {}

--- a/node-tests/fixtures/util-test/addon-default-nested.js
+++ b/node-tests/fixtures/util-test/addon-default-nested.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Utility | foo/bar-baz');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let result = fooBarBaz();
   assert.ok(result);
 });

--- a/node-tests/fixtures/util-test/addon-default.js
+++ b/node-tests/fixtures/util-test/addon-default.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Utility | foo-bar');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let result = fooBar();
   assert.ok(result);
 });

--- a/node-tests/fixtures/util-test/default-nested.js
+++ b/node-tests/fixtures/util-test/default-nested.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Utility | foo/bar-baz');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let result = fooBarBaz();
   assert.ok(result);
 });

--- a/node-tests/fixtures/util-test/default.js
+++ b/node-tests/fixtures/util-test/default.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Utility | foo-bar');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let result = fooBar();
   assert.ok(result);
 });

--- a/node-tests/fixtures/util-test/dummy.js
+++ b/node-tests/fixtures/util-test/dummy.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Utility | foo-bar');
 
 // TODO: Replace this with your real tests.
-test('it works', function(assert) {
+test('it works', function (assert) {
   let result = fooBar();
   assert.ok(result);
 });

--- a/node-tests/fixtures/util-test/mocha-rfc232.js
+++ b/node-tests/fixtures/util-test/mocha-rfc232.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import fooBar from 'my-app/utils/foo-bar';
 
-describe('Unit | Utility | foo-bar', function() {
+describe('Unit | Utility | foo-bar', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let result = fooBar();
     expect(result).to.be.ok;
   });

--- a/node-tests/fixtures/util-test/mocha.js
+++ b/node-tests/fixtures/util-test/mocha.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import fooBar from 'my-app/utils/foo-bar';
 
-describe('Unit | Utility | foo-bar', function() {
+describe('Unit | Utility | foo-bar', function () {
   // TODO: Replace this with your real tests.
-  it('works', function() {
+  it('works', function () {
     let result = fooBar();
     expect(result).to.be.ok;
   });

--- a/node-tests/fixtures/util-test/rfc232.js
+++ b/node-tests/fixtures/util-test/rfc232.js
@@ -1,10 +1,9 @@
 import fooBar from 'my-app/utils/foo-bar';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | foo-bar', function() {
-
+module('Unit | Utility | foo-bar', function () {
   // TODO: Replace this with your real tests.
-  test('it works', function(assert) {
+  test('it works', function (assert) {
     let result = fooBar();
     assert.ok(result);
   });


### PR DESCRIPTION
Ember uses Prettier, but it has the blueprints and blueprint fixtures ignored by ESLint.

As such, the templates for the blueprints as well as the fixtures against which the blueprints are tested break Prettier formatting rules, most notably forbidding `function()` in favor of `function ()`.

There are two steps here: 
- forcing Prettier to format the fixtures (which are regular JavaScript and, hence, can formatted with no trouble) 
- adjusting the blueprint files, as well as occasionally the actual blueprint and sometimes the corresponding test to match the fixtures.

When I had to adjust the blueprint proper and/or the corresponding test, it was usually because either was not checking against a files template or a fixture. This takes the form of adjusting `{${EOL}}` and taking out the linebreak.

Somehow, running `ember g route foo` on my computer yields:

```js
import Route from '@ember/routing/route';

export default class FooRoute extends Route {}
```

I suppose Ember/Ember-cli reformats the files as it is making them, because the fixture against which this command [is tested](https://github.com/emberjs/ember.js/blob/master/node-tests/fixtures/route/route.js) in Ember is:

```js
import Route from '@ember/routing/route';

export default class FooRoute extends Route {
}
```

With this PR, the `route` blueprint generates something with `Route {}` and the fixture against which the blueprint is tested is also expecting `Route {}`.
