### PR TITLE
Update error message instructions

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/-disallow-dynamic-resolution.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/-disallow-dynamic-resolution.ts
@@ -46,7 +46,7 @@ export default internalHelper(({ positional, named }: CapturedArguments) => {
         `(You specified \`(${type} ${original})\` and \`${original}\` evaluated into "${nameOrValue}".) ` +
         `This ensures we can statically analyze the template and determine which ${type}s are used. ` +
         `If the ${type} name is always the same, use a string literal instead, i.e. \`(${type} "${nameOrValue}")\`. ` +
-        `Otherwise, import the ${type}s into JavaScript and pass them to the ${type} keyword. ` +
+        `Otherwise, import the ${type}s into JavaScript and pass them directly. ` +
         'See https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#4-no-dynamic-resolution for details. ' +
         loc,
       typeof nameOrValue !== 'string'


### PR DESCRIPTION
Since Ember 3.25 it's unnecessary to pass a helper or modifier class to the corresponding template keyword before you can use them. They are first-class values that can be used directly.

This updates the error message to stop suggesting the now-unnecessary use of the helper and modifier keywords.

Before:

> Assertion Failed: Passing a dynamic string to the (helper) keyword is disallowed. (You specified (helper s) and s evaluated into "my-helper".) This ensures we can statically analyze the template and determine which helpers are used. If the helper name is always the same, use a string literal instead, i.e. (helper "my-helper"). Otherwise, import the helpers into JavaScript **and pass them to the helper keyword**. See https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#4-no-dynamic-resolution for details. ('sample2/templates/application.hbs' @ L3:C9)

After:

> Assertion Failed: Passing a dynamic string to the (helper) keyword is disallowed. (You specified (helper s) and s evaluated into "my-helper".) This ensures we can statically analyze the template and determine which helpers are used. If the helper name is always the same, use a string literal instead, i.e. (helper "my-helper"). Otherwise, import the helpers into JavaScript **and pass them directly**. See https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#4-no-dynamic-resolution for details. ('sample2/templates/application.hbs' @ L3:C9)