### PR TITLE
export `renderSettled` via `@ember/renderer` package

### DIFF
--- a/packages/@ember/renderer/index.ts
+++ b/packages/@ember/renderer/index.ts
@@ -1,0 +1,21 @@
+/**
+  @module @ember/renderer
+  @public
+*/
+
+/**
+ * @class Renderer
+ * @public
+ */
+
+/**
+  Returns a promise which will resolve when rendering has settled. Settled in
+  this context is defined as when all of the tags in use are "current" (e.g.
+  `renderers.every(r => r._isValid())`). When this is checked at the _end_ of
+  the run loop, this essentially guarantees that all rendering is completed.
+
+  @method renderSettled
+  @return {Promise<void>} a promise which fulfills when rendering has settled
+  @public
+*/
+export { renderSettled } from '@ember/-internals/glimmer';

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -420,6 +420,7 @@ module.exports = {
     'removeObjects',
     'removeObserver',
     'removeTestHelpers',
+    'renderSettled',
     'reopen',
     'reopenClass',
     'replace',


### PR DESCRIPTION
Serves as the first step in the implementation of https://github.com/cafreeman/rfcs/blob/dont-use-this-for-template-values-in-tests/text/0785-remove-set-get-in-tests.md

This PR simply exposes an existing utility (which is already fully tested) in a public package so that it can be consumed in `ember-test-helpers`.