### PR TITLE
Remove `optional jQuery` from CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn lint
 
   basic-test:
-    name: Debug and Prebuilt (All Tests by Package + Canary Features + Optional Jquery)
+    name: Debug and Prebuilt (All Tests by Package + Canary Features)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
jQuery isn't supported in Ember 4 and isn't part of the test suite so ✂️ 