### PR TITLE
Update docs to match native class syntax

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route.ts
+++ b/packages/@ember/-internals/routing/lib/system/route.ts
@@ -149,7 +149,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
     (assuming a query param whose controller property is `page`):
 
     ```javascript
-    queryParams: {
+    queryParams = {
       page: {
         // By default, controller query param properties don't
         // cause a full transition when they are changed, but
@@ -177,7 +177,7 @@ class Route extends EmberObject.extend(ActionHandler, Evented) implements IRoute
         // different URL key.
         as: 'page'
       }
-    }
+    };
     ```
 
     @property queryParams


### PR DESCRIPTION
The example code snippet here assumes it will be used in a classic-style class body, but all the rest of the docs are updated for native class syntax.