### PR TITLE
[BUGFIX beta] bind all methods on the router service for use with fn …

### DIFF
--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -2,6 +2,7 @@ import { getOwner } from '@ember/-internals/owner';
 import { Evented } from '@ember/-internals/runtime';
 import { symbol } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import Service from '@ember/service';
 import { consumeTag, tagFor } from '@glimmer/validator';
@@ -122,6 +123,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
        attempted transition
      @public
    */
+  @action
   transitionTo(...args: RouteArgs<R>): Transition {
     if (resemblesURL(args[0])) {
       // NOTE: this `args[0] as string` cast is safe and TS correctly infers it
@@ -171,6 +173,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
        attempted transition
      @public
    */
+  @action
   replaceWith(...args: RouteArgs<R>): Transition {
     return this.transitionTo(...args).method('replace');
   }
@@ -243,6 +246,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
      @return {String} the string representing the generated URL
      @public
    */
+  @action
   urlFor(routeName: string, ...args: ModelFor<R>[] | [...ModelFor<R>[], RouteOptions]) {
     this._router.setupRouter();
     return this._router.generate(routeName, ...args);
@@ -295,6 +299,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
      @return {boolean} true if the provided routeName/models/queryParams are active
      @public
    */
+  @action
   isActive(...args: RouteArgs<R>) {
     let { routeName, models, queryParams } = extractRouteArgs(args);
     let routerMicrolib = this._router._routerMicrolib;
@@ -383,6 +388,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
       @return {RouteInfo | null}
       @public
     */
+  @action
   recognize(url: string): RouteInfo | null {
     assert(
       `You must pass a url that begins with the application's rootURL "${this.rootURL}"`,
@@ -405,6 +411,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
       @return {RouteInfo}
       @public
    */
+  @action
   recognizeAndLoad(url: string): Promise<RouteInfoWithAttributes> {
     assert(
       `You must pass a url that begins with the application's rootURL "${this.rootURL}"`,
@@ -561,6 +568,7 @@ class RouterService<R extends Route> extends Service.extend(Evented) {
    * @return Transition
    * @public
    */
+  @action
   refresh(pivotRouteName?: string): Transition {
     if (!pivotRouteName) {
       return this._router._routerMicrolib.refresh();


### PR DESCRIPTION
…and default helper manager

**This PR is rebased off of https://github.com/emberjs/ember.js/pull/20018 so review that first**

This resolves an issue where this code:
```hbs
{{#if (this.router.isActive 'some.route')}}
```
Would lose the `this` binding.
[Discovered here](https://github.com/NullVoxPopuli/limber/pull/452/files#diff-968eba8222b55852309d2cd2c5814657ed4cdf53dfc78f9f40851a6e83fa47e0L21)


This is only an issue since the:
https://github.com/emberjs/rfcs/pull/756
(and https://github.com/NullVoxPopuli/ember-functions-as-helper-polyfill/)

[Explanation here](https://github.com/NullVoxPopuli/ember-functions-as-helper-polyfill/issues/103#issuecomment-1031496450)

_but_, I'm still upset that bound methods on classes aren't default 😅 
anywho, I used `@action` here, idk if that's the right call since action does a bunch of other stuff, too.

I also noticed that the refresh method was still marked as canary.
refresh was declared as released in 4.1: https://blog.emberjs.com/ember-4-1-released/
so I removed the feature flag.