### PR TITLE
[DOCS] Add explicit module names for the `RouteInfo` and `Transition` classes

### DIFF
--- a/packages/@ember/-internals/routing/lib/system/route-info.ts
+++ b/packages/@ember/-internals/routing/lib/system/route-info.ts
@@ -1,6 +1,10 @@
 export { RouteInfo, RouteInfoWithAttributes } from 'router_js';
 
 /**
+ @module @ember/routing
+*/
+
+/**
   A `RouteInfoWithAttributes` is an object that contains
   metadata, including the resolved value from the routes
   `model` hook. Like `RouteInfo`, a `RouteInfoWithAttributes`

--- a/packages/@ember/-internals/routing/lib/system/transition.ts
+++ b/packages/@ember/-internals/routing/lib/system/transition.ts
@@ -1,4 +1,8 @@
 /**
+ @module @ember/routing
+*/
+
+/**
   A Transition is a thennable (a promise-like object) that represents
   an attempt to transition to another route. It can be aborted, either
   explicitly via `abort` or by attempting another transition while a


### PR DESCRIPTION
This came up in a [Discord discussion](https://discord.com/channels/480462759797063690/480777444203429888/945819493479886858). 

[`RouteInfo`](https://api.emberjs.com/ember/release/classes/RouteInfo) is currently listed under the ember module instead of `@ember/routing`. It seems that YUIDoc uses the last defined module name if a class doesn't define one itself. It also seems to parse files alphabetically. RouteInfo doesn't define a module name and comes after the `generate_controller` file which uses `ember` as the module name. Adding the explicit module name fixes the problem:

![image](https://user-images.githubusercontent.com/3533236/158079162-3da7c636-5ace-45ad-91ed-d55918bb174a.png)


Transition does appear in the right package, but I added the module anyway to prevent it from changing in the future if files are moved / refactored.