### PR TITLE
[BUGFIX beta] Correctly associate props with factory and owner in FactoryManager

### DIFF
--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -504,13 +504,9 @@ export class FactoryManager<T, C extends FactoryClass | object = FactoryClass> {
       );
     }
 
-    let props = {};
+    let props = options ? { ...options } : {};
     setOwner(props, container.owner!);
     setFactoryFor(props, this);
-
-    if (options !== undefined) {
-      props = Object.assign({}, props, options);
-    }
 
     if (DEBUG) {
       let lazyInjections;


### PR DESCRIPTION
Previously, we stomped the `props` binding with an `Object.assign()`, which meant that the original empty props object would get GC'd after the end of the method and the item passed into the class created at the end of the `FactoryManager.create` call would be a *different* object, which does *not* have the factory or owner associations.

Fixes #20023

Also fixes a bunch of unnecessary type casts.