### PR TITLE
[BUGFIX LTS] remove bad `setFactoryFor` call

### DIFF
--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -481,10 +481,6 @@ export class FactoryManager<T, C extends FactoryClass | object = FactoryClass> {
     this.madeToString = undefined;
     this.injections = undefined;
     setFactoryFor(this, this);
-
-    if (isInstantiatable(container, fullName)) {
-      setFactoryFor(factory, this);
-    }
   }
 
   toString(): string {


### PR DESCRIPTION
This call *attempted* to avoid setting the `INIT_FACTORY` on items which did not need it (specifically, it avoided setting it on things which were not instantiable), but ultimately failed to do. It was ultimately setting the new `FactoryManager` instance as the `INIT_FACTORY` value on each instantiable object, which includes classes and not just class instances, since objects are only treated as non-instantiable when they explicitly specify `instantiate: false`.

The net was a memory leak: the routing service *class* ended up with an `INIT_FACTORY` pointing to a `FactoryManager` instance which in turn always had a `container` on it, which meant that there was a cycle (the container also referenced the service) and thus a leak. This affects both tests and FastBoot, where we construct new instances of the service whenever we call the `visit` API.