### PR TITLE
[BUGFIX beta] remove unneeded `setFactoryFor(this, this)`

### DIFF
--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -480,7 +480,6 @@ export class FactoryManager<T, C extends FactoryClass | object = FactoryClass> {
     this.normalizedName = normalizedName;
     this.madeToString = undefined;
     this.injections = undefined;
-    setFactoryFor(this, this);
 
     if (isInstantiatable(container, fullName)) {
       setFactoryFor(factory, this);


### PR DESCRIPTION
Identified as part of the work on #20025, this particular `setFactoryFor` was needed at one time but is now defunct. Remove it.