### PR TITLE
[DOC 3.28] Fix invokeHelper code example documentation

### DIFF
--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -264,8 +264,8 @@
     }
   }
 
-  export default class PlusOne extends Component {
-    plusOne = invokeHelper(this, RemoteData, () => {
+  export default class PlusOneComponent extends Component {
+    plusOne = invokeHelper(this, PlusOne, () => {
       return {
         positional: [this.args.number],
       };


### PR DESCRIPTION
- The code example in the documentation  for `invokeHelper` was incorrect.
- In `@ember/helper>=4.0` documentation it is fine.
