### PR TITLE
enhancement: do not throw Proxy `Ember.get` error from CoreObject

### DIFF
--- a/packages/@ember/-internals/runtime/lib/system/core_object.ts
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.ts
@@ -244,21 +244,7 @@ class CoreObject {
     (this.constructor as typeof CoreObject).proto();
 
     let self;
-    if (DEBUG && hasUnknownProperty(this)) {
-      let messageFor = (obj: unknown, property: unknown) => {
-        return (
-          `You attempted to access the \`${String(property)}\` property (of ${obj}).\n` +
-          `Since Ember 3.1, this is usually fine as you no longer need to use \`.get()\`\n` +
-          `to access computed properties. However, in this case, the object in question\n` +
-          `is a special kind of Ember object (a proxy). Therefore, it is still necessary\n` +
-          `to use \`.get('${String(property)}')\` in this case.\n\n` +
-          `If you encountered this error because of third-party code that you don't control,\n` +
-          `there is more information at https://github.com/emberjs/ember.js/issues/16148, and\n` +
-          `you can help us improve this error message by telling us more about what happened in\n` +
-          `this situation.`
-        );
-      };
-
+    if (hasUnknownProperty(this)) {
       /* globals Proxy Reflect */
       self = new Proxy(this, {
         get(target: CoreObject & HasUnknownProperty, property, receiver) {
@@ -282,12 +268,6 @@ class CoreObject {
             property in target
           ) {
             return Reflect.get(target, property, receiver);
-          }
-
-          let value = target.unknownProperty.call(receiver, property);
-
-          if (typeof value !== 'function') {
-            assert(messageFor(receiver, property), value === undefined || value === null);
           }
         },
       });

--- a/packages/@ember/-internals/runtime/lib/system/core_object.ts
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.ts
@@ -258,11 +258,6 @@ class CoreObject {
             property === 'toJSON' ||
             property === 'toString' ||
             property === 'toStringExtension' ||
-            property === 'didDefineProperty' ||
-            property === 'willWatchProperty' ||
-            property === 'didUnwatchProperty' ||
-            property === 'didAddListener' ||
-            property === 'didRemoveListener' ||
             property === 'isDescriptor' ||
             property === '_onLookup' ||
             property in target

--- a/packages/@ember/-internals/runtime/lib/system/core_object.ts
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.ts
@@ -244,7 +244,7 @@ class CoreObject {
     (this.constructor as typeof CoreObject).proto();
 
     let self;
-    if (hasUnknownProperty(this)) {
+    if (DEBUG && hasUnknownProperty(this)) {
       /* globals Proxy Reflect */
       self = new Proxy(this, {
         get(target: CoreObject & HasUnknownProperty, property, receiver) {

--- a/packages/@ember/-internals/runtime/lib/system/core_object.ts
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.ts
@@ -264,6 +264,10 @@ class CoreObject {
           ) {
             return Reflect.get(target, property, receiver);
           }
+
+          let value = target.unknownProperty.call(receiver, property);
+
+          return value;
         },
       });
     } else {

--- a/packages/@ember/-internals/runtime/lib/system/core_object.ts
+++ b/packages/@ember/-internals/runtime/lib/system/core_object.ts
@@ -244,7 +244,7 @@ class CoreObject {
     (this.constructor as typeof CoreObject).proto();
 
     let self;
-    if (DEBUG && hasUnknownProperty(this)) {
+    if (hasUnknownProperty(this)) {
       /* globals Proxy Reflect */
       self = new Proxy(this, {
         get(target: CoreObject & HasUnknownProperty, property, receiver) {

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -151,6 +151,20 @@ moduleFor(
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
     }
 
+    ['@test getting proxied properties works'](assert) {
+      if (DEBUG) {
+        let proxy = ObjectProxy.create({
+          content: {
+            foo: 'FOO',
+          },
+        });
+
+        assert.expect(proxy.foo, 'FOO');
+      } else {
+        assert.expect(0);
+      }
+    }
+
     async ['@test should work with watched properties'](assert) {
       let content1 = { firstName: 'Tom', lastName: 'Dale' };
       let content2 = { firstName: 'Yehuda', lastName: 'Katz' };

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -87,7 +87,6 @@ moduleFor(
       });
 
       assert.equal(get(proxy, 'foo'), 'FOO');
-      assert.equal(proxy.foo, 'FOO');
     }
 
     [`@test JSON.stringify doens't assert`](assert) {

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -151,20 +151,6 @@ moduleFor(
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
     }
 
-    ['@test getting proxied properties with [] should be an error'](assert) {
-      if (DEBUG) {
-        let proxy = ObjectProxy.create({
-          content: {
-            foo: 'FOO',
-          },
-        });
-
-        expectAssertion(() => proxy.foo, /\.get\('foo'\)/);
-      } else {
-        assert.expect(0);
-      }
-    }
-
     async ['@test should work with watched properties'](assert) {
       let content1 = { firstName: 'Tom', lastName: 'Dale' };
       let content2 = { firstName: 'Yehuda', lastName: 'Katz' };

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -87,6 +87,7 @@ moduleFor(
       });
 
       assert.equal(get(proxy, 'foo'), 'FOO');
+      assert.equal(proxy.foo, 'FOO');
     }
 
     [`@test JSON.stringify doens't assert`](assert) {

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -79,7 +79,7 @@ moduleFor(
       assert.equal(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
     }
 
-    ['@test getting proxied properties with Ember.get should work'](assert) {
+    ['@test getting proxied properties work'](assert) {
       let proxy = ObjectProxy.create({
         content: {
           foo: 'FOO',
@@ -87,6 +87,7 @@ moduleFor(
       });
 
       assert.equal(get(proxy, 'foo'), 'FOO');
+      assert.equal(proxy.foo, 'FOO');
     }
 
     [`@test JSON.stringify doens't assert`](assert) {
@@ -149,20 +150,6 @@ moduleFor(
       });
 
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
-    }
-
-    ['@test getting proxied properties works'](assert) {
-      if (DEBUG) {
-        let proxy = ObjectProxy.create({
-          content: {
-            foo: 'FOO',
-          },
-        });
-
-        assert.expect(proxy.foo, 'FOO');
-      } else {
-        assert.expect(0);
-      }
     }
 
     async ['@test should work with watched properties'](assert) {


### PR DESCRIPTION
It would be nice to get rid of this message, especially when returning async data to a component tree without resolving at the Route.

Eps since Proxy is supported in 4.0 (dropped IE11)