### PR TITLE
export `renderSettled` via renderer package

### DIFF
--- a/packages/@ember/renderer/index.ts
+++ b/packages/@ember/renderer/index.ts
@@ -1,0 +1,29 @@
+/**
+  @module @ember/renderer
+  @public
+*/
+
+/**
+ * @class Renderer
+ * @public
+ */
+
+/**
+  Returns a promise which will resolve when rendering has completed. In
+  this context, rendering is completed when all auto-tracked state that is
+  consumed in the template (including any tracked state in models, services,
+    etc.  that are then used in a template) has been updated in the DOM.
+
+    For example, in a test you might want to update some tracked state and
+    then run some assertions after rendering has completed. You _could_ use
+    `await settled()` in that location, but in some contexts you don't want to
+    wait for full settledness (which includes test waiters, pending AJAX/fetch,
+    run loops, etc) but instead only want to know when that updated value has
+    been rendered in the DOM. **THAT** is what `await rerender()` is _perfect_
+    for.
+  @method renderSettled
+  @returns {Promise<void>} a promise which fulfills when rendering has completed
+  @public
+*/
+
+export { renderSettled } from '@ember/-internals/glimmer';

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -420,6 +420,7 @@ module.exports = {
     'removeObjects',
     'removeObserver',
     'removeTestHelpers',
+    'renderSettled',
     'reopen',
     'reopenClass',
     'replace',


### PR DESCRIPTION
Second attempt at https://github.com/emberjs/ember.js/pull/20000 now that https://github.com/emberjs/rfcs/pull/785 is in FCP and is expected to be merged soon.

Serves as the first step in the implementation of https://github.com/emberjs/rfcs/pull/785.

This PR simply exposes an existing utility (which is already fully tested) in a public package so that it can be consumed in ember-test-helpers.

*NOTE: do not merge until the RFC has merged*