### PR TITLE
[DOC release] Documenting the @cached decorator

### DIFF
--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -97,6 +97,7 @@ module.exports = {
     'buildRegistry',
     'buildRouteInfoMetadata',
     'cache',
+    'cached',
     'cacheFor',
     'camelize',
     'canCatalogEntriesByType',


### PR DESCRIPTION
Merged in 4.1, the `@cached` decorator was not yet documented.

The text is mostly a repurpose of the original RFC text.

3 notes:
- I didn't quite know how to incorporate the paragraph about the Cycles ([RFC](https://github.com/emberjs/rfcs/blob/7404b446087374c38c342af9ae08d8ed12065ce6/text/0566-memo-decorator.md)), it seemed very 'internal API', so I left it out for now.
- Since the decorator was added in 4.1, should the PR land on other branches after the merge on the master branch ?
- Is there any other files to update or stuff to do after the merge ? Notably [the code of the decorator](https://github.com/emberjs/ember.js/blob/d8f82663599cdced3f51a5b6b0e73308b640fc8c/packages/%40ember/-internals/metal/lib/cached.ts) warns that it is duplicated from glimmer, so maybe this piece of documentation should land there aswell ?