### PR TITLE
[BUGFIX release] Make sure the `blueprints-js` folder is published

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "files": [
     "build-metadata.json",
     "blueprints",
+    "blueprints-js",
     "dist/packages",
     "dist/dependencies",
     "dist/header",


### PR DESCRIPTION
This folder is needed to generate plain JS files:
https://github.com/emberjs/ember.js/blob/master/blueprints/-maybe-polyfill-typescript-blueprints.js#L14-L15

Closes #20081.