### PR TITLE
Application class: convert docs to ES6 syntax

### DIFF
--- a/packages/@ember/application/lib/application.ts
+++ b/packages/@ember/application/lib/application.ts
@@ -43,11 +43,11 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
   initialized.
 
   ```app/app.js
-  const App = Application.extend({
+  export default class App extends Application {
     ready() {
       // your code here
     }
-  })
+  }
   ```
 
   Because `Application` ultimately inherits from `Ember.Namespace`, any classes
@@ -84,12 +84,12 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
   ```app/app.js
   import Application from '@ember/application';
 
-  let App = Application.extend({
-    customEvents: {
+  export default class App extends Application {
+    customEvents = {
       // add support for the paste event
       paste: 'paste'
     }
-  });
+  }
   ```
 
   To prevent Ember from setting up a listener for a default event,
@@ -99,13 +99,13 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
   ```app/app.js
   import Application from '@ember/application';
 
-  let App = Application.extend({
-    customEvents: {
+  export default class App extends Application {
+    customEvents = {
       // prevent listeners for mouseenter/mouseleave events
       mouseenter: null,
       mouseleave: null
     }
-  });
+  }
   ```
 
   By default, the application sets up these event listeners on the document
@@ -119,9 +119,9 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
   ```app/app.js
   import Application from '@ember/application';
 
-  let App = Application.extend({
-    rootElement: '#ember-app'
-  });
+  export default class App extends Application {
+    rootElement = '#ember-app'
+  }
   ```
 
   The `rootElement` can be either a DOM element or a CSS selector


### PR DESCRIPTION
I think we could update the docs on the `Application` class to ES6 syntax. Although, I believe the docs are not wrong and you still can `.extend()` but having ES6 syntax would make it more modern and be in line with the current blueprint: https://github.com/ember-cli/ember-cli/blob/v4.4.0/blueprints/app/files/app/app.js