### PR TITLE
[BUGFIX release] Fix generated import paths for test setup functions in addons

### DIFF
--- a/blueprints-js/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints-js/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { setupApplicationTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupApplicationTest } from '<%= modulePrefix %>/tests/helpers';
 import { visit, currentURL } from '@ember/test-helpers';
 
 describe('<%= friendlyTestName %>', function () {

--- a/blueprints-js/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
+++ b/blueprints-js/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupApplicationTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestName %>', function (hooks) {
   setupApplicationTest(hooks);

--- a/blueprints-js/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,6 +1,6 @@
 <% if (testType === 'integration') { %>import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
@@ -26,7 +26,7 @@ describe('<%= friendlyTestDescription %>', function () {
   });
 });<% } else if (testType === 'unit') { %>import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 describe('<%= friendlyTestDescription %>', function () {
   setupTest();

--- a/blueprints-js/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,5 +1,5 @@
 <% if (testType === 'integration') { %>import { module, test } from 'qunit';
-import { setupRenderingTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
@@ -24,7 +24,7 @@ module('<%= friendlyTestDescription %>', function (hooks) {
     assert.dom(this.element).hasText('template block text');
   });
 });<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints-js/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints-js/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 describe('<%= friendlyTestDescription %>', function () {
   setupTest();

--- a/blueprints-js/route-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/route-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints-js/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints/-utils.js
+++ b/blueprints/-utils.js
@@ -1,0 +1,9 @@
+const { dasherize } = require('ember-cli-string-utils');
+
+function modulePrefixForProject(project) {
+  return dasherize(project.config().modulePrefix);
+}
+
+module.exports = {
+  modulePrefixForProject,
+};

--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -6,6 +6,7 @@ const pathUtil = require('ember-cli-path-utils');
 const stringUtils = require('ember-cli-string-utils');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
@@ -35,7 +36,8 @@ module.exports = useTestFrameworkDetector({
     ].join(' | ');
 
     return {
-      testFolderRoot: testFolderRoot,
+      modulePrefix: modulePrefixForProject(options.project),
+      testFolderRoot,
       friendlyTestName,
       destroyAppExists,
     };

--- a/blueprints/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.ts
+++ b/blueprints/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { setupApplicationTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupApplicationTest } from '<%= modulePrefix %>/tests/helpers';
 import { visit, currentURL } from '@ember/test-helpers';
 
 describe('<%= friendlyTestName %>', function () {

--- a/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.ts
+++ b/blueprints/acceptance-test/qunit-rfc-232-files/tests/acceptance/__name__-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupApplicationTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestName %>', function (hooks) {
   setupApplicationTest(hooks);

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -7,6 +7,7 @@ const getPathOption = require('ember-cli-get-component-path-option');
 const semver = require('semver');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 function invocationFor(options) {
@@ -81,6 +82,7 @@ module.exports = useTestFrameworkDetector({
     let selfCloseComponent = (descriptor) => `<${descriptor} />`;
 
     return {
+      modulePrefix: modulePrefixForProject(options.project),
       path: getPathOption(options),
       testType: testType,
       componentName,

--- a/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,6 +1,6 @@
 <% if (testType === 'integration') { %>import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
@@ -26,7 +26,7 @@ describe('<%= friendlyTestDescription %>', function () {
   });
 });<% } else if (testType === 'unit') { %>import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 describe('<%= friendlyTestDescription %>', function () {
   setupTest();

--- a/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,5 +1,5 @@
 <% if (testType === 'integration') { %>import { module, test } from 'qunit';
-import { setupRenderingTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 
@@ -24,7 +24,7 @@ module('<%= friendlyTestDescription %>', function (hooks) {
     assert.dom(this.element).hasText('template block text');
   });
 });<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -6,6 +6,7 @@ const useTestFrameworkDetector = require('../test-framework-detector');
 const path = require('path');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a controller unit test.',
@@ -22,6 +23,7 @@ module.exports = useTestFrameworkDetector({
     let controllerPathName = dasherizedModuleName;
 
     return {
+      modulePrefix: modulePrefixForProject(options.project),
       controllerPathName: controllerPathName,
       friendlyTestDescription: ['Unit', 'Controller', dasherizedModuleName].join(' | '),
     };

--- a/blueprints/controller-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/controller-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 describe('<%= friendlyTestDescription %>', function () {
   setupTest();

--- a/blueprints/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/controller-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const stringUtils = require('ember-cli-string-utils');
 const isPackageMissing = require('ember-cli-is-package-missing');
 const semver = require('semver');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
 
@@ -34,15 +34,14 @@ module.exports = useTestFrameworkDetector({
 
   locals: function (options) {
     let friendlyTestName = ['Integration', 'Helper', options.entity.name].join(' | ');
-    let dasherizedModulePrefix = stringUtils.dasherize(options.project.config().modulePrefix);
 
     let hbsImportStatement = this._useNamedHbsImport()
       ? "import { hbs } from 'ember-cli-htmlbars';"
       : "import hbs from 'htmlbars-inline-precompile';";
 
     return {
+      modulePrefix: modulePrefixForProject(options.project),
       friendlyTestName,
-      dasherizedModulePrefix,
       hbsImportStatement,
     };
   },

--- a/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.ts
+++ b/blueprints/helper-test/mocha-rfc-232-files/__root__/__testType__/__collection__/__name__-test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 

--- a/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.ts
+++ b/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/__collection__/__name__-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
 import { render } from '@ember/test-helpers';
 <%= hbsImportStatement %>
 

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -5,6 +5,7 @@ const stringUtil = require('ember-cli-string-utils');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 
 module.exports = useTestFrameworkDetector({
   description: 'Generates a route unit test.',
@@ -57,6 +58,7 @@ module.exports = useTestFrameworkDetector({
     }
 
     return {
+      modulePrefix: modulePrefixForProject(options.project),
       friendlyTestDescription: ['Unit', 'Route', options.entity.name].join(' | '),
       moduleName: stringUtil.dasherize(moduleName),
     };

--- a/blueprints/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 describe('<%= friendlyTestDescription %>', function () {
   setupTest();

--- a/blueprints/route-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/route-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
@@ -26,6 +27,7 @@ module.exports = useTestFrameworkDetector({
 
   locals(options) {
     return {
+      modulePrefix: modulePrefixForProject(options.project),
       friendlyTestDescription: ['Unit', 'Service', options.entity.name].join(' | '),
     };
   },

--- a/blueprints/service-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/service-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 describe('<%= friendlyTestDescription %>', function () {
   setupTest();

--- a/blueprints/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/service-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from '<%= dasherizedPackageName %>/tests/helpers';
+import { setupTest } from '<%= modulePrefix %>/tests/helpers';
 
 module('<%= friendlyTestDescription %>', function (hooks) {
   setupTest(hooks);

--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -144,5 +144,23 @@ describe('Blueprint: acceptance-test', function () {
         });
       });
     });
+
+    describe('with ember-mocha@0.16.2', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.16.2');
+      });
+
+      it('acceptance-test foo', function () {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], (_file) => {
+          expect(_file('tests/acceptance/foo-test.js')).to.equal(
+            fixture('acceptance-test/mocha-rfc268-addon.js')
+          );
+        });
+      });
+    });
   });
 });

--- a/node-tests/blueprints/component-test-test.js
+++ b/node-tests/blueprints/component-test-test.js
@@ -193,43 +193,90 @@ describe('Blueprint: component-test', function () {
 
   describe('in addon', function () {
     beforeEach(function () {
-      return emberNew({ target: 'addon' })
-        .then(() =>
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ])
-        )
-        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
+      return emberNew({ target: 'addon' });
     });
 
-    it('component-test x-foo', function () {
-      return emberGenerateDestroy(['component-test', 'x-foo'], (_file) => {
-        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
-          fixture('component-test/default.js')
-        );
+    describe('with ember-cli-qunit@4.1.0', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
 
-        expect(_file('app/component-test/x-foo.js')).to.not.exist;
+      it('component-test x-foo', function () {
+        return emberGenerateDestroy(['component-test', 'x-foo'], (_file) => {
+          expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+            fixture('component-test/default.js')
+          );
+
+          expect(_file('app/component-test/x-foo.js')).to.not.exist;
+        });
+      });
+
+      it('component-test x-foo --unit', function () {
+        return emberGenerateDestroy(['component-test', 'x-foo', '--unit'], (_file) => {
+          expect(_file('tests/unit/components/x-foo-test.js')).to.equal(
+            fixture('component-test/unit.js')
+          );
+
+          expect(_file('app/component-test/x-foo.js')).to.not.exist;
+        });
+      });
+
+      it('component-test x-foo --dummy', function () {
+        return emberGenerateDestroy(['component-test', 'x-foo', '--dummy'], (_file) => {
+          expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
+            fixture('component-test/default.js')
+          );
+
+          expect(_file('app/component-test/x-foo.js')).to.not.exist;
+        });
       });
     });
 
-    it('component-test x-foo --unit', function () {
-      return emberGenerateDestroy(['component-test', 'x-foo', '--unit'], (_file) => {
-        expect(_file('tests/unit/components/x-foo-test.js')).to.equal(
-          fixture('component-test/unit.js')
-        );
+    describe('with ember-qunit (default)', function () {
+      it('component-test foo', function () {
+        return emberGenerateDestroy(['component-test', 'foo'], (_file) => {
+          expect(_file('tests/integration/components/foo-test.js')).to.equal(
+            fixture('component-test/rfc232-addon.js')
+          );
+        });
+      });
 
-        expect(_file('app/component-test/x-foo.js')).to.not.exist;
+      it('component-test foo --unit', function () {
+        return emberGenerateDestroy(['component-test', 'foo', '--unit'], (_file) => {
+          expect(_file('tests/unit/components/foo-test.js')).to.equal(
+            fixture('component-test/rfc232-unit-addon.js')
+          );
+        });
       });
     });
 
-    it('component-test x-foo --dummy', function () {
-      return emberGenerateDestroy(['component-test', 'x-foo', '--dummy'], (_file) => {
-        expect(_file('tests/integration/components/x-foo-test.js')).to.equal(
-          fixture('component-test/default.js')
-        );
+    describe('with ember-mocha@0.16.2', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.16.2');
+      });
 
-        expect(_file('app/component-test/x-foo.js')).to.not.exist;
+      it('component-test foo', function () {
+        return emberGenerateDestroy(['component-test', 'foo'], (_file) => {
+          expect(_file('tests/integration/components/foo-test.js')).to.equal(
+            fixture('component-test/mocha-rfc232-addon.js')
+          );
+        });
+      });
+
+      it('component-test foo --unit', function () {
+        return emberGenerateDestroy(['component-test', 'foo', '--unit'], (_file) => {
+          expect(_file('tests/unit/components/foo-test.js')).to.equal(
+            fixture('component-test/mocha-rfc232-unit-addon.js')
+          );
+        });
       });
     });
   });

--- a/node-tests/blueprints/controller-test-test.js
+++ b/node-tests/blueprints/controller-test-test.js
@@ -153,29 +153,60 @@ describe('Blueprint: controller-test', function () {
 
   describe('in addon', function () {
     beforeEach(function () {
-      return emberNew({ target: 'addon' })
-        .then(() =>
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ])
-        )
-        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
+      return emberNew({ target: 'addon' });
     });
 
-    it('controller-test foo', function () {
-      return emberGenerateDestroy(['controller-test', 'foo'], (_file) => {
-        expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
-          fixture('controller-test/default.js')
-        );
+    describe('with ember-cli-qunit@4.1.0', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('controller-test foo', function () {
+        return emberGenerateDestroy(['controller-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+            fixture('controller-test/default.js')
+          );
+        });
+      });
+
+      it('controller-test foo/bar', function () {
+        return emberGenerateDestroy(['controller-test', 'foo/bar'], (_file) => {
+          expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
+            fixture('controller-test/default-nested.js')
+          );
+        });
       });
     });
 
-    it('controller-test foo/bar', function () {
-      return emberGenerateDestroy(['controller-test', 'foo/bar'], (_file) => {
-        expect(_file('tests/unit/controllers/foo/bar-test.js')).to.equal(
-          fixture('controller-test/default-nested.js')
-        );
+    describe('with ember-qunit (default)', function () {
+      it('controller-test foo', function () {
+        return emberGenerateDestroy(['controller-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+            fixture('controller-test/rfc232-addon.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.16.2', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.16.2');
+      });
+
+      it('controller-test foo', function () {
+        return emberGenerateDestroy(['controller-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/controllers/foo-test.js')).to.equal(
+            fixture('controller-test/mocha-rfc232-addon.js')
+          );
+        });
       });
     });
   });

--- a/node-tests/blueprints/helper-test-test.js
+++ b/node-tests/blueprints/helper-test-test.js
@@ -121,20 +121,52 @@ describe('Blueprint: helper-test', function () {
 
   describe('in addon', function () {
     beforeEach(function () {
-      return emberNew({ target: 'addon' }).then(() => {
+      return emberNew({ target: 'addon' });
+    });
+
+    describe('with ember-cli-qunit@4.1.0', function () {
+      beforeEach(function () {
         modifyPackages([
           { name: 'ember-qunit', delete: true },
           { name: 'ember-cli-qunit', dev: true },
         ]);
         generateFakePackageManifest('ember-cli-qunit', '4.1.0');
       });
+
+      it('helper-test foo/bar-baz', function () {
+        return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], (_file) => {
+          expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
+            fixture('helper-test/integration.js')
+          );
+        });
+      });
     });
 
-    it('helper-test foo/bar-baz', function () {
-      return emberGenerateDestroy(['helper-test', 'foo/bar-baz'], (_file) => {
-        expect(_file('tests/integration/helpers/foo/bar-baz-test.js')).to.equal(
-          fixture('helper-test/integration.js')
-        );
+    describe('with ember-qunit (default)', function () {
+      it('helper-test foo', function () {
+        return emberGenerateDestroy(['helper-test', 'foo'], (_file) => {
+          expect(_file('tests/integration/helpers/foo-test.js')).to.equal(
+            fixture('helper-test/rfc232-addon.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.16.2', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.16.2');
+      });
+
+      it('helper-test foo', function () {
+        return emberGenerateDestroy(['helper-test', 'foo'], (_file) => {
+          expect(_file('tests/integration/helpers/foo-test.js')).to.equal(
+            fixture('helper-test/mocha-rfc232-addon.js')
+          );
+        });
       });
     });
   });

--- a/node-tests/blueprints/route-test-test.js
+++ b/node-tests/blueprints/route-test-test.js
@@ -107,19 +107,50 @@ describe('Blueprint: route-test', function () {
 
   describe('in addon', function () {
     beforeEach(function () {
-      return emberNew({ target: 'addon' })
-        .then(() =>
-          modifyPackages([
-            { name: 'ember-qunit', delete: true },
-            { name: 'ember-cli-qunit', dev: true },
-          ])
-        )
-        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
+      return emberNew({ target: 'addon' });
     });
 
-    it('route-test foo', function () {
-      return emberGenerateDestroy(['route-test', 'foo'], (_file) => {
-        expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+    describe('with ember-cli-qunit@4.1.0', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-cli-qunit', dev: true },
+        ]);
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('route-test foo', function () {
+        return emberGenerateDestroy(['route-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/routes/foo-test.js')).to.equal(fixture('route-test/default.js'));
+        });
+      });
+    });
+
+    describe('with ember-qunit (default)', function () {
+      it('route-test foo', function () {
+        return emberGenerateDestroy(['route-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/routes/foo-test.js')).to.equal(
+            fixture('route-test/rfc232-addon.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.16.2', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.16.2');
+      });
+
+      it('route-test foo', function () {
+        return emberGenerateDestroy(['route-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/routes/foo-test.js')).to.equal(
+            fixture('route-test/mocha-rfc232-addon.js')
+          );
+        });
       });
     });
   });

--- a/node-tests/blueprints/service-test-test.js
+++ b/node-tests/blueprints/service-test-test.js
@@ -151,5 +151,33 @@ describe('Blueprint: service-test', function () {
         });
       });
     });
+
+    describe('with ember-qunit (default)', function () {
+      it('service-test foo', function () {
+        return emberGenerateDestroy(['service-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/services/foo-test.js')).to.equal(
+            fixture('service-test/rfc232-addon.js')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.16.2', function () {
+      beforeEach(function () {
+        modifyPackages([
+          { name: 'ember-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.16.2');
+      });
+
+      it('service-test foo', function () {
+        return emberGenerateDestroy(['service-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/services/foo-test.js')).to.equal(
+            fixture('service-test/mocha-rfc232-addon.js')
+          );
+        });
+      });
+    });
   });
 });

--- a/node-tests/fixtures/acceptance-test/mocha-rfc268-addon.js
+++ b/node-tests/fixtures/acceptance-test/mocha-rfc268-addon.js
@@ -1,0 +1,13 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { visit, currentURL } from '@ember/test-helpers';
+
+describe('Acceptance | foo', function () {
+  setupApplicationTest();
+
+  it('can visit /foo', async function () {
+    await visit('/foo');
+    expect(currentURL()).to.equal('/foo');
+  });
+});

--- a/node-tests/fixtures/acceptance-test/qunit-rfc268-addon.js
+++ b/node-tests/fixtures/acceptance-test/qunit-rfc268-addon.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'my-addon/tests/helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 
 module('Acceptance | foo', function (hooks) {
   setupApplicationTest(hooks);

--- a/node-tests/fixtures/component-test/mocha-rfc232-addon.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232-addon.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | foo', function () {
+  setupRenderingTest();
+
+  it('renders', async function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Foo />`);
+
+    expect(this.element.textContent.trim()).to.equal('');
+
+    // Template block usage:
+    await render(hbs`
+      <Foo>
+        template block text
+      </Foo>
+    `);
+
+    expect(this.element.textContent.trim()).to.equal('template block text');
+  });
+});

--- a/node-tests/fixtures/component-test/mocha-rfc232-unit-addon.js
+++ b/node-tests/fixtures/component-test/mocha-rfc232-unit-addon.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'dummy/tests/helpers';
+
+describe('Unit | Component | foo', function () {
+  setupTest();
+
+  it('exists', function () {
+    let component = this.owner.factoryFor('component:foo').create();
+    expect(component).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/component-test/rfc232-addon.js
+++ b/node-tests/fixtures/component-test/rfc232-addon.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | foo', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Foo />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Foo>
+        template block text
+      </Foo>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/node-tests/fixtures/component-test/rfc232-unit-addon.js
+++ b/node-tests/fixtures/component-test/rfc232-unit-addon.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Component | foo', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let component = this.owner.factoryFor('component:foo').create();
+    assert.ok(component);
+  });
+});

--- a/node-tests/fixtures/controller-test/mocha-rfc232-addon.js
+++ b/node-tests/fixtures/controller-test/mocha-rfc232-addon.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= modulePrefix %>/tests/helpers';
+import { setupTest } from 'dummy/tests/helpers';
 
-describe('<%= friendlyTestDescription %>', function () {
+describe('Unit | Controller | foo', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
   it('exists', function () {
-    let controller = this.owner.lookup('controller:<%= controllerPathName %>');
+    let controller = this.owner.lookup('controller:foo');
     expect(controller).to.be.ok;
   });
 });

--- a/node-tests/fixtures/controller-test/rfc232-addon.js
+++ b/node-tests/fixtures/controller-test/rfc232-addon.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Controller | foo', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:foo');
+    assert.ok(controller);
+  });
+});

--- a/node-tests/fixtures/helper-test/mocha-rfc232-addon.js
+++ b/node-tests/fixtures/helper-test/mocha-rfc232-addon.js
@@ -1,17 +1,17 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { render } from '@ember/test-helpers';
-<%= hbsImportStatement %>
+import hbs from 'htmlbars-inline-precompile';
 
-describe('<%= friendlyTestName %>', function () {
+describe('Integration | Helper | foo', function () {
   setupRenderingTest();
 
   // TODO: Replace this with your real tests.
   it('renders', async function () {
     this.set('inputValue', '1234');
 
-    await render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);
+    await render(hbs`{{foo this.inputValue}}`);
 
     expect(this.element.textContent.trim()).to.equal('1234');
   });

--- a/node-tests/fixtures/helper-test/rfc232-addon.js
+++ b/node-tests/fixtures/helper-test/rfc232-addon.js
@@ -1,16 +1,16 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from '<%= modulePrefix %>/tests/helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { render } from '@ember/test-helpers';
-<%= hbsImportStatement %>
+import hbs from 'htmlbars-inline-precompile';
 
-module('<%= friendlyTestName %>', function (hooks) {
+module('Integration | Helper | foo', function (hooks) {
   setupRenderingTest(hooks);
 
   // TODO: Replace this with your real tests.
   test('it renders', async function (assert) {
     this.set('inputValue', '1234');
 
-    await render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);
+    await render(hbs`{{foo this.inputValue}}`);
 
     assert.dom(this.element).hasText('1234');
   });

--- a/node-tests/fixtures/route-test/mocha-rfc232-addon.js
+++ b/node-tests/fixtures/route-test/mocha-rfc232-addon.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'dummy/tests/helpers';
+
+describe('Unit | Route | foo', function () {
+  setupTest();
+
+  it('exists', function () {
+    let route = this.owner.lookup('route:foo');
+    expect(route).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/route-test/rfc232-addon.js
+++ b/node-tests/fixtures/route-test/rfc232-addon.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Route | foo', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:foo');
+    assert.ok(route);
+  });
+});

--- a/node-tests/fixtures/service-test/mocha-rfc232-addon.js
+++ b/node-tests/fixtures/service-test/mocha-rfc232-addon.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { setupTest } from '<%= modulePrefix %>/tests/helpers';
+import { setupTest } from 'dummy/tests/helpers';
 
-describe('<%= friendlyTestDescription %>', function () {
+describe('Unit | Service | foo', function () {
   setupTest();
 
   // TODO: Replace this with your real tests.
   it('exists', function () {
-    let service = this.owner.lookup('service:<%= dasherizedModuleName %>');
+    let service = this.owner.lookup('service:foo');
     expect(service).to.be.ok;
   });
 });

--- a/node-tests/fixtures/service-test/rfc232-addon.js
+++ b/node-tests/fixtures/service-test/rfc232-addon.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Service | foo', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:foo');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
I introduced a regression when implementing https://github.com/emberjs/ember.js/pull/19981.
The project's module prefix should be used instead of the addon's package name when generating these import paths, as these test setup functions are _not_ located in the addon's `addon` folder, but in `/tests/helpers/index.js`.

When approved, I will implement the same fix over in Ember Data.

Closes #20110.