### PR TITLE
Consistent determination of `modulePrefix` in blueprints

### DIFF
--- a/blueprints-js/util-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints-js/util-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -1,4 +1,4 @@
-import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
+import <%= camelizedModuleName %> from '<%= modulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');

--- a/blueprints-js/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
+++ b/blueprints-js/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.js
@@ -1,4 +1,4 @@
-import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
+import <%= camelizedModuleName %> from '<%= modulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>', function () {

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -2,9 +2,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const stringUtils = require('ember-cli-string-utils');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
@@ -29,10 +29,9 @@ module.exports = useTestFrameworkDetector({
   },
 
   locals: function (options) {
-    let modulePrefix = stringUtils.dasherize(options.project.config().modulePrefix);
     return {
       friendlyTestName: ['Unit', 'Initializer', options.entity.name].join(' | '),
-      modulePrefix,
+      modulePrefix: modulePrefixForProject(options.project),
       destroyAppExists: fs.existsSync(
         path.join(this.project.root, '/tests/helpers/destroy-app.js')
       ),

--- a/blueprints/instance-initializer-test/index.js
+++ b/blueprints/instance-initializer-test/index.js
@@ -2,9 +2,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const stringUtils = require('ember-cli-string-utils');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
@@ -28,11 +28,9 @@ module.exports = useTestFrameworkDetector({
     };
   },
   locals: function (options) {
-    let modulePrefix = stringUtils.dasherize(options.project.config().modulePrefix);
-
     return {
       friendlyTestName: ['Unit', 'Instance Initializer', options.entity.name].join(' | '),
-      modulePrefix,
+      modulePrefix: modulePrefixForProject(options.project),
       destroyAppExists: fs.existsSync(
         path.join(this.project.root, '/tests/helpers/destroy-app.js')
       ),

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const stringUtils = require('ember-cli-string-utils');
 const path = require('path');
 
 const maybePolyfillTypeScriptBlueprints = require('../-maybe-polyfill-typescript-blueprints');
+const { modulePrefixForProject } = require('../-utils');
 const useTestFrameworkDetector = require('../test-framework-detector');
 
 module.exports = useTestFrameworkDetector({
@@ -30,7 +30,7 @@ module.exports = useTestFrameworkDetector({
   locals: function (options) {
     return {
       friendlyTestName: ['Unit', 'Utility', options.entity.name].join(' | '),
-      dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix),
+      modulePrefix: modulePrefixForProject(options.project),
     };
   },
 });

--- a/blueprints/util-test/qunit-files/__root__/__testType__/__name__-test.js
+++ b/blueprints/util-test/qunit-files/__root__/__testType__/__name__-test.js
@@ -1,4 +1,4 @@
-import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
+import <%= camelizedModuleName %> from '<%= modulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>');

--- a/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.ts
+++ b/blueprints/util-test/qunit-rfc-232-files/__root__/__testType__/__name__-test.ts
@@ -1,4 +1,4 @@
-import <%= camelizedModuleName %> from '<%= dasherizedModulePrefix %>/utils/<%= dasherizedModuleName %>';
+import <%= camelizedModuleName %> from '<%= modulePrefix %>/utils/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>', function () {


### PR DESCRIPTION
Addresses https://github.com/emberjs/ember.js/pull/20114#issuecomment-1152960129.

Use the new util introduced in https://github.com/emberjs/ember.js/pull/20114 for determining the `modulePrefix` in all blueprints.

/cc @kategengler.