### PR TITLE
[CLEANUP beta] Replace deprecated substr() method with substring() method

### DIFF
--- a/packages/@ember/-internals/metal/lib/chain-tags.ts
+++ b/packages/@ember/-internals/metal/lib/chain-tags.ts
@@ -182,7 +182,7 @@ function getChainTags(
       } else {
         // use metaFor here to ensure we have the meta for the instance
         let lazyChains = instanceMeta.writableLazyChainsFor(segment);
-        let rest = path.substr(segmentEnd + 1);
+        let rest = path.substring(segmentEnd + 1);
 
         let placeholderTag = createUpdatableTag();
 

--- a/packages/@ember/-internals/routing/lib/location/auto_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/auto_location.ts
@@ -275,7 +275,7 @@ function detectImplementation(options: DetectionOptions) {
     // the history location with no redirects.
     if (currentPath === historyPath) {
       implementation = 'history';
-    } else if (currentPath.substr(0, 2) === '/#') {
+    } else if (currentPath.substring(0, 2) === '/#') {
       history.replaceState({ path: historyPath }, '', historyPath);
       implementation = 'history';
     } else {
@@ -326,16 +326,16 @@ export function getHistoryPath(rootURL: string, location: Location): string {
   // By convention, Ember.js routes using HashLocation are required to start
   // with `#/`. Anything else should NOT be considered a route and should
   // be passed straight through, without transformation.
-  if (hash.substr(0, 2) === '#/') {
+  if (hash.substring(0, 2) === '#/') {
     // There could be extra hash segments after the route
-    hashParts = hash.substr(1).split('#');
+    hashParts = hash.substring(1).split('#');
     // The first one is always the route url
     routeHash = hashParts.shift() as string;
 
     // If the path already has a trailing slash, remove the one
     // from the hashed route so we don't double up.
     if (path.charAt(path.length - 1) === '/') {
-      routeHash = routeHash.substr(1);
+      routeHash = routeHash.substring(1);
     }
 
     // This is the "expected" final order
@@ -362,7 +362,7 @@ export function getHistoryPath(rootURL: string, location: Location): string {
 export function getHashPath(rootURL: string, location: Location): string {
   let path = rootURL;
   let historyPath = getHistoryPath(rootURL, location);
-  let routePath = historyPath.substr(rootURL.length);
+  let routePath = historyPath.substring(rootURL.length);
 
   if (routePath !== '') {
     if (routePath[0] !== '/') {

--- a/packages/@ember/-internals/routing/lib/location/hash_location.ts
+++ b/packages/@ember/-internals/routing/lib/location/hash_location.ts
@@ -72,7 +72,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
     @method getURL
   */
   getURL(): string {
-    let originalPath = this.getHash().substr(1);
+    let originalPath = this.getHash().substring(1);
     let outPath = originalPath;
 
     if (outPath[0] !== '/') {

--- a/packages/@ember/-internals/routing/lib/location/util.ts
+++ b/packages/@ember/-internals/routing/lib/location/util.ts
@@ -29,7 +29,7 @@ export function getQuery(location: Location): string {
 */
 export function getHash(location: Location): string {
   if (location.hash !== undefined) {
-    return location.hash.substr(0);
+    return location.hash.substring(0);
   }
 
   return '';

--- a/packages/@ember/-internals/routing/lib/services/router.ts
+++ b/packages/@ember/-internals/routing/lib/services/router.ts
@@ -18,7 +18,7 @@ function cleanURL(url: string, rootURL: string) {
     return url;
   }
 
-  return url.substr(rootURL.length, url.length);
+  return url.substring(rootURL.length);
 }
 
 /**

--- a/packages/@ember/-internals/routing/lib/utils.ts
+++ b/packages/@ember/-internals/routing/lib/utils.ts
@@ -153,7 +153,7 @@ export function calculateCacheKey(prefix: string, parts: string[] = [], values: 
     if (values) {
       if (cacheValuePrefix && cacheValuePrefix in values) {
         let partRemovedPrefix =
-          part.indexOf(cacheValuePrefix) === 0 ? part.substr(cacheValuePrefix.length + 1) : part;
+          part.indexOf(cacheValuePrefix) === 0 ? part.substring(cacheValuePrefix.length + 1) : part;
         value = get((values as any)[cacheValuePrefix], partRemovedPrefix);
       } else {
         value = get(values, part);

--- a/packages/ember-template-compiler/lib/plugins/assert-against-attrs.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-against-attrs.ts
@@ -56,7 +56,7 @@ export default function assertAgainstAttrs(env: EmberASTPluginEnvironment): ASTP
 
       PathExpression(node: AST.PathExpression): AST.Node | void {
         if (isAttrs(node, stack[stack.length - 1]!)) {
-          let path = b.path(node.original.substr(6));
+          let path = b.path(node.original.substring(6));
 
           assert(
             `Using {{attrs}} to reference named arguments is not supported. {{attrs.${


### PR DESCRIPTION
Replaced all implementations of deprecated String.prototype.substr() method with String.prototype.substring() method.