### PR TITLE
Replacing Firefox detection using InstallTrigger resolves #20098

### DIFF
--- a/packages/@ember/-internals/browser-environment/index.ts
+++ b/packages/@ember/-internals/browser-environment/index.ts
@@ -1,6 +1,5 @@
 import hasDom from './lib/has-dom';
 
-declare const InstallTrigger: unknown;
 declare const chrome: unknown;
 declare const opera: unknown;
 declare const MSInputMethodContext: unknown;
@@ -12,7 +11,7 @@ export const location = hasDom ? self.location : null;
 export const history = hasDom ? self.history : null;
 export const userAgent = hasDom ? self.navigator.userAgent : 'Lynx (textmode)';
 export const isChrome = hasDom ? typeof chrome === 'object' && !(typeof opera === 'object') : false;
-export const isFirefox = hasDom ? typeof InstallTrigger !== 'undefined' : false;
+export const isFirefox = hasDom ? /Firefox|FxiOS/.test(userAgent) : false;
 export const isIE = hasDom
   ? typeof MSInputMethodContext !== 'undefined' && typeof documentMode !== 'undefined'
   : false;


### PR DESCRIPTION
Deprecated InstallTrigger was used to detect Firefox. Replaced it with regex based UA detection using suggestion from here https://bugzilla.mozilla.org/show_bug.cgi?id=1754441#c30