### PR TITLE
[bug] TypeWatcher invoking itself during onChange

### DIFF
--- a/packages/@ember/debug/data-adapter.ts
+++ b/packages/@ember/debug/data-adapter.ts
@@ -1,6 +1,6 @@
 import type { Owner } from '@ember/-internals/owner';
 import { getOwner } from '@ember/-internals/owner';
-import { _backburner } from '@ember/runloop';
+import { _backburner, next } from '@ember/runloop';
 import { get } from '@ember/object';
 import { dasherize } from '@ember/string';
 import Namespace from '@ember/application/namespace';
@@ -141,7 +141,7 @@ class TypeWatcher {
       consumeTag(tagFor(records, '[]'));
 
       if (hasBeenAccessed === true) {
-        onChange();
+        next(onChange);
       } else {
         hasBeenAccessed = true;
       }


### PR DESCRIPTION
When using ember inspector and loading data through api it can cause a tracking assertion for [] and also ["Assertion Failed: Illegal set of identifier"](https://github.com/emberjs/ember-inspector/issues/1875#)

this happens when the type is first found and has new data. the type watcher will call onChange immediately, which calls this.wrapModelType  then this.getRecords and then ember data does an internal sync again which causes this issue.

similar issue here: https://github.com/emberjs/data/issues/8006

also fixes https://github.com/emberjs/ember-inspector/issues/1875