### PR TITLE
[BUGFIX LTS] Fix mixin merging with getters

### DIFF
--- a/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
@@ -1,0 +1,35 @@
+import EmberObject from '@ember/object';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'runtime: Mixin Accessors',
+  class extends RenderingTestCase {
+    ['@test works with getters'](assert) {
+      let Base = EmberObject.extend({
+        get foo() {
+          throw new Error('base-foo getter');
+        },
+      });
+
+      Base.proto();
+
+      class Zebra extends Base {
+        get foo() {
+          throw new Error('zebra-foo getter');
+        }
+      }
+
+      Zebra.proto();
+
+      let Final = Zebra.extend({
+        get foo() {
+          throw new Error('final-foo getter');
+        },
+      });
+
+      Final.create();
+
+      assert.ok(true, 'no error thrown while merging mixin with getter');
+    }
+  }
+);


### PR DESCRIPTION
Our handling of getters and setters works correctly for cases where we have only classic classes, or only native classes, or native classes extending classic classes. In some cases, however, it fails when we have "zebra-striping" of class types, with a classic class extending a native class which extends a (stack of) classic class(es). We correctly handle native getters in mixin and POJOs passed to `.extend()`, but—quite reasonably—do *not* handle getters on native classes when calling `.extend(SomeNativeClass)`. The result is that those getters are not decorated the way they are in mixins, so mixin merging ends up invoking the getter rather than defining a decorator which returns it.

Fixes #18860