### PR TITLE
[DOCS] add examples for yield

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -142,6 +142,157 @@
     First name: <input type="text" />
   </label>
   ```
+
+  `yield` can also be used with the `hash` helper:
+
+  ```app/templates/application.hbs
+  <DateRanges @value={{@model.date}} |range|>
+    Start date: {{range.start}}
+    End date: {{range.end}}
+  </DateRanges>
+  ```
+
+  ```app/components/date-ranges.hbs
+  <div>
+    {{yield (hash start=@value.start end=@value.end)}}
+  </div>
+  ```
+
+  Result:
+
+  ```html
+  <div>
+    Start Date: July 1st
+    End Date: July 30th
+  </div>
+  ```
+
+  Multiple values can be yielded as block params:
+
+  ```app/templates/application.hbs
+  <Banner @value={{@model}} |title subtitle body|>
+    <h1>{{title}}</h1>
+    <h2>{{subtitle}}</h2>
+    {{body}}
+  </Banner>
+  ```
+
+  ```app/components/Banner.hbs
+  <div>
+    {{yield "Hello title" "hello subtitle" "body text"}}
+  </div>
+  ```
+
+  Result:
+
+  ```html
+  <div>
+    <h1>Hello title</h1>
+    <h2>hello subtitle</h2>
+    body text
+  </div>
+  ```
+
+  However, it is preferred to use the hash helper, as this can prevent breaking changes to your component and also simplify the api for the component.
+
+  Multiple components can be yielded with the `hash` and `component` helper:
+
+  ```app/templates/application.hbs
+  <Banner @value={{@model}} |banner|>
+    <banner.Title>Banner title</banner.Title>
+    <banner.Subtitle>Banner subtitle</banner.Subtitle>
+    <banner.Body>A load of body text</banner.Body>
+  </Banner>
+  ```
+
+  ```app/components/banner.ts
+  import Title from './title';
+  import Subtitle from './subtitle';
+  import Body from './body';
+
+  export default class Banner extends Component {
+    Title = Title;
+    Subtitle = Subtitle;
+    Body = Body;
+  }
+  ```
+
+  ```app/components/banner.hbs
+  <div>
+    {{yield (hash
+      Title=this.Title
+      Subtitle=this.Subtitle
+      Body=(component this.Body defaultArg="some value")
+    )}}
+  </div>
+  ```
+
+  Result:
+
+  ```html
+  <div>
+    <h1>Banner title</h1>
+    <h2>Banner subtitle</h2>
+    A load of body text
+  </div>
+  ```
+
+  A benefit of using this pattern is that the user of the component can change the order the components are displayed.
+
+  ```app/templates/application.hbs
+  <Banner @value={{@model}} |banner|>
+    <banner.Subtitle>Banner subtitle</banner.Subtitle>
+    <banner.Title>Banner title</banner.Title>
+    <banner.Body>A load of body text</banner.Body>
+  </Banner>
+  ```
+
+  Result:
+
+  ```html
+  <div>
+    <h2>Banner subtitle</h2>
+    <h1>Banner title</h1>
+    A load of body text
+  </div>
+  ```
+
+  Another benefit to using `yield` with the `hash` and `component` helper
+  is you can pass attributes and arguments to these components:
+
+  ```app/templates/application.hbs
+  <Banner @value={{@model}} |banner|>
+    <banner.Subtitle class="mb-1">Banner subtitle</banner.Subtitle>
+    <banner.Title @variant="loud">Banner title</banner.Title>
+    <banner.Body>A load of body text</banner.Body>
+  </Banner>
+  ```
+
+  ```app/components/banner/subtitle.hbs
+  {{!-- note the use of ..attributes --}}
+  <div ...attributes>
+    {{yield}}
+  </div>
+  ```
+
+  ```app/components/banner/title.hbs
+  {{#if @variant "loud"}}
+      <h1 class="loud">{{yield}}</h1>
+  {{else}}
+      <h1 class="quiet">{{yield}}</h1>
+  {{/if}}
+  ```
+
+  Result:
+
+  ```html
+  <div>
+    <h2 class="mb-1">Banner subtitle</h2>
+    <h1 class="loud">Banner title</h1>
+    A load of body text
+  </div>
+  ```
+
   @method yield
   @for Ember.Templates.helpers
   @param {Hash} options

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -162,8 +162,8 @@
 
   ```html
   <div>
-    Start Date: July 1st
-    End Date: July 30th
+    Start date: July 1st
+    End date: July 30th
   </div>
   ```
 
@@ -177,7 +177,7 @@
   </Banner>
   ```
 
-  ```app/components/Banner.hbs
+  ```app/components/banner.hbs
   <div>
     {{yield "Hello title" "hello subtitle" "body text"}}
   </div>
@@ -205,10 +205,10 @@
   </Banner>
   ```
 
-  ```app/components/banner.ts
-  import Title from './title';
-  import Subtitle from './subtitle';
-  import Body from './body';
+  ```app/components/banner.js
+  import Title from './banner/title';
+  import Subtitle from './banner/subtitle';
+  import Body from './banner/body';
 
   export default class Banner extends Component {
     Title = Title;
@@ -270,13 +270,13 @@
 
   ```app/components/banner/subtitle.hbs
   {{!-- note the use of ..attributes --}}
-  <div ...attributes>
+  <h2 ...attributes>
     {{yield}}
-  </div>
+  </h2>
   ```
 
   ```app/components/banner/title.hbs
-  {{#if @variant "loud"}}
+  {{#if (eq @variant "loud")}}
       <h1 class="loud">{{yield}}</h1>
   {{else}}
       <h1 class="quiet">{{yield}}</h1>

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -146,7 +146,7 @@
   `yield` can also be used with the `hash` helper:
 
   ```app/templates/application.hbs
-  <DateRanges @value={{@model.date}} |range|>
+  <DateRanges @value={{@model.date}} as |range|>
     Start date: {{range.start}}
     End date: {{range.end}}
   </DateRanges>
@@ -170,7 +170,7 @@
   Multiple values can be yielded as block params:
 
   ```app/templates/application.hbs
-  <Banner @value={{@model}} |title subtitle body|>
+  <Banner @value={{@model}} as |title subtitle body|>
     <h1>{{title}}</h1>
     <h2>{{subtitle}}</h2>
     {{body}}
@@ -198,7 +198,7 @@
   Multiple components can be yielded with the `hash` and `component` helper:
 
   ```app/templates/application.hbs
-  <Banner @value={{@model}} |banner|>
+  <Banner @value={{@model}} as |banner|>
     <banner.Title>Banner title</banner.Title>
     <banner.Subtitle>Banner subtitle</banner.Subtitle>
     <banner.Body>A load of body text</banner.Body>
@@ -240,7 +240,7 @@
   A benefit of using this pattern is that the user of the component can change the order the components are displayed.
 
   ```app/templates/application.hbs
-  <Banner @value={{@model}} |banner|>
+  <Banner @value={{@model}} as |banner|>
     <banner.Subtitle>Banner subtitle</banner.Subtitle>
     <banner.Title>Banner title</banner.Title>
     <banner.Body>A load of body text</banner.Body>
@@ -261,7 +261,7 @@
   is you can pass attributes and arguments to these components:
 
   ```app/templates/application.hbs
-  <Banner @value={{@model}} |banner|>
+  <Banner @value={{@model}} as |banner|>
     <banner.Subtitle class="mb-1">Banner subtitle</banner.Subtitle>
     <banner.Title @variant="loud">Banner title</banner.Title>
     <banner.Body>A load of body text</banner.Body>


### PR DESCRIPTION
## What changed
Added in more examples for `yield`

https://api.emberjs.com/ember/4.4/classes/Ember.Templates.helpers/methods/yield?anchor=yield

- [x] add yield with hash helper
- [x] add yield with hash and component helper
- [x] add yield for multiple block parameters
- [x] add yield with hash and component helper with attributes and args

## Rationale
Coming from React, yield is a bit of a weird concept. Having more examples of how to use `yield` with `hash` and `component` helpers will help people making components who are coming from another framework and are trying to make more composable components with a small API footprint (more "HTML" like components)

Partly inspired by: https://www.youtube.com/watch?v=uTFxv0kReYk&list=PLRtznLaEWGuf87iG3LZarzyMb24JCX9Pv

- wanted to show that you could use @arguments and attributes
- wanted to show that you could move components around