### PR TITLE
[internal] improve `Cache` types and implementation

### DIFF
--- a/packages/@ember/-internals/metal/lib/path_cache.ts
+++ b/packages/@ember/-internals/metal/lib/path_cache.ts
@@ -2,6 +2,6 @@ import { Cache } from '@ember/-internals/utils';
 
 const firstDotIndexCache = new Cache<string, number>(1000, (key) => key.indexOf('.'));
 
-export function isPath(path: any): boolean {
+export function isPath(path: unknown): boolean {
   return typeof path === 'string' && firstDotIndexCache.get(path) !== -1;
 }

--- a/packages/@ember/-internals/utils/lib/cache.ts
+++ b/packages/@ember/-internals/utils/lib/cache.ts
@@ -3,15 +3,17 @@ export default class Cache<T, V> {
   public misses = 0;
   public hits = 0;
 
-  constructor(private limit: number, private func: (obj: T) => V, private store?: any) {
-    this.store = store || new Map();
-  }
+  constructor(
+    private limit: number,
+    private func: (obj: T) => V,
+    private store: Map<T, V> = new Map()
+  ) {}
 
   get(key: T): V {
     if (this.store.has(key)) {
       this.hits++;
-
-      return this.store.get(key);
+      // SAFETY: we know the value is present because `.has(key)` was `true`.
+      return this.store.get(key) as V;
     } else {
       this.misses++;
       return this.set(key, this.func(key));


### PR DESCRIPTION
I happened to look at this while working on publishing preview types, and noticed that the types here were using a non-null assertion, and switched it to an explicit cast with a `// SAFETY: ...` comment.

Next, use the optional parameter initialization shorthand to make the constructor more clear (a constructor which defines properties *and* has a body is extremely confusing to contributors, including me!) and avoid doing something in the body which the language can do for us, and eliminate an `any` there by defining the type correctly as a `Map`.

Finally, switch one use of `any` to `unknown`, in one of the usage sites for `Cache`.