### PR TITLE
[FEATURE] Use service registry in owner.lookup

### DIFF
--- a/type-tests/preview/@ember/owner-tests.ts
+++ b/type-tests/preview/@ember/owner-tests.ts
@@ -64,6 +64,13 @@ expectTypeOf(owner.lookup('type:name')).toEqualTypeOf<unknown>();
 owner.lookup('non-namespace-string');
 expectTypeOf(owner.lookup('namespace@type:name')).toEqualTypeOf<unknown>();
 
+declare module '@ember/service' {
+  interface Registry {
+    'my-type-test-service': ConstructThis;
+  }
+}
+expectTypeOf(owner.lookup('service:my-type-test-service')).toEqualTypeOf<ConstructThis>();
+
 expectTypeOf(owner.register('type:name', aFactory)).toEqualTypeOf<void>();
 expectTypeOf(owner.register('type:name', aFactory, {})).toEqualTypeOf<void>();
 expectTypeOf(owner.register('type:name', aFactory, { instantiate: true })).toEqualTypeOf<void>();

--- a/types/preview/@ember/owner/index.d.ts
+++ b/types/preview/@ember/owner/index.d.ts
@@ -1,13 +1,12 @@
 declare module '@ember/owner' {
+  import type { Registry } from '@ember/service';
+
   /**
    * The name for a factory consists of a namespace and the name of a specific
    * type within that namespace, like `'service:session'`.
    */
   export type FullName = `${string}:${string}`;
 
-  // TODO: when migrating into Ember proper, evaluate whether we should introduce
-  // a registry which users can provide to resolve known types, so e.g.
-  // `owner.lookup('service:session')` can return the right thing.
   /**
    * Framework objects in an Ember application (components, services, routes,
    * etc.) are created via a factory and dependency injection system. Each of
@@ -18,6 +17,7 @@ declare module '@ember/owner' {
     /**
      * Given a {@linkcode FullName} return a corresponding instance.
      */
+    lookup<Name extends keyof Registry>(fullName: `service:${Name}`): Registry[Name];
     lookup(fullName: FullName): unknown;
 
     /**


### PR DESCRIPTION
This enhances the type of `owner.lookup` so it respects the (already existing) service type registry. This means that `owner.lookup('service:foo')` will have the correct type as long as you do:

```ts
declare module '@ember/service' {
  interface Registry {
    'foo': MyFooService;
  }
}
```

I recognize that this `Registry` might not be the long-term plan, but as long as it's defined and supported by the service injection decorators it seems helpful to also support it in `lookup`.