### PR TITLE
[DOC] moving comment docs to interface methods – `Evented`

### DIFF
--- a/packages/@ember/object/evented.ts
+++ b/packages/@ember/object/evented.ts
@@ -61,6 +61,13 @@ interface Evented {
     be set as the "this" for the callback. This is a good way to give your
     function access to the object triggering the event. When the target
     parameter is used the callback method becomes the third argument.
+
+    @method on
+    @param {String} name The name of the event
+    @param {Object} [target] The "this" binding for the callback
+    @param {Function|String} method A function or the name of a function to be called on `target`
+    @return this
+    @public
   */
   on<Target>(
     name: string,
@@ -76,6 +83,13 @@ interface Evented {
     This function takes an optional 2nd argument that will become the "this"
     value for the callback. When the target parameter is used the callback method
     becomes the third argument.
+
+    @method one
+    @param {String} name The name of the event
+    @param {Object} [target] The "this" binding for the callback
+    @param {Function|String} method A function or the name of a function to be called on `target`
+    @return this
+    @public
   */
   one<Target>(
     name: string,
@@ -97,10 +111,22 @@ interface Evented {
 
     // outputs: person ate some broccoli
     ```
+
+    @method trigger
+    @param {String} name The name of the event
+    @param {Object...} args Optional arguments to pass on
+    @public
   */
   trigger(name: string, ...args: any[]): any;
   /**
     Cancels subscription for given name, target, and method.
+
+    @method off
+    @param {String} name The name of the event
+    @param {Object} target The target of the subscription
+    @param {Function|String} method The function or the name of a function of the subscription
+    @return this
+    @public
   */
   off<Target>(
     name: string,
@@ -110,6 +136,11 @@ interface Evented {
   off(name: string, method: string | ((...args: any[]) => void)): this;
   /**
     Checks to see if object has any subscriptions for named event.
+
+    @method has
+    @param {String} name The name of the event
+    @return {Boolean} does the object have a subscription for event
+    @public
    */
   has(name: string): boolean;
 }

--- a/packages/@ember/object/evented.ts
+++ b/packages/@ember/object/evented.ts
@@ -49,8 +49,19 @@ export { on } from '@ember/-internals/metal';
  */
 interface Evented {
   /**
-   * Subscribes to a named event with given function.
-   */
+    Subscribes to a named event with given function.
+
+    ```javascript
+    person.on('didLoad', function() {
+      // fired once the person has loaded
+    });
+    ```
+
+    An optional target can be passed in as the 2nd argument that will
+    be set as the "this" for the callback. This is a good way to give your
+    function access to the object triggering the event. When the target
+    parameter is used the callback method becomes the third argument.
+  */
   on<Target>(
     name: string,
     target: Target,
@@ -58,10 +69,14 @@ interface Evented {
   ): this;
   on(name: string, method: ((...args: any[]) => void) | string): this;
   /**
-   * Subscribes a function to a named event and then cancels the subscription
-   * after the first time the event is triggered. It is good to use ``one`` when
-   * you only care about the first time an event has taken place.
-   */
+    Subscribes a function to a named event and then cancels the subscription
+    after the first time the event is triggered. It is good to use ``one`` when
+    you only care about the first time an event has taken place.
+
+    This function takes an optional 2nd argument that will become the "this"
+    value for the callback. When the target parameter is used the callback method
+    becomes the third argument.
+  */
   one<Target>(
     name: string,
     target: Target,
@@ -69,14 +84,24 @@ interface Evented {
   ): this;
   one(name: string, method: string | ((...args: any[]) => void)): this;
   /**
-   * Triggers a named event for the object. Any additional arguments
-   * will be passed as parameters to the functions that are subscribed to the
-   * event.
-   */
+    Triggers a named event for the object. Any additional arguments
+    will be passed as parameters to the functions that are subscribed to the
+    event.
+
+    ```javascript
+    person.on('didEat', function(food) {
+      console.log('person ate some ' + food);
+    });
+
+    person.trigger('didEat', 'broccoli');
+
+    // outputs: person ate some broccoli
+    ```
+  */
   trigger(name: string, ...args: any[]): any;
   /**
-   * Cancels subscription for given name, target, and method.
-   */
+    Cancels subscription for given name, target, and method.
+  */
   off<Target>(
     name: string,
     target: Target,
@@ -84,7 +109,7 @@ interface Evented {
   ): this;
   off(name: string, method: string | ((...args: any[]) => void)): this;
   /**
-   * Checks to see if object has any subscriptions for named event.
+    Checks to see if object has any subscriptions for named event.
    */
   has(name: string): boolean;
 }

--- a/packages/@ember/object/evented.ts
+++ b/packages/@ember/object/evented.ts
@@ -114,99 +114,25 @@ interface Evented {
   has(name: string): boolean;
 }
 const Evented = Mixin.create({
-  /**
-    Subscribes to a named event with given function.
-
-    ```javascript
-    person.on('didLoad', function() {
-      // fired once the person has loaded
-    });
-    ```
-
-    An optional target can be passed in as the 2nd argument that will
-    be set as the "this" for the callback. This is a good way to give your
-    function access to the object triggering the event. When the target
-    parameter is used the callback method becomes the third argument.
-
-    @method on
-    @param {String} name The name of the event
-    @param {Object} [target] The "this" binding for the callback
-    @param {Function|String} method A function or the name of a function to be called on `target`
-    @return this
-    @public
-  */
   on(name: string, target: object, method?: string | Function) {
     addListener(this, name, target, method);
     return this;
   },
 
-  /**
-    Subscribes a function to a named event and then cancels the subscription
-    after the first time the event is triggered. It is good to use ``one`` when
-    you only care about the first time an event has taken place.
-
-    This function takes an optional 2nd argument that will become the "this"
-    value for the callback. When the target parameter is used the callback method
-    becomes the third argument.
-
-    @method one
-    @param {String} name The name of the event
-    @param {Object} [target] The "this" binding for the callback
-    @param {Function|String} method A function or the name of a function to be called on `target`
-    @return this
-    @public
-  */
   one(name: string, target: object, method?: string | Function) {
     addListener(this, name, target, method, true);
     return this;
   },
 
-  /**
-    Triggers a named event for the object. Any additional arguments
-    will be passed as parameters to the functions that are subscribed to the
-    event.
-
-    ```javascript
-    person.on('didEat', function(food) {
-      console.log('person ate some ' + food);
-    });
-
-    person.trigger('didEat', 'broccoli');
-
-    // outputs: person ate some broccoli
-    ```
-    @method trigger
-    @param {String} name The name of the event
-    @param {Object...} args Optional arguments to pass on
-    @public
-  */
   trigger(name: string, ...args: any[]) {
     sendEvent(this, name, args);
   },
 
-  /**
-    Cancels subscription for given name, target, and method.
-
-    @method off
-    @param {String} name The name of the event
-    @param {Object} target The target of the subscription
-    @param {Function|String} method The function or the name of a function of the subscription
-    @return this
-    @public
-  */
   off(name: string, target: object, method?: string | Function) {
     removeListener(this, name, target, method);
     return this;
   },
 
-  /**
-    Checks to see if object has any subscriptions for named event.
-
-    @method has
-    @param {String} name The name of the event
-    @return {Boolean} does the object have a subscription for event
-    @public
-   */
   has(name: string) {
     return hasListeners(this, name);
   },


### PR DESCRIPTION
In response to [QUEST#20172](https://github.com/emberjs/ember.js/issues/20172).

Moving docs for evented.ts where automation failed, as assigned. Ignoring @ comments, such as @param & @returns.