### PR TITLE
[BUGFIX beta] Provide a `.d.ts` file at types/stable

### DIFF
--- a/types/stable/index.d.ts
+++ b/types/stable/index.d.ts
@@ -1,0 +1,12 @@
+// Future home of stable Ember types! This file currently does nothing, but in
+// the months ahead will look more and more like the `/types/preview/index.d.ts`
+// while that one empties. This is just here so that someone who writes the
+// import we recommend--
+//
+// ```ts
+// import 'ember-source';
+// import 'ember-source/preview';
+// ```
+//
+// --will not get warnings from TypeScript while we wait on putting actual
+// things here!


### PR DESCRIPTION
This file currently does nothing, but in the months ahead will look more and more like the `/types/preview/index.d.ts` while that one empties. This is just here so that someone who writes the import we recommend—

```ts
import 'ember-source';
import 'ember-source/preview';
```

—will not get warnings from TypeScript while we wait on putting actual things here!

---

Discovered this gap yesterday while prepping the preview types blog post! Note that it does not cause a compile error *not* to have this, but people will notice a warning in their editors.