### PR TITLE
[BUGFIX beta] types imports are at 'ember-source/types'

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,10 @@
     "after": "ember-cli-legacy-blueprints"
   },
   "typesVersions": {
-    "*": {
+    "types/*": {
+      "stable": [
+        "./types/stable"
+      ],
       "preview": [
         "./types/preview"
       ]

--- a/types/stable/index.d.ts
+++ b/types/stable/index.d.ts
@@ -4,8 +4,8 @@
 // import we recommend--
 //
 // ```ts
-// import 'ember-source';
-// import 'ember-source/preview';
+// import 'ember-source/types';
+// import 'ember-source/types/preview';
 // ```
 //
 // --will not get warnings from TypeScript while we wait on putting actual


### PR DESCRIPTION
This avoids the weird case of being able to just import `'ember-source'`, which is quite unclear as to *what* is being imported. Since these imports will only ever be typed at most once per app or addon (and will mostly be *generated for people*!) this is a big win in clarity for a small-to-zero cost for users.

Notably, these imports *already worked correctly*; this change mostly makes sure that the *other* import does *not* work.