### PR TITLE
[DOC] Format API docs for Typescript - @ember/array

### DIFF
--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -255,6 +255,9 @@ interface EmberArray<T> extends Enumerable {
 
     Your array must support the `length` property. Your replace methods should
     set this property whenever it changes.
+
+    @property {Number} length
+    @public
   */
   length: number;
   /**
@@ -275,6 +278,11 @@ interface EmberArray<T> extends Enumerable {
     arr.objectAt(4);   // undefined
     arr.objectAt(5);   // undefined
     ```
+
+    @method objectAt
+    @param {Number} idx The index of the item to return.
+    @return {*} item at index or undefined
+    @public
   */
   objectAt(idx: number): T | undefined;
   /**
@@ -286,6 +294,11 @@ interface EmberArray<T> extends Enumerable {
     arr.objectsAt([0, 1, 2]);  // ['a', 'b', 'c']
     arr.objectsAt([2, 3, 4]);  // ['c', 'd', undefined]
     ```
+
+    @method objectsAt
+    @param {Array} indexes An array of indexes of items to return.
+    @return {Array}
+    @public
    */
   objectsAt(indexes: number[]): Array<T | undefined>;
   /**
@@ -301,6 +314,10 @@ interface EmberArray<T> extends Enumerable {
     peopleToMoon.set('[]', ['Collins']); // ['Collins']
     peopleToMoon.get('[]'); // ['Collins']
     ```
+
+    @property []
+    @return this
+    @public
   */
   '[]': this;
   /**
@@ -319,10 +336,18 @@ interface EmberArray<T> extends Enumerable {
     vowels.clear();
     vowels.firstObject; // undefined
     ```
+
+    @property firstObject
+    @return {Object | undefined} The first object in the array
+    @public
   */
   firstObject: T | undefined;
   /**
     The last object in the array, or `undefined` if the array is empty.
+
+    @property lastObject
+    @return {Object | undefined} The last object in the array
+    @public
   */
   lastObject: T | undefined;
   /**
@@ -337,6 +362,12 @@ interface EmberArray<T> extends Enumerable {
     arr.slice(0, 2);    // ['red', 'green']
     arr.slice(1, 100);  // ['green', 'blue']
     ```
+
+    @method slice
+    @param {Number} beginIndex (Optional) index to begin slicing from.
+    @param {Number} endIndex (Optional) index to end the slice at (but not included).
+    @return {Array} New array with specified slice
+    @public
   */
   slice(beginIndex?: number, endIndex?: number): NativeArray<T>;
   /**
@@ -369,6 +400,12 @@ interface EmberArray<T> extends Enumerable {
     people.indexOf(newPerson, -4); //  0
     people.indexOf(newPerson, 10); // -1
     ```
+
+    @method indexOf
+    @param {Object} object the item to search for
+    @param {Number} startAt optional starting location to search, default 0
+    @return {Number} index or -1 if not found
+    @public
   */
   indexOf(object: T, startAt?: number): number;
   /**
@@ -396,6 +433,14 @@ interface EmberArray<T> extends Enumerable {
     arr.lastIndexOf('b', 3);    //  1
     arr.lastIndexOf('a', 100);  //  4
     ```
+
+    @method lastIndexOf
+    @param {Object} object the item to search for
+    @param {Number} startAt optional starting location to search from
+    backwards, defaults to `(array.length - 1)`
+    @return {Number} The last index of the `object` in the array or -1
+    if not found
+    @public
   */
   lastIndexOf(object: T, startAt?: number): number;
   /**
@@ -438,6 +483,12 @@ interface EmberArray<T> extends Enumerable {
     // 2/3 banana
     // 3/3 carrot
     ```
+
+    @method forEach
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Object} receiver
+    @public
   */
   forEach<Target>(
     callback: (this: Target, item: T, index: number, arr: this) => void,
@@ -458,6 +509,11 @@ interface EmberArray<T> extends Enumerable {
     people.getEach('nonexistentProperty');
     // [undefined, undefined];
     ```
+
+    @method getEach
+    @param {String} key name of the property
+    @return {Array} The mapped array.
+    @public
   */
   getEach<K extends string>(key: K): NativeArray<Value<T, K>>;
   /**
@@ -472,6 +528,12 @@ interface EmberArray<T> extends Enumerable {
     people.setEach('zipCode', '10011');
     // [{name: 'Joe', zipCode: '10011'}, {name: 'Matt', zipCode: '10011'}];
     ```
+
+    @method setEach
+    @param {String} key The key to set
+    @param {Object} value The object to set
+    @return {Object} receiver
+    @public
   */
   setEach<K extends string>(key: K, value: Value<T, K>): this;
   /**
@@ -501,6 +563,12 @@ interface EmberArray<T> extends Enumerable {
     Note that in addition to a callback, you can also pass an optional target
     object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
+
+    @method map
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Array} The mapped array.
+    @public
   */
   map<U, Target>(
     callback: (this: Target, item: T, index: number, arr: this) => U,
@@ -519,6 +587,11 @@ interface EmberArray<T> extends Enumerable {
     people.mapBy('unknownProperty');
     // [undefined, undefined];
     ```
+
+    @method mapBy
+    @param {String} key name of the property
+    @return {Array} The mapped array.
+    @public
   */
   mapBy<K extends string>(key: K): NativeArray<Value<T, K>>;
   /**
@@ -573,6 +646,12 @@ interface EmberArray<T> extends Enumerable {
     let collection = new AdultsCollection({ engineering: true });
     collection.people.filter(isAdultAndEngineer, { target: collection });
     ```
+
+    @method filter
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Array} A filtered array.
+    @public
   */
   filter<Target>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -611,6 +690,12 @@ interface EmberArray<T> extends Enumerable {
       return thing.isFruit;
     }); // [{food: 'bread', isFruit: false}]
     ```
+
+    @method reject
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Array} A rejected array.
+    @public
   */
   reject<Target>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -629,6 +714,12 @@ interface EmberArray<T> extends Enumerable {
     things.filterBy('food', 'beans'); // [{ food: 'beans', isFruit: false }]
     things.filterBy('isFruit'); // [{ food: 'apple', isFruit: true }]
     ```
+
+    @method filterBy
+    @param {String} key the property to test
+    @param {*} [value] optional value to test against.
+    @return {Array} filtered array
+    @public
   */
   filterBy(key: string, value?: unknown): NativeArray<T>;
   /**
@@ -647,6 +738,12 @@ interface EmberArray<T> extends Enumerable {
       food.rejectBy('isFruit'); // [{ name: "carrot", isFruit: false }, { name: "bread", isFruit: false }]
       food.rejectBy('name', 'carrot'); // [{ name: "apple", isFruit: true }}, { name: "bread", isFruit: false }]
     ```
+
+    @method rejectBy
+    @param {String} key the property to test
+    @param {*} [value] optional value to test against.
+    @return {Array} rejected array
+    @public
   */
   rejectBy(key: string, value?: unknown): NativeArray<T>;
   find<S extends T, Target = void>(
@@ -688,6 +785,12 @@ interface EmberArray<T> extends Enumerable {
     users.find((user) => user.name == 'Tom'); // [{ id: 2, name: 'Tom' }]
     users.find(({ id }) => id == 3); // [{ id: 3, name: 'Melanie' }]
     ```
+
+    @method find
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Object} Found item or `undefined`.
+    @public
   */
   find<Target = void>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -714,6 +817,12 @@ interface EmberArray<T> extends Enumerable {
     users.findBy('name', 'Melanie'); // { id: 3, name: 'Melanie', isTom: false }
     users.findBy('isTom'); // { id: 2, name: 'Tom', isTom: true }
     ```
+
+    @method findBy
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against.
+    @return {Object} found item or `undefined`
+    @public
   */
   findBy<K extends string>(key: K, value?: Value<T, K>): T | undefined;
   /**
@@ -746,6 +855,12 @@ interface EmberArray<T> extends Enumerable {
     const people = Ember.A([{ name: 'John', age: 24 }, { name: 'Joan', age: 45 }]);
     const areAllAdults = people.every(isAdult);
     ```
+
+    @method every
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Boolean}
+    @public
   */
   every<Target = void>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -781,6 +896,13 @@ interface EmberArray<T> extends Enumerable {
     compiledLanguages.isEvery('programmingLanguage'); // true
     languagesKnownByMe.isEvery('programmingLanguage'); // false
     ```
+
+    @method isEvery
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against. Defaults to `true`
+    @return {Boolean}
+    @since 1.3.0
+    @public
   */
   isEvery<K extends string>(key: K, value?: Value<T, K>): boolean;
   /**
@@ -815,6 +937,12 @@ interface EmberArray<T> extends Enumerable {
       Paychecks.addBiggerBonus();
     }
     ```
+
+    @method any
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Boolean} `true` if the passed function returns `true` for any item
+    @public
   */
   any<Target = void>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -885,6 +1013,13 @@ interface EmberArray<T> extends Enumerable {
         return truthValue && current;
       }); // false (true && false && false)
     ```
+
+    @method isAny
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against. Defaults to `true`
+    @return {Boolean}
+    @since 1.3.0
+    @public
   */
   reduce<V>(
     callback: (summation: V, current: T, index: number, arr: this) => V,
@@ -913,6 +1048,12 @@ interface EmberArray<T> extends Enumerable {
     people.invoke('greet'); // ['Hello Joe', 'Hello Matt']
     people.invoke('greet', 'Bonjour'); // ['Bonjour Joe', 'Bonjour Matt']
     ```
+
+    @method invoke
+    @param {String} methodName the name of the method
+    @param {Object...} args optional arguments to pass as well.
+    @return {Array} return values from calling invoke.
+    @public
   */
   invoke<K extends string>(
     methodName: K,
@@ -921,6 +1062,10 @@ interface EmberArray<T> extends Enumerable {
   /**
     Simply converts the object into a genuine array. The order is not
     guaranteed. Corresponds to the method implemented by Prototype.
+
+    @method toArray
+    @return {Array} the object as an array.
+    @public
   */
   toArray(): T[];
   /**
@@ -930,6 +1075,10 @@ interface EmberArray<T> extends Enumerable {
     let arr = ['a', null, 'c', undefined];
     arr.compact();  // ['a', 'c']
     ```
+
+    @method compact
+    @return {Array} the array without null and undefined elements.
+    @public
   */
   compact(): NativeArray<Exclude<T, null>>;
   /**
@@ -954,6 +1103,12 @@ interface EmberArray<T> extends Enumerable {
     [1, 2, 3].includes(1, -4); // true
     [1, 2, NaN].includes(NaN); // true
     ```
+
+    @method includes
+    @param {Object} object The object to search for.
+    @param {Number} startAt optional starting location to search, default 0
+    @return {Boolean} `true` if object is found in the array.
+    @public
   */
   includes(object: T, startAt?: number): boolean;
   /**
@@ -974,6 +1129,11 @@ interface EmberArray<T> extends Enumerable {
    colors.sortBy('weight', 'name');
    // [{name: 'blue', weight: 500}, {name: 'red', weight: 500}, {name: 'green', weight: 600}]
    ```
+    @method sortBy
+    @param {String} property name(s) to sort on
+    @return {Array} The sorted array.
+    @since 1.2.0
+    @public
   */
   sortBy(key: string): T[];
   /**
@@ -986,6 +1146,10 @@ interface EmberArray<T> extends Enumerable {
     ```
 
     This only works on primitive data types, e.g. Strings, Numbers, etc.
+
+    @method uniq
+    @return {EmberArray}
+    @public
   */
   uniq(): NativeArray<T>;
   /**
@@ -999,6 +1163,11 @@ interface EmberArray<T> extends Enumerable {
     let arr = [2.2, 2.1, 3.2, 3.3];
     arr.uniqBy(Math.floor);  // [2.2, 3.2];
     ```
+
+    @method uniqBy
+    @param {String,Function} key
+    @return {EmberArray}
+    @public
   */
   uniqBy(key: string): NativeArray<T>;
   /**
@@ -1010,6 +1179,11 @@ interface EmberArray<T> extends Enumerable {
     let arr = ['a', 'b', 'a', 'c'];
     arr.without('a');  // ['b', 'c']
     ```
+
+    @method without
+    @param {Object} value
+    @return {EmberArray}
+    @public
   */
   without(value: T): NativeArray<T>;
 }
@@ -1303,6 +1477,15 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     passed array.
 
     Note that this method is expected to validate the type(s) of objects that it expects.
+
+    @method replace
+    @param {Number} idx Starting index in the array to replace. If
+      idx >= length, then append to the end of the array.
+    @param {Number} amt Number of elements that should be removed from
+      the array, starting at *idx*.
+    @param {EmberArray} [objects] An optional array of zero or more objects that should be
+      inserted into the array at *idx*
+    @public
   */
   replace(idx: number, amt: number, objects?: readonly T[]): void;
   /**
@@ -1316,6 +1499,10 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.clear(); // []
     colors.length;  // 0
     ```
+
+    @method clear
+    @return {Array} An empty Array.
+    @public
   */
   clear(): this;
   /**
@@ -1328,6 +1515,12 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.insertAt(2, 'yellow');  // ['red', 'green', 'yellow', 'blue']
     colors.insertAt(5, 'orange');  // Error: Index out of range
     ```
+
+    @method insertAt
+    @param {Number} idx index of insert the object at.
+    @param {Object} object object to insert
+    @return {EmberArray} receiver
+    @public
   */
   insertAt(idx: number, object: T): this;
   /**
@@ -1344,6 +1537,12 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.removeAt(2, 2);  // ['green', 'blue']
     colors.removeAt(4, 2);  // Error: Index out of range
     ```
+
+    @method removeAt
+    @param {Number} start index, start of range
+    @param {Number} len length of passing range
+    @return {EmberArray} receiver
+    @public
   */
   removeAt(start: number, len?: number): this;
   /**
@@ -1356,6 +1555,11 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.pushObject('black');     // ['red', 'green', 'black']
     colors.pushObject(['yellow']);  // ['red', 'green', ['yellow']]
     ```
+
+    @method pushObject
+    @param {*} obj object to push
+    @return object same object passed as a param
+    @public
   */
   pushObject(obj: T): this;
   /**
@@ -1367,6 +1571,11 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
 
     colors.pushObjects(['yellow', 'orange']);  // ['red', 'yellow', 'orange']
     ```
+
+    @method pushObjects
+    @param {Array} objects the objects to add
+    @return {MutableArray} receiver
+    @public
   */
   pushObjects(objects: T[]): this;
   /**
@@ -1379,6 +1588,10 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.popObject();   // 'blue'
     console.log(colors);  // ['red', 'green']
     ```
+
+    @method popObject
+    @return object
+    @public
   */
   popObject(): T | undefined;
   /**
@@ -1391,6 +1604,10 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.shiftObject();  // 'red'
     console.log(colors);   // ['green', 'blue']
     ```
+
+    @method shiftObject
+    @return object
+    @public
   */
   shiftObject(): T | null | undefined;
   /**
@@ -1403,6 +1620,11 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.unshiftObject('yellow');    // ['yellow', 'red']
     colors.unshiftObject(['black']);   // [['black'], 'yellow', 'red']
     ```
+
+    @method unshiftObject
+    @param {*} obj object to unshift
+    @return object same object passed as a param
+    @public
   */
   unshiftObject(object: T): this;
   /**
@@ -1415,11 +1637,20 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.unshiftObjects(['black', 'white']);   // ['black', 'white', 'red']
     colors.unshiftObjects('yellow'); // Type Error: 'undefined' is not a function
     ```
+
+    @method unshiftObjects
+    @param {Enumerable} objects the objects to add
+    @return {EmberArray} receiver
+    @public
   */
   unshiftObjects(objects: T[]): this;
   /**
     Reverse objects in the array. Works just like `reverse()` but it is
     KVO-compliant.
+
+    @method reverseObjects
+    @return {EmberArray} receiver
+    @public
   */
   reverseObjects(): this;
   /**
@@ -1432,6 +1663,12 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     colors.setObjects(['black', 'white']);  // ['black', 'white']
     colors.setObjects([]);                  // []
     ```
+
+    @method setObjects
+    @param {EmberArray} objects array whose content will be used for replacing
+        the content of the receiver
+    @return {EmberArray} receiver with the new content
+    @public
   */
   setObjects(object: T[]): this;
   /**
@@ -1444,10 +1681,20 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     cities.removeObject('Lima');     // ['Berlin']
     cities.removeObject('Tokyo')     // ['Berlin']
     ```
+
+    @method removeObject
+    @param {*} obj object to remove
+    @return {EmberArray} receiver
+    @public
   */
   removeObject(object: T): this;
   /**
     Removes each object in the passed array from the receiver.
+
+    @method removeObjects
+    @param {EmberArray} objects the objects to remove
+    @return {EmberArray} receiver
+    @public
   */
   removeObjects(objects: T[]): this;
   /**
@@ -1460,10 +1707,20 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
     cities.addObject('Lima');    // ['Chicago', 'Berlin', 'Lima']
     cities.addObject('Berlin');  // ['Chicago', 'Berlin', 'Lima']
     ```
+
+    @method addObject
+    @param {*} obj object to add, if not already present
+    @return {EmberArray} receiver
+    @public
   */
   addObject(obj: T): this;
   /**
     Adds each object in the passed array to the receiver.
+
+    @method addObjects
+    @param {EmberArray} objects the objects to add.
+    @return {EmberArray} receiver
+    @public
   */
   addObjects(objects: T[]): this;
 }

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -964,6 +964,13 @@ interface EmberArray<T> extends Enumerable {
 
     food.isAny('isFruit'); // true
     ```
+
+    @method isAny
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against. Defaults to `true`
+    @return {Boolean}
+    @since 1.3.0
+    @public
   */
   isAny<K extends string>(key: K, value?: Value<T, K>): boolean;
   /**

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -250,76 +250,6 @@ function mapBy<T>(this: EmberArray<T>, key: string) {
   @public
 */
 interface EmberArray<T> extends Enumerable {
-  length: number;
-  objectAt(idx: number): T | undefined;
-  objectsAt(indexes: number[]): Array<T | undefined>;
-  firstObject: T | undefined;
-  lastObject: T | undefined;
-  slice(beginIndex?: number, endIndex?: number): NativeArray<T>;
-  indexOf(object: T, startAt?: number): number;
-  lastIndexOf(object: T, startAt?: number): number;
-  forEach<Target>(
-    callback: (this: Target, item: T, index: number, arr: this) => void,
-    target?: Target
-  ): this;
-  getEach<K extends string>(key: K): NativeArray<Value<T, K>>;
-  setEach<K extends string>(key: K, value: Value<T, K>): this;
-  map<U, Target>(
-    callback: (this: Target, item: T, index: number, arr: this) => U,
-    target?: Target
-  ): NativeArray<U>;
-  mapBy<K extends string>(key: K): NativeArray<Value<T, K>>;
-  filter<Target>(
-    callback: (this: Target, item: T, index: number, arr: this) => unknown,
-    target?: Target
-  ): NativeArray<T>;
-  reject<Target>(
-    callback: (this: Target, item: T, index: number, arr: this) => unknown,
-    target?: Target
-  ): NativeArray<T>;
-  filterBy(key: string, value?: unknown): NativeArray<T>;
-  rejectBy(key: string, value?: unknown): NativeArray<T>;
-  find<S extends T, Target = void>(
-    predicate: (this: void, value: T, index: number, obj: T[]) => value is S,
-    thisArg?: Target
-  ): S | undefined;
-  find<Target = void>(
-    callback: (this: Target, item: T, index: number, arr: this) => unknown,
-    target?: Target
-  ): T | undefined;
-  findBy<K extends string>(key: K, value?: Value<T, K>): T | undefined;
-  every<Target = void>(
-    callback: (this: Target, item: T, index: number, arr: this) => unknown,
-    target?: Target
-  ): boolean;
-  isEvery<K extends string>(key: K, value?: Value<T, K>): boolean;
-  any<Target = void>(
-    callback: (this: Target, item: T, index: number, arr: this) => unknown,
-    target?: Target
-  ): boolean;
-  isAny<K extends string>(key: K, value?: Value<T, K>): boolean;
-  reduce<V>(
-    callback: (summation: V, current: T, index: number, arr: this) => V,
-    initialValue?: V
-  ): V;
-  invoke<K extends string>(
-    methodName: K,
-    ...args: Value<T, K> extends AnyFn ? Parameters<Value<T, K>> : unknown[]
-  ): NativeArray<Value<T, K> extends AnyFn ? ReturnType<Value<T, K>> : unknown>;
-  toArray(): T[];
-  compact(): NativeArray<Exclude<T, null>>;
-  includes(object: T, startAt?: number): boolean;
-  sortBy(key: string): T[];
-  uniq(): NativeArray<T>;
-  uniqBy(key: string): NativeArray<T>;
-  without(value: T): NativeArray<T>;
-}
-const EmberArray = Mixin.create(Enumerable, {
-  init() {
-    this._super(...arguments);
-    setEmberArray(this);
-  },
-
   /**
     __Required.__ You must implement this method to apply this mixin.
 
@@ -329,7 +259,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @property {Number} length
     @public
   */
-
+  length: number;
   /**
     Returns the object at the given `index`. If the given `index` is negative
     or is greater or equal than the array length, returns `undefined`.
@@ -354,7 +284,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {*} item at index or undefined
     @public
   */
-
+  objectAt(idx: number): T | undefined;
   /**
     This returns the objects at the specified indexes, using `objectAt`.
 
@@ -370,10 +300,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array}
     @public
    */
-  objectsAt(indexes: number[]) {
-    return indexes.map((idx) => objectAt(this, idx));
-  },
-
+  objectsAt(indexes: number[]): Array<T | undefined>;
   /**
     This is the handler for the special array content property. If you get
     this property, it will return this. If you set this property to a new
@@ -392,16 +319,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return this
     @public
   */
-  '[]': nonEnumerableComputed({
-    get() {
-      return this;
-    },
-    set(_key, value) {
-      this.replace(0, this.length, value);
-      return this;
-    },
-  }),
-
+  '[]': this;
   /**
     The first object in the array, or `undefined` if the array is empty.
 
@@ -423,10 +341,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object | undefined} The first object in the array
     @public
   */
-  firstObject: nonEnumerableComputed(function () {
-    return objectAt(this, 0);
-  }).readOnly(),
-
+  firstObject: T | undefined;
   /**
     The last object in the array, or `undefined` if the array is empty.
 
@@ -434,11 +349,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object | undefined} The last object in the array
     @public
   */
-  lastObject: nonEnumerableComputed(function () {
-    return objectAt(this, this.length - 1);
-  }).readOnly(),
-
-  // Add any extra methods to EmberArray that are native to the built-in Array.
+  lastObject: T | undefined;
   /**
     Returns a new array that is a slice of the receiver. This implementation
     uses the observable array methods to retrieve the objects for the new
@@ -458,30 +369,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} New array with specified slice
     @public
   */
-  slice(beginIndex = 0, endIndex?: number) {
-    let ret = A();
-    let length = this.length;
-
-    if (beginIndex < 0) {
-      beginIndex = length + beginIndex;
-    }
-
-    let validatedEndIndex: number;
-    if (endIndex === undefined || endIndex > length) {
-      validatedEndIndex = length;
-    } else if (endIndex < 0) {
-      validatedEndIndex = length + endIndex;
-    } else {
-      validatedEndIndex = endIndex;
-    }
-
-    while (beginIndex < validatedEndIndex) {
-      ret[ret.length] = objectAt(this, beginIndex++);
-    }
-
-    return ret;
-  },
-
+  slice(beginIndex?: number, endIndex?: number): NativeArray<T>;
   /**
     Used to determine the passed object's first occurrence in the array.
     Returns the index if found, -1 if no match is found.
@@ -519,11 +407,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Number} index or -1 if not found
     @public
   */
-
-  indexOf<T>(object: T, startAt?: number) {
-    return indexOf(this, object, startAt, false);
-  },
-
+  indexOf(object: T, startAt?: number): number;
   /**
     Returns the index of the given `object`'s last occurrence.
 
@@ -558,26 +442,7 @@ const EmberArray = Mixin.create(Enumerable, {
     if not found
     @public
   */
-  lastIndexOf<T>(object: T, startAt?: number) {
-    let len = this.length;
-
-    if (startAt === undefined || startAt >= len) {
-      startAt = len - 1;
-    }
-
-    if (startAt < 0) {
-      startAt += len;
-    }
-
-    for (let idx = startAt; idx >= 0; idx--) {
-      if (objectAt(this, idx) === object) {
-        return idx;
-      }
-    }
-
-    return -1;
-  },
-
+  lastIndexOf(object: T, startAt?: number): number;
   /**
     Iterates through the array, calling the passed function on each
     item. This method corresponds to the `forEach()` method defined in
@@ -625,19 +490,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object} receiver
     @public
   */
-  forEach(callback: <T>(item: T, index: number, arr: EmberArray<T>) => void, target = null) {
-    assert('`forEach` expects a function as first argument.', typeof callback === 'function');
-
-    let length = this.length;
-
-    for (let index = 0; index < length; index++) {
-      let item = this.objectAt(index);
-      callback.call(target, item, index, this);
-    }
-
-    return this;
-  },
-
+  forEach<Target>(
+    callback: (this: Target, item: T, index: number, arr: this) => void,
+    target?: Target
+  ): this;
   /**
     Alias for `mapBy`.
 
@@ -659,8 +515,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} The mapped array.
     @public
   */
-  getEach: mapBy,
-
+  getEach<K extends string>(key: K): NativeArray<Value<T, K>>;
   /**
     Sets the value on the named property for each member. This is more
     ergonomic than using other methods defined on this helper. If the object
@@ -680,10 +535,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object} receiver
     @public
   */
-  setEach(key: string, value: unknown) {
-    return this.forEach((item: object) => set(item, key, value));
-  },
-
+  setEach<K extends string>(key: K, value: Value<T, K>): this;
   /**
     Maps all of the items in the enumeration to another value, returning
     a new array. This method corresponds to `map()` defined in JavaScript 1.6.
@@ -718,20 +570,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} The mapped array.
     @public
   */
-  map<T>(
-    this: EmberArray<T>,
-    callback: (item: T, index: number, arr: EmberArray<T>) => unknown,
-    target = null
-  ) {
-    assert('`map` expects a function as first argument.', typeof callback === 'function');
-
-    let ret = A();
-
-    this.forEach((x, idx, i) => (ret[idx] = callback.call(target, x, idx, i)));
-
-    return ret;
-  },
-
+  map<U, Target>(
+    callback: (this: Target, item: T, index: number, arr: this) => U,
+    target?: Target
+  ): NativeArray<U>;
   /**
     Similar to map, this specialized function returns the value of the named
     property on all items in the enumeration.
@@ -751,8 +593,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} The mapped array.
     @public
   */
-  mapBy,
-
+  mapBy<K extends string>(key: K): NativeArray<Value<T, K>>;
   /**
     Returns a new array with all of the items in the enumeration that the provided
     callback function returns true for. This method corresponds to [Array.prototype.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
@@ -812,24 +653,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} A filtered array.
     @public
   */
-  filter<T>(
-    this: EmberArray<T>,
-    callback: (item: T, index: number, arr: EmberArray<T>) => unknown,
-    target = null
-  ) {
-    assert('`filter` expects a function as first argument.', typeof callback === 'function');
-
-    let ret = A();
-
-    this.forEach((x, idx, i) => {
-      if (callback.call(target, x, idx, i)) {
-        ret.push(x);
-      }
-    });
-
-    return ret;
-  },
-
+  filter<Target>(
+    callback: (this: Target, item: T, index: number, arr: this) => unknown,
+    target?: Target
+  ): NativeArray<T>;
   /**
     Returns an array with all of the items in the enumeration where the passed
     function returns false. This method is the inverse of filter().
@@ -870,18 +697,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} A rejected array.
     @public
   */
-  reject<T>(
-    this: EmberArray<T>,
-    callback: (item: T, index: number, arr: EmberArray<T>) => unknown,
-    target = null
-  ) {
-    assert('`reject` expects a function as first argument.', typeof callback === 'function');
-    return this.filter(function () {
-      // @ts-expect-error TS doesn't like us using arguments like this
-      return !callback.apply(target, arguments);
-    });
-  },
-
+  reject<Target>(
+    callback: (this: Target, item: T, index: number, arr: this) => unknown,
+    target?: Target
+  ): NativeArray<T>;
   /**
     Filters the array by the property and an optional value. If a value is given, it returns
     the items that have said value for the property. If not, it returns all the items that
@@ -902,11 +721,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} filtered array
     @public
   */
-  filterBy() {
-    // @ts-expect-error TS doesn't like the ...arguments spread here.
-    return this.filter(iter(...arguments));
-  },
-
+  filterBy(key: string, value?: unknown): NativeArray<T>;
   /**
     Returns an array with the items that do not have truthy values for the provided key.
     You can pass an optional second argument with a target value to reject for the key.
@@ -930,11 +745,11 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} rejected array
     @public
   */
-  rejectBy() {
-    // @ts-expect-error TS doesn't like the ...arguments spread here.
-    return this.reject(iter(...arguments));
-  },
-
+  rejectBy(key: string, value?: unknown): NativeArray<T>;
+  find<S extends T, Target = void>(
+    predicate: (this: void, value: T, index: number, obj: T[]) => value is S,
+    thisArg?: Target
+  ): S | undefined;
   /**
     Returns the first item in the array for which the callback returns true.
     This method is similar to the `find()` method defined in ECMAScript 2015.
@@ -977,11 +792,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object} Found item or `undefined`.
     @public
   */
-  find(callback: <T>(item: T, index: number, arr: EmberArray<T>) => unknown, target = null) {
-    assert('`find` expects a function as first argument.', typeof callback === 'function');
-    return find(this, callback, target);
-  },
-
+  find<Target = void>(
+    callback: (this: Target, item: T, index: number, arr: this) => unknown,
+    target?: Target
+  ): T | undefined;
   /**
     Returns the first item with a property matching the passed value. You
     can pass an optional second argument with the target value. Otherwise
@@ -1010,12 +824,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object} found item or `undefined`
     @public
   */
-  findBy() {
-    // @ts-expect-error TS doesn't like the ...arguments spread here.
-    let callback = iter(...arguments);
-    return find(this, callback);
-  },
-
+  findBy<K extends string>(key: K, value?: Value<T, K>): T | undefined;
   /**
     Returns `true` if the passed function returns true for every item in the
     enumeration. This corresponds with the `Array.prototype.every()` method defined in ES5.
@@ -1053,11 +862,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Boolean}
     @public
   */
-  every(callback: <T>(item: T, index: number, arr: EmberArray<T>) => unknown, target = null) {
-    assert('`every` expects a function as first argument.', typeof callback === 'function');
-    return every(this, callback, target);
-  },
-
+  every<Target = void>(
+    callback: (this: Target, item: T, index: number, arr: this) => unknown,
+    target?: Target
+  ): boolean;
   /**
     Returns `true` if the passed property resolves to the value of the second
     argument for all items in the array. This method is often simpler/faster
@@ -1096,12 +904,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @since 1.3.0
     @public
   */
-  isEvery() {
-    // @ts-expect-error TS doesn't like the ...arguments spread here.
-    let callback = iter(...arguments);
-    return every(this, callback);
-  },
-
+  isEvery<K extends string>(key: K, value?: Value<T, K>): boolean;
   /**
     The any() method executes the callback function once for each element
     present in the array until it finds the one where callback returns a truthy
@@ -1141,11 +944,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Boolean} `true` if the passed function returns `true` for any item
     @public
   */
-  any(callback: <T>(item: T, index: number, arr: EmberArray<T>) => unknown, target = null) {
-    assert('`any` expects a function as first argument.', typeof callback === 'function');
-    return any(this, callback, target);
-  },
-
+  any<Target = void>(
+    callback: (this: Target, item: T, index: number, arr: this) => unknown,
+    target?: Target
+  ): boolean;
   /**
     Returns `true` if the passed property resolves to the value of the second
     argument for any item in the array. This method is often simpler/faster
@@ -1170,12 +972,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @since 1.3.0
     @public
   */
-  isAny() {
-    // @ts-expect-error TS doesn't like us using arguments like this
-    let callback = iter(...arguments);
-    return any(this, callback);
-  },
-
+  isAny<K extends string>(key: K, value?: Value<T, K>): boolean;
   /**
     This will combine the values of the array into a single value. It
     is a useful way to collect a summary value from an array. This
@@ -1230,23 +1027,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Object} The reduced value.
     @public
   */
-  // FIXME: When called without initialValue, behavior does not match native behavior
-  reduce<T, V>(
-    this: EmberArray<T>,
-    callback: (summation: V, current: T, index: number, arr: EmberArray<T>) => V,
-    initialValue: V
-  ) {
-    assert('`reduce` expects a function as first argument.', typeof callback === 'function');
-
-    let ret = initialValue;
-
-    this.forEach(function (item, i) {
-      ret = callback(ret, item, i, this);
-    }, this);
-
-    return ret;
-  },
-
+  reduce<V>(
+    callback: (summation: V, current: T, index: number, arr: this) => V,
+    initialValue?: V
+  ): V;
   /**
     Invokes the named method on every object in the receiver that
     implements it. This method corresponds to the implementation in
@@ -1277,15 +1061,10 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} return values from calling invoke.
     @public
   */
-  invoke<T>(this: EmberArray<T>, methodName: string, ...args: unknown[]) {
-    let ret = A();
-
-    // SAFETY: This is not entirely safe and the code will not work with Ember proxies
-    this.forEach((item: T) => ret.push((item as any)[methodName]?.(...args)));
-
-    return ret;
-  },
-
+  invoke<K extends string>(
+    methodName: K,
+    ...args: Value<T, K> extends AnyFn ? Parameters<Value<T, K>> : unknown[]
+  ): NativeArray<Value<T, K> extends AnyFn ? ReturnType<Value<T, K>> : unknown>;
   /**
     Simply converts the object into a genuine array. The order is not
     guaranteed. Corresponds to the method implemented by Prototype.
@@ -1294,10 +1073,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} the object as an array.
     @public
   */
-  toArray<T>(this: EmberArray<T>) {
-    return this.map((item: T) => item);
-  },
-
+  toArray(): T[];
   /**
     Returns a copy of the array with all `null` and `undefined` elements removed.
 
@@ -1310,10 +1086,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Array} the array without null and undefined elements.
     @public
   */
-  compact<T>(this: EmberArray<T>) {
-    return this.filter((value: T) => value != null);
-  },
-
+  compact(): NativeArray<Exclude<T, null>>;
   /**
     Used to determine if the array contains the passed object.
     Returns `true` if found, `false` otherwise.
@@ -1343,10 +1116,7 @@ const EmberArray = Mixin.create(Enumerable, {
     @return {Boolean} `true` if object is found in the array.
     @public
   */
-  includes<T>(this: EmberArray<T>, object: T, startAt?: number) {
-    return indexOf(this, object, startAt, true) !== -1;
-  },
-
+  includes(object: T, startAt?: number): boolean;
   /**
     Sorts the array by the keys specified in the argument.
 
@@ -1372,6 +1142,281 @@ const EmberArray = Mixin.create(Enumerable, {
     @since 1.2.0
     @public
   */
+  sortBy(key: string): T[];
+  /**
+    Returns a new array that contains only unique values. The default
+    implementation returns an array regardless of the receiver type.
+
+    ```javascript
+    let arr = ['a', 'a', 'b', 'b'];
+    arr.uniq();  // ['a', 'b']
+    ```
+
+    This only works on primitive data types, e.g. Strings, Numbers, etc.
+
+    @method uniq
+    @return {EmberArray}
+    @public
+  */
+  uniq(): NativeArray<T>;
+  /**
+    Returns a new array that contains only items containing a unique property value.
+    The default implementation returns an array regardless of the receiver type.
+
+    ```javascript
+    let arr = [{ value: 'a' }, { value: 'a' }, { value: 'b' }, { value: 'b' }];
+    arr.uniqBy('value');  // [{ value: 'a' }, { value: 'b' }]
+
+    let arr = [2.2, 2.1, 3.2, 3.3];
+    arr.uniqBy(Math.floor);  // [2.2, 3.2];
+    ```
+
+    @method uniqBy
+    @param {String,Function} key
+    @return {EmberArray}
+    @public
+  */
+  uniqBy(key: string): NativeArray<T>;
+  /**
+    Returns a new array that excludes the passed value. The default
+    implementation returns an array regardless of the receiver type.
+    If the receiver does not contain the value it returns the original array.
+
+    ```javascript
+    let arr = ['a', 'b', 'a', 'c'];
+    arr.without('a');  // ['b', 'c']
+    ```
+
+    @method without
+    @param {Object} value
+    @return {EmberArray}
+    @public
+  */
+  without(value: T): NativeArray<T>;
+}
+const EmberArray = Mixin.create(Enumerable, {
+  init() {
+    this._super(...arguments);
+    setEmberArray(this);
+  },
+
+  objectsAt(indexes: number[]) {
+    return indexes.map((idx) => objectAt(this, idx));
+  },
+
+  '[]': nonEnumerableComputed({
+    get() {
+      return this;
+    },
+    set(_key, value) {
+      this.replace(0, this.length, value);
+      return this;
+    },
+  }),
+
+  firstObject: nonEnumerableComputed(function () {
+    return objectAt(this, 0);
+  }).readOnly(),
+
+  lastObject: nonEnumerableComputed(function () {
+    return objectAt(this, this.length - 1);
+  }).readOnly(),
+
+  // Add any extra methods to EmberArray that are native to the built-in Array.
+  slice(beginIndex = 0, endIndex?: number) {
+    let ret = A();
+    let length = this.length;
+
+    if (beginIndex < 0) {
+      beginIndex = length + beginIndex;
+    }
+
+    let validatedEndIndex: number;
+    if (endIndex === undefined || endIndex > length) {
+      validatedEndIndex = length;
+    } else if (endIndex < 0) {
+      validatedEndIndex = length + endIndex;
+    } else {
+      validatedEndIndex = endIndex;
+    }
+
+    while (beginIndex < validatedEndIndex) {
+      ret[ret.length] = objectAt(this, beginIndex++);
+    }
+
+    return ret;
+  },
+
+  indexOf<T>(object: T, startAt?: number) {
+    return indexOf(this, object, startAt, false);
+  },
+
+  lastIndexOf<T>(object: T, startAt?: number) {
+    let len = this.length;
+
+    if (startAt === undefined || startAt >= len) {
+      startAt = len - 1;
+    }
+
+    if (startAt < 0) {
+      startAt += len;
+    }
+
+    for (let idx = startAt; idx >= 0; idx--) {
+      if (objectAt(this, idx) === object) {
+        return idx;
+      }
+    }
+
+    return -1;
+  },
+
+  forEach(callback: <T>(item: T, index: number, arr: EmberArray<T>) => void, target = null) {
+    assert('`forEach` expects a function as first argument.', typeof callback === 'function');
+
+    let length = this.length;
+
+    for (let index = 0; index < length; index++) {
+      let item = this.objectAt(index);
+      callback.call(target, item, index, this);
+    }
+
+    return this;
+  },
+
+  getEach: mapBy,
+
+  setEach(key: string, value: unknown) {
+    return this.forEach((item: object) => set(item, key, value));
+  },
+
+  map<T>(
+    this: EmberArray<T>,
+    callback: (item: T, index: number, arr: EmberArray<T>) => unknown,
+    target = null
+  ) {
+    assert('`map` expects a function as first argument.', typeof callback === 'function');
+
+    let ret = A();
+
+    this.forEach((x, idx, i) => (ret[idx] = callback.call(target, x, idx, i)));
+
+    return ret;
+  },
+
+  mapBy,
+
+  filter<T>(
+    this: EmberArray<T>,
+    callback: (item: T, index: number, arr: EmberArray<T>) => unknown,
+    target = null
+  ) {
+    assert('`filter` expects a function as first argument.', typeof callback === 'function');
+
+    let ret = A();
+
+    this.forEach((x, idx, i) => {
+      if (callback.call(target, x, idx, i)) {
+        ret.push(x);
+      }
+    });
+
+    return ret;
+  },
+
+  reject<T>(
+    this: EmberArray<T>,
+    callback: (item: T, index: number, arr: EmberArray<T>) => unknown,
+    target = null
+  ) {
+    assert('`reject` expects a function as first argument.', typeof callback === 'function');
+    return this.filter(function () {
+      // @ts-expect-error TS doesn't like us using arguments like this
+      return !callback.apply(target, arguments);
+    });
+  },
+
+  filterBy() {
+    // @ts-expect-error TS doesn't like the ...arguments spread here.
+    return this.filter(iter(...arguments));
+  },
+
+  rejectBy() {
+    // @ts-expect-error TS doesn't like the ...arguments spread here.
+    return this.reject(iter(...arguments));
+  },
+
+  find(callback: <T>(item: T, index: number, arr: EmberArray<T>) => unknown, target = null) {
+    assert('`find` expects a function as first argument.', typeof callback === 'function');
+    return find(this, callback, target);
+  },
+
+  findBy() {
+    // @ts-expect-error TS doesn't like the ...arguments spread here.
+    let callback = iter(...arguments);
+    return find(this, callback);
+  },
+
+  every(callback: <T>(item: T, index: number, arr: EmberArray<T>) => unknown, target = null) {
+    assert('`every` expects a function as first argument.', typeof callback === 'function');
+    return every(this, callback, target);
+  },
+
+  isEvery() {
+    // @ts-expect-error TS doesn't like the ...arguments spread here.
+    let callback = iter(...arguments);
+    return every(this, callback);
+  },
+
+  any(callback: <T>(item: T, index: number, arr: EmberArray<T>) => unknown, target = null) {
+    assert('`any` expects a function as first argument.', typeof callback === 'function');
+    return any(this, callback, target);
+  },
+
+  isAny() {
+    // @ts-expect-error TS doesn't like us using arguments like this
+    let callback = iter(...arguments);
+    return any(this, callback);
+  },
+
+  // FIXME: When called without initialValue, behavior does not match native behavior
+  reduce<T, V>(
+    this: EmberArray<T>,
+    callback: (summation: V, current: T, index: number, arr: EmberArray<T>) => V,
+    initialValue: V
+  ) {
+    assert('`reduce` expects a function as first argument.', typeof callback === 'function');
+
+    let ret = initialValue;
+
+    this.forEach(function (item, i) {
+      ret = callback(ret, item, i, this);
+    }, this);
+
+    return ret;
+  },
+
+  invoke<T>(this: EmberArray<T>, methodName: string, ...args: unknown[]) {
+    let ret = A();
+
+    // SAFETY: This is not entirely safe and the code will not work with Ember proxies
+    this.forEach((item: T) => ret.push((item as any)[methodName]?.(...args)));
+
+    return ret;
+  },
+
+  toArray<T>(this: EmberArray<T>) {
+    return this.map((item: T) => item);
+  },
+
+  compact<T>(this: EmberArray<T>) {
+    return this.filter((value: T) => value != null);
+  },
+
+  includes<T>(this: EmberArray<T>, object: T, startAt?: number) {
+    return indexOf(this, object, startAt, true) !== -1;
+  },
+
   sortBy<T>(this: EmberArray<T>) {
     let sortKeys = arguments;
 
@@ -1391,62 +1436,14 @@ const EmberArray = Mixin.create(Enumerable, {
     });
   },
 
-  /**
-    Returns a new array that contains only unique values. The default
-    implementation returns an array regardless of the receiver type.
-
-    ```javascript
-    let arr = ['a', 'a', 'b', 'b'];
-    arr.uniq();  // ['a', 'b']
-    ```
-
-    This only works on primitive data types, e.g. Strings, Numbers, etc.
-
-    @method uniq
-    @return {EmberArray}
-    @public
-  */
   uniq() {
     return uniqBy(this);
   },
-
-  /**
-    Returns a new array that contains only items containing a unique property value.
-    The default implementation returns an array regardless of the receiver type.
-
-    ```javascript
-    let arr = [{ value: 'a' }, { value: 'a' }, { value: 'b' }, { value: 'b' }];
-    arr.uniqBy('value');  // [{ value: 'a' }, { value: 'b' }]
-
-    let arr = [2.2, 2.1, 3.2, 3.3];
-    arr.uniqBy(Math.floor);  // [2.2, 3.2];
-    ```
-
-    @method uniqBy
-    @param {String,Function} key
-    @return {EmberArray}
-    @public
-  */
 
   uniqBy(key: string) {
     return uniqBy(this, key);
   },
 
-  /**
-    Returns a new array that excludes the passed value. The default
-    implementation returns an array regardless of the receiver type.
-    If the receiver does not contain the value it returns the original array.
-
-    ```javascript
-    let arr = ['a', 'b', 'a', 'c'];
-    arr.without('a');  // ['b', 'c']
-    ```
-
-    @method without
-    @param {Object} value
-    @return {EmberArray}
-    @public
-  */
   without<T>(this: EmberArray<T>, value: T) {
     if (!this.includes(value)) {
       return this; // nothing to do

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1021,11 +1021,10 @@ interface EmberArray<T> extends Enumerable {
       }); // false (true && false && false)
     ```
 
-    @method isAny
-    @param {String} key the property to test
-    @param {String} [value] optional value to test against. Defaults to `true`
-    @return {Boolean}
-    @since 1.3.0
+    @method reduce
+    @param {Function} callback The callback to execute
+    @param {Object} initialValue Initial value for the reduce
+    @return {Object} The reduced value.
     @public
   */
   reduce<V>(

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -255,9 +255,6 @@ interface EmberArray<T> extends Enumerable {
 
     Your array must support the `length` property. Your replace methods should
     set this property whenever it changes.
-
-    @property {Number} length
-    @public
   */
   length: number;
   /**
@@ -278,11 +275,6 @@ interface EmberArray<T> extends Enumerable {
     arr.objectAt(4);   // undefined
     arr.objectAt(5);   // undefined
     ```
-
-    @method objectAt
-    @param {Number} idx The index of the item to return.
-    @return {*} item at index or undefined
-    @public
   */
   objectAt(idx: number): T | undefined;
   /**
@@ -294,11 +286,6 @@ interface EmberArray<T> extends Enumerable {
     arr.objectsAt([0, 1, 2]);  // ['a', 'b', 'c']
     arr.objectsAt([2, 3, 4]);  // ['c', 'd', undefined]
     ```
-
-    @method objectsAt
-    @param {Array} indexes An array of indexes of items to return.
-    @return {Array}
-    @public
    */
   objectsAt(indexes: number[]): Array<T | undefined>;
   /**
@@ -314,10 +301,6 @@ interface EmberArray<T> extends Enumerable {
     peopleToMoon.set('[]', ['Collins']); // ['Collins']
     peopleToMoon.get('[]'); // ['Collins']
     ```
-
-    @property []
-    @return this
-    @public
   */
   '[]': this;
   /**
@@ -336,18 +319,10 @@ interface EmberArray<T> extends Enumerable {
     vowels.clear();
     vowels.firstObject; // undefined
     ```
-
-    @property firstObject
-    @return {Object | undefined} The first object in the array
-    @public
   */
   firstObject: T | undefined;
   /**
     The last object in the array, or `undefined` if the array is empty.
-
-    @property lastObject
-    @return {Object | undefined} The last object in the array
-    @public
   */
   lastObject: T | undefined;
   /**
@@ -362,12 +337,6 @@ interface EmberArray<T> extends Enumerable {
     arr.slice(0, 2);    // ['red', 'green']
     arr.slice(1, 100);  // ['green', 'blue']
     ```
-
-    @method slice
-    @param {Number} beginIndex (Optional) index to begin slicing from.
-    @param {Number} endIndex (Optional) index to end the slice at (but not included).
-    @return {Array} New array with specified slice
-    @public
   */
   slice(beginIndex?: number, endIndex?: number): NativeArray<T>;
   /**
@@ -400,12 +369,6 @@ interface EmberArray<T> extends Enumerable {
     people.indexOf(newPerson, -4); //  0
     people.indexOf(newPerson, 10); // -1
     ```
-
-    @method indexOf
-    @param {Object} object the item to search for
-    @param {Number} startAt optional starting location to search, default 0
-    @return {Number} index or -1 if not found
-    @public
   */
   indexOf(object: T, startAt?: number): number;
   /**
@@ -433,14 +396,6 @@ interface EmberArray<T> extends Enumerable {
     arr.lastIndexOf('b', 3);    //  1
     arr.lastIndexOf('a', 100);  //  4
     ```
-
-    @method lastIndexOf
-    @param {Object} object the item to search for
-    @param {Number} startAt optional starting location to search from
-    backwards, defaults to `(array.length - 1)`
-    @return {Number} The last index of the `object` in the array or -1
-    if not found
-    @public
   */
   lastIndexOf(object: T, startAt?: number): number;
   /**
@@ -483,12 +438,6 @@ interface EmberArray<T> extends Enumerable {
     // 2/3 banana
     // 3/3 carrot
     ```
-
-    @method forEach
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Object} receiver
-    @public
   */
   forEach<Target>(
     callback: (this: Target, item: T, index: number, arr: this) => void,
@@ -509,11 +458,6 @@ interface EmberArray<T> extends Enumerable {
     people.getEach('nonexistentProperty');
     // [undefined, undefined];
     ```
-
-    @method getEach
-    @param {String} key name of the property
-    @return {Array} The mapped array.
-    @public
   */
   getEach<K extends string>(key: K): NativeArray<Value<T, K>>;
   /**
@@ -528,12 +472,6 @@ interface EmberArray<T> extends Enumerable {
     people.setEach('zipCode', '10011');
     // [{name: 'Joe', zipCode: '10011'}, {name: 'Matt', zipCode: '10011'}];
     ```
-
-    @method setEach
-    @param {String} key The key to set
-    @param {Object} value The object to set
-    @return {Object} receiver
-    @public
   */
   setEach<K extends string>(key: K, value: Value<T, K>): this;
   /**
@@ -563,12 +501,6 @@ interface EmberArray<T> extends Enumerable {
     Note that in addition to a callback, you can also pass an optional target
     object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
-
-    @method map
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Array} The mapped array.
-    @public
   */
   map<U, Target>(
     callback: (this: Target, item: T, index: number, arr: this) => U,
@@ -587,11 +519,6 @@ interface EmberArray<T> extends Enumerable {
     people.mapBy('unknownProperty');
     // [undefined, undefined];
     ```
-
-    @method mapBy
-    @param {String} key name of the property
-    @return {Array} The mapped array.
-    @public
   */
   mapBy<K extends string>(key: K): NativeArray<Value<T, K>>;
   /**
@@ -646,12 +573,6 @@ interface EmberArray<T> extends Enumerable {
     let collection = new AdultsCollection({ engineering: true });
     collection.people.filter(isAdultAndEngineer, { target: collection });
     ```
-
-    @method filter
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Array} A filtered array.
-    @public
   */
   filter<Target>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -690,12 +611,6 @@ interface EmberArray<T> extends Enumerable {
       return thing.isFruit;
     }); // [{food: 'bread', isFruit: false}]
     ```
-
-    @method reject
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Array} A rejected array.
-    @public
   */
   reject<Target>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -714,12 +629,6 @@ interface EmberArray<T> extends Enumerable {
     things.filterBy('food', 'beans'); // [{ food: 'beans', isFruit: false }]
     things.filterBy('isFruit'); // [{ food: 'apple', isFruit: true }]
     ```
-
-    @method filterBy
-    @param {String} key the property to test
-    @param {*} [value] optional value to test against.
-    @return {Array} filtered array
-    @public
   */
   filterBy(key: string, value?: unknown): NativeArray<T>;
   /**
@@ -738,12 +647,6 @@ interface EmberArray<T> extends Enumerable {
       food.rejectBy('isFruit'); // [{ name: "carrot", isFruit: false }, { name: "bread", isFruit: false }]
       food.rejectBy('name', 'carrot'); // [{ name: "apple", isFruit: true }}, { name: "bread", isFruit: false }]
     ```
-
-    @method rejectBy
-    @param {String} key the property to test
-    @param {*} [value] optional value to test against.
-    @return {Array} rejected array
-    @public
   */
   rejectBy(key: string, value?: unknown): NativeArray<T>;
   find<S extends T, Target = void>(
@@ -785,12 +688,6 @@ interface EmberArray<T> extends Enumerable {
     users.find((user) => user.name == 'Tom'); // [{ id: 2, name: 'Tom' }]
     users.find(({ id }) => id == 3); // [{ id: 3, name: 'Melanie' }]
     ```
-
-    @method find
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Object} Found item or `undefined`.
-    @public
   */
   find<Target = void>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -817,12 +714,6 @@ interface EmberArray<T> extends Enumerable {
     users.findBy('name', 'Melanie'); // { id: 3, name: 'Melanie', isTom: false }
     users.findBy('isTom'); // { id: 2, name: 'Tom', isTom: true }
     ```
-
-    @method findBy
-    @param {String} key the property to test
-    @param {String} [value] optional value to test against.
-    @return {Object} found item or `undefined`
-    @public
   */
   findBy<K extends string>(key: K, value?: Value<T, K>): T | undefined;
   /**
@@ -855,12 +746,6 @@ interface EmberArray<T> extends Enumerable {
     const people = Ember.A([{ name: 'John', age: 24 }, { name: 'Joan', age: 45 }]);
     const areAllAdults = people.every(isAdult);
     ```
-
-    @method every
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Boolean}
-    @public
   */
   every<Target = void>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -896,13 +781,6 @@ interface EmberArray<T> extends Enumerable {
     compiledLanguages.isEvery('programmingLanguage'); // true
     languagesKnownByMe.isEvery('programmingLanguage'); // false
     ```
-
-    @method isEvery
-    @param {String} key the property to test
-    @param {String} [value] optional value to test against. Defaults to `true`
-    @return {Boolean}
-    @since 1.3.0
-    @public
   */
   isEvery<K extends string>(key: K, value?: Value<T, K>): boolean;
   /**
@@ -937,12 +815,6 @@ interface EmberArray<T> extends Enumerable {
       Paychecks.addBiggerBonus();
     }
     ```
-
-    @method any
-    @param {Function} callback The callback to execute
-    @param {Object} [target] The target object to use
-    @return {Boolean} `true` if the passed function returns `true` for any item
-    @public
   */
   any<Target = void>(
     callback: (this: Target, item: T, index: number, arr: this) => unknown,
@@ -964,13 +836,6 @@ interface EmberArray<T> extends Enumerable {
 
     food.isAny('isFruit'); // true
     ```
-
-    @method isAny
-    @param {String} key the property to test
-    @param {String} [value] optional value to test against. Defaults to `true`
-    @return {Boolean}
-    @since 1.3.0
-    @public
   */
   isAny<K extends string>(key: K, value?: Value<T, K>): boolean;
   /**
@@ -1020,12 +885,6 @@ interface EmberArray<T> extends Enumerable {
         return truthValue && current;
       }); // false (true && false && false)
     ```
-
-    @method reduce
-    @param {Function} callback The callback to execute
-    @param {Object} initialValue Initial value for the reduce
-    @return {Object} The reduced value.
-    @public
   */
   reduce<V>(
     callback: (summation: V, current: T, index: number, arr: this) => V,
@@ -1054,12 +913,6 @@ interface EmberArray<T> extends Enumerable {
     people.invoke('greet'); // ['Hello Joe', 'Hello Matt']
     people.invoke('greet', 'Bonjour'); // ['Bonjour Joe', 'Bonjour Matt']
     ```
-
-    @method invoke
-    @param {String} methodName the name of the method
-    @param {Object...} args optional arguments to pass as well.
-    @return {Array} return values from calling invoke.
-    @public
   */
   invoke<K extends string>(
     methodName: K,
@@ -1068,10 +921,6 @@ interface EmberArray<T> extends Enumerable {
   /**
     Simply converts the object into a genuine array. The order is not
     guaranteed. Corresponds to the method implemented by Prototype.
-
-    @method toArray
-    @return {Array} the object as an array.
-    @public
   */
   toArray(): T[];
   /**
@@ -1081,10 +930,6 @@ interface EmberArray<T> extends Enumerable {
     let arr = ['a', null, 'c', undefined];
     arr.compact();  // ['a', 'c']
     ```
-
-    @method compact
-    @return {Array} the array without null and undefined elements.
-    @public
   */
   compact(): NativeArray<Exclude<T, null>>;
   /**
@@ -1109,12 +954,6 @@ interface EmberArray<T> extends Enumerable {
     [1, 2, 3].includes(1, -4); // true
     [1, 2, NaN].includes(NaN); // true
     ```
-
-    @method includes
-    @param {Object} object The object to search for.
-    @param {Number} startAt optional starting location to search, default 0
-    @return {Boolean} `true` if object is found in the array.
-    @public
   */
   includes(object: T, startAt?: number): boolean;
   /**
@@ -1135,12 +974,6 @@ interface EmberArray<T> extends Enumerable {
    colors.sortBy('weight', 'name');
    // [{name: 'blue', weight: 500}, {name: 'red', weight: 500}, {name: 'green', weight: 600}]
    ```
-
-    @method sortBy
-    @param {String} property name(s) to sort on
-    @return {Array} The sorted array.
-    @since 1.2.0
-    @public
   */
   sortBy(key: string): T[];
   /**
@@ -1153,10 +986,6 @@ interface EmberArray<T> extends Enumerable {
     ```
 
     This only works on primitive data types, e.g. Strings, Numbers, etc.
-
-    @method uniq
-    @return {EmberArray}
-    @public
   */
   uniq(): NativeArray<T>;
   /**
@@ -1170,11 +999,6 @@ interface EmberArray<T> extends Enumerable {
     let arr = [2.2, 2.1, 3.2, 3.3];
     arr.uniqBy(Math.floor);  // [2.2, 3.2];
     ```
-
-    @method uniqBy
-    @param {String,Function} key
-    @return {EmberArray}
-    @public
   */
   uniqBy(key: string): NativeArray<T>;
   /**
@@ -1186,11 +1010,6 @@ interface EmberArray<T> extends Enumerable {
     let arr = ['a', 'b', 'a', 'c'];
     arr.without('a');  // ['b', 'c']
     ```
-
-    @method without
-    @param {Object} value
-    @return {EmberArray}
-    @public
   */
   without(value: T): NativeArray<T>;
 }

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1295,24 +1295,6 @@ const EmberArray = Mixin.create(Enumerable, {
   @public
 */
 interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
-  replace(idx: number, amt: number, objects?: readonly T[]): void;
-  clear(): this;
-  insertAt(idx: number, object: T): this;
-  removeAt(start: number, len?: number): this;
-  pushObject(obj: T): this;
-  pushObjects(objects: T[]): this;
-  popObject(): T | undefined;
-  shiftObject(): T | null | undefined;
-  unshiftObject(object: T): this;
-  unshiftObjects(objects: T[]): this;
-  reverseObjects(): this;
-  setObjects(object: T[]): this;
-  removeObject(object: T): this;
-  removeObjects(objects: T[]): this;
-  addObject(obj: T): this;
-  addObjects(objects: T[]): this;
-}
-const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
   /**
     __Required.__ You must implement this method to apply this mixin.
 
@@ -1321,17 +1303,8 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     passed array.
 
     Note that this method is expected to validate the type(s) of objects that it expects.
-
-    @method replace
-    @param {Number} idx Starting index in the array to replace. If
-      idx >= length, then append to the end of the array.
-    @param {Number} amt Number of elements that should be removed from
-      the array, starting at *idx*.
-    @param {EmberArray} [objects] An optional array of zero or more objects that should be
-      inserted into the array at *idx*
-    @public
   */
-
+  replace(idx: number, amt: number, objects?: readonly T[]): void;
   /**
     Remove all elements from the array. This is useful if you
     want to reuse an existing array without having to recreate it.
@@ -1343,21 +1316,8 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     colors.clear(); // []
     colors.length;  // 0
     ```
-
-    @method clear
-    @return {Array} An empty Array.
-    @public
   */
-  clear() {
-    let len = this.length;
-    if (len === 0) {
-      return this;
-    }
-
-    this.replace(0, len, EMPTY_ARRAY);
-    return this;
-  },
-
+  clear(): this;
   /**
     This will use the primitive `replace()` method to insert an object at the
     specified index.
@@ -1368,18 +1328,8 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     colors.insertAt(2, 'yellow');  // ['red', 'green', 'yellow', 'blue']
     colors.insertAt(5, 'orange');  // Error: Index out of range
     ```
-
-    @method insertAt
-    @param {Number} idx index of insert the object at.
-    @param {Object} object object to insert
-    @return {EmberArray} receiver
-    @public
   */
-  insertAt(idx: number, object: unknown) {
-    insertAt(this, idx, object);
-    return this;
-  },
-
+  insertAt(idx: number, object: T): this;
   /**
     Remove an object at the specified index using the `replace()` primitive
     method. You can pass either a single index, or a start and a length.
@@ -1394,17 +1344,8 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     colors.removeAt(2, 2);  // ['green', 'blue']
     colors.removeAt(4, 2);  // Error: Index out of range
     ```
-
-    @method removeAt
-    @param {Number} start index, start of range
-    @param {Number} len length of passing range
-    @return {EmberArray} receiver
-    @public
   */
-  removeAt(start: number, len?: number) {
-    return removeAt(this, start, len);
-  },
-
+  removeAt(start: number, len?: number): this;
   /**
     Push the object onto the end of the array. Works just like `push()` but it
     is KVO-compliant.
@@ -1415,16 +1356,8 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     colors.pushObject('black');     // ['red', 'green', 'black']
     colors.pushObject(['yellow']);  // ['red', 'green', ['yellow']]
     ```
-
-    @method pushObject
-    @param {*} obj object to push
-    @return object same object passed as a param
-    @public
   */
-  pushObject<T>(this: MutableArray<T>, obj: T) {
-    return insertAt(this, this.length, obj);
-  },
-
+  pushObject(obj: T): this;
   /**
     Add the objects in the passed array to the end of the array. Defers
     notifying observers of the change until all objects are added.
@@ -1434,17 +1367,8 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
 
     colors.pushObjects(['yellow', 'orange']);  // ['red', 'yellow', 'orange']
     ```
-
-    @method pushObjects
-    @param {Array} objects the objects to add
-    @return {MutableArray} receiver
-    @public
   */
-  pushObjects<T>(this: MutableArray<T>, objects: T[]) {
-    this.replace(this.length, 0, objects);
-    return this;
-  },
-
+  pushObjects(objects: T[]): this;
   /**
     Pop object from array or nil if none are left. Works just like `pop()` but
     it is KVO-compliant.
@@ -1455,11 +1379,123 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     colors.popObject();   // 'blue'
     console.log(colors);  // ['red', 'green']
     ```
-
-    @method popObject
-    @return object
-    @public
   */
+  popObject(): T | undefined;
+  /**
+    Shift an object from start of array or nil if none are left. Works just
+    like `shift()` but it is KVO-compliant.
+
+    ```javascript
+    let colors = ['red', 'green', 'blue'];
+
+    colors.shiftObject();  // 'red'
+    console.log(colors);   // ['green', 'blue']
+    ```
+  */
+  shiftObject(): T | null | undefined;
+  /**
+    Unshift an object to start of array. Works just like `unshift()` but it is
+    KVO-compliant.
+
+    ```javascript
+    let colors = ['red'];
+
+    colors.unshiftObject('yellow');    // ['yellow', 'red']
+    colors.unshiftObject(['black']);   // [['black'], 'yellow', 'red']
+    ```
+  */
+  unshiftObject(object: T): this;
+  /**
+    Adds the named objects to the beginning of the array. Defers notifying
+    observers until all objects have been added.
+
+    ```javascript
+    let colors = ['red'];
+
+    colors.unshiftObjects(['black', 'white']);   // ['black', 'white', 'red']
+    colors.unshiftObjects('yellow'); // Type Error: 'undefined' is not a function
+    ```
+  */
+  unshiftObjects(objects: T[]): this;
+  /**
+    Reverse objects in the array. Works just like `reverse()` but it is
+    KVO-compliant.
+  */
+  reverseObjects(): this;
+  /**
+    Replace all the receiver's content with content of the argument.
+    If argument is an empty array receiver will be cleared.
+
+    ```javascript
+    let colors = ['red', 'green', 'blue'];
+
+    colors.setObjects(['black', 'white']);  // ['black', 'white']
+    colors.setObjects([]);                  // []
+    ```
+  */
+  setObjects(object: T[]): this;
+  /**
+    Remove all occurrences of an object in the array.
+
+    ```javascript
+    let cities = ['Chicago', 'Berlin', 'Lima', 'Chicago'];
+
+    cities.removeObject('Chicago');  // ['Berlin', 'Lima']
+    cities.removeObject('Lima');     // ['Berlin']
+    cities.removeObject('Tokyo')     // ['Berlin']
+    ```
+  */
+  removeObject(object: T): this;
+  /**
+    Removes each object in the passed array from the receiver.
+  */
+  removeObjects(objects: T[]): this;
+  /**
+    Push the object onto the end of the array if it is not already
+    present in the array.
+
+    ```javascript
+    let cities = ['Chicago', 'Berlin'];
+
+    cities.addObject('Lima');    // ['Chicago', 'Berlin', 'Lima']
+    cities.addObject('Berlin');  // ['Chicago', 'Berlin', 'Lima']
+    ```
+  */
+  addObject(obj: T): this;
+  /**
+    Adds each object in the passed array to the receiver.
+  */
+  addObjects(objects: T[]): this;
+}
+const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
+  clear() {
+    let len = this.length;
+    if (len === 0) {
+      return this;
+    }
+
+    this.replace(0, len, EMPTY_ARRAY);
+    return this;
+  },
+
+  insertAt(idx: number, object: unknown) {
+    insertAt(this, idx, object);
+    return this;
+  },
+
+  removeAt(start: number, len?: number) {
+    return removeAt(this, start, len);
+  },
+
+  pushObject<T>(this: MutableArray<T>, obj: T) {
+    return insertAt(this, this.length, obj);
+  },
+
+  pushObjects<T>(this: MutableArray<T>, objects: T[]) {
+    this.replace(this.length, 0, objects);
+    return this;
+  },
+
   popObject() {
     let len = this.length;
     if (len === 0) {
@@ -1471,21 +1507,6 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return ret;
   },
 
-  /**
-    Shift an object from start of array or nil if none are left. Works just
-    like `shift()` but it is KVO-compliant.
-
-    ```javascript
-    let colors = ['red', 'green', 'blue'];
-
-    colors.shiftObject();  // 'red'
-    console.log(colors);   // ['green', 'blue']
-    ```
-
-    @method shiftObject
-    @return object
-    @public
-  */
   shiftObject() {
     if (this.length === 0) {
       return null;
@@ -1496,55 +1517,15 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return ret;
   },
 
-  /**
-    Unshift an object to start of array. Works just like `unshift()` but it is
-    KVO-compliant.
-
-    ```javascript
-    let colors = ['red'];
-
-    colors.unshiftObject('yellow');    // ['yellow', 'red']
-    colors.unshiftObject(['black']);   // [['black'], 'yellow', 'red']
-    ```
-
-    @method unshiftObject
-    @param {*} obj object to unshift
-    @return object same object passed as a param
-    @public
-  */
   unshiftObject<T>(this: MutableArray<T>, obj: T) {
     return insertAt(this, 0, obj);
   },
 
-  /**
-    Adds the named objects to the beginning of the array. Defers notifying
-    observers until all objects have been added.
-
-    ```javascript
-    let colors = ['red'];
-
-    colors.unshiftObjects(['black', 'white']);   // ['black', 'white', 'red']
-    colors.unshiftObjects('yellow'); // Type Error: 'undefined' is not a function
-    ```
-
-    @method unshiftObjects
-    @param {Enumerable} objects the objects to add
-    @return {EmberArray} receiver
-    @public
-  */
   unshiftObjects<T>(this: MutableArray<T>, objects: T[]) {
     this.replace(0, 0, objects);
     return this;
   },
 
-  /**
-    Reverse objects in the array. Works just like `reverse()` but it is
-    KVO-compliant.
-
-    @method reverseObjects
-    @return {EmberArray} receiver
-     @public
-  */
   reverseObjects() {
     let len = this.length;
     if (len === 0) {
@@ -1556,23 +1537,6 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return this;
   },
 
-  /**
-    Replace all the receiver's content with content of the argument.
-    If argument is an empty array receiver will be cleared.
-
-    ```javascript
-    let colors = ['red', 'green', 'blue'];
-
-    colors.setObjects(['black', 'white']);  // ['black', 'white']
-    colors.setObjects([]);                  // []
-    ```
-
-    @method setObjects
-    @param {EmberArray} objects array whose content will be used for replacing
-        the content of the receiver
-    @return {EmberArray} receiver with the new content
-    @public
-  */
   setObjects<T>(this: MutableArray<T>, objects: T[]) {
     if (objects.length === 0) {
       return this.clear();
@@ -1583,22 +1547,6 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return this;
   },
 
-  /**
-    Remove all occurrences of an object in the array.
-
-    ```javascript
-    let cities = ['Chicago', 'Berlin', 'Lima', 'Chicago'];
-
-    cities.removeObject('Chicago');  // ['Berlin', 'Lima']
-    cities.removeObject('Lima');     // ['Berlin']
-    cities.removeObject('Tokyo')     // ['Berlin']
-    ```
-
-    @method removeObject
-    @param {*} obj object to remove
-    @return {EmberArray} receiver
-    @public
-  */
   removeObject<T>(this: MutableArray<T>, obj: T) {
     let loc = this.length || 0;
     while (--loc >= 0) {
@@ -1611,14 +1559,6 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return this;
   },
 
-  /**
-    Removes each object in the passed array from the receiver.
-
-    @method removeObjects
-    @param {EmberArray} objects the objects to remove
-    @return {EmberArray} receiver
-    @public
-  */
   removeObjects<T>(this: MutableArray<T>, objects: T[]) {
     beginPropertyChanges();
     for (let i = objects.length - 1; i >= 0; i--) {
@@ -1629,22 +1569,6 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return this;
   },
 
-  /**
-    Push the object onto the end of the array if it is not already
-    present in the array.
-
-    ```javascript
-    let cities = ['Chicago', 'Berlin'];
-
-    cities.addObject('Lima');    // ['Chicago', 'Berlin', 'Lima']
-    cities.addObject('Berlin');  // ['Chicago', 'Berlin', 'Lima']
-    ```
-
-    @method addObject
-    @param {*} obj object to add, if not already present
-    @return {EmberArray} receiver
-    @public
-  */
   addObject<T>(this: MutableArray<T>, obj: T) {
     let included = this.includes(obj);
 
@@ -1655,14 +1579,6 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     return this;
   },
 
-  /**
-    Adds each object in the passed array to the receiver.
-
-    @method addObjects
-    @param {EmberArray} objects the objects to add.
-    @return {EmberArray} receiver
-    @public
-  */
   addObjects<T>(this: MutableArray<T>, objects: T[]) {
     beginPropertyChanges();
     objects.forEach((obj) => this.addObject(obj));

--- a/packages/@ember/array/proxy.ts
+++ b/packages/@ember/array/proxy.ts
@@ -120,12 +120,19 @@ interface ArrayProxy<T, C extends EmberArray<T> | T[] = T[]> extends MutableArra
   /**
     The content array. Must be an object that implements `Array` and/or
     `MutableArray.`
+
+    @property content
+    @type EmberArray
+    @public
   */
   content: C | null;
   /**
     The array that the proxy pretends to be. In the default `ArrayProxy`
     implementation, this and `content` are the same. Subclasses of `ArrayProxy`
     can override this property to provide things like sorting and filtering.
+
+    @property arrangedContent
+    @public
   */
   arrangedContent: C | null;
   /**
@@ -134,6 +141,11 @@ interface ArrayProxy<T, C extends EmberArray<T> | T[] = T[]> extends MutableArra
     content item to something new.
 
     This method will only be called if content is non-`null`.
+
+    @method objectAtContent
+    @param {Number} idx The index to retrieve.
+    @return {Object} the value or undefined if none found
+    @public
   */
   objectAtContent(idx: number): T | undefined;
   /**
@@ -142,6 +154,13 @@ interface ArrayProxy<T, C extends EmberArray<T> | T[] = T[]> extends MutableArra
     into something new.
 
     This method will only be called if content is non-`null`.
+
+    @method replaceContent
+    @param {Number} idx The starting index
+    @param {Number} amt The number of items to remove from the content.
+    @param {Array} objects Optional array of objects to insert.
+    @return {void}
+    @public
   */
   replaceContent(idx: number, amt: number, objects?: T[]): void;
 }

--- a/packages/@ember/array/proxy.ts
+++ b/packages/@ember/array/proxy.ts
@@ -116,8 +116,35 @@ function customTagForArrayProxy(proxy: object, key: string) {
   @uses MutableArray
   @public
 */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
-interface ArrayProxy<T, C extends EmberArray<T> | T[] = T[]> extends MutableArray<T> {}
+interface ArrayProxy<T, C extends EmberArray<T> | T[] = T[]> extends MutableArray<T> {
+  /**
+    The content array. Must be an object that implements `Array` and/or
+    `MutableArray.`
+  */
+  content: C | null;
+  /**
+    The array that the proxy pretends to be. In the default `ArrayProxy`
+    implementation, this and `content` are the same. Subclasses of `ArrayProxy`
+    can override this property to provide things like sorting and filtering.
+  */
+  arrangedContent: C | null;
+  /**
+    Should actually retrieve the object at the specified index from the
+    content. You can override this method in subclasses to transform the
+    content item to something new.
+
+    This method will only be called if content is non-`null`.
+  */
+  objectAtContent(idx: number): T | undefined;
+  /**
+    Should actually replace the specified objects on the content array.
+    You can override this method in subclasses to transform the content item
+    into something new.
+
+    This method will only be called if content is non-`null`.
+  */
+  replaceContent(idx: number, amt: number, objects?: T[]): void;
+}
 class ArrayProxy<T, C extends EmberArray<T> | T[] = T[]>
   extends EmberObject
   implements PropertyDidChange
@@ -169,30 +196,10 @@ class ArrayProxy<T, C extends EmberArray<T> | T[] = T[]>
     this._removeArrangedContentArrayObserver();
   }
 
-  /**
-    The content array. Must be an object that implements `Array` and/or
-    `MutableArray.`
-
-    @property content
-    @type EmberArray
-    @public
-  */
   declare content: C | null;
 
   declare arrangedContent: C | null;
 
-  /**
-    Should actually retrieve the object at the specified index from the
-    content. You can override this method in subclasses to transform the
-    content item to something new.
-
-    This method will only be called if content is non-`null`.
-
-    @method objectAtContent
-    @param {Number} idx The index to retrieve.
-    @return {Object} the value or undefined if none found
-    @public
-  */
   objectAtContent(idx: number) {
     let arrangedContent = get(this, 'arrangedContent');
     assert('[BUG] Called objectAtContent without content', arrangedContent);
@@ -209,20 +216,6 @@ class ArrayProxy<T, C extends EmberArray<T> | T[] = T[]>
     this.replaceContent(idx, amt, objects);
   }
 
-  /**
-    Should actually replace the specified objects on the content array.
-    You can override this method in subclasses to transform the content item
-    into something new.
-
-    This method will only be called if content is non-`null`.
-
-    @method replaceContent
-    @param {Number} idx The starting index
-    @param {Number} amt The number of items to remove from the content.
-    @param {Array} objects Optional array of objects to insert.
-    @return {void}
-    @public
-  */
   replaceContent(idx: number, amt: number, objects?: T[]) {
     let content = get(this, 'content');
     assert('[BUG] Called replaceContent without content', content);
@@ -398,14 +391,6 @@ class ArrayProxy<T, C extends EmberArray<T> | T[] = T[]>
 }
 
 ArrayProxy.reopen(MutableArray, {
-  /**
-    The array that the proxy pretends to be. In the default `ArrayProxy`
-    implementation, this and `content` are the same. Subclasses of `ArrayProxy`
-    can override this property to provide things like sorting and filtering.
-
-    @property arrangedContent
-    @public
-  */
   arrangedContent: alias('content'),
 });
 


### PR DESCRIPTION
**Issue**: https://github.com/emberjs/ember.js/issues/20172.

**Details**:
- Moved comments from Mixin.create({...}) to interface.
- Added missing interface property for `[]` in `array/index`.
- Added interface properties for `array/proxy`