### PR TITLE
[BUGFIX beta]: fix type definition for `Route`

### DIFF
--- a/type-tests/preview/ember/route.ts
+++ b/type-tests/preview/ember/route.ts
@@ -2,6 +2,8 @@ import Route from '@ember/routing/route';
 import Array from '@ember/array';
 import Ember from 'ember'; // currently needed for Transition
 import Transition from '@ember/routing/transition';
+import { expectTypeOf } from 'expect-type';
+import { AnyFn } from 'ember/-private/type-utils';
 
 // Ensure that Ember.Transition is private
 // @ts-expect-error
@@ -82,5 +84,21 @@ class WithBadReturningBeforeAndModelHooks extends Route {
   afterModel(resolvedModel: unknown, transition: Transition): void {
     // @ts-expect-error
     return "returning anything else is nonsensical (if 'legal')";
+  }
+}
+
+class HasEvented extends Route {
+  methodUsingEvented() {
+    this.on('some-event', this, 'aMethod');
+  }
+
+  aMethod() {}
+}
+
+class HasActionHandler extends Route {
+  methodUsingActionHandler() {
+    expectTypeOf(this.actions).toEqualTypeOf<{
+      [index: string]: AnyFn;
+    }>();
   }
 }

--- a/types/preview/@ember/routing/route.d.ts
+++ b/types/preview/@ember/routing/route.d.ts
@@ -8,14 +8,13 @@ declare module '@ember/routing/route' {
 
   type RouteModel = object | string | number;
 
+  export default interface Route<Model, Params extends object> extends ActionHandler, Evented {}
+
   /**
    * The `Ember.Route` class is used to define individual routes. Refer to
    * the [routing guide](http://emberjs.com/guides/routing/) for documentation.
    */
-  export default class Route<
-    Model = unknown,
-    Params extends object = object
-  > extends EmberObject.extend(ActionHandler, Evented) {
+  export default class Route<Model = unknown, Params extends object = object> extends EmberObject {
     // methods
     /**
      * This hook is called after this route's model has resolved. It follows


### PR DESCRIPTION
This was the only remaining use of `.extend()` to apply the associated mixin, and the types were longer working correctly since `.extend()` no longer creates new types.