### PR TITLE
[FEATURE] Update to Typescript 4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "simple-dom": "^1.4.0",
     "testem": "^3.8.0",
     "testem-failure-only-reporter": "^1.0.0",
-    "typescript": "~4.6.4"
+    "typescript": "~4.8.3"
   },
   "peerDependencies": {
     "@glimmer/component": "^1.1.2"

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -105,7 +105,10 @@ class Helper extends FrameworkObject {
   static isHelperFactory = true;
   static [IS_CLASSIC_HELPER] = true;
 
-  [RECOMPUTE_TAG]: DirtyableTag;
+  // SAFETY: this is initialized in `init`, rather than `constructor`. It is
+  // safe to `declare` like this *if and only if* nothing uses the constructor
+  // directly in this class, since nothing else can run before `init`.
+  declare [RECOMPUTE_TAG]: DirtyableTag;
 
   init(properties: object | undefined) {
     super.init(properties);

--- a/packages/@ember/-internals/metal/lib/libraries.ts
+++ b/packages/@ember/-internals/metal/lib/libraries.ts
@@ -86,7 +86,7 @@ if (DEBUG) {
     let nameLengths = libs.map((item) => get(item, 'name.length'));
     assert(
       'nameLengths is number array',
-      nameLengths instanceof Array && nameLengths.every((n) => typeof n === 'number')
+      nameLengths instanceof Array && nameLengths.every((n): n is number => typeof n === 'number')
     );
     let maxNameLength = Math.max.apply(null, nameLengths);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10239,10 +10239,10 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@~4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@~4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
We were previously using 4.6. We'll aim to keep this up to date going forward.

Here, update the dependency and then address two safety issues it caught on either 4.7 or 4.8 but did not back on 4.6.

In the *next* PR I’ll also be adding CI support for testing a range, but *only* targeting 4.8 at the moment with it because we don’t *want* to couple ourselves to a wider range needlessly. See that PR for further details!