### PR TITLE
[FEATURE] Test all supported TS versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,40 @@ jobs:
       - name: linting
         run: yarn lint
 
+  types:
+    name: Type Checking (current version)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          cache: yarn
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: Check types
+        run: yarn type-check
+
+  types-range:
+    name: Type Checking (other supported versions)
+    runs-on: ubuntu-latest
+    needs: ['types']
+    strategy:
+      matrix:
+        ts-version: ['next']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          cache: yarn
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: install TS@${{matrix.ts-version}}
+        run: yarn add -D typescript@${{ matrix.ts-version }}
+      - name: Check types with TS@${{matrix.ts-version}}
+        run: yarn type-check
+
   basic-test:
     name: Debug and Prebuilt (All Tests by Package + Canary Features)
     runs-on: ubuntu-latest
@@ -61,7 +95,7 @@ jobs:
   browserstack-test:
     name: Browserstack Tests (Safari, Edge)
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -87,7 +121,7 @@ jobs:
   smoke-test:
     name: Smoke tests (Full Ember Apps)
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
@@ -110,7 +144,7 @@ jobs:
   production-test:
     name: Production (All Tests + Canary Features)
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -130,7 +164,7 @@ jobs:
   production-debug-render-test:
     name: Production (All Tests + Canary Features with Debug Render Tree)
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -151,7 +185,7 @@ jobs:
   extend-prototypes-test:
     name: Extend Prototypes
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -172,7 +206,7 @@ jobs:
   node-test:
     name: Node.js Tests
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -212,7 +246,7 @@ jobs:
   browser-test:
     name: Browser Tests (Firefox)
     runs-on: ubuntu-latest
-    needs: [basic-test, lint]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -236,7 +270,18 @@ jobs:
   deploy-tag:
     name: Deploy tags to npm
     runs-on: ubuntu-latest
-    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
+    needs:
+      [
+        basic-test,
+        lint,
+        browserstack-test,
+        production-test,
+        production-debug-render-test,
+        extend-prototypes-test,
+        node-test,
+        blueprint-test,
+        browser-test,
+      ]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v3
@@ -257,7 +302,18 @@ jobs:
   publish:
     name: Publish channel to s3
     runs-on: ubuntu-latest
-    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
+    needs:
+      [
+        basic-test,
+        lint,
+        browserstack-test,
+        production-test,
+        production-debug-render-test,
+        extend-prototypes-test,
+        node-test,
+        blueprint-test,
+        browser-test,
+      ]
     # Only run on pushes to branches that are not from the cron workflow
     if: github.event_name == 'push' && contains(github.ref, 'cron') != true
     steps:
@@ -280,7 +336,18 @@ jobs:
   publish-alpha:
     name: Publish alpha from default branch
     runs-on: ubuntu-latest
-    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
+    needs:
+      [
+        basic-test,
+        lint,
+        browserstack-test,
+        production-test,
+        production-debug-render-test,
+        extend-prototypes-test,
+        node-test,
+        blueprint-test,
+        browser-test,
+      ]
     # Only run on pushes to master
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
@@ -301,4 +368,3 @@ jobs:
           S3_BUCKET_NAME: 'builds.emberjs.com'
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY}}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID}}
-

--- a/.github/workflows/night-ts.yml
+++ b/.github/workflows/night-ts.yml
@@ -1,0 +1,18 @@
+name: Nightly TypeScript Run
+
+jobs:
+  ts-next:
+    name: typescript@next
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: yarn add -D typescript@next
+      - run: yarn type-check
+
+# ...nightly at midnight
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
     "lint:docs": "qunit tests/docs/coverage-test.js",
     "lint:eslint": "eslint --report-unused-disable-directives --cache .",
     "lint:eslint:fix": "npm-run-all \"lint:eslint --fix\"",
-    "lint:tsc:stable": "tsc --noEmit",
-    "lint:tsc:preview": "tsc --noEmit --project type-tests/preview",
-    "lint:tsc": "npm-run-all lint:tsc:*",
     "lint:fix": "npm-run-all lint:*:fix",
     "test": "node bin/run-tests.js",
     "test:blueprints:js": "mocha node-tests/blueprints/**/*-test.js",
     "test:blueprints:ts": "EMBER_TYPESCRIPT_BLUEPRINTS=true yarn test:blueprints:js",
     "test:blueprints": "yarn test:blueprints:js && yarn test:blueprints:ts",
     "test:node": "qunit tests/node/**/*-test.js",
-    "test:browserstack": "node bin/run-browserstack-tests.js"
+    "test:browserstack": "node bin/run-browserstack-tests.js",
+    "type-check:stable": "tsc --noEmit",
+    "type-check:preview": "tsc --noEmit --project type-tests/preview",
+    "type-check": "npm-run-all type-check:*"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@glimmer/validator": "0.84.2",
     "@simple-dom/document": "^1.4.0",
     "@tsconfig/ember": "^1.0.1",
+    "@types/node": "^18.7.23",
     "@types/qunit": "^2.19.2",
     "@types/rsvp": "^4.0.4",
     "@typescript-eslint/eslint-plugin": "^5.38.0",

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -353,7 +353,7 @@ class Route<T = unknown>
     if (params.length === 1) {
       let [name] = params;
       assert('has name', name);
-      if (name in model) {
+      if (typeof model === 'object' && name in model) {
         object[name] = get(model, name);
       } else if (/_id$/.test(name)) {
         object[name] = get(model, 'id');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
   integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
+"@types/node@^18.7.23":
+  version "18.7.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
+  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
+
 "@types/node@^9.6.0":
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.0.tgz#d3480ee666df9784b1001a1872a2f6ccefb6c2d7"
@@ -7708,9 +7713,9 @@ morgan@^1.10.0:
     on-headers "~1.0.2"
 
 mout@^1.0.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/mout/-/mout-1.2.4.tgz#9ffd261c4d6509e7ebcbf6b641a89b36ecdf8155"
-  integrity sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/mout/-/mout-1.2.3.tgz#bd1477d8c7f2db5fcf43c91de30b6cc746b78e10"
+  integrity sha512-vtE+eZcSj/sBkIp6gxB87MznryWP+gHIp0XX9SKrzA5TAkvz6y7VTuNruBjYdJozd8NY5i9XVIsn8cn3SwNjzg==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As part of implementing RFC 0800, introduce support for testing all supported versions of TypeScript against our types. For the moment, the only additional supported version is the TypeScript nightly (`next`) build. When we get to publishing stable types, the current version will be the first version we support, and we will add new versions to the matrix over time in line with the "rolling window" support policy.

Additionally, *remove* type checking from the `lint` scripts and create a new set of `type-check` scripts instead. This is pragmatic, not philosophical: we treat it differently from the "lints" here in that we need to be able to run it repeatedly against different versions, whereas the lints are all one-and-done.

---

- Depends on #20203.
- Fixes #20185.