### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 20 * * 3' # weekly (Wednesday)
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 20 * * 3' # weekly (Wednesday)
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     name: Basic Test
@@ -22,6 +25,9 @@ jobs:
         run: pnpm test
 
   release:
+    permissions:
+      contents: write # to push tag
+
     name: Tag + Release
     runs-on: ubuntu-latest
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
       - 'CHANGELOG.md'
   pull_request:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   lint:
     name: Linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,8 +5,15 @@ on:
     - cron:  '0 7 * * *' # daily, 7am
   workflow_dispatch:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   trigger-ci:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      checks: read # to list check suites
+
     name: Trigger cron build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   trigger-ci:
     permissions:
-      contents: read # to fetch code (actions/checkout)
-      checks: read # to list check suites
+      contents: read # the push uses a non-default token so it will trigger workflows
+      checks: read
 
     name: Trigger cron build
     runs-on: ubuntu-latest

--- a/.github/workflows/night-ts.yml
+++ b/.github/workflows/night-ts.yml
@@ -1,5 +1,8 @@
 name: Nightly TypeScript Run
 
+permissions:
+  contents: read
+
 jobs:
   ts-next:
     name: typescript@next


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.