### PR TITLE
[BUGFIX beta] remove wrong exports from preview routing types

### DIFF
--- a/types/preview/@ember/application/index.d.ts
+++ b/types/preview/@ember/application/index.d.ts
@@ -3,7 +3,7 @@ declare module '@ember/application' {
   import ApplicationInstance from '@ember/application/instance';
   import EventDispatcher from '@ember/application/-private/event-dispatcher';
   import { EventDispatcherEvents } from '@ember/application/types';
-  import { Router } from '@ember/routing';
+  import Router from '@ember/routing/router';
   import Registry from '@ember/application/-private/registry';
   import type { Resolver } from '@ember/-internals/resolver';
   import { AnyFn } from 'ember/-private/type-utils';

--- a/types/preview/@ember/routing/index.d.ts
+++ b/types/preview/@ember/routing/index.d.ts
@@ -1,7 +1,4 @@
 declare module '@ember/routing' {
-  export { default as Route } from '@ember/routing/route';
-  export { default as Router } from '@ember/routing/router';
-
   import { Opaque } from 'ember/-private/type-utils';
 
   // In normal TypeScript, this component is essentially an opaque token


### PR DESCRIPTION
These exports appeared in the DefinitelyTyped definitions for a very long time, and were missed when migrating them for the preview. This change aligns the type exports with the actual public API.

Same fix on DT: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62475