### PR TITLE
[BUGFIX] Restore mixin based EmberArray detection

### DIFF
--- a/packages/@ember/-internals/utils/lib/ember-array.ts
+++ b/packages/@ember/-internals/utils/lib/ember-array.ts
@@ -1,4 +1,4 @@
-import type EmberArray from '@ember/array';
+import EmberArray from '@ember/array';
 import { _WeakSet } from '@glimmer/util';
 
 const EMBER_ARRAYS = new _WeakSet();
@@ -8,5 +8,9 @@ export function setEmberArray(obj: object) {
 }
 
 export function isEmberArray(obj: unknown): obj is EmberArray<unknown> {
-  return EMBER_ARRAYS.has(obj as object);
+  if (EMBER_ARRAYS.has(obj as object)) {
+    return true;
+  }
+
+  return EmberArray.detect(obj);
 }

--- a/packages/@ember/-internals/utils/lib/ember-array.ts
+++ b/packages/@ember/-internals/utils/lib/ember-array.ts
@@ -1,4 +1,4 @@
-import EmberArray from '@ember/array';
+import type EmberArray from '@ember/array';
 import { _WeakSet } from '@glimmer/util';
 
 const EMBER_ARRAYS = new _WeakSet();
@@ -8,9 +8,5 @@ export function setEmberArray(obj: object) {
 }
 
 export function isEmberArray(obj: unknown): obj is EmberArray<unknown> {
-  if (EMBER_ARRAYS.has(obj as object)) {
-    return true;
-  }
-
-  return EmberArray.detect(obj);
+  return EMBER_ARRAYS.has(obj as object);
 }

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1950,11 +1950,20 @@ if (ENV.EXTEND_PROTOTYPES.Array) {
     return (arr || []) as NativeArray<T>;
   };
 } else {
-  A = function <T>(this: unknown, arr?: Array<T>) {
+  interface IsEmberAAble {
+    preventEmberA(): boolean;
+  }
+  A = function <T>(this: unknown, arr?: Array<T> | IsEmberAAble) {
     assert(
       'You cannot create an Ember Array with `new A()`, please update to calling A as a function: `A()`',
       !(this instanceof A)
     );
+
+    if (typeof (arr as IsEmberAAble)?.preventEmberA === 'function') {
+      if ((arr as IsEmberAAble).preventEmberA()) {
+        return arr as NativeArray<T>;
+      }
+    }
 
     if (isEmberArray(arr)) {
       // SAFETY: If it's a true native array and it is also an EmberArray then it should be an Ember NativeArray


### PR DESCRIPTION
This is needed for ember-data to tap into and masquerade as an EmberArray to avoid being clobbered by Ember.A().

Refs emberjs/data#8202

This functionality was dropped in ~#20092~ #20086

I couldn't figure out where a test for this would go, but opening a PR as a starting place for discussion and happy to update as needed.