### PR TITLE
Integrate types for the `warn` method

### DIFF
--- a/packages/@ember/debug/lib/warn.ts
+++ b/packages/@ember/debug/lib/warn.ts
@@ -93,10 +93,11 @@ if (DEBUG) {
     @for @ember/debug
     @static
     @param {String} message A warning to display.
-    @param {Boolean} test An optional boolean. If falsy, the warning
-      will be displayed.
-    @param {Object} options An object that can be used to pass a unique
-      `id` for this warning.  The `id` can be used by Ember debugging tools
+    @param {Boolean|Object} test An optional boolean. If falsy, the warning
+      will be displayed. If `test` is an object, the `test` parameter can
+      be used as the `options` parameter and the warning is displayed.
+    @param {Object} options
+    @param {String} options.id The `id` can be used by Ember debugging tools
       to change the behavior (raise, log, or silence) for that specific warning.
       The `id` should be namespaced by dots, e.g. "ember-debug.feature-flag-with-features-stripped"
     @public

--- a/packages/@ember/debug/lib/warn.ts
+++ b/packages/@ember/debug/lib/warn.ts
@@ -112,8 +112,10 @@ if (DEBUG) {
     assert(missingOptionsDeprecation, Boolean(options));
     assert(missingOptionsIdDeprecation, Boolean(options && options.id));
 
-    // SAFETY: we checked this by way of the `arguments` check above.
-    invoke('warn', message, test as boolean, options);
+    // SAFETY: we have explicitly assigned `false` if the user invoked the
+    // arity-2 version of the overload, so we know `test` is always either
+    // `undefined` or a `boolean` for type-safe callers.
+    invoke('warn', message, test as boolean | undefined, options);
   };
 }
 


### PR DESCRIPTION
This PR consist of two commits (if they are okay, I can them squash them)

1. Mention the `id` property in the options object of the `warn` method. The `deprecate` method mentions the sub-options properties and I tried to align the doc's for the warn method.
2. integrate the Typescript types for the `warn` method. Right now, the `test` parameter can be used as a `test`-condition or as a shortcut for the `options` object to always display the warning. The `options` object itself is required for the warning.

What do you think?