### PR TITLE
[BUGFIX release] Fix unsafe internal cast for NativeArray

### DIFF
--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1958,7 +1958,7 @@ if (ENV.EXTEND_PROTOTYPES.Array) {
 
     if (isEmberArray(arr)) {
       // SAFETY: If it's a true native array and it is also an EmberArray then it should be an Ember NativeArray
-      return arr as NativeArray<T>;
+      return arr as unknown as NativeArray<T>;
     } else {
       // SAFETY: This will return an NativeArray but TS can't infer that.
       return NativeArray.apply(arr ?? []) as NativeArray<T>;

--- a/packages/@ember/object/core.ts
+++ b/packages/@ember/object/core.ts
@@ -261,7 +261,7 @@ class CoreObject {
 
       /* globals Proxy Reflect */
       self = new Proxy(this, {
-        get(target: CoreObject & HasUnknownProperty, property, receiver) {
+        get(target: typeof this & HasUnknownProperty, property, receiver) {
           if (property === PROXY_CONTENT) {
             return target;
           } else if (


### PR DESCRIPTION
- For casting to `NativeArray` from `T[] & EmberArray<unknown>`: we do not have enough information to be able to tell TypeScript that the cast is safe here (and likely never will). TS 4.9 seems to handle the intersection type more robustly, though it is not yet documented. Here we make the cast from `T[] & EmberArray<T>` to `NativeArray<T>` even *more* explicitly unsafe via an `as unknown` intermediary cast.

- For handling a proxy getter: TS' intersection of the `this` type for the `get()` method on a proxy receiver object used in `CoreObject` now flags up that the type of `this` may *not* be exactly `CoreObject`. Using `typeof this` in that intersection instead allows TS to see that the trap is safe.