### PR TITLE
[BUGFIX release] Remove type export for ControllerMixin

### DIFF
--- a/types/preview/@ember/controller/index.d.ts
+++ b/types/preview/@ember/controller/index.d.ts
@@ -16,7 +16,7 @@ declare module '@ember/controller' {
   /**
    * Additional methods for the Controller.
    */
-  export interface ControllerMixin extends ActionHandler {
+  interface ControllerMixin extends ActionHandler {
     /**
      * @deprecated until 5.0. Use `RouterService.replaceWith` instead.
      */
@@ -33,7 +33,6 @@ declare module '@ember/controller' {
     queryParams: Array<string | Record<string, QueryParamConfig | string | undefined>>;
     target: object;
   }
-  export const ControllerMixin: Mixin;
 
   export default class Controller extends EmberObject {}
   export default interface Controller extends ControllerMixin {}


### PR DESCRIPTION
This type does not exist to be imported from the location it existed at in the definitions, and so the types could auto-suggest an import which would produce a runtime error. Remove it to prevent users from being misled this way.

See also: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62784