### PR TITLE
[BUGFIX beta] Update Node.js versions to match support policy

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -2,7 +2,7 @@ name: Alpha Releases
 
 on:
   schedule:
-    - cron:  '0 20 * * 3' # weekly (Wednesday)
+    - cron: '0 20 * * 3' # weekly (Wednesday)
 
 jobs:
   test:
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
       - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -211,7 +211,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -232,7 +232,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -251,7 +251,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -287,7 +287,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - name: install dependencies
@@ -320,7 +320,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -354,7 +354,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@glimmer/component": "^1.1.2"
   },
   "engines": {
-    "node": ">= 12.*"
+    "node": ">= 14.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"

--- a/smoke-tests/ember-test-app/package.json
+++ b/smoke-tests/ember-test-app/package.json
@@ -63,7 +63,7 @@
     "webpack": "^5.65.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Ember CLI dropped support for Node 12 in 4.6.0.