### PR TITLE
[BUGFIX release] expose getComponentTemplate type

### DIFF
--- a/types/preview/@ember/component/index.d.ts
+++ b/types/preview/@ember/component/index.d.ts
@@ -106,6 +106,15 @@ declare module '@ember/component' {
     object: T
   ): T;
 
+/**
+ * Takes a component class and returns the template associated with the given component class,
+ * if any, or one of its superclasses, if any, or undefined if no template association was found.
+ *
+ * @param object the component object
+ * @return the template factory of the given component
+ */
+ export function getComponentTemplate(obj: object): TemplateFactory | undefined;
+
   // In normal TypeScript, these built-in components are essentially opaque tokens
   // that just need to be importable. Declaring them with unique interfaces
   // like this, however, gives tools like Glint (that DO have a richer


### PR DESCRIPTION
`getComponentTemplate` is [public API](https://github.com/emberjs/rfcs/pull/481) and is missing from the types. This type is exposed in the Definitively Typed types but missing here.