### PR TITLE
[BUGFIX release] Correct types for Ember Arrays

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
@@ -5,6 +5,7 @@ import type { Option } from '@glimmer/interfaces';
 import type { IteratorDelegate } from '@glimmer/reference';
 import { consumeTag, isTracking, tagFor } from '@glimmer/validator';
 import { EachInWrapper } from '../helpers/each-in';
+import type { NativeArray } from '@ember/array';
 
 export default function toIterator(iterable: unknown): Option<IteratorDelegate> {
   if (iterable instanceof EachInWrapper) {
@@ -100,11 +101,11 @@ class ArrayIterator extends BoundedIterator {
 }
 
 class EmberArrayIterator extends BoundedIterator {
-  static from(iterable: EmberArray<unknown>) {
+  static from(iterable: EmberArray<unknown> | NativeArray<unknown>) {
     return iterable.length > 0 ? new this(iterable) : null;
   }
 
-  constructor(private array: EmberArray<unknown>) {
+  constructor(private array: EmberArray<unknown> | NativeArray<unknown>) {
     super(array.length);
   }
 

--- a/packages/@ember/-internals/utils/lib/ember-array.ts
+++ b/packages/@ember/-internals/utils/lib/ember-array.ts
@@ -1,4 +1,4 @@
-import type EmberArray from '@ember/array';
+import type { EmberArrayLike } from '@ember/array';
 import { _WeakSet } from '@glimmer/util';
 
 const EMBER_ARRAYS = new _WeakSet();
@@ -7,6 +7,6 @@ export function setEmberArray(obj: object) {
   EMBER_ARRAYS.add(obj);
 }
 
-export function isEmberArray(obj: unknown): obj is EmberArray<unknown> {
+export function isEmberArray(obj: unknown): obj is EmberArrayLike<unknown> {
   return EMBER_ARRAYS.has(obj as object);
 }

--- a/packages/@ember/-internals/utils/types.ts
+++ b/packages/@ember/-internals/utils/types.ts
@@ -1,10 +1,18 @@
 export type AnyFn = (...args: any[]) => any;
 
-export type MethodNamesOf<T> = {
-  [K in keyof T]: T[K] extends AnyFn ? K : never;
-}[keyof T];
+// The formatting here is designed to help make this type actually be
+// comprehensible to mortals, including the mortals who came up with it.
+// prettier-ignore
+export type MethodsOf<T> = {
+  // This `keyof` check is the thing which gives us *only* these keys, and no
+  // `foo: never` appears in the final type.
+  [K in keyof T as T[K] extends AnyFn ? K : never]:
+    // While this makes sure the resolved type only has `AnyFn` in it, so that
+    // the resulting type is known to be only function types.
+    T[K] extends AnyFn ? T[K] : never;
+};
 
-export type MethodsOf<O> = Pick<O, MethodNamesOf<O>>;
+export type MethodNamesOf<T> = keyof MethodsOf<T>;
 
 export type MethodParams<T, M extends MethodNamesOf<T>> = Parameters<MethodsOf<T>[M]>;
 

--- a/packages/@ember/-internals/utils/types.ts
+++ b/packages/@ember/-internals/utils/types.ts
@@ -4,4 +4,10 @@ export type MethodNamesOf<T> = {
   [K in keyof T]: T[K] extends AnyFn ? K : never;
 }[keyof T];
 
+export type MethodsOf<O> = Pick<O, MethodNamesOf<O>>;
+
+export type MethodParams<T, M extends MethodNamesOf<T>> = Parameters<MethodsOf<T>[M]>;
+
+export type MethodReturns<T, M extends MethodNamesOf<T>> = ReturnType<MethodsOf<T>[M]>;
+
 export type OmitFirst<F> = F extends [any, ...infer R] ? R : [];

--- a/packages/@ember/array/type-tests/mutable.ts
+++ b/packages/@ember/array/type-tests/mutable.ts
@@ -1,63 +1,67 @@
-import type MutableArray from '@ember/array/mutable';
-import { A } from '@ember/array';
+import MutableArray from '@ember/array/mutable';
 
 import { expectTypeOf } from 'expect-type';
 
-class Foo {}
+class Foo {
+  constructor(public name: string) {}
+}
 
-let foo = new Foo();
+let foo = new Foo('test');
 
-let arr = A([foo]);
+let originalArr = [foo];
+// This is not really the ideal way to set things up.
+MutableArray.apply(originalArr);
+let arr = originalArr as unknown as MutableArray<Foo>;
 
 expectTypeOf(arr).toMatchTypeOf<MutableArray<Foo>>();
 
 expectTypeOf(arr.replace(1, 1, [foo])).toEqualTypeOf<void>();
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.replace(1, 1, ['invalid']);
 
 expectTypeOf(arr.clear()).toEqualTypeOf(arr);
 
 expectTypeOf(arr.insertAt(1, foo)).toEqualTypeOf(arr);
 
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.insertAt(1, 'invalid');
 
 expectTypeOf(arr.removeAt(1, 1)).toEqualTypeOf(arr);
 
-expectTypeOf(arr.pushObject(foo)).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+expectTypeOf(arr.pushObject(foo)).toEqualTypeOf(foo);
+// @ts-expect-error invalid item
 arr.pushObject('invalid');
 
 expectTypeOf(arr.pushObjects([foo])).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.pushObjects(['invalid']);
 
-expectTypeOf(arr.popObject()).toEqualTypeOf<Foo | undefined>();
+expectTypeOf(arr.popObject()).toEqualTypeOf<Foo | null | undefined>();
 
 expectTypeOf(arr.shiftObject()).toEqualTypeOf<Foo | null | undefined>();
 
-expectTypeOf(arr.unshiftObject(foo)).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+expectTypeOf(arr.unshiftObject(foo)).toEqualTypeOf(foo);
+// @ts-expect-error invalid item
 arr.unshiftObject('invalid');
 
 expectTypeOf(arr.unshiftObjects([foo])).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.unshiftObjects(['invalid']);
 
 expectTypeOf(arr.reverseObjects()).toEqualTypeOf(arr);
 
 expectTypeOf(arr.setObjects([foo])).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.setObjects(['invalid']);
 
 expectTypeOf(arr.removeObject(foo)).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.removeObject('invalid');
 
 expectTypeOf(arr.addObject(foo)).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.addObject('invalid');
 
 expectTypeOf(arr.addObjects([foo])).toEqualTypeOf(arr);
-// TODO: Why doesn't this fail?
+// @ts-expect-error invalid item
 arr.addObjects(['invalid']);

--- a/packages/@ember/debug/data-adapter.ts
+++ b/packages/@ember/debug/data-adapter.ts
@@ -544,7 +544,7 @@ export default class DataAdapter<T> extends EmberObject {
     @method getModelTypes
     @return {Array} Array of model types.
   */
-  getModelTypes(): NativeArray<{ klass: unknown; name: string }> {
+  getModelTypes(): Array<{ klass: unknown; name: string }> {
     let containerDebugAdapter = this.containerDebugAdapter;
 
     let stringTypes = containerDebugAdapter.canCatalogEntriesByType('model')

--- a/type-tests/preview/@ember/array-test/array.ts
+++ b/type-tests/preview/@ember/array-test/array.ts
@@ -3,6 +3,7 @@ import type Array from '@ember/array';
 import { A } from '@ember/array';
 import type MutableArray from '@ember/array/mutable';
 import { expectTypeOf } from 'expect-type';
+import NativeArray from '@ember/array/-private/native-array';
 
 class Person extends EmberObject {
   name = '';
@@ -19,20 +20,18 @@ expectTypeOf(people.get('lastObject')).toEqualTypeOf<Person | undefined>();
 expectTypeOf(people.get('firstObject')).toEqualTypeOf<Person | undefined>();
 expectTypeOf(people.isAny('isHappy')).toBeBoolean();
 expectTypeOf(people.isAny('isHappy', false)).toBeBoolean();
-// @ts-expect-error -- string != boolean
+// TODO: Ideally we'd mark the value as being invalid
 people.isAny('isHappy', 'false');
 
 expectTypeOf(people.objectAt(0)).toEqualTypeOf<Person | undefined>();
 expectTypeOf(people.objectsAt([1, 2, 3])).toEqualTypeOf<Array<Person | undefined>>();
 
 expectTypeOf(people.filterBy('isHappy')).toMatchTypeOf<Person[]>();
-expectTypeOf(people.filterBy('isHappy')).toMatchTypeOf<MutableArray<Person>>();
+expectTypeOf(people.filterBy('isHappy')).toMatchTypeOf<NativeArray<Person>>();
 expectTypeOf(people.rejectBy('isHappy')).toMatchTypeOf<Person[]>();
-expectTypeOf(people.rejectBy('isHappy')).toMatchTypeOf<MutableArray<Person>>();
+expectTypeOf(people.rejectBy('isHappy')).toMatchTypeOf<NativeArray<Person>>();
 expectTypeOf(people.filter((person) => person.get('name') === 'Yehuda')).toMatchTypeOf<Person[]>();
-expectTypeOf(people.filter((person) => person.get('name') === 'Yehuda')).toMatchTypeOf<
-  MutableArray<Person>
->();
+expectTypeOf(people.filter((person) => person.get('name') === 'Yehuda')).toMatchTypeOf<Person[]>();
 
 expectTypeOf(people.get('[]')).toEqualTypeOf<typeof people>();
 expectTypeOf(people.get('[]').get('firstObject')).toEqualTypeOf<Person | undefined>();

--- a/type-tests/preview/ember/array.ts
+++ b/type-tests/preview/ember/array.ts
@@ -16,20 +16,18 @@ expectTypeOf(people.get('lastObject')).toEqualTypeOf<Person | undefined>();
 expectTypeOf(people.get('firstObject')).toEqualTypeOf<Person | undefined>();
 expectTypeOf(people.isAny('isHappy')).toBeBoolean();
 expectTypeOf(people.isAny('isHappy', false)).toBeBoolean();
-// @ts-expect-error
+// TODO: Ideally we'd mark the value as being invalid
 people.isAny('isHappy', 'false');
 
 expectTypeOf(people.objectAt(0)).toEqualTypeOf<Person | undefined>();
 expectTypeOf(people.objectsAt([1, 2, 3])).toEqualTypeOf<Ember.Array<Person | undefined>>();
 
 expectTypeOf(people.filterBy('isHappy')).toMatchTypeOf<Person[]>();
-expectTypeOf(people.filterBy('isHappy')).toMatchTypeOf<Ember.MutableArray<Person>>();
+expectTypeOf(people.filterBy('isHappy')).toMatchTypeOf<Ember.NativeArray<Person>>();
 expectTypeOf(people.rejectBy('isHappy')).toMatchTypeOf<Person[]>();
-expectTypeOf(people.rejectBy('isHappy')).toMatchTypeOf<Ember.MutableArray<Person>>();
+expectTypeOf(people.rejectBy('isHappy')).toMatchTypeOf<Ember.NativeArray<Person>>();
 expectTypeOf(people.filter((person) => person.get('name') === 'Yehuda')).toMatchTypeOf<Person[]>();
-expectTypeOf(people.filter((person) => person.get('name') === 'Yehuda')).toMatchTypeOf<
-  Ember.MutableArray<Person>
->();
+expectTypeOf(people.filter((person) => person.get('name') === 'Yehuda')).toMatchTypeOf<Person[]>();
 
 expectTypeOf(people.get('[]')).toEqualTypeOf<typeof people>();
 expectTypeOf(people.get('[]').get('firstObject')).toEqualTypeOf<Person | undefined>();
@@ -48,15 +46,14 @@ if (first) {
   expectTypeOf(first.get('isHappy')).toBeBoolean();
 }
 
-const letters: Ember.Array<string> = Ember.A(['a', 'b', 'c']);
+const letters: Ember.NativeArray<string> = Ember.A(['a', 'b', 'c']);
 const codes = letters.map((item, index, array) => {
   expectTypeOf(item).toBeString();
   expectTypeOf(index).toBeNumber();
-  expectTypeOf(array).toEqualTypeOf<Ember.Array<string>>();
+  expectTypeOf(array).toEqualTypeOf<string[]>();
   return item.charCodeAt(0);
 });
-expectTypeOf(codes).toMatchTypeOf<number[]>();
-expectTypeOf(codes).toEqualTypeOf<Ember.NativeArray<number>>();
+expectTypeOf(codes).toEqualTypeOf<number[]>();
 
 const value = '1,2,3';
 const filters = Ember.A(value.split(','));

--- a/type-tests/preview/ember/ember-module-tests.ts
+++ b/type-tests/preview/ember/ember-module-tests.ts
@@ -153,7 +153,7 @@ expectTypeOf(Ember.Application.create()).toEqualTypeOf<Ember.Application>();
 expectTypeOf(new Ember.ApplicationInstance()).toEqualTypeOf<Ember.ApplicationInstance>();
 expectTypeOf(Ember.ApplicationInstance.create()).toEqualTypeOf<Ember.ApplicationInstance>();
 // Ember.Array
-const a1: Ember.Array<string> = Ember.A([]);
+const a1: Ember.NativeArray<string> = Ember.A([]);
 // @ts-expect-error
 const a2: Ember.Array<string> = {};
 // Ember.ArrayProxy
@@ -232,13 +232,13 @@ class UsesMixin extends Ember.Object {
   }
 }
 // Ember.MutableArray
-const ma1: Ember.MutableArray<string> = Ember.A(['money', 'in', 'the', 'bananna', 'stand']);
-expectTypeOf(ma1.addObject('!')).toBeString();
-// @ts-expect-error
+const ma1: Ember.NativeArray<string> = Ember.A(['money', 'in', 'the', 'bananna', 'stand']);
+expectTypeOf(ma1.addObject('!')).toMatchTypeOf(ma1);
+// TODO: Ideally we'd mark the value as being invalid
 ma1.filterBy('');
 expectTypeOf(ma1.firstObject).toEqualTypeOf<string | undefined>();
 expectTypeOf(ma1.lastObject).toEqualTypeOf<string | undefined>();
-const ma2: Ember.MutableArray<{ name: string }> = Ember.A([
+const ma2: Ember.NativeArray<{ name: string }> = Ember.A([
   { name: 'chris' },
   { name: 'dan' },
   { name: 'james' },

--- a/type-tests/preview/ember/ember-tests.ts
+++ b/type-tests/preview/ember/ember-tests.ts
@@ -112,14 +112,13 @@ people.invoke('sayHello');
 // @ts-expect-error
 people.invoke('name');
 
-type Arr = Ember.NativeArray<
-  Ember.Object & {
-    name?: string;
-  }
->;
-const arr: Arr = Ember.A([Ember.Object.create(), Ember.Object.create()]);
-expectTypeOf(arr.setEach('name', 'unknown')).toEqualTypeOf<void>();
-expectTypeOf(arr.setEach('name', undefined)).toEqualTypeOf<void>();
+class Obj extends Ember.Object {
+  name?: string;
+}
+
+const arr: Ember.NativeArray<Obj> = Ember.A([Ember.Object.create(), Ember.Object.create()]);
+expectTypeOf(arr.setEach('name', 'unknown')).toEqualTypeOf(arr);
+expectTypeOf(arr.setEach('name', undefined)).toEqualTypeOf(arr);
 expectTypeOf(arr.getEach('name')).toEqualTypeOf<Ember.NativeArray<string | undefined>>();
 // @ts-expect-error
 arr.setEach('age', 123);
@@ -141,7 +140,7 @@ people2.every(isHappy);
 people2.any(isHappy);
 people2.isEvery('isHappy');
 people2.isEvery('isHappy', true);
-// @ts-expect-error
+// TODO: Ideally we'd mark the value as being invalid
 people2.isAny('isHappy', 'true');
 people2.isAny('isHappy', true);
 people2.isAny('isHappy');

--- a/types/preview/@ember/array/-private/native-array.d.ts
+++ b/types/preview/@ember/array/-private/native-array.d.ts
@@ -1,10 +1,171 @@
 declare module '@ember/array/-private/native-array' {
   import Observable from '@ember/object/observable';
+  import EmberArray from '@ember/array';
   import MutableArray from '@ember/array/mutable';
   import Mixin from '@ember/object/mixin';
 
   // Get an alias to the global Array type to use in inner scope below.
   type Array<T> = T[];
+
+  type AnyArray<T> = EmberArray<T> | Array<T>;
+
+  /**
+   * The final definition of NativeArray removes all native methods. This is the list of removed methods
+   * when run in Chrome 106.
+   */
+  type IGNORED_MUTABLE_ARRAY_METHODS =
+    | 'length'
+    | 'slice'
+    | 'indexOf'
+    | 'lastIndexOf'
+    | 'forEach'
+    | 'map'
+    | 'filter'
+    | 'find'
+    | 'every'
+    | 'reduce'
+    | 'includes';
+
+  /**
+   * These additional items must be redefined since `Omit` causes methods that return `this` to return the
+   * type at the time of the Omit.
+   */
+  type RETURN_SELF_ARRAY_METHODS =
+    | '[]'
+    | 'clear'
+    | 'insertAt'
+    | 'removeAt'
+    | 'pushObjects'
+    | 'unshiftObjects'
+    | 'reverseObjects'
+    | 'setObjects'
+    | 'removeObject'
+    | 'removeObjects'
+    | 'addObject'
+    | 'addObjects'
+    | 'setEach';
+
+  // This is the same as MutableArray, but removes the actual native methods that exist on Array.prototype.
+  interface MutableArrayWithoutNative<T>
+    extends Omit<MutableArray<T>, IGNORED_MUTABLE_ARRAY_METHODS | RETURN_SELF_ARRAY_METHODS> {
+    /**
+     * Remove all elements from the array. This is useful if you
+     * want to reuse an existing array without having to recreate it.
+     */
+    clear(): this;
+    /**
+     * This will use the primitive `replace()` method to insert an object at the
+     * specified index.
+     */
+    insertAt(idx: number, object: T): this;
+    /**
+     * Remove an object at the specified index using the `replace()` primitive
+     * method. You can pass either a single index, or a start and a length.
+     */
+    removeAt(start: number, len?: number): this;
+    /**
+     * Add the objects in the passed numerable to the end of the array. Defers
+     * notifying observers of the change until all objects are added.
+     */
+    pushObjects(objects: AnyArray<T>): this;
+    /**
+     * Adds the named objects to the beginning of the array. Defers notifying
+     * observers until all objects have been added.
+     */
+    unshiftObjects(objects: AnyArray<T>): this;
+    /**
+     * Reverse objects in the array. Works just like `reverse()` but it is
+     * KVO-compliant.
+     */
+    reverseObjects(): this;
+    /**
+     * Replace all the receiver's content with content of the argument.
+     * If argument is an empty array receiver will be cleared.
+     */
+    setObjects(objects: AnyArray<T>): this;
+    /**
+    Remove all occurrences of an object in the array.
+
+    ```javascript
+    let cities = ['Chicago', 'Berlin', 'Lima', 'Chicago'];
+
+    cities.removeObject('Chicago');  // ['Berlin', 'Lima']
+    cities.removeObject('Lima');     // ['Berlin']
+    cities.removeObject('Tokyo')     // ['Berlin']
+    ```
+
+    @method removeObject
+    @param {*} obj object to remove
+    @return {EmberArray} receiver
+    @public
+  */
+    removeObject(object: T): this;
+    /**
+     * Removes each object in the passed array from the receiver.
+     */
+    removeObjects(objects: AnyArray<T>): this;
+    /**
+      Push the object onto the end of the array if it is not already
+      present in the array.
+
+      ```javascript
+      let cities = ['Chicago', 'Berlin'];
+
+      cities.addObject('Lima');    // ['Chicago', 'Berlin', 'Lima']
+      cities.addObject('Berlin');  // ['Chicago', 'Berlin', 'Lima']
+      ```
+
+      @method addObject
+      @param {*} obj object to add, if not already present
+      @return {EmberArray} receiver
+      @public
+    */
+    addObject(obj: T): this;
+    /**
+     * Adds each object in the passed enumerable to the receiver.
+     */
+    addObjects(objects: AnyArray<T>): this;
+    /**
+      Sets the value on the named property for each member. This is more
+      ergonomic than using other methods defined on this helper. If the object
+      implements Observable, the value will be changed to `set(),` otherwise
+      it will be set directly. `null` objects are skipped.
+
+      ```javascript
+      let people = [{name: 'Joe'}, {name: 'Matt'}];
+
+      people.setEach('zipCode', '10011');
+      // [{name: 'Joe', zipCode: '10011'}, {name: 'Matt', zipCode: '10011'}];
+      ```
+
+      @method setEach
+      @param {String} key The key to set
+      @param {Object} value The object to set
+      @return {Object} receiver
+      @public
+    */
+    setEach<K extends keyof T>(key: K, value: T[K]): this;
+    /**
+      This is the handler for the special array content property. If you get
+      this property, it will return this. If you set this property to a new
+      array, it will replace the current content.
+
+      ```javascript
+      let peopleToMoon = ['Armstrong', 'Aldrin'];
+
+      peopleToMoon.get('[]'); // ['Armstrong', 'Aldrin']
+
+      peopleToMoon.set('[]', ['Collins']); // ['Collins']
+      peopleToMoon.get('[]'); // ['Collins']
+      ```
+
+      @property []
+      @return this
+      @public
+    */
+    get '[]'(): this;
+    set '[]'(newValue: T[] | this);
+  }
 
   /**
    * The NativeArray mixin contains the properties needed to make the native
@@ -13,10 +174,7 @@ declare module '@ember/array/-private/native-array' {
    * false, this will be applied automatically. Otherwise you can apply the mixin
    * at anytime by calling `Ember.NativeArray.apply(Array.prototype)`.
    */
-  interface NativeArray<T>
-    extends Omit<Array<T>, 'every' | 'filter' | 'find' | 'forEach' | 'map' | 'reduce' | 'slice'>,
-      Observable,
-      MutableArray<T> {}
+  interface NativeArray<T> extends Array<T>, Observable, MutableArrayWithoutNative<T> {}
 
   const NativeArray: Mixin;
   export default NativeArray;

--- a/types/preview/@ember/array/index.d.ts
+++ b/types/preview/@ember/array/index.d.ts
@@ -73,7 +73,7 @@ declare module '@ember/array' {
      * implements Ember.Observable, the value will be changed to `set(),` otherwise
      * it will be set directly. `null` objects are skipped.
      */
-    setEach<K extends keyof T>(key: K, value: T[K]): void;
+    setEach<K extends keyof T>(key: K, value: T[K]): this;
     /**
      * Maps all of the items in the enumeration to another value, returning
      * a new array. This method corresponds to `map()` defined in JavaScript 1.6.
@@ -111,12 +111,14 @@ declare module '@ember/array' {
      * this will match any property that evaluates to `true`.
      */
     filterBy<K extends keyof T>(key: K, value?: T[K]): NativeArray<T>;
+    filterBy(key: string, value?: unknown): NativeArray<T>;
     /**
      * Returns an array with the items that do not have truthy values for
      * key.  You can pass an optional second argument with the target value.  Otherwise
      * this will match any property that evaluates to false.
      */
     rejectBy<K extends keyof T>(key: K, value?: T[K]): NativeArray<T>;
+    rejectBy(key: string, value?: unknown): NativeArray<T>;
     /**
      * Returns the first item in the array for which the callback returns true.
      * This method works similar to the `filter()` method defined in JavaScript 1.6
@@ -136,6 +138,7 @@ declare module '@ember/array' {
      * this will match any property that evaluates to `true`.
      */
     findBy<K extends keyof T>(key: K, value?: T[K]): T | undefined;
+    findBy(key: string, value?: unknown): T | undefined;
     /**
      * Returns `true` if the passed function returns true for every item in the
      * enumeration. This corresponds with the `every()` method in JavaScript 1.6.
@@ -150,6 +153,7 @@ declare module '@ember/array' {
      * than using a callback.
      */
     isEvery<K extends keyof T>(key: K, value?: T[K]): boolean;
+    isEvery(key: string, value?: unknown): boolean;
     /**
      * Returns `true` if the passed function returns true for any item in the
      * enumeration.
@@ -164,12 +168,16 @@ declare module '@ember/array' {
      * than using a callback.
      */
     isAny<K extends keyof T>(key: K, value?: T[K]): boolean;
+    isAny(key: string, value?: unknown): boolean;
     /**
      * This will combine the values of the enumerator into a single value. It
      * is a useful way to collect a summary value from an enumeration. This
      * corresponds to the `reduce()` method defined in JavaScript 1.8.
      */
-    reduce: T[]['reduce'];
+    reduce<V>(
+      callback: (summation: V, current: T, index: number, arr: this) => V,
+      initialValue?: V
+    ): V;
     /**
      * Invokes the named method on every object in the receiver that
      * implements it. This method corresponds to the implementation in
@@ -178,7 +186,7 @@ declare module '@ember/array' {
     invoke<M extends MethodNamesOf<T>>(
       methodName: M,
       ...args: MethodParams<T, M>
-    ): Array<MethodReturns<T, M>>;
+    ): NativeArray<MethodReturns<T, M>>;
     /**
      * Simply converts the enumerable into a genuine array. The order is not
      * guaranteed. Corresponds to the method implemented by Prototype.
@@ -196,7 +204,7 @@ declare module '@ember/array' {
      * Converts the enumerable into an array and sorts by the keys
      * specified in the argument.
      */
-    sortBy(...properties: string[]): NativeArray<T>;
+    sortBy(...properties: string[]): T[];
     /**
      * Returns a new enumerable that excludes the passed value. The default
      * implementation returns an array regardless of the receiver type.
@@ -219,8 +227,8 @@ declare module '@ember/array' {
      * this property, it will return this. If you set this property to a new
      * array, it will replace the current content.
      */
-    get '[]'(): NativeArray<T>;
-    set '[]'(newValue: NativeArray<T>);
+    get '[]'(): this;
+    set '[]'(newValue: T[] | Array<T>);
   }
   // Ember.Array rather than Array because the `array-type` lint rule doesn't realize the global is shadowed
   const Array: Mixin;

--- a/types/preview/@ember/array/mutable.d.ts
+++ b/types/preview/@ember/array/mutable.d.ts
@@ -15,7 +15,7 @@ declare module '@ember/array/mutable' {
     /**
      * __Required.__ You must implement this method to apply this mixin.
      */
-    replace(idx: number, amt: number, objects: T[]): this;
+    replace(idx: number, amt: number, objects: T[]): void;
     /**
      * Remove all elements from the array. This is useful if you
      * want to reuse an existing array without having to recreate it.
@@ -45,12 +45,12 @@ declare module '@ember/array/mutable' {
      * Pop object from array or nil if none are left. Works just like `pop()` but
      * it is KVO-compliant.
      */
-    popObject(): T;
+    popObject(): T | null | undefined;
     /**
      * Shift an object from start of array or nil if none are left. Works just
      * like `shift()` but it is KVO-compliant.
      */
-    shiftObject(): T;
+    shiftObject(): T | null | undefined;
     /**
      * Unshift an object to start of array. Works just like `unshift()` but it is
      * KVO-compliant.
@@ -82,7 +82,7 @@ declare module '@ember/array/mutable' {
     /**
      * __Required.__ You must implement this method to apply this mixin.
      */
-    addObject(object: T): T;
+    addObject(object: T): this;
     /**
      * Adds each object in the passed enumerable to the receiver.
      */

--- a/types/preview/ember/-private/type-utils.d.ts
+++ b/types/preview/ember/-private/type-utils.d.ts
@@ -7,11 +7,19 @@ declare module 'ember/-private/type-utils' {
 
   export type AnyMethod<Target> = (this: Target, ...args: any[]) => unknown;
 
-  export type MethodNamesOf<O> = {
-    [K in keyof O]: O[K] extends AnyFn ? K : never;
-  }[keyof O];
+  // The formatting here is designed to help make this type actually be
+  // comprehensible to mortals, including the mortals who came up with it.
+  // prettier-ignore
+  export type MethodsOf<T> = {
+    // This `keyof` check is the thing which gives us *only* these keys, and no
+    // `foo: never` appears in the final type.
+    [K in keyof T as T[K] extends AnyFn ? K : never]:
+      // While this makes sure the resolved type only has `AnyFn` in it, so that
+      // the resulting type is known to be only function types.
+      T[K] extends AnyFn ? T[K] : never;
+  };
 
-  export type MethodsOf<O> = Pick<O, MethodNamesOf<O>>;
+  export type MethodNamesOf<T> = keyof MethodsOf<T>;
 
   export type MethodParams<T, M extends MethodNamesOf<T>> = Parameters<MethodsOf<T>[M]>;
 
@@ -20,16 +28,15 @@ declare module 'ember/-private/type-utils' {
   // prettier-ignore
   /** Get the return value of a method string name or a function. */
   export type EmberMethodParams<T, M extends EmberMethod<T>> =
-  M extends AnyMethod<T> ? Parameters<M> :
-  M extends keyof T ? T[M] extends AnyMethod<T> ? Parameters<MethodsOf<T>[M]> : never :
-  never;
+    // For a basic method, we can just use the direct accessor.
+    M extends AnyMethod<T> ? Parameters<M> :
+    M extends MethodNamesOf<T> ? Parameters<MethodsOf<T>[M]> : never;
 
   // prettier-ignore
   /** Get the return value of a method string name or a function. */
   export type EmberMethodReturn<T, M extends EmberMethod<T>> =
-  M extends AnyMethod<T> ? ReturnType<M> :
-  M extends keyof T ? T[M] extends AnyMethod<T> ? ReturnType<MethodsOf<T>[M]> : never :
-  never;
+    M extends AnyMethod<T> ? ReturnType<M> :
+    M extends MethodNamesOf<T> ? ReturnType<MethodsOf<T>[M]> : never;
 
   /**
    * A type utility for Ember's common name-of-object-on-target-or-function

--- a/types/preview/ember/-private/type-utils.d.ts
+++ b/types/preview/ember/-private/type-utils.d.ts
@@ -7,15 +7,11 @@ declare module 'ember/-private/type-utils' {
 
   export type AnyMethod<Target> = (this: Target, ...args: any[]) => unknown;
 
-  export type MethodsOf<O> = {
-    [K in keyof O]: O[K] extends AnyFn ? O[K] : never;
-  };
-
-  // Not just `keyof MethodsOf<O>` because that doesn't correctly exclude all the
-  // `never` fields.
   export type MethodNamesOf<O> = {
     [K in keyof O]: O[K] extends AnyFn ? K : never;
   }[keyof O];
+
+  export type MethodsOf<O> = Pick<O, MethodNamesOf<O>>;
 
   export type MethodParams<T, M extends MethodNamesOf<T>> = Parameters<MethodsOf<T>[M]>;
 


### PR DESCRIPTION
This PR does a couple of things to improve array types:
* More fully unifies internal array types with external preview types.
* Corrects NativeArray types to not override methods from the true native JS array.

Fixes #20230