### PR TITLE
[BUGFIX release] Fix types for `getOwner` and `GlimmerComponent`

### DIFF
--- a/type-tests/preview/@ember/owner-tests.ts
+++ b/type-tests/preview/@ember/owner-tests.ts
@@ -6,7 +6,11 @@ import Owner, {
   Resolver,
   KnownForTypeResult,
 } from '@ember/owner';
+import Component from '@glimmer/component';
 import { expectTypeOf } from 'expect-type';
+// TODO: once we move the runtime export to `@ember/owner`, update this import
+// as well. (That's why it's tested in this module!)
+import { getOwner } from '@ember/application';
 
 // Just a class we can construct in the Factory and FactoryManager tests
 declare class ConstructThis {
@@ -142,6 +146,30 @@ typedStrings.map((aString) => owner.lookup(aString));
 // Also make sure it keeps working with const bindings
 const aConstName = 'type:name';
 expectTypeOf(owner.lookup(aConstName)).toBeUnknown();
+
+// Check handling with Glimmer components carrying a Signature: they should
+// properly resolve to `Owner`, *not* `Owner | undefined`.
+interface Sig<T> {
+  Args: {
+    name: string;
+    age: number;
+    extra: T;
+  };
+  Element: HTMLParagraphElement;
+  Blocks: {
+    default: [greeting: string];
+    extra: [T];
+  };
+}
+
+class ExampleComponent<T> extends Component<Sig<T>> {
+  checkThis() {
+    expectTypeOf(getOwner(this)).toEqualTypeOf<Owner>();
+  }
+}
+
+declare let example: ExampleComponent<string>;
+expectTypeOf(getOwner(example)).toEqualTypeOf<Owner>();
 
 // ----- Minimal further coverage for POJOs ----- //
 // `Factory` and `FactoryManager` don't have to deal in actual classes. :sigh:

--- a/types/preview/@ember/application/index.d.ts
+++ b/types/preview/@ember/application/index.d.ts
@@ -122,7 +122,13 @@ declare module '@ember/application' {
   // whenever we add new base classes to the framework. For example, if we
   // introduce a standalone `Service` or `Route` base class which *does not*
   // extend from `EmberObject`, it will need to be added here.
-  type FrameworkObject = EmberObject | GlimmerComponent;
+  //
+  // NOTE: we use `any` here because we need to make sure *not* to fix the
+  // actual GlimmerComponent type; using `unknown` or `{}` or `never` (the
+  // obvious alternatives here) results in a version which is too narrow, such
+  // that any subclass which applies a signature does not get resolved by the
+  // definition of `getOwner()` below.
+  type KnownFrameworkObject = EmberObject | GlimmerComponent<any>;
 
   /**
    * Framework objects in an Ember application (components, services, routes, etc.)
@@ -131,6 +137,7 @@ declare module '@ember/application' {
    * instantiation and manages its lifetime.
    */
   export function getOwner(object: FrameworkObject): Owner;
+  export function getOwner(object: KnownFrameworkObject): Owner;
   export function getOwner(object: unknown): Owner | undefined;
   /**
    * `setOwner` forces a new owner on a given object instance. This is primarily

--- a/types/preview/@ember/application/index.d.ts
+++ b/types/preview/@ember/application/index.d.ts
@@ -136,7 +136,14 @@ declare module '@ember/application' {
    * objects is the responsibility of an "owner", which handled its
    * instantiation and manages its lifetime.
    */
-  export function getOwner(object: FrameworkObject): Owner;
+  // SAFETY: this first overload is, strictly speaking, *unsafe*. It is possible
+  // to do `let x = EmberObject.create(); getOwner(x);` and the result will *not*
+  // be `Owner` but instead `undefined`. However, that's quite unusual at this
+  // point, and more to the point we cannot actually distinguish a `Service`
+  // subclass from `EmberObject` at this point: `Service` subclasses `EmberObject`
+  // and adds nothing to it. Accordingly, if we want to catch `Service`s with this
+  // (and `getOwner(this)` for some service will definitely be defined!), it has
+  // to be this way. :sigh:
   export function getOwner(object: KnownFrameworkObject): Owner;
   export function getOwner(object: unknown): Owner | undefined;
   /**


### PR DESCRIPTION
The type for `getOwner()` is *intended* to return `Owner` in cases where we can safely assume that the object instance does in fact have an owner. However, as pointed out by @bendemboski today [in Discord][d], this does not work correctly in the scenario where we have a component which actually has a signature defined:

[d]: https://discord.com/channels/480462759797063690/484421406659182603/1039287698076209173

```ts
class Example extends Component<{ Args: { anyWillDo: true } }> {
  method() {
    getOwner(this); // should be `Owner`, not `| undefined`
  }
}
```

Presently, we return `Owner | undefined` instead.

This PR fixes this by using `GlimmerComponent<any>` instead of plain `GlimmerComponent`, since the latter resolves to the default `GlimmerComponent<unknown>`, which ends up being too narrow to resolve correctly with `getOwner` when any actual signature is applied.

As a bonus, rename `FrameworkObject` in this context to the somewhat more verbose `KnownFrameworkObject`, which avoids a conflict with the actual `FrameworkObject` type used internally.

---

Additionally: The type for `getOwner()` is *technically* unsafe, but this unsafety is one which end users will rarely hit in practice and, courtesy of Ember's current types, is unavoidable if `getOwner(someService)` is to correctly return `Owner` instead of `Owner | undefined`.

The Typed Ember folks have discussed this point at some length, but I realized on looking at this to make the changes in the first two commits for this PR that we didn't have it committed to the code base anywhere, so this PR *also* introduces a long comment explaining it. When we switch from preview to stable types, this comment should come along!
