### PR TITLE
[CLEANUP] Make `intern` utility type safe

### DIFF
--- a/packages/@ember/-internals/utils/lib/intern.ts
+++ b/packages/@ember/-internals/utils/lib/intern.ts
@@ -37,8 +37,8 @@
   @private
   @return {String} interned version of the provided string
 */
-export default function intern(str: string): string {
-  let obj: Record<string, number> = {};
+export default function intern<S extends string>(str: S): S {
+  let obj: Record<S, number> = Object.create(null);
   obj[str] = 1;
   for (let key in obj) {
     if (key === str) {


### PR DESCRIPTION
Experimenting with removing/improving some *other* types while implementing RFC 0821. revealed that this function needed to preserve its input type when that type was narrower than just `string`, so introduce a type parameter to keep that information around. Then, switch to using `Object.create(null)` so it can be used in the `Record` type safely.

Pulling this out into its own commit makes it easier to land, and it also allows us to guarantee that we are making changes *only* to the types and module layout for the PR implementing RFC 0821.