### PR TITLE
[FEATURE] Introduce new `@ember/routing` sub-modules (RFC 0821)

### DIFF
--- a/packages/@ember/routing/route-info.ts
+++ b/packages/@ember/routing/route-info.ts
@@ -1,0 +1,8 @@
+/**
+ * Provides the `RouteInfo` and `RouteInfoWithMetadata` types which appear as
+ * the target and source routes for `Transition`s.
+ *
+ * @module @ember/routing/route-info
+ */
+
+export type { RouteInfo as default, RouteInfoWithAttributes } from './lib/route-info';

--- a/packages/@ember/routing/transition.ts
+++ b/packages/@ember/routing/transition.ts
@@ -1,0 +1,8 @@
+/**
+ * Provides the `Transition` type which are used in Ember's routing transitions,
+ * e.g. `RouterService.on('routeDidChange', (transition) => { ... })`.
+ *
+ * @module @ember/routing/transition
+ */
+
+export type { Transition as default } from 'router_js';

--- a/types/preview/@ember/routing/route-info.d.ts
+++ b/types/preview/@ember/routing/route-info.d.ts
@@ -1,5 +1,4 @@
 declare module '@ember/routing/route-info' {
-  // https://api.emberjs.com/ember/4.0/classes/RouteInfo
   /**
    * A `RouteInfo` is an object that contains metadata about a specific route within a `Transition`.
    * It is read-only and internally immutable.


### PR DESCRIPTION
Add the `@ember/routing/transition` and `@ember/routing/route-info`, per RFC 0821. These match the existing public preview types.

Notably, these modules currently *only* supply types.