### PR TITLE
[DOC] Fix typo in destroyable docs

### DIFF
--- a/packages/@ember/destroyable/index.ts
+++ b/packages/@ember/destroyable/index.ts
@@ -19,7 +19,7 @@ import {
 
   This destroyables API exposes the basic building blocks for destruction:
 
-  * registering a function to be ran when an object is destroyyed
+  * registering a function to be ran when an object is destroyed
   * checking if an object is in a destroying state
   * associate an object as a child of another so that the child object will be destroyed
     when the associated parent object is destroyed.


### PR DESCRIPTION
This is just a minor typo fix in the @ember/destroyable documentation.