### PR TITLE
[BUGFIX] Fix `typesVersions` key for stable types

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,12 +172,12 @@
     "after": "ember-cli-legacy-blueprints"
   },
   "typesVersions": {
-    "types/*": {
-      "stable": [
-        "./types/stable"
+    "*": {
+      "types": [
+        "types/stable"
       ],
-      "preview": [
-        "./types/preview"
+      "types/preview": [
+        "types/preview"
       ]
     }
   }


### PR DESCRIPTION
This does not affect existing consumers of the preview types, for whom the existing configuration worked correctly, and we are not actually *publishing* stable types yet, so this doesn't need to get backported, but it *is* important that we have it in place as we start publishing stable types.