### PR TITLE
Don't double-run `tsc` for generating types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "ember build --environment production",
     "docs": "ember ember-cli-yuidoc",
-    "types": "tsc --project tsconfig/publish-types.json && node types/publish.mjs",
+    "types": "node types/publish.mjs",
     "link:glimmer": "node bin/yarn-link-glimmer.js",
     "start": "ember serve",
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel \"lint:!(fix)\"",


### PR DESCRIPTION
The package script here was duplicating what the script does. 🤦🏼‍♂️ 