### PR TITLE
[BUGFIX beta] revert TS `compilerOptions.target` to ES2017

### DIFF
--- a/tsconfig/compiler-options.json
+++ b/tsconfig/compiler-options.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     // Compilation Configuration
-    "target": "es2019",
+    "target": "es2017",
     "sourceMap": true,
     "baseUrl": "../packages",
     "rootDir": "../packages",


### PR DESCRIPTION
Fixes #20281. We should, at minimum, only make this change in `target` intentionally, rather than incidentally.