### PR TITLE
Update to TS v4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "simple-dom": "^1.4.0",
     "testem": "^3.9.0",
     "testem-failure-only-reporter": "^1.0.0",
-    "typescript": "~4.8.3"
+    "typescript": "4.9"
   },
   "peerDependencies": {
     "@glimmer/component": "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10690,10 +10690,10 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@~4.8.3:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.9:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
+  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This lets us take advantage of much smarter `in`-based type narrowing and the new `satisfies` operator internally. We'll need to make a decision about what versions to support when we actually "stabilize" the types: not merely publishing them, but opting consumers into them by default. However, it's likely that 4.9 and 5.0 will be reasonable targets at that point, and even if not the particular 4.9 features we might rely on are "runtime" TS features, so we should be able to add a CI check for 4.8 if we want to add support for it in the test matrix.