### PR TITLE
[BUGFIX LTS] Allow class-based helpers in strict-mode

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -191,7 +191,7 @@ class ClassicHelperManager implements HelperManager<ClassicHelperStateBucket> {
   }
 
   getDebugName(definition: ClassHelperFactory) {
-    return getDebugName!(definition.class!['prototype']);
+    return getDebugName!((definition.class || definition)!['prototype']);
   }
 }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-helper-test.js
@@ -1,0 +1,78 @@
+import { RenderingTestCase, moduleFor, strip } from 'internal-test-helpers';
+
+import { precompileJSON } from '@glimmer/compiler';
+import { getTemplateLocals } from '@glimmer/syntax';
+import { createTemplateFactory } from '@ember/template-factory';
+
+import { Helper } from '../../index';
+import { setComponentTemplate } from '@glimmer/manager';
+import { templateOnlyComponent } from '@glimmer/runtime';
+
+// eslint-disable-next-line ember-internal/require-yuidoc-access
+/**
+ * The template-compiler does not support strict mode at this time.
+ * precompile from ember-template-compiler returns a string and
+ * not a template-factory, so it doesn't help with strict-mode testing.
+ *
+ * We also can't import from `@ember/template-compiler` because it
+ * doesn't exist to this kind of test, otherwise we'd be able to use
+ * precompileTemplate, which would be perfect :D
+ *
+ * Copied(ish) from https://github.com/NullVoxPopuli/ember-repl/blob/main/addon/hbs.ts#L51
+ */
+function precompileTemplate(source, { moduleName, scope = {} }) {
+  let locals = getTemplateLocals(source);
+
+  let options = {
+    strictMode: true,
+    moduleName,
+    locals,
+    isProduction: false,
+    meta: { moduleName },
+  };
+
+  // Copied from @glimmer/compiler/lib/compiler#precompile
+  let [block, usedLocals] = precompileJSON(source, options);
+  let usedScope = usedLocals.map((key) => scope[key]);
+
+  let blockJSON = JSON.stringify(block);
+  let templateJSONObject = {
+    id: moduleName,
+    block: blockJSON,
+    moduleName: moduleName ?? '(unknown template module)',
+    scope: () => usedScope,
+    isStrictMode: true,
+  };
+
+  let factory = createTemplateFactory(templateJSONObject);
+
+  return factory;
+}
+
+moduleFor(
+  'Custom Helper test',
+  class extends RenderingTestCase {
+    ['@test works with strict-mode']() {
+      class Custom extends Helper {
+        compute([value]) {
+          return `${value}-custom`;
+        }
+      }
+
+      let template = strip`
+        {{ (Custom 'my-test') }}
+      `;
+
+      let templateFactory = precompileTemplate(template, {
+        moduleName: 'strict-mode',
+        scope: { Custom },
+      });
+
+      let TestComponent = setComponentTemplate(templateFactory, templateOnlyComponent());
+
+      this.render(`<this.TestComponent />`, { TestComponent });
+      this.assertText('my-test-custom');
+      this.assertStableRerender();
+    }
+  }
+);


### PR DESCRIPTION
# Summary

Backports the fix to https://github.com/emberjs/ember.js/issues/19877 (originally submitted in https://github.com/emberjs/ember.js/pull/19878) to work under 3.28. 

## Bug

Using class based helpers in strict mode results in the following in 3.28

```
TypeError: Cannot read properties of undefined (reading 'prototype')
                at ClassicHelperManager.getDebugName (http://localhost:7357/i18n-dummy/assets/vendor.js:7334:55)
                at http://localhost:7357/i18n-dummy/assets/vendor.js:40951:146
                at Object.evaluate (http://localhost:7357/i18n-dummy/assets/vendor.js:46402:17)
                at AppendOpcodes.evaluate (http://localhost:7357/i18n-dummy/assets/vendor.js:45783:19)
                at LowLevelVM.evaluateSyscall (http://localhost:7357/i18n-dummy/assets/vendor.js:48994:22)
                at LowLevelVM.evaluateInner (http://localhost:7357/i18n-dummy/assets/vendor.js:48965:14)
                at LowLevelVM.evaluateOuter (http://localhost:7357/i18n-dummy/assets/vendor.js:48958:14)
                at VM.next (http://localhost:7357/i18n-dummy/assets/vendor.js:49789:24)
                at VM._execute (http://localhost:7357/i18n-dummy/assets/vendor.js:49776:23)
                at VM.execute (http://localhost:7357/i18n-dummy/assets/vendor.js:49751:28)
```