### PR TITLE
Stop using the @ember/error package internally and improve types

### DIFF
--- a/packages/@ember/-internals/metal/lib/alias.ts
+++ b/packages/@ember/-internals/metal/lib/alias.ts
@@ -2,7 +2,6 @@ import type { Meta } from '@ember/-internals/meta';
 import { meta as metaFor } from '@ember/-internals/meta';
 import { inspect } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import EmberError from '@ember/error';
 import type { UpdatableTag } from '@glimmer/validator';
 import {
   consumeTag,
@@ -115,7 +114,7 @@ export class AliasedProperty extends ComputedDescriptor {
 }
 
 function AliasedProperty_readOnlySet(obj: object, keyName: string): never {
-  throw new EmberError(`Cannot set read-only property '${keyName}' on object: ${inspect(obj)}`);
+  throw new Error(`Cannot set read-only property '${keyName}' on object: ${inspect(obj)}`);
 }
 
 function AliasedProperty_oneWaySet(obj: object, keyName: string, value: any): any {

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -2,7 +2,6 @@ import type { Meta } from '@ember/-internals/meta';
 import { meta as metaFor } from '@ember/-internals/meta';
 import { inspect, toString } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import EmberError from '@ember/error';
 import { isDestroyed } from '@glimmer/destroyable';
 import { DEBUG } from '@glimmer/env';
 import type { UpdatableTag } from '@glimmer/validator';
@@ -513,7 +512,7 @@ export class ComputedProperty extends ComputedDescriptor {
   }
 
   _throwReadOnlyError(obj: object, keyName: string): never {
-    throw new EmberError(`Cannot set read-only property "${keyName}" on object: ${inspect(obj)}`);
+    throw new Error(`Cannot set read-only property "${keyName}" on object: ${inspect(obj)}`);
   }
 
   _set(obj: object, keyName: string, value: unknown, meta: Meta): unknown {

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -1,6 +1,5 @@
 import { lookupDescriptor, setWithMandatorySetter, toString } from '@ember/-internals/utils';
 import { assert } from '@ember/debug';
-import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
 import { COMPUTED_SETTERS } from './decorator';
 import { isPath } from './path_cache';
@@ -115,9 +114,7 @@ function _setPath(root: object, path: string, value: any, tolerant?: boolean): a
   if (newRoot !== null && newRoot !== undefined) {
     return set(newRoot, keyName, value);
   } else if (!tolerant) {
-    throw new EmberError(
-      `Property set failed: object in path "${parts.join('.')}" could not be found.`
-    );
+    throw new Error(`Property set failed: object in path "${parts.join('.')}" could not be found.`);
   }
 }
 

--- a/packages/@ember/-internals/views/lib/views/states/default.ts
+++ b/packages/@ember/-internals/views/lib/views/states/default.ts
@@ -1,10 +1,9 @@
-import EmberError from '@ember/error';
 import type { ViewState } from '../states';
 
 const _default: ViewState = {
   // appendChild is only legal while rendering the buffer.
   appendChild() {
-    throw new EmberError("You can't use appendChild outside of the rendering process");
+    throw new Error("You can't use appendChild outside of the rendering process");
   },
 
   // Handle events from `Ember.EventDispatcher`

--- a/packages/@ember/-internals/views/lib/views/states/destroying.ts
+++ b/packages/@ember/-internals/views/lib/views/states/destroying.ts
@@ -1,4 +1,3 @@
-import EmberError from '@ember/error';
 import type { ViewState } from '../states';
 import _default from './default';
 
@@ -6,11 +5,11 @@ const destroying: ViewState = {
   ..._default,
 
   appendChild() {
-    throw new EmberError("You can't call appendChild on a view being destroyed");
+    throw new Error("You can't call appendChild on a view being destroyed");
   },
 
   rerender() {
-    throw new EmberError("You can't call rerender on a view being destroyed");
+    throw new Error("You can't call rerender on a view being destroyed");
   },
 };
 

--- a/packages/@ember/-internals/views/lib/views/states/in_dom.ts
+++ b/packages/@ember/-internals/views/lib/views/states/in_dom.ts
@@ -1,7 +1,6 @@
 import { teardownMandatorySetter } from '@ember/-internals/utils';
 import type Component from '@ember/component';
 import { assert } from '@ember/debug';
-import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
 import type { ViewState } from '../states';
 import hasElement from './has_element';
@@ -32,7 +31,7 @@ const inDOM: ViewState = {
         },
         set(value) {
           if (value !== elementId) {
-            throw new EmberError("Changing a view's elementId after creation is not allowed");
+            throw new Error("Changing a view's elementId after creation is not allowed");
           }
         },
       });

--- a/packages/@ember/debug/index.ts
+++ b/packages/@ember/debug/index.ts
@@ -1,6 +1,5 @@
 import { isChrome, isFirefox } from '@ember/-internals/browser-environment';
 import type { AnyFn } from '@ember/-internals/utils/types';
-import EmberError from '@ember/error';
 import { DEBUG } from '@glimmer/env';
 import type { DeprecateFunc, DeprecationOptions } from './lib/deprecate';
 import _deprecate from './lib/deprecate';
@@ -169,7 +168,7 @@ if (DEBUG) {
   */
   setDebugFunction('assert', function assert(desc, test) {
     if (!test) {
-      throw new EmberError(`Assertion Failed: ${desc}`);
+      throw new Error(`Assertion Failed: ${desc}`);
     }
   });
 

--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -5,7 +5,6 @@
 import EmberObject from '@ember/object';
 import { RSVP } from '@ember/-internals/runtime';
 import { assert } from '@ember/debug';
-import EmberError from '@ember/error';
 import { Registry, privatize as P } from '@ember/-internals/container';
 import { guidFor } from '@ember/-internals/utils';
 import { ENGINE_PARENT, getEngineParent, setEngineParent } from './lib/engine-parent';
@@ -203,7 +202,7 @@ class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerPro
     let Engine = this.lookup(`engine:${name}`);
 
     if (!Engine) {
-      throw new EmberError(
+      throw new Error(
         `You attempted to mount the engine '${name}', but it is not registered with its parent.`
       );
     }

--- a/packages/@ember/error/tests/index_test.js
+++ b/packages/@ember/error/tests/index_test.js
@@ -1,4 +1,3 @@
-import EmberError from '@ember/error';
 import { moduleFor, AbstractTestCase as TestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -7,7 +6,7 @@ moduleFor(
     ['@test new EmberError displays provided message'](assert) {
       assert.throws(
         () => {
-          throw new EmberError('A Message');
+          throw new Error('A Message');
         },
         function (e) {
           return e.message === 'A Message';

--- a/packages/@ember/object/promise-proxy-mixin.ts
+++ b/packages/@ember/object/promise-proxy-mixin.ts
@@ -1,7 +1,6 @@
 import { get, setProperties, computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import type { AnyFn, MethodNamesOf } from '@ember/-internals/utils/types';
-import EmberError from '@ember/error';
 import type RSVP from 'rsvp';
 import type CoreObject from '@ember/object/core';
 
@@ -227,7 +226,7 @@ const PromiseProxyMixin = Mixin.create({
 
   promise: computed({
     get() {
-      throw new EmberError("PromiseProxy's promise must be set");
+      throw new Error("PromiseProxy's promise must be set");
     },
     set(_key, promise: RSVP.Promise<unknown>) {
       return tap(this, promise);

--- a/packages/@ember/routing/lib/utils.ts
+++ b/packages/@ember/routing/lib/utils.ts
@@ -3,7 +3,6 @@ import { getOwner } from '@ember/-internals/owner';
 import type { ControllerQueryParam, ControllerQueryParamType } from '@ember/controller';
 import { assert, deprecate } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
-import EmberError from '@ember/error';
 import type { InternalRouteInfo, ModelFor } from 'router_js';
 import type Router from 'router_js';
 import { STATE_SYMBOL } from 'router_js';
@@ -252,7 +251,7 @@ export function prefixRouteNameArg<T extends NamedRouteArgs<Route> | UnnamedRout
   if (owner.routable && typeof args[0] === 'string') {
     routeName = args[0];
     if (resemblesURL(routeName)) {
-      throw new EmberError(
+      throw new Error(
         'Programmatic transitions by URL cannot be used within an Engine. Please use the route name instead.'
       );
     } else {

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -23,7 +23,6 @@ import { A as emberA } from '@ember/array';
 import { typeOf } from '@ember/utils';
 import Evented from '@ember/object/evented';
 import { assert, deprecate, info } from '@ember/debug';
-import EmberError from '@ember/error';
 import { cancel, once, run, scheduleOnce } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import type { QueryParamMeta, RenderOptions } from '@ember/routing/route';
@@ -1757,7 +1756,7 @@ export function triggerEvent<
       return;
     }
     // TODO: update?
-    throw new EmberError(
+    throw new Error(
       `Can't trigger action '${name}' because your app hasn't finished transitioning into its first route. To trigger an action on destination routes during a transition, you can call \`.send()\` on the \`Transition\` object passed to the \`model/beforeModel/afterModel\` hooks.`
     );
   }
@@ -1791,7 +1790,7 @@ export function triggerEvent<
   }
 
   if (!eventWasHandled && !ignoreFailure) {
-    throw new EmberError(
+    throw new Error(
       `Nothing handled the action '${name}'. If you did handle the action, this error can be caused by returning true from an action handler in a controller, causing the action to bubble.`
     );
   }

--- a/type-tests/@ember/error-tests.ts
+++ b/type-tests/@ember/error-tests.ts
@@ -1,7 +1,7 @@
-import Error from '@ember/error';
+import EmberError from '@ember/error';
 import { expectTypeOf } from 'expect-type';
 
-expectTypeOf(new Error('Fuuuuuuuu')).toEqualTypeOf<Error>();
+expectTypeOf(new EmberError('Fuuuuuuuu')).toEqualTypeOf<Error>();
 
 // allows to extend from EmberError
 class AjaxError extends Error {}

--- a/types/preview/@ember/error/index.d.ts
+++ b/types/preview/@ember/error/index.d.ts
@@ -1,6 +1,6 @@
 declare module '@ember/error' {
   /**
-   * A subclass of the JavaScript Error object for use in Ember.
+   * The native JavaScript Error class.
    */
-  export default class EmberError extends Error {}
+  export default Error;
 }

--- a/types/preview/ember/index.d.ts
+++ b/types/preview/ember/index.d.ts
@@ -129,7 +129,7 @@ declare module 'ember' {
     /**
      * A subclass of the JavaScript Error object for use in Ember.
      */
-    const Error: typeof EmberError;
+    const Error: ErrorConstructor;
 
     const Evented: typeof EmberObjectEventedNs.default;
     interface Evented extends EmberObjectEventedNs.default {}


### PR DESCRIPTION
This package just re-exports the native Error class. We should remove it entirely, but in the meantime, stop using it internally.