### PR TITLE
Build types when checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
-      - name: build stable type definitions
-        run: yarn build:types
       - name: Check published types
         run: yarn type-check:types
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:node": "qunit tests/node/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "type-check:internals": "tsc --noEmit",
-    "type-check:types": "tsc --noEmit --project type-tests",
+    "type-check:types": "yarn build:types && tsc --noEmit --project type-tests",
     "type-check": "npm-run-all type-check:*"
   },
   "dependencies": {


### PR DESCRIPTION
This makes it easy to just run `yarn type-check` while developing.

Should we also remove the separate build step from the Linting CI?