### PR TITLE
Replace most `InternalOwner` uses with `Owner`

### DIFF
--- a/packages/@ember/component/type-tests/helper/index.test.ts
+++ b/packages/@ember/component/type-tests/helper/index.test.ts
@@ -1,10 +1,10 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type { FrameworkObject } from '@ember/object/-internals';
 import Helper from '@ember/component/helper';
 import { expectTypeOf } from 'expect-type';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 // NOTE: The types for `compute` are not actually safe. Glint helps with this.
 

--- a/packages/@ember/component/type-tests/set-component-manager.test.ts
+++ b/packages/@ember/component/type-tests/set-component-manager.test.ts
@@ -1,4 +1,4 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import { setComponentManager } from '@ember/component';
 import type { ComponentManager } from '@glimmer/interfaces';
 import { expectTypeOf } from 'expect-type';
@@ -9,7 +9,7 @@ let manager = {} as ComponentManager<unknown>;
 class Foo {}
 let foo = new Foo();
 
-expectTypeOf(setComponentManager((_owner: InternalOwner) => manager, foo)).toEqualTypeOf<Foo>();
+expectTypeOf(setComponentManager((_owner: Owner) => manager, foo)).toEqualTypeOf<Foo>();
 
 // @ts-expect-error invalid callback
 setComponentManager(() => {

--- a/packages/@ember/controller/type-tests/index.test.ts
+++ b/packages/@ember/controller/type-tests/index.test.ts
@@ -1,10 +1,10 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import Controller, { inject } from '@ember/controller';
 
 import { expectTypeOf } from 'expect-type';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 class Foo {}
 

--- a/packages/@ember/debug/container-debug-adapter.ts
+++ b/packages/@ember/debug/container-debug-adapter.ts
@@ -1,7 +1,7 @@
 import { classify, dasherize } from '@ember/string';
 import EmberObject from '@ember/object';
 import { typeOf } from '@ember/utils';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import { getOwner } from '@ember/-internals/owner';
 import type { Resolver } from '@ember/owner';
 import Namespace from '@ember/application/namespace';
@@ -45,7 +45,7 @@ import Namespace from '@ember/application/namespace';
   @public
 */
 export default class ContainerDebugAdapter extends EmberObject {
-  constructor(owner: InternalOwner) {
+  constructor(owner: Owner) {
     super(owner);
 
     this.resolver = getOwner(this)!.lookup('resolver-for-debugging:main') as Resolver;

--- a/packages/@ember/debug/data-adapter.ts
+++ b/packages/@ember/debug/data-adapter.ts
@@ -1,4 +1,4 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import { getOwner } from '@ember/-internals/owner';
 import { _backburner, next } from '@ember/runloop';
 import { get } from '@ember/object';
@@ -219,7 +219,7 @@ export default class DataAdapter<T> extends EmberObject {
   // TODO: Revisit this
   declare containerDebugAdapter: ContainerDebugAdapter;
 
-  constructor(owner: InternalOwner) {
+  constructor(owner: Owner) {
     super(owner);
     this.containerDebugAdapter = getOwner(this)!.lookup(
       'container-debug-adapter:main'

--- a/packages/@ember/debug/lib/capture-render-tree.ts
+++ b/packages/@ember/debug/lib/capture-render-tree.ts
@@ -1,5 +1,5 @@
 import type { Renderer } from '@ember/-internals/glimmer';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type { CapturedRenderNode } from '@glimmer/interfaces';
 import { expect } from '@glimmer/util';
 
@@ -19,7 +19,7 @@ import { expect } from '@glimmer/util';
   @param app {ApplicationInstance} An `ApplicationInstance`.
   @since 3.14.0
 */
-export default function captureRenderTree(app: InternalOwner): CapturedRenderNode[] {
+export default function captureRenderTree(app: Owner): CapturedRenderNode[] {
   // SAFETY: Ideally we'd assert here but that causes awkward circular requires since this is also in @ember/debug.
   // This is only for debug stuff so not very risky.
   let renderer = expect(app.lookup('renderer:-dom') as Renderer, `BUG: owner is missing renderer`);

--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -49,7 +49,10 @@ export interface EngineInstanceOptions {
 // Note on types: since `EngineInstance` uses `RegistryProxyMixin` and
 // `ContainerProxyMixin`, which respectively implement the same `RegistryMixin`
 // and `ContainerMixin` types used to define `InternalOwner`, this is the same
-// type as `InternalOwner` from TS's POV.
+// type as `InternalOwner` from TS's POV. The point of the explicit `extends`
+// clauses for `InternalOwner` and `Owner` is to keep us honest: if this stops
+// type checking, we have broken part of our public API contract. Medium-term,
+// the goal here is to `EngineInstance` simple be `Owner`.
 interface EngineInstance extends RegistryProxyMixin, ContainerProxyMixin, InternalOwner, Owner {}
 class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin) {
   /**

--- a/packages/@ember/engine/type-tests/instance.test.ts
+++ b/packages/@ember/engine/type-tests/instance.test.ts
@@ -1,13 +1,14 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type { default as Owner, InternalOwner } from '@ember/-internals/owner';
 import EngineInstance from '@ember/engine/instance';
 import type EmberObject from '@ember/object';
 import { expectTypeOf } from 'expect-type';
 
 expectTypeOf<EngineInstance>().toMatchTypeOf<EmberObject>();
 expectTypeOf<EngineInstance>().toMatchTypeOf<InternalOwner>();
+expectTypeOf<EngineInstance>().toMatchTypeOf<Owner>();
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 let instance = new EngineInstance(owner);
 
 expectTypeOf(instance.boot()).resolves.toEqualTypeOf<EngineInstance>();

--- a/packages/@ember/object/type-tests/core/index.test.ts
+++ b/packages/@ember/object/type-tests/core/index.test.ts
@@ -1,9 +1,9 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import CoreObject from '@ember/object/core';
 import { expectTypeOf } from 'expect-type';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 expectTypeOf(CoreObject.create()).toEqualTypeOf<CoreObject>();
 

--- a/packages/@ember/object/type-tests/ember-object.test.ts
+++ b/packages/@ember/object/type-tests/ember-object.test.ts
@@ -1,10 +1,10 @@
 import { expectTypeOf } from 'expect-type';
 
 import EmberObject from '@ember/object';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 expectTypeOf(EmberObject.create()).toEqualTypeOf<EmberObject>();
 
@@ -106,7 +106,7 @@ Person.reopenClass({ fullName: 6 });
 class MyComponent extends EmberObject {
   foo = 'bar';
 
-  constructor(owner: InternalOwner) {
+  constructor(owner: Owner) {
     super(owner);
 
     this.addObserver('foo', this, 'fooDidChange');

--- a/packages/@ember/object/type-tests/events/index.test.ts
+++ b/packages/@ember/object/type-tests/events/index.test.ts
@@ -2,7 +2,7 @@ import { addListener, removeListener, sendEvent } from '@ember/object/events';
 
 import EmberObject from '@ember/object';
 import { on } from '@ember/object/evented';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 
 class Job extends EmberObject {
   logStartOrUpdate = on('started', 'updated', () => {
@@ -23,7 +23,7 @@ sendEvent(job, 'updated'); // Logs 'Job updated!'
 sendEvent(job, 'completed'); // Logs 'Job completed!'
 
 class MyClass extends EmberObject {
-  constructor(owner: InternalOwner) {
+  constructor(owner: Owner) {
     super(owner);
     addListener(this, 'willDestroy', this, 'willDestroyListener');
     addListener(this, 'willDestroy', this, 'willDestroyListener', true);

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -5,7 +5,7 @@ import {
   descriptorForProperty,
   flushAsyncObservers,
 } from '@ember/-internals/metal';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import { getOwner } from '@ember/-internals/owner';
 import { BucketCache } from '@ember/routing/-internals';
 import EmberObject, { computed, get, set, getProperties, setProperties } from '@ember/object';
@@ -273,7 +273,7 @@ class Route<T = unknown>
   declare _topLevelViewTemplate: any;
   declare _environment: any;
 
-  constructor(owner: InternalOwner) {
+  constructor(owner: Owner) {
     super(owner);
 
     if (owner) {
@@ -2195,7 +2195,7 @@ function buildRenderOptions(
 }
 
 export interface RenderOptions {
-  owner: InternalOwner;
+  owner: Owner;
   into?: string;
   outlet: string;
   name: string;

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -1717,6 +1717,7 @@ function findRouteStateName(route: Route, state: string) {
   return routeHasBeenDefined(owner, router, stateName, stateNameFull) ? stateNameFull : '';
 }
 
+// TODO: rewrite `InternalOwner` to `Owner` by switching to `factoryFor`.
 /**
   Determines whether or not a route has been defined by checking that the route
   is in the Router's map and the owner has a registration for that route.
@@ -1736,8 +1737,7 @@ function routeHasBeenDefined(
 ) {
   let routerHasRoute = router.hasRoute(fullName);
   let ownerHasRoute =
-    owner.hasRegistration(`template:${localName}` as const) ||
-    owner.hasRegistration(`route:${localName}` as const);
+    owner.hasRegistration(`template:${localName}`) || owner.hasRegistration(`route:${localName}`);
   return routerHasRoute && ownerHasRoute;
 }
 

--- a/packages/@ember/routing/type-tests/auto-location.test.ts
+++ b/packages/@ember/routing/type-tests/auto-location.test.ts
@@ -1,11 +1,11 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type EmberObject from '@ember/object';
 import AutoLocation from '@ember/routing/auto-location';
 import type { ILocation } from '@ember/routing/location';
 import { expectTypeOf } from 'expect-type';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 // This doesn't have any public API
 

--- a/packages/@ember/routing/type-tests/hash-location.test.ts
+++ b/packages/@ember/routing/type-tests/hash-location.test.ts
@@ -2,10 +2,10 @@ import type { ILocation } from '@ember/routing/location';
 import type EmberObject from '@ember/object';
 import HashLocation from '@ember/routing/hash-location';
 import { expectTypeOf } from 'expect-type';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 // This doesn't have any public API
 

--- a/packages/@ember/routing/type-tests/history-location.test.ts
+++ b/packages/@ember/routing/type-tests/history-location.test.ts
@@ -1,11 +1,11 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type EmberObject from '@ember/object';
 import HistoryLocation from '@ember/routing/history-location';
 import type { ILocation } from '@ember/routing/location';
 import { expectTypeOf } from 'expect-type';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 // This doesn't have any public API
 

--- a/packages/@ember/routing/type-tests/none-location.test.ts
+++ b/packages/@ember/routing/type-tests/none-location.test.ts
@@ -2,10 +2,10 @@ import type EmberObject from '@ember/object';
 import NoneLocation from '@ember/routing/none-location';
 import type { ILocation } from '@ember/routing/location';
 import { expectTypeOf } from 'expect-type';
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 // This doesn't have any public API
 

--- a/packages/@ember/routing/type-tests/route/index.test.ts
+++ b/packages/@ember/routing/type-tests/route/index.test.ts
@@ -1,4 +1,4 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type Controller from '@ember/controller';
 import type EmberObject from '@ember/object';
 import Route from '@ember/routing/route';
@@ -6,7 +6,7 @@ import { expectTypeOf } from 'expect-type';
 import type { Transition } from 'router_js';
 
 // NOTE: This is invalid, but acceptable for type tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 let route = new Route(owner);
 
 expectTypeOf(route).toMatchTypeOf<EmberObject>();

--- a/packages/@ember/routing/type-tests/route/overrides.test.ts
+++ b/packages/@ember/routing/type-tests/route/overrides.test.ts
@@ -1,11 +1,11 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type Controller from '@ember/controller';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import type { Transition } from 'router_js';
 
 // NOTE: This is invalid, but acceptable for type tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 class Foo {}
 
 class MyRoute extends Route<Foo> {

--- a/packages/@ember/routing/type-tests/route/query-params.test.ts
+++ b/packages/@ember/routing/type-tests/route/query-params.test.ts
@@ -1,8 +1,8 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import Route from '@ember/routing/route';
 
 // NOTE: This is invalid, but acceptable for type tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 class MyRoute extends Route {
   queryParams = {

--- a/packages/@ember/routing/type-tests/route/send.test.ts
+++ b/packages/@ember/routing/type-tests/route/send.test.ts
@@ -1,4 +1,4 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
@@ -12,7 +12,7 @@ class MyRoute extends Route {
 }
 
 // NOTE: This is invalid, but acceptable for type tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 let route = new MyRoute(owner);
 
 route.send('topLevel', 1);

--- a/packages/@ember/routing/type-tests/router-service.test.ts
+++ b/packages/@ember/routing/type-tests/router-service.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-self-assign */
 
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type { ILocation as EmberLocation } from '@ember/routing/location';
 import type Route from '@ember/routing/route';
 import type { RouteInfo, RouteInfoWithAttributes } from '@ember/routing/router-service';
@@ -10,7 +10,7 @@ import { expectTypeOf } from 'expect-type';
 import type { Transition } from 'router_js';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 class Post {}
 class Comment {}

--- a/packages/@ember/routing/type-tests/router/index.test.ts
+++ b/packages/@ember/routing/type-tests/router/index.test.ts
@@ -1,4 +1,4 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type EmberObject from '@ember/object';
 import type Evented from '@ember/object/evented';
 import type { ILocation } from '@ember/routing/location';
@@ -10,7 +10,7 @@ expectTypeOf<Router>().toMatchTypeOf<EmberObject>();
 expectTypeOf<Router>().toMatchTypeOf<Evented>();
 
 // NOTE: This is invalid, but acceptable for type tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 let router = new Router(owner);
 
 expectTypeOf(router.rootURL).toEqualTypeOf<string>();

--- a/packages/@ember/service/type-tests/index.test.ts
+++ b/packages/@ember/service/type-tests/index.test.ts
@@ -1,11 +1,11 @@
-import type { InternalOwner } from '@ember/-internals/owner';
+import type Owner from '@ember/owner';
 import type { FrameworkObject } from '@ember/object/-internals';
 import EmberObject from '@ember/object';
 import Service, { inject, service } from '@ember/service';
 import { expectTypeOf } from 'expect-type';
 
 // Good enough for tests
-let owner = {} as InternalOwner;
+let owner = {} as Owner;
 
 class MainService extends Service {}
 class FooService extends Service {}


### PR DESCRIPTION
We only *need* the public API in most places, since most things which depend on the internal/private API are actually using `EngineInstance` or `ApplicationInstance`, and there aren't many of them! There are a couple remaining spots we have `InternalOwner`:

- When defining the type of `EngineInstance` itself, we use the type to guarantee we implement what we *say* we implement.

- We use `hasRegistration` or `resolveRegistration` in a couple places; both can be replaced with `Owner#factoryFor`, but I am keeping those separate so that this can be a clean types-only change.

Part of the work for #20303.