### PR TITLE
Remove runtime dependence on `InternalOwner`

### DIFF
--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -6,7 +6,7 @@ import type {
 } from '@ember/-internals/glimmer';
 import { computed, get, set } from '@ember/object';
 import type { default as Owner, FactoryManager } from '@ember/owner';
-import { getOwner, type InternalOwner } from '@ember/-internals/owner';
+import { getOwner } from '@ember/owner';
 import { BucketCache, DSL, RouterState } from '@ember/routing/-internals';
 import type { DSLCallback, EngineRouteInfo } from '@ember/routing/-internals';
 import {
@@ -1717,27 +1717,21 @@ function findRouteStateName(route: Route, state: string) {
   return routeHasBeenDefined(owner, router, stateName, stateNameFull) ? stateNameFull : '';
 }
 
-// TODO: rewrite `InternalOwner` to `Owner` by switching to `factoryFor`.
 /**
   Determines whether or not a route has been defined by checking that the route
   is in the Router's map and the owner has a registration for that route.
 
   @private
-  @param {InternalOwner} owner
+  @param {Owner} owner
   @param {Router} router
   @param {String} localName
   @param {String} fullName
   @return {Boolean}
 */
-function routeHasBeenDefined(
-  owner: InternalOwner,
-  router: any,
-  localName: string,
-  fullName: string
-) {
+function routeHasBeenDefined(owner: Owner, router: any, localName: string, fullName: string) {
   let routerHasRoute = router.hasRoute(fullName);
   let ownerHasRoute =
-    owner.hasRegistration(`template:${localName}`) || owner.hasRegistration(`route:${localName}`);
+    owner.factoryFor(`template:${localName}`) || owner.factoryFor(`route:${localName}`);
   return routerHasRoute && ownerHasRoute;
 }
 

--- a/packages/internal-test-helpers/lib/registry-check.ts
+++ b/packages/internal-test-helpers/lib/registry-check.ts
@@ -1,5 +1,6 @@
-import type { FullName, default as Owner } from '@ember/-internals/owner';
+import type { FullName } from '@ember/-internals/owner';
+import type Engine from '@ember/engine';
 
-export function verifyRegistration(assert: QUnit['assert'], owner: Owner, fullName: FullName) {
-  assert.ok(owner.factoryFor(fullName), `has registration: ${fullName}`);
+export function verifyRegistration(assert: QUnit['assert'], owner: Engine, fullName: FullName) {
+  assert.ok(owner.resolveRegistration(fullName), `has registration: ${fullName}`);
 }

--- a/packages/internal-test-helpers/lib/registry-check.ts
+++ b/packages/internal-test-helpers/lib/registry-check.ts
@@ -1,9 +1,5 @@
-import type { FullName, InternalOwner } from '@ember/-internals/owner';
+import type { FullName, default as Owner } from '@ember/-internals/owner';
 
-export function verifyRegistration(
-  assert: QUnit['assert'],
-  owner: InternalOwner,
-  fullName: FullName
-) {
-  assert.ok(owner.resolveRegistration(fullName), `has registration: ${fullName}`);
+export function verifyRegistration(assert: QUnit['assert'], owner: Owner, fullName: FullName) {
+  assert.ok(owner.factoryFor(fullName), `has registration: ${fullName}`);
 }


### PR DESCRIPTION
As a follow-on to #20310, this removes all remaining direct uses of the `InternalOwner` type; the only place we use it now is in the defintion of `EngineInstance`. This frees us to start chipping away further at this type: we can deprecate *nearly all of it*, and we know that our internal code does not depend on any of it except where it explicitly uses `EngineInstance`.

Part of #20303.