### PR TITLE
[BUGFIX beta] Types: resolve services with `Owner.lookup`

### DIFF
--- a/packages/@ember/service/index.ts
+++ b/packages/@ember/service/index.ts
@@ -93,3 +93,16 @@ export function service(
 export default class Service extends FrameworkObject {
   static isServiceFactory = true;
 }
+
+/**
+  A type registry for Ember `Service`s. Meant to be declaration-merged so string
+  lookups resolve to the correct type.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Registry extends Record<string, Service> {}
+
+declare module '@ember/owner' {
+  export interface DIRegistry {
+    service: Registry;
+  }
+}


### PR DESCRIPTION
Integrate the service registry into the `DIRegistry` introduced as part of rationalizing the `Owner` types in PR #20271 (94276b5). This allows `Owner.lookup('service:foo')` to resolve a `FooService` if one is set up in the `@ember/service` module's `Registry` interface. The preview types already used this mechanic (as of 5658b13), so this just means that when we ship the stable (i.e. built from source) version of `@ember/service`, it will *continue* working.

Meta: Shipping this implementation for the lookup was blocked on being able to publish type modules with `declare module`, which was implemented in PR #20316 (9adcd15). We will likely need to rework other parts of the type hierarchy to support publishing from source.