### PR TITLE
[BUGFIX LTS] ContainerDebugAdapter extends EmberObject

### DIFF
--- a/types/preview/@ember/debug/container-debug-adapter.d.ts
+++ b/types/preview/@ember/debug/container-debug-adapter.d.ts
@@ -1,11 +1,12 @@
 declare module '@ember/debug/container-debug-adapter' {
+  import EmberObject from '@ember/object';
   import type { Resolver } from '@ember/owner';
 
   /**
    * The ContainerDebugAdapter helps the container and resolver interface
    * with tools that debug Ember such as the Ember Inspector for Chrome and Firefox.
    */
-  export default class ContainerDebugAdapter extends Object {
+  export default class ContainerDebugAdapter extends EmberObject {
     resolver: Resolver;
     canCatalogEntriesByType(type: string): boolean;
     catalogEntriesByType(type: string): string[];


### PR DESCRIPTION
The preview types had `extends Object` instead, which... uh, yeah, most things in JavaScript do that. Whoops.