### PR TITLE
Fix more bugs in type publishing infra

### DIFF
--- a/packages/@ember/debug/lib/deprecate.ts
+++ b/packages/@ember/debug/lib/deprecate.ts
@@ -5,11 +5,13 @@ import { assert } from '../index';
 import type { HandlerCallback } from './handlers';
 import { invoke, registerHandler as genericRegisterHandler } from './handlers';
 
-declare global {
-  const __fail__: {
-    fail(): void;
-  };
-}
+// This is a "global", but instead of declaring it as `declare global`, which
+// will expose it to all other modules, declare it *locally* (and don't export
+// it) so that it has the desired "private global" semantics -- however odd that
+// particular notion is.
+declare const __fail__: {
+  fail(): void;
+};
 
 interface Available {
   available: string;

--- a/packages/internal-test-helpers/lib/ember-dev/assertion.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/assertion.ts
@@ -5,12 +5,11 @@ import { callWithStub, checkTest } from './utils';
 type ExpectAssertionFunc = (func: () => void, expectedMessage: Message) => void;
 type IgnoreAssertionFunc = (func: () => void) => void;
 
-declare global {
-  interface Window {
+type ExtendedWindow = Window &
+  typeof globalThis & {
     expectAssertion: ExpectAssertionFunc | null;
     ignoreAssertion: IgnoreAssertionFunc | null;
-  }
-}
+  };
 
 const BREAK = {};
 
@@ -68,8 +67,9 @@ export function setupAssertionHelpers(hooks: NestedHooks, env: DebugEnv): void {
       callWithStub(env, 'assert', func);
     };
 
-    window.expectAssertion = expectAssertion;
-    window.ignoreAssertion = ignoreAssertion;
+    let w = window as ExtendedWindow;
+    w.expectAssertion = expectAssertion;
+    w.ignoreAssertion = ignoreAssertion;
   });
 
   hooks.afterEach(function () {
@@ -77,8 +77,9 @@ export function setupAssertionHelpers(hooks: NestedHooks, env: DebugEnv): void {
     // sure we restore the original assert function
     env.setDebugFunction('assert', originalAssertFunc);
 
-    window.expectAssertion = null;
-    window.ignoreAssertion = null;
+    let w = window as ExtendedWindow;
+    w.expectAssertion = null;
+    w.ignoreAssertion = null;
   });
 }
 

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -2,15 +2,15 @@ import { assert } from '@ember/debug';
 import DebugAssert from './debug';
 import type { DebugEnv, Message } from './utils';
 import { callWithStub } from './utils';
-declare global {
-  interface Window {
+
+type ExtendedWindow = Window &
+  typeof globalThis & {
     expectNoDeprecation: DeprecationAssert['expectNoDeprecation'] | undefined;
     expectNoDeprecationAsync: DeprecationAssert['expectNoDeprecationAsync'] | undefined;
     expectDeprecation: DeprecationAssert['expectDeprecation'] | undefined;
     expectDeprecationAsync: DeprecationAssert['expectDeprecationAsync'] | undefined;
     ignoreDeprecation: DeprecationAssert['ignoreDeprecation'] | undefined;
-  }
-}
+  };
 
 export function setupDeprecationHelpers(hooks: NestedHooks, env: DebugEnv): void {
   let assertion = new DeprecationAssert(env);
@@ -62,22 +62,24 @@ class DeprecationAssert extends DebugAssert {
   }
 
   inject(): void {
-    window.expectNoDeprecation = expectNoDeprecation = this.expectNoDeprecation.bind(this);
-    window.expectNoDeprecationAsync = expectNoDeprecationAsync =
+    let w = window as ExtendedWindow;
+    w.expectNoDeprecation = expectNoDeprecation = this.expectNoDeprecation.bind(this);
+    w.expectNoDeprecationAsync = expectNoDeprecationAsync =
       this.expectNoDeprecationAsync.bind(this);
-    window.expectDeprecation = expectDeprecation = this.expectDeprecation.bind(this);
-    window.expectDeprecationAsync = expectDeprecationAsync = this.expectDeprecationAsync.bind(this);
-    window.ignoreDeprecation = ignoreDeprecation = this.ignoreDeprecation.bind(this);
+    w.expectDeprecation = expectDeprecation = this.expectDeprecation.bind(this);
+    w.expectDeprecationAsync = expectDeprecationAsync = this.expectDeprecationAsync.bind(this);
+    w.ignoreDeprecation = ignoreDeprecation = this.ignoreDeprecation.bind(this);
     super.inject();
   }
 
   restore(): void {
     super.restore();
-    window.expectNoDeprecation = undefined;
-    window.expectNoDeprecationAsync = undefined;
-    window.expectDeprecation = undefined;
-    window.expectDeprecationAsync = undefined;
-    window.ignoreDeprecation = undefined;
+    let w = window as ExtendedWindow;
+    w.expectNoDeprecation = undefined;
+    w.expectNoDeprecationAsync = undefined;
+    w.expectDeprecation = undefined;
+    w.expectDeprecationAsync = undefined;
+    w.ignoreDeprecation = undefined;
   }
 
   // Expects no deprecation to happen within a function, or if no function is

--- a/packages/internal-test-helpers/lib/ember-dev/warning.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/warning.ts
@@ -9,13 +9,12 @@ type ExpectWarningFunc = (
 ) => void;
 type IgnoreWarningFunc = (func: () => void) => void;
 
-declare global {
-  interface Window {
+type ExtendedWindow = Window &
+  typeof globalThis & {
     expectNoWarning: ExpectNoWarningFunc | null;
     expectWarning: ExpectWarningFunc | null;
     ignoreWarning: IgnoreWarningFunc | null;
-  }
-}
+  };
 
 export function setupWarningHelpers(hooks: NestedHooks, env: DebugEnv) {
   let assertion = new WarningAssert(env);
@@ -95,16 +94,19 @@ class WarningAssert extends DebugAssert {
       callWithStub(this.env, 'warn', func);
     };
 
-    window.expectNoWarning = expectNoWarning;
-    window.expectWarning = expectWarning;
-    window.ignoreWarning = ignoreWarning;
+    let w = window as ExtendedWindow;
+
+    w.expectNoWarning = expectNoWarning;
+    w.expectWarning = expectWarning;
+    w.ignoreWarning = ignoreWarning;
   }
 
   restore() {
     super.restore();
-    window.expectWarning = null;
-    window.expectNoWarning = null;
-    window.ignoreWarning = null;
+    let w = window as ExtendedWindow;
+    w.expectWarning = null;
+    w.expectNoWarning = null;
+    w.ignoreWarning = null;
   }
 }
 

--- a/types/publish.mjs
+++ b/types/publish.mjs
@@ -40,6 +40,7 @@ import {
   isStringLiteral,
   isVariableDeclaration,
   isTSDeclareFunction,
+  isTSEnumDeclaration,
 } from '@babel/types';
 import { builders as b, visit } from 'ast-types';
 import { parse, print } from 'recast';
@@ -548,6 +549,14 @@ export function rewriteModule(code, moduleName) {
       this.traverse(path);
     },
 
+    // Remove `declare` from `declare enum` in the top-level module.
+    visitTSEnumDeclaration(path) {
+      if (isTSEnumDeclaration(path.node) && !hasParentModuleDeclarationBlock(path)) {
+        path.node.declare = false;
+      }
+      this.traverse(path);
+    },
+
     // For any relative imports like `import { something } from './somewhere';`,
     // rewrite as `import { something } from '@ember/some-package/somewhere';`
     // since relative imports are not allowed in `declare module { }` blocks.
@@ -561,12 +570,18 @@ export function rewriteModule(code, moduleName) {
 
     // Do the same for `export ... from './relative-path'`.
     visitExportNamedDeclaration(path) {
-      let source = path.node.source;
-      if (isStringLiteral(source)) {
-        if (source.value.startsWith('./') || source.value.startsWith('../')) {
-          source.value = normalizeSpecifier(moduleName, source.value);
-        }
+      let specifier = path.node.source;
+      if (isStringLiteral(specifier)) {
+        specifier.value = normalizeSpecifier(moduleName, specifier.value);
       }
+      this.traverse(path);
+    },
+
+    // We need to rewrite annotations like `export const: import('./foo').foo`
+    // to use relative paths, as well.
+    visitTSImportType(path) {
+      let specifier = path.node.argument.value;
+      path.node.argument.value = normalizeSpecifier(moduleName, specifier);
       this.traverse(path);
     },
   });
@@ -604,16 +619,32 @@ function hasParentModuleDeclarationBlock(path) {
 
 const TERMINAL_MODULE_RE = /\/[\w-_]+\.d\.ts$/;
 const NEIGHBOR_PATH_RE = /^(\.)\//;
+const SHOULD_BE_ABSOLUTE = /(\.\.\/)+(@.*)/;
 
 /**
-  Given a relative path, `./` or `(../)+`, rewrite it as an absolute path.
+  Given a relative path, `'.'`, `./`, or `(../)+`, rewrite it as an absolute path.
 
   @param {string} moduleName The name of the host module we are declaring.
   @param {string} specifier The name of the module it is importing.
   @return {string}
  */
 function normalizeSpecifier(moduleName, specifier) {
-  if (specifier.startsWith('./')) {
+  // One particularly degenerate case is `import()` type annotations which TS
+  // generates as relative paths, e.g. `'../../@ember/object'`, since we cannot
+  // yet use project references and therefore also cannot use dependencies
+  // properly and therefore also cannot get TS to understand that it should be
+  // writing that as an absolute specifier.
+  let nonsensicalRelativePath = specifier.match(SHOULD_BE_ABSOLUTE);
+  // First match is the whole string, second match is the (last) leading `../`,
+  // third match is the package we care about.
+  if (nonsensicalRelativePath && nonsensicalRelativePath[2]) {
+    return nonsensicalRelativePath[2];
+  }
+
+  // The other cases are more normal: we replace
+  if (specifier === '.') {
+    return moduleName.replace(TERMINAL_MODULE_RE, '');
+  } else if (specifier.startsWith('./')) {
     let parentModuleName = moduleName.replace(TERMINAL_MODULE_RE, '');
     let sansLeadingDot = specifier.replace(NEIGHBOR_PATH_RE, '');
     let newImportName = `${parentModuleName}/${sansLeadingDot}`;


### PR DESCRIPTION
- Properly handle `import SomeItem, { anotherItem } from '.'` relative declarations, i.e. imports from the root/`index` of a directory.

- Handle `const item: import('<some path>').Type` declarations TS emits for cases like `export default opaquify(InternalClass)`.

  One particularly degenerate case is `import()` type annotations which TS generates as relative paths, e.g. `'../../@ember/object'`, since we cannot yet use project references and therefore also cannot use dependencies properly and therefore also cannot get TS to understand that it should be writing that as an absolute specifier.

- Remove `declare enum` as with as all other `declare <item>` cases.

- Noticing that we actually *cannot* handle `declare global { ... }` declarations, update the handful of places we do that internally. This has an added benefit of not adding those to the actual global type scope for the whole rest of the program!