### PR TITLE
[BUGFIX LTS] Fix the types for the mutation-methods of `NativeArray`

### DIFF
--- a/types/preview/@ember/array/-private/native-array.d.ts
+++ b/types/preview/@ember/array/-private/native-array.d.ts
@@ -7,7 +7,7 @@ declare module '@ember/array/-private/native-array' {
   // Get an alias to the global Array type to use in inner scope below.
   type Array<T> = T[];
 
-  type AnyArray<T> = EmberArray<T> | Array<T>;
+  type AnyArray<T> = EmberArray<T> | Array<T> | ReadonlyArray<T>;
 
   /**
    * The final definition of NativeArray removes all native methods. This is the list of removed methods


### PR DESCRIPTION
It's really annoying that I can't do:

```ts
const array = [1, 2, 3] as readonly number[];
const other = A().setObjects(array); // same with `pushObjects`, `unshiftObjects`, `removeObjects` and `addObjects`
```

I believe this PR fixes that.

cc @chriskrycho 