### PR TITLE
Normalize to always import from `'backburner.js'`

### DIFF
--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -43,7 +43,7 @@ import type {
   TransitionState,
 } from 'router_js';
 import Router, { logAbort, STATE_SYMBOL } from 'router_js';
-import type { Timer } from 'backburner';
+import type { Timer } from 'backburner.js';
 import EngineInstance from '@ember/engine/instance';
 import type { QueryParams } from 'route-recognizer';
 import type { AnyFn, MethodNamesOf, OmitFirst } from '@ember/-internals/utility-types';

--- a/packages/@ember/runloop/index.ts
+++ b/packages/@ember/runloop/index.ts
@@ -1,8 +1,8 @@
 import { assert } from '@ember/debug';
 import { onErrorTarget } from '@ember/-internals/error-handling';
 import { flushAsyncObservers } from '@ember/-internals/metal';
-import type { DeferredActionQueues } from 'backburner';
-import Backburner, { Timer } from 'backburner';
+import type { DeferredActionQueues } from 'backburner.js';
+import Backburner, { Timer } from 'backburner.js';
 import type { AnyFn } from '@ember/-internals/utility-types';
 
 export { Timer };

--- a/packages/ember/index.ts
+++ b/packages/ember/index.ts
@@ -13,7 +13,7 @@ import * as metal from '@ember/-internals/metal';
 import { FEATURES, isEnabled } from '@ember/canary-features';
 import * as EmberDebug from '@ember/debug';
 import { assert, captureRenderTree, deprecate } from '@ember/debug';
-import Backburner from 'backburner';
+import Backburner from 'backburner.js';
 import Controller, { inject as injectController, ControllerMixin } from '@ember/controller';
 import {
   _getStrings,


### PR DESCRIPTION
We had a mix of different import locations for this, both the ES imports via `backburner.js` and the Ember CLI-munged version available at `backburner`. Switch to only using the Node-resolveable version, so TS can resolve it correctly; and enforce it by removing `backburner` from the list of `core` modules in the ESLint config.