### PR TITLE
types: work around backburner runtime paths shenanigans

### DIFF
--- a/types/publish.mjs
+++ b/types/publish.mjs
@@ -563,6 +563,14 @@ export function rewriteModule(code, moduleName) {
       let source = path.node.source;
       if (isStringLiteral(source)) {
         source.value = normalizeSpecifier(moduleName, source.value);
+
+        // This makes it so that the types we publish point to the types defined
+        // by `backburner.js`, basically doing the type-time equivalent of the
+        // no good, very bad runtime shenanigans Ember does... *somewhere*... in
+        // the build to make `import Backburner from 'backburner'` work.
+        if (source.value === 'backburner') {
+          source.value = 'backburner.js';
+        }
       }
       this.traverse(path);
     },


### PR DESCRIPTION
The legal runtime import for the `backburner.js` package is apparently `backburner`, but I have not yet been able to identify where that rename occurs. We should ultimately align that to use the package name instead of a custom import specifier, but for now, unblock publishing types from source by rewriting all imports in the emitted types from `'backburner'` to `'backburner.js'`.