### PR TITLE
Types publishing: always `this.traverse(path)` in visitors

### DIFF
--- a/types/publish.mjs
+++ b/types/publish.mjs
@@ -552,7 +552,7 @@ export function rewriteModule(code, moduleName) {
       if (!hasParentModuleDeclarationBlock(path)) {
         path.node.declare = false;
       }
-      this.traverse(false);
+      this.traverse(path);
     },
 
     // Remove `declare` from `declare enum` in the top-level module.


### PR DESCRIPTION
#20331 merged despite the relevant bits here being broken because the relevant checks weren't set as “Required”, so I’ve changed that and we won't be able to merge things which don't pas CI going forward. 🎉 