### PR TITLE
[DOC] Improve didTransition in routing

### DIFF
--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -145,7 +145,7 @@ interface Route<T = unknown> extends IRoute<T> {
     export default class LoginRoute extends Route {
       @action
       didTransition() {
-        this.controller.get('errors.base').clear();
+        // your code there
         return true; // Bubble the didTransition event
       }
     }


### PR DESCRIPTION
Issue:

1. This part of code: `this.controller.get('errors.base').clear();` breaks https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-controller-access-in-routes.md rule.
2. Using `didTransition` this way is deprecated in favor of https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events