### PR TITLE
Re-enable deprecations for importing `htmlSafe` and `isHTMLSafe` from `@ember/string`. They have moved to `@ember/template`.

### DIFF
--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -240,16 +240,14 @@ function deprecateImportFromString(
   name: string,
   message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
 ) {
-  // Disabling this deprecation due to unintended errors in 3.25
-  // See https://github.com/emberjs/ember.js/issues/19393 fo more information.
-  deprecate(message, true, {
+  deprecate(message, false, {
     id: 'ember-string.htmlsafe-ishtmlsafe',
     for: 'ember-source',
     since: {
-      available: '3.25',
-      enabled: '3.25',
+      available: '4.10',
+      enabled: '4.10',
     },
-    until: '4.0.0',
+    until: '5.0.0',
     url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
   });
 }

--- a/packages/ember/index.ts
+++ b/packages/ember/index.ts
@@ -637,16 +637,14 @@ const deprecateImportFromString = function (
   name: string,
   message = `Importing ${name} from '@ember/string' is deprecated. Please import ${name} from '@ember/template' instead.`
 ) {
-  // Disabling this deprecation due to unintended errors in 3.25
-  // See https://github.com/emberjs/ember.js/issues/19393 fo more information.
-  deprecate(message, true, {
+  deprecate(message, false, {
     id: 'ember-string.htmlsafe-ishtmlsafe',
     for: 'ember-source',
     since: {
-      available: '3.25',
-      enabled: '3.25',
+      available: '4.10',
+      enabled: '4.10',
     },
-    until: '4.0.0',
+    until: '5.0.0',
     url: 'https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe',
   });
 };

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -1,8 +1,8 @@
 import Ember from '../index';
-import require from 'require';
 import { FEATURES } from '@ember/canary-features';
 import { AbstractTestCase, confirmExport, moduleFor } from 'internal-test-helpers';
 import { DEBUG } from '@glimmer/env';
+import require from 'require';
 
 moduleFor(
   'ember reexports',
@@ -20,7 +20,7 @@ moduleFor(
       });
     }
 
-    ['@skip Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
+    ['@test Ember.String.htmlSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
         assert.equal(
@@ -32,7 +32,7 @@ moduleFor(
       assert.notEqual(glimmer.htmlSafe, undefined, 'Ember.String.htmlSafe is not `undefined`');
     }
 
-    ['@skip Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
+    ['@test Ember.String.isHTMLSafe exports correctly (but deprecated)'](assert) {
       let glimmer = require('@ember/-internals/glimmer');
       expectDeprecation(() => {
         assert.equal(
@@ -260,15 +260,13 @@ let allExports = [
   ['String.classify', '@ember/string', 'classify'],
   ['String.dasherize', '@ember/string', 'dasherize'],
   ['String.decamelize', '@ember/string', 'decamelize'],
-  ['String.htmlSafe', '@ember/-internals/glimmer', 'htmlSafe'],
-  ['String.isHTMLSafe', '@ember/-internals/glimmer', 'isHTMLSafe'],
   ['String.underscore', '@ember/string', 'underscore'],
   ['String.w', '@ember/string', 'w'],
   ['STRINGS', '@ember/string', { get: '_getStrings', set: '_setStrings' }],
 
   // @ember/template
-  ['String.htmlSafe', '@ember/template', 'htmlSafe'],
-  ['String.isHTMLSafe', '@ember/template', 'isHTMLSafe'],
+  [null, '@ember/template', 'htmlSafe'],
+  [null, '@ember/template', 'isHTMLSafe'],
 
   // @ember/template-compilation
   ['HTMLBars.compile', '@ember/template-compilation', 'compileTemplate'],


### PR DESCRIPTION

See #20340 