### PR TITLE
[FEATURE] generate type registry entry in service blueprint

### DIFF
--- a/blueprints/service/files/__root__/__path__/__name__.ts
+++ b/blueprints/service/files/__root__/__path__/__name__.ts
@@ -1,3 +1,13 @@
 import Service from '@ember/service';
 
 export default class <%= classifiedModuleName %>Service extends Service {}
+
+// Don't remove this declaration: this is what enables TypeScript to resolve
+// this service using `Owner.lookup('service:<%= dasherizedModuleName %>')`, as well
+// as to check when you pass the service name as an argument to the decorator,
+// like `@service('<%= dasherizedModuleName %>') declare altName: <%= classifiedModuleName %>Service;`.
+declare module '@ember/service' {
+  interface Registry {
+    '<%= dasherizedModuleName %>': <%= classifiedModuleName %>Service;
+  }
+}


### PR DESCRIPTION
We have support for this capability in the types, so the blueprints should make sure that there is a registry entry for each service. We originally left this out because we were unsure of the future of the service registry, but we made `Owner.lookup()` smart enough to resolve it, and the `@service` decorator continues to expect it.

Helps unblock #20352.