### PR TITLE
[FEATURE] generate `Signature` in component blueprints

### DIFF
--- a/blueprints/-maybe-polyfill-typescript-blueprints.js
+++ b/blueprints/-maybe-polyfill-typescript-blueprints.js
@@ -8,10 +8,12 @@ function canEmitTypeScript() {
 }
 
 module.exports = function (context) {
-  if (canEmitTypeScript()) {
+  let canUseTypeScript = canEmitTypeScript();
+  if (canUseTypeScript) {
     typescriptBlueprintPolyfill(context);
   } else {
     // Use the plain old JS templates from before
     context.path = context.path.replace('blueprints', 'blueprints-js');
   }
+  return canUseTypeScript;
 };

--- a/blueprints/component/files/__root__/__path__/__name__.ts
+++ b/blueprints/component/files/__root__/__path__/__name__.ts
@@ -1,3 +1,4 @@
 <%= importComponent %>
 <%= importTemplate %>
+<%= componentSignature %>
 export default <%= defaultExport %>


### PR DESCRIPTION
Since [RFC 0748][0748], Glimmer components support a `Signature` type which specifies any arguments they accept, any blocks they yield, and the element types to which `...attributes` are applied. Incorporate the signature when generating TS blueprints for Glimmer components, including template-only components. Do *not* generate them for Ember (classic) components, since there are severe limitations in using classic components that way, and since we only support the Octane programming model in our TypeScript support per [RFC 0800][0800].

Unblocks #20352 and thus #20177!

[0748]: https://rfcs.emberjs.com/id/https://rfcs.emberjs.com/id/0748-glimmer-component-signature/
[0800]: https://rfcs.emberjs.com/id/https://rfcs.emberjs.com/id/0800-ts-adoption-plan/