### PR TITLE
[DRAFT] Redesign API for trusted (unsafe) strings

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -451,7 +451,13 @@ export { default as LinkTo } from './lib/components/link-to';
 export { default as Textarea } from './lib/components/textarea';
 export { default as Component } from './lib/component';
 export { default as Helper, helper } from './lib/helper';
-export { SafeString, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export {
+  type TrustedString,
+  unsafelyTrustString,
+  isTrustedString,
+  htmlSafe,
+  isHTMLSafe,
+} from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -451,7 +451,7 @@ export { default as LinkTo } from './lib/components/link-to';
 export { default as Textarea } from './lib/components/textarea';
 export { default as Component } from './lib/component';
 export { default as Helper, helper } from './lib/helper';
-export { SafeString, escapeExpression, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export { SafeString, htmlSafe, isHTMLSafe } from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -2,14 +2,13 @@
 @module @ember/template
 */
 
-export class SafeString {
-  private readonly string: string;
+import type { SafeString } from '@glimmer/runtime';
+import { deprecate } from '@ember/debug';
 
-  constructor(string: string) {
-    this.string = string;
-  }
+class _TrustedString implements SafeString {
+  constructor(private readonly string: string) {}
 
-  toString(): string {
+  private toString(): string {
     return `${this.string}`;
   }
 
@@ -17,6 +16,20 @@ export class SafeString {
     return this.toString();
   }
 }
+
+// TODO: before merging this, find a good home for type-only imports (presumably
+// as part of landing stable types).
+
+// A way of representing non-user-constructible types. You can conveniently use
+// this by doing `interface Type extends Data<'some-type-name'> { ... }` for
+// simple types, and/or you can type-parameterize it as makes sense for your use
+// case (see e.g. `@ember/component/helper`'s use with functional helpers).
+declare const Data: unique symbol;
+declare class Opaque<Data> {
+  private [Data]: Data;
+}
+
+export interface TrustedString extends _TrustedString, Opaque<'@ember/template:TrustedString'> {}
 
 /**
   Use this method to indicate that a string should be rendered as HTML
@@ -43,16 +56,62 @@ export class SafeString {
   @method htmlSafe
   @for @ember/template
   @static
-  @return {SafeString} A string that will not be HTML escaped by Handlebars.
+  @return {TrustedString} A string that will not be HTML escaped by Handlebars.
+  @public
+  @deprecated
+*/
+export function htmlSafe(str: string): TrustedString {
+  deprecate(
+    'As of Ember 4.12, the `htmlSafe()` function is deprecated in favor of `unsafelyTrustString`. ' +
+      'The two have identical behavior, but `unsafelyTrustString` is clearer about what it does.',
+    true, // TODO: flip it (better yet: automatically flip it!)
+    {
+      id: 'remove-html-safe',
+      for: 'ember-source',
+      url: 'TODO',
+      until: '6.0.0',
+      since: {
+        available: '4.12.0',
+        enabled: '5.0.0',
+      },
+    }
+  );
+
+  return unsafelyTrustString(str);
+}
+
+/**
+  Use this method to indicate that a string should be rendered as HTML when the
+  string is used in a template. To say this another way, strings marked with
+  `unsafelyTrustString` will not be HTML escaped.
+
+  A word of warning -   The `unsafelyTrustString` method does not make the
+  string safe; it only tells the framework to treat the string as if it is safe
+  to render as HTML. If a string contains user inputs or other untrusted data,
+  you must sanitize the string before using the `unsafelyTrustString` method.
+  Otherwise your code is vulnerable to [Cross-Site Scripting][XSS]. There are
+  many open source sanitization libraries to choose from, both for front end and
+  server-side sanitization.
+
+  [XSS]: https://owasp.org/www-community/attacks/DOM_Based_XSS
+
+  ```javascript
+  import { unsafelyTrustString } from '@ember/template';
+
+  const someTrustedOrSanitizedString = "<div>Hello!</div>"
+
+  unsafelyTrustString(someTrustedorSanitizedString)
+  ```
+
+  @method unsafelyTrustString
+  @for @ember/template
+  @static
+  @return {TrustedString} A string that will not be HTML escaped by Handlebars.
   @public
 */
-export function htmlSafe(str: string): SafeString {
-  if (str === null || str === undefined) {
-    str = '';
-  } else if (typeof str !== 'string') {
-    str = String(str);
-  }
-  return new SafeString(str);
+export function unsafelyTrustString(str: string): TrustedString {
+  let string = str === null || str === undefined ? '' : String(str);
+  return new _TrustedString(string) as TrustedString;
 }
 
 /**
@@ -61,8 +120,8 @@ export function htmlSafe(str: string): SafeString {
   ```javascript
   import { htmlSafe, isHTMLSafe } from '@ember/template';
 
-  var plainString = 'plain string',
-      safeString = htmlSafe('<div>someValue</div>');
+  let plainString = 'plain string';
+  let safeString = htmlSafe('<div>someValue</div>');
 
   isHTMLSafe(plainString); // false
   isHTMLSafe(safeString);  // true
@@ -73,13 +132,51 @@ export function htmlSafe(str: string): SafeString {
   @static
   @return {Boolean} `true` if the string was decorated with `htmlSafe`, `false` otherwise.
   @public
+  @deprecated use `isTrustedString` instead
 */
-export function isHTMLSafe(str: unknown): str is SafeString {
-  return (
-    // SAFETY: cast `as SafeString` only present to make this check "legal"; we
-    // can further improve this by changing the behavior to do an `in` check
-    // instead, but that's worth landing as a separate change for bisecting if
-    // it happens to have an impact on e.g. perf.
-    str !== null && typeof str === 'object' && typeof (str as SafeString).toHTML === 'function'
+export function isHTMLSafe(str: unknown): str is TrustedString {
+  deprecate(
+    'As of Ember 4.12, the `isHTMLSafe()` function is deprecated in favor of `isTrustedString`. ' +
+      'The two have the same basic behavior, but `isTrustedString` is clearer about what it does.',
+    true, // TODO: flip it (better yet: automatically flip it!)
+    {
+      id: 'remove-html-safe',
+      for: 'ember-source',
+      url: 'TODO',
+      until: '6.0.0',
+      since: {
+        available: '4.12.0',
+        enabled: '5.0.0',
+      },
+    }
   );
+
+  return (
+    str !== null &&
+    typeof str === 'object' &&
+    typeof (str as TrustedString)['toHTML'] === 'function'
+  );
+}
+
+/**
+  Detects if a string was explicitly trusted using `unsafelyTrustString`.
+
+  ```javascript
+  import { unsafelyTrustString, isTrustedString } from '@ember/template';
+
+  let plainString = 'plain string';
+  let safeString = unsafelyTrustString('<div>someValue</div>');
+
+  isTrustedString(plainString); // false
+  isTrustedString(safeString);  // true
+  ```
+
+  @method isTrustedString
+  @for @ember/template
+  @static
+  @return {Boolean} `true` if the string was decorated with `htmlSafe`, `false` otherwise.
+  @public
+*/
+export function isTrustedString(str: unknown): str is TrustedString {
+  return str instanceof _TrustedString;
 }

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -290,7 +290,7 @@ export function htmlSafe(str: string): SafeString {
   return internalHtmlSafe(str);
 }
 
-export function isHTMLSafe(str: any | null | undefined): str is SafeString {
+export function isHTMLSafe(str: unknown): str is SafeString {
   deprecateImportFromString('isHTMLSafe');
 
   return internalIsHtmlSafe(str);

--- a/packages/@ember/template/index.ts
+++ b/packages/@ember/template/index.ts
@@ -1,1 +1,8 @@
-export { htmlSafe, isHTMLSafe } from '@ember/-internals/glimmer';
+export {
+  htmlSafe,
+  isHTMLSafe,
+  isTrustedString,
+  unsafelyTrustString,
+  toHTML,
+  type TrustedString,
+} from '@ember/-internals/glimmer';

--- a/packages/ember/index.ts
+++ b/packages/ember/index.ts
@@ -57,7 +57,6 @@ import {
   componentCapabilities,
   modifierCapabilities,
   setComponentManager,
-  escapeExpression,
   getTemplates,
   htmlSafe,
   isHTMLSafe,
@@ -479,9 +478,6 @@ const PartialEmber = {
 
 interface EmberHandlebars {
   template: typeof template;
-  Utils: {
-    escapeExpression: typeof escapeExpression;
-  };
   compile?: typeof compile;
   precompile?: typeof precompile;
 }
@@ -688,9 +684,6 @@ runLoadHooks('Ember.Application', Application);
 
 let EmberHandlebars: EmberHandlebars = {
   template,
-  Utils: {
-    escapeExpression,
-  },
 };
 
 let EmberHTMLBars: EmberHTMLBars = {

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -388,7 +388,6 @@ let allExports = [
 
   // @ember/-internals/glimmer
   ['TEMPLATES', '@ember/-internals/glimmer', { get: 'getTemplates', set: 'setTemplates' }],
-  ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression'],
   ['_Input', '@ember/-internals/glimmer', 'Input'],
 
   // @ember/-internals/runtime

--- a/type-tests/@ember/template-tests.ts
+++ b/type-tests/@ember/template-tests.ts
@@ -1,18 +1,24 @@
-import { SafeString } from '@ember/template/-private/handlebars';
-import { htmlSafe, isHTMLSafe } from '@ember/template';
+import {
+  htmlSafe,
+  isHTMLSafe,
+  isTrustedString,
+  unsafelyTrustString,
+  type TrustedString,
+} from '@ember/template';
 import { expectTypeOf } from 'expect-type';
 
-const handlebarsSafeString: SafeString = htmlSafe('lorem ipsum...');
-expectTypeOf(htmlSafe('lorem ipsum...')).toEqualTypeOf<SafeString>();
-// @ts-expect-error
-const regularString: string = htmlSafe('lorem ipsum...');
+expectTypeOf(unsafelyTrustString('lorem ipsum...')).toEqualTypeOf<TrustedString>();
+expectTypeOf(isTrustedString).guards.toEqualTypeOf<TrustedString>();
 
-expectTypeOf(isHTMLSafe).guards.toEqualTypeOf<SafeString>();
+expectTypeOf(unsafelyTrustString('lorem ipsum...')).not.toBeString();
 
-function isSafeTest(a: string | SafeString) {
-  if (isHTMLSafe(a)) {
-    a = a.toString();
+expectTypeOf(htmlSafe).toEqualTypeOf(unsafelyTrustString);
+expectTypeOf(isHTMLSafe).toEqualTypeOf(isTrustedString);
+
+function isSafeTest(s: string | TrustedString) {
+  if (isTrustedString(s)) {
+    s = s.toHTML();
   }
 
-  a.toLowerCase();
+  s.toLowerCase();
 }

--- a/types/preview/@ember/template/-private/handlebars.d.ts
+++ b/types/preview/@ember/template/-private/handlebars.d.ts
@@ -1,7 +1,12 @@
 declare module '@ember/template/-private/handlebars' {
-  export class SafeString {
+  import { SafeString } from '@glimmer/runtime';
+  import { Opaque } from 'ember/-private/type-utils';
+
+  class _TrustedString implements SafeString {
     constructor(str: string);
-    toString(): string;
+    private toString(): string;
     toHTML(): string;
   }
+
+  export interface TrustedString extends _TrustedString, Opaque<'@ember/template:SafeString'> {}
 }

--- a/types/preview/@ember/template/index.d.ts
+++ b/types/preview/@ember/template/index.d.ts
@@ -1,5 +1,12 @@
 declare module '@ember/template' {
-  import { SafeString } from '@ember/template/-private/handlebars';
-  export function htmlSafe(str: string): SafeString;
-  export function isHTMLSafe(str: unknown): str is SafeString;
+  import { TrustedString } from '@ember/template/-private/handlebars';
+  export type { TrustedString };
+
+  export function unsafelyTrustString(str: string): TrustedString;
+  export function isTrustedString(str: unknown): str is TrustedString;
+
+  /** @deprecated use `unsafelyTrustString` instead */
+  export function htmlSafe(str: string): TrustedString;
+  /** @deprecated use `isTrustedString` instead */
+  export function isHTMLSafe(str: unknown): str is TrustedString;
 }


### PR DESCRIPTION
This is a draft PR to accompany a forthcoming proposal to improve this API along lines folks have talked about for years; I drafted the change to make it easier to discuss concretely with the accompanying RFC. This should not be taken as indicating we *are* doing this, only that I am *proposing* we do it and making it easy if we decide to do so!

---

- Introduce an opaque public type for the result of marking a string as trusted, `TrustedString`. Make all the mechanical details of the class private, accessible *only* within the internal module. Define the type as an opaque type that other users can neither instantiate nor subclass, which implements the `SafeString` contract from Glimmer, i.e. it provides only a `toHTML(): string` method.

- Deprecate `htmlSafe` and `isHTMLSafe` and introduce new names which indicate what they actually do/are: `unsafelyTrustString` and `isTrustedString`.
