### PR TITLE
Remove `escapeExpression` from `@ember/template`

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -451,7 +451,7 @@ export { default as LinkTo } from './lib/components/link-to';
 export { default as Textarea } from './lib/components/textarea';
 export { default as Component } from './lib/component';
 export { default as Helper, helper } from './lib/helper';
-export { SafeString, escapeExpression, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export { SafeString, htmlSafe, isHTMLSafe } from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/@ember/string/index.ts
+++ b/packages/@ember/string/index.ts
@@ -290,7 +290,7 @@ export function htmlSafe(str: string): SafeString {
   return internalHtmlSafe(str);
 }
 
-export function isHTMLSafe(str: any | null | undefined): str is SafeString {
+export function isHTMLSafe(str: unknown): str is SafeString {
   deprecateImportFromString('isHTMLSafe');
 
   return internalIsHtmlSafe(str);

--- a/packages/ember/index.ts
+++ b/packages/ember/index.ts
@@ -57,7 +57,6 @@ import {
   componentCapabilities,
   modifierCapabilities,
   setComponentManager,
-  escapeExpression,
   getTemplates,
   htmlSafe,
   isHTMLSafe,
@@ -479,9 +478,6 @@ const PartialEmber = {
 
 interface EmberHandlebars {
   template: typeof template;
-  Utils: {
-    escapeExpression: typeof escapeExpression;
-  };
   compile?: typeof compile;
   precompile?: typeof precompile;
 }
@@ -688,9 +684,6 @@ runLoadHooks('Ember.Application', Application);
 
 let EmberHandlebars: EmberHandlebars = {
   template,
-  Utils: {
-    escapeExpression,
-  },
 };
 
 let EmberHTMLBars: EmberHTMLBars = {

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -388,7 +388,6 @@ let allExports = [
 
   // @ember/-internals/glimmer
   ['TEMPLATES', '@ember/-internals/glimmer', { get: 'getTemplates', set: 'setTemplates' }],
-  ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression'],
   ['_Input', '@ember/-internals/glimmer', 'Input'],
 
   // @ember/-internals/runtime


### PR DESCRIPTION
This is unused elsewhere in the framework itself and is not public API, so it should be safe to remove. Additionally, since this is just a copy of the API from within Handlebars itself, users who want to use it should directly use Handlebars' (or some other library's) escaping library instead. See [the discussion at #16817][16817] for background.

[16817]: https://github.com/emberjs/ember.js/issues/16817