### PR TITLE
[BUGFIX BETA] Make the *type* for `SafeString` public

### DIFF
--- a/packages/@ember/template/index.ts
+++ b/packages/@ember/template/index.ts
@@ -1,1 +1,3 @@
-export { htmlSafe, isHTMLSafe } from '@ember/-internals/glimmer';
+// NOTE: this intentionally *only* exports the *type* `SafeString`, not its
+// value, since it should not be constructed by users.
+export { htmlSafe, isHTMLSafe, type SafeString } from '@ember/-internals/glimmer';


### PR DESCRIPTION
This type has been effectively "intimate" for many years, and fits in the same bucket as e.g. `Transition`: it is not user-constructible, but will be constructed by the framework and users need to be able to name it. For example, `ember-intl` needs to be able to see that a string has been marked as trusted to do the right thing to emit it.

Internally, clean up a few long-standing TS issues (`any` etc.), make `SafeString` explicitly implement the contract from Glimmer so that if that contract changes, we will know at the definition site, and make the implementation details of how `SafeString` handles the string it wraps `private`. (This does not use a `#`-private field because private class fields have some non-trivial overhead in transpiled contexts, and `SafeString` can appear in fairly hot rendering paths.)

---

I will back port this to the preview types as well once we merge this.