### PR TITLE
[BUGFIX LTS] Improve SafeString type tests, include in preview types

### DIFF
--- a/type-tests/@ember/template-tests.ts
+++ b/type-tests/@ember/template-tests.ts
@@ -1,18 +1,17 @@
-import { SafeString } from '@ember/template/-private/handlebars';
-import { htmlSafe, isHTMLSafe } from '@ember/template';
+import { htmlSafe, isHTMLSafe, SafeString } from '@ember/template';
 import { expectTypeOf } from 'expect-type';
 
-const handlebarsSafeString: SafeString = htmlSafe('lorem ipsum...');
-expectTypeOf(htmlSafe('lorem ipsum...')).toEqualTypeOf<SafeString>();
-// @ts-expect-error
-const regularString: string = htmlSafe('lorem ipsum...');
-
+let trusted = htmlSafe('lorem ipsum...');
+expectTypeOf(trusted).toEqualTypeOf<SafeString>();
+expectTypeOf(trusted).not.toBeString();
 expectTypeOf(isHTMLSafe).guards.toEqualTypeOf<SafeString>();
+expectTypeOf(trusted.toHTML()).toBeString();
+expectTypeOf(trusted.toString()).toBeString();
 
-function isSafeTest(a: string | SafeString) {
-  if (isHTMLSafe(a)) {
-    a = a.toString();
-  }
+expectTypeOf<SafeString>().toMatchTypeOf<{
+  toString(): string;
+  toHTML(): string;
+}>();
 
-  a.toLowerCase();
-}
+// @ts-expect-error -- we do not allow construction by exporting only the type.
+new SafeString('whatever');

--- a/types/preview/@ember/template/index.d.ts
+++ b/types/preview/@ember/template/index.d.ts
@@ -1,5 +1,6 @@
 declare module '@ember/template' {
   import { SafeString } from '@ember/template/-private/handlebars';
+  export type { SafeString };
   export function htmlSafe(str: string): SafeString;
   export function isHTMLSafe(str: unknown): str is SafeString;
 }


### PR DESCRIPTION
Building on the previous, beta-only PR (#20373), update the type tests to check for the constructibility of the type, and make sure it is included in the types users can actually consume. (This is the part we will end up backporting to LTS!)