### PR TITLE
Add unused generics to `ComputedProperty` types for compatibility with `@types/ember__object`

### DIFF
--- a/types/preview/@ember/object/computed.d.ts
+++ b/types/preview/@ember/object/computed.d.ts
@@ -5,7 +5,11 @@ declare module '@ember/object/computed' {
    * will be cached. You can specify various properties that your computed property is dependent on.
    * This will force the cached result to be recomputed if the dependencies are modified.
    */
-  export default class ComputedProperty {
+  export default class ComputedProperty<
+    // Unused generics for compat with @types/ember__object package.
+    // see https://github.com/machty/ember-concurrency/issues/510
+    Get = unknown, Set = Get
+  > {
     /**
      * Call on a computed property to set it into read-only mode. When in this
      * mode the computed property will throw an error when set.


### PR DESCRIPTION
Ember's preview-types remove the generic `Get` and `Set` parameters from the `ComputedProperty` type that are [included in `@types/ember__object`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ember__object/computed.d.ts).

Unfortunately, this change caused compatibility issues for libraries that need to support both the `@types` packages and preview-types. While these libraries _could_ drop support of "unwrapping" computed properties for `get`, this ends up being a pretty big change, as shown here: https://github.com/machty/ember-concurrency/pull/512.

See https://github.com/machty/ember-concurrency/issues/510 for more details. Until that issue is resolved, users of ember-concurrency are blocked from using preview-types.

Would love thoughts from @chriskrycho on this.