### PR TITLE
[BUGFIX LTS 4.4] Don't run getters while applying mixins

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -2,7 +2,7 @@ name: Alpha Releases
 
 on:
   schedule:
-    - cron:  '0 20 * * 3' # weekly (Wednesday)
+    - cron: '0 20 * * 3' # weekly (Wednesday)
 
 jobs:
   test:
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
       - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - beta
       - release
       # release branches
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -236,13 +236,24 @@ jobs:
   deploy-tag:
     name: Deploy tags to npm
     runs-on: ubuntu-latest
-    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
+    needs:
+      [
+        basic-test,
+        lint,
+        browserstack-test,
+        production-test,
+        production-debug-render-test,
+        extend-prototypes-test,
+        node-test,
+        blueprint-test,
+        browser-test,
+      ]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - name: install dependencies
@@ -257,14 +268,25 @@ jobs:
   publish:
     name: Publish channel to s3
     runs-on: ubuntu-latest
-    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
+    needs:
+      [
+        basic-test,
+        lint,
+        browserstack-test,
+        production-test,
+        production-debug-render-test,
+        extend-prototypes-test,
+        node-test,
+        blueprint-test,
+        browser-test,
+      ]
     # Only run on pushes to branches that are not from the cron workflow
     if: github.event_name == 'push' && contains(github.ref, 'cron') != true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -280,14 +302,25 @@ jobs:
   publish-alpha:
     name: Publish alpha from default branch
     runs-on: ubuntu-latest
-    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
-    # Only run on pushes to master
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs:
+      [
+        basic-test,
+        lint,
+        browserstack-test,
+        production-test,
+        production-debug-render-test,
+        extend-prototypes-test,
+        node-test,
+        blueprint-test,
+        browser-test,
+      ]
+    # Only run on pushes to main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -301,4 +334,3 @@ jobs:
           S3_BUCKET_NAME: 'builds.emberjs.com'
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY}}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID}}
-

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: Cron
 
 on:
   schedule:
-    - cron:  '0 7 * * *' # daily, 7am
+    - cron: '0 7 * * *' # daily, 7am
 
 jobs:
   trigger-ci:
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - master
+          - main
           - beta
           - release
     steps:

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "typescript": "~4.6.0"
   },
   "engines": {
-    "node": ">= 12.*"
+    "node": ">= 14.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"

--- a/packages/@ember/-internals/metal/lib/mixin.ts
+++ b/packages/@ember/-internals/metal/lib/mixin.ts
@@ -27,6 +27,7 @@ import {
   descriptorForDecorator,
   makeComputedDecorator,
   nativeDescDecorator,
+  isClassicDecorator,
 } from './decorator';
 import { addListener, removeListener } from './events';
 import expandProperties from './expand_properties';
@@ -230,7 +231,7 @@ function mergeMixins(
   keys: string[],
   keysWithSuper: string[]
 ): void {
-  let currentMixin;
+  let currentMixin: MixinLike | undefined;
 
   for (let i = 0; i < mixins.length; i++) {
     currentMixin = mixins[i];
@@ -304,12 +305,17 @@ function mergeProps(
       let desc = meta.peekDescriptors(key);
 
       if (desc === undefined) {
-        // The superclass did not have a CP, which means it may have
-        // observers or listeners on that property.
-        let prev = (values[key] = base[key]);
+        // If the value is a classic decorator, we don't want to actually
+        // access it, because that will execute the decorator while we're
+        // building the class.
+        if (!isClassicDecorator(value)) {
+          // The superclass did not have a CP, which means it may have
+          // observers or listeners on that property.
+          let prev = (values[key] = base[key]);
 
-        if (typeof prev === 'function') {
-          updateObserversAndListeners(base, key, prev, false);
+          if (typeof prev === 'function') {
+            updateObserversAndListeners(base, key, prev, false);
+          }
         }
       } else {
         descs[key] = desc;

--- a/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
@@ -1,0 +1,56 @@
+import EmberObject from '@ember/object';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'runtime: Mixin Accessors',
+  class extends RenderingTestCase {
+    ['@test works with getters'](assert) {
+      let value = 'building';
+
+      let Base = EmberObject.extend({
+        get foo() {
+          if (value === 'building') {
+            throw Error('base should not be called yet');
+          }
+
+          return "base's foo";
+        },
+      });
+
+      // force Base to be finalized so its properties will contain `foo`
+      Base.proto();
+
+      class Child extends Base {
+        get foo() {
+          if (value === 'building') {
+            throw Error('child should not be called yet');
+          }
+
+          return "child's foo";
+        }
+      }
+
+      Child.proto();
+
+      let Grandchild = Child.extend({
+        get foo() {
+          if (value === 'building') {
+            throw Error('grandchild should not be called yet');
+          }
+
+          return value;
+        },
+      });
+
+      let instance = Grandchild.create();
+
+      value = 'done building';
+
+      assert.equal(instance.foo, 'done building', 'getter defined correctly');
+
+      value = 'changed value';
+
+      assert.equal(instance.foo, 'changed value', 'the value is a real getter, not a snapshot');
+    }
+  }
+);

--- a/smoke-tests/ember-test-app/package.json
+++ b/smoke-tests/ember-test-app/package.json
@@ -63,7 +63,7 @@
     "webpack": "^5.65.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Backport of https://github.com/emberjs/ember.js/pull/20388

This change ensures that getters are never evaluated while applying mixins.

It relies on the fact that all getters (including undecorated ones) get converted into classic decorators when the mixin is originally created.