### PR TITLE
[DOC LTS] Moving array, concat, fn, get, and hash to @ember/helper

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/array.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/array.ts
@@ -31,7 +31,7 @@
    Where the 3rd item in the array is bound to updates of the `myOtherPerson` property.
 
    @method array
-   @for Ember.Templates.helpers
+   @for @ember/helper
    @param {Array} options
    @return {Array} Array
    @since 3.8.0

--- a/packages/@ember/-internals/glimmer/lib/helpers/concat.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/concat.ts
@@ -21,6 +21,6 @@
 
   @public
   @method concat
-  @for Ember.Templates.helpers
+  @for @ember/helper
   @since 1.13.0
 */

--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -65,7 +65,7 @@
   See also [partial application](https://en.wikipedia.org/wiki/Partial_application).
 
   @method fn
-  @for Ember.Templates.helpers
+  @for @ember/helper
   @public
   @since 3.11.0
 */

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -93,6 +93,6 @@
 
   @public
   @method get
-  @for Ember.Templates.helpers
+  @for @ember/helper
   @since 2.1.0
  */

--- a/packages/@ember/-internals/glimmer/lib/helpers/hash.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/hash.ts
@@ -34,7 +34,7 @@
    ```
 
    @method hash
-   @for Ember.Templates.helpers
+   @for @ember/helper
    @param {Object} options
    @return {Object} Hash
    @since 2.3.0


### PR DESCRIPTION
This change addresses the documentation issue for array, concat, fn, get and hash in [this issue](https://github.com/emberjs/ember.js/issues/20153). I tested this change by running ```yarn install && yarn test``` in ember-js, and then verified the documentation change in ember-jsonapi-docs by following [these instructions](https://github.com/ember-learn/ember-jsonapi-docs#quickstart). It looks correct to me based on the linked issue, but please let me know what I missed as I'm new to this repo.