### PR TITLE
[CLEANUP] Finish cleaning up `Location` interface

### DIFF
--- a/packages/@ember/routing/hash-location.ts
+++ b/packages/@ember/routing/hash-location.ts
@@ -1,4 +1,4 @@
-import EmberObject, { set } from '@ember/object';
+import EmberObject from '@ember/object';
 import { bind } from '@ember/runloop';
 import type { Location as EmberLocation, UpdateCallback } from '@ember/routing/location';
 import { getHash } from './lib/location-utils';
@@ -36,14 +36,13 @@ import { getHash } from './lib/location-utils';
   @protected
 */
 export default class HashLocation extends EmberObject implements EmberLocation {
-  implementation = 'hash';
   _hashchangeHandler?: EventListener;
 
   private _location?: Location;
   declare location: Location;
 
   init(): void {
-    set(this, 'location', this._location || window.location);
+    this.location = this._location ?? window.location;
     this._hashchangeHandler = undefined;
   }
 
@@ -100,7 +99,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
   */
   setURL(path: string): void {
     this.location.hash = path;
-    set(this, 'lastSetURL', path);
+    this.lastSetURL = path;
   }
 
   /**
@@ -113,7 +112,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
   */
   replaceURL(path: string): void {
     this.location.replace(`#${path}`);
-    set(this, 'lastSetURL', path);
+    this.lastSetURL = path;
   }
 
   lastSetURL: string | null = null;
@@ -135,7 +134,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
         return;
       }
 
-      set(this, 'lastSetURL', null);
+      this.lastSetURL = null;
 
       callback(path);
     });

--- a/packages/@ember/routing/history-location.ts
+++ b/packages/@ember/routing/history-location.ts
@@ -1,4 +1,5 @@
-import EmberObject, { set } from '@ember/object';
+import EmberObject from '@ember/object';
+import { assert } from '@ember/debug';
 import type { Location as EmberLocation, UpdateCallback } from '@ember/routing/location';
 import { getHash } from './lib/location-utils';
 
@@ -58,10 +59,11 @@ function _uuid() {
   @protected
 */
 export default class HistoryLocation extends EmberObject implements EmberLocation {
+  // SAFETY: both of these properties initialized via `init`.
   declare location: Location;
   declare baseURL: string;
 
-  history?: any;
+  history?: Window['history'];
 
   implementation = 'history';
   _previousURL?: string;
@@ -75,6 +77,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     @private
   */
   rootURL = '/';
+
   /**
     @private
 
@@ -95,8 +98,8 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
       baseURL = base.getAttribute('href') ?? '';
     }
 
-    set(this, 'baseURL', baseURL);
-    set(this, 'location', this.location || window.location);
+    this.baseURL = baseURL;
+    this.location = this.location ?? window.location;
 
     this._popstateHandler = undefined;
   }
@@ -108,8 +111,8 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     @method initState
   */
   initState(): void {
-    let history = this.history || window.history;
-    set(this, 'history', history);
+    let history = this.history ?? window.history;
+    this.history = history;
 
     let { state } = history;
     let path = this.formatURL(this.getURL());
@@ -157,6 +160,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     @param path {String}
   */
   setURL(path: string): void {
+    assert('HistoryLocation.history is unexpectedly missing', this.history);
     let { state } = this.history;
     path = this.formatURL(path);
 
@@ -174,6 +178,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     @param path {String}
   */
   replaceURL(path: string): void {
+    assert('HistoryLocation.history is unexpectedly missing', this.history);
     let { state } = this.history;
     path = this.formatURL(path);
 
@@ -192,7 +197,8 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
   pushState(path: string): void {
     let state = { path, uuid: _uuid() };
 
-    this.history.pushState(state, null, path);
+    assert('HistoryLocation.history is unexpectedly missing', this.history);
+    this.history.pushState(state, '', path);
 
     // used for webkit workaround
     this._previousURL = this.getURL();
@@ -208,7 +214,8 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
   replaceState(path: string): void {
     let state = { path, uuid: _uuid() };
 
-    this.history.replaceState(state, null, path);
+    assert('HistoryLocation.history is unexpectedly missing', this.history);
+    this.history.replaceState(state, '', path);
 
     // used for webkit workaround
     this._previousURL = this.getURL();

--- a/packages/@ember/routing/location.ts
+++ b/packages/@ember/routing/location.ts
@@ -20,16 +20,11 @@
 
   Each location implementation must provide the following methods:
 
-  * `implementation`: returns the string name used to reference the implementation.
   * `getURL`: returns the current URL.
   * `setURL(path)`: sets the current URL.
   * `replaceURL(path)`: replace the current URL (optional).
   * `onUpdateURL(callback)`: triggers the callback when the URL changes.
   * `formatURL(url)`: formats `url` to be placed into `href` attribute.
-  * `detect()` (optional): instructs the location to do any feature detection
-      necessary. If the location needs to redirect to a different URL, it
-      can cancel routing by setting the `cancelRouterSetup` property on itself
-      to `false`.
 
   Calling `setURL` or `replaceURL` will not trigger onUpdateURL callbacks.
 
@@ -65,15 +60,6 @@
   @public
 */
 export interface Location {
-  /**
-   * Returns the string name used to reference the implementation.
-   *
-   * @property implementation
-   * @type String
-   * @public
-   */
-  implementation: keyof Registry & string;
-
   /**
    * If the location needs to redirect to a different URL, it can cancel routing
    * by setting the `cancelRouterSetup` property on itself to false.
@@ -128,12 +114,6 @@ export interface Location {
    * @param {String} url the url to format
    */
   formatURL(url: string): string;
-  /**
-   * Instructs the location to do any feature detection necessary. If the
-   * location needs to redirect to a different URL, it can cancel routing by
-   * setting the cancelRouterSetup property on itself to false.
-   */
-  detect?(): void;
 
   initState?(): void;
   destroy(): void;

--- a/packages/@ember/routing/none-location.ts
+++ b/packages/@ember/routing/none-location.ts
@@ -1,4 +1,4 @@
-import EmberObject, { set } from '@ember/object';
+import EmberObject from '@ember/object';
 import { assert } from '@ember/debug';
 import type { Location as EmberLocation, UpdateCallback } from '@ember/routing/location';
 
@@ -21,8 +21,7 @@ import type { Location as EmberLocation, UpdateCallback } from '@ember/routing/l
   @protected
 */
 export default class NoneLocation extends EmberObject implements EmberLocation {
-  declare updateCallback: UpdateCallback;
-  implementation = 'none';
+  updateCallback?: UpdateCallback;
 
   // Set in reopen so it can be overwritten with extend
   declare path: string;
@@ -77,7 +76,7 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
     @param path {String}
   */
   setURL(path: string): void {
-    set(this, 'path', path);
+    this.path = path;
   }
 
   /**
@@ -101,8 +100,10 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
     @param url {String}
   */
   handleURL(url: string): void {
-    set(this, 'path', url);
-    this.updateCallback(url);
+    this.path = url;
+    if (this.updateCallback) {
+      this.updateCallback(url);
+    }
   }
 
   /**
@@ -114,7 +115,7 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
 
     @private
     @method formatURL
-    @param url {String}
+    @param {String} url
     @return {String} url
   */
   formatURL(url: string): string {

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -254,7 +254,6 @@ module.exports = {
     'helperContainer',
     'htmlSafe',
     'if',
-    'implementation',
     'in-element',
     'includes',
     'incrementProperty',


### PR DESCRIPTION
Catches the last few pieces ID'd by @sandstrom in #20406 as well as miscellaneous clean-up of the classes I noticed while working on them. 🎉 

- Remove `detect` and `implementation` from interface and its implementations.
- Just use normal JS property setters instead of `set`.
- Improve type safety in several spots.