### PR TITLE
[BUGFIX stable] TS lint-level error in `mixins/-proxy.ts`

### DIFF
--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.ts
@@ -119,9 +119,7 @@ const ProxyMixin = Mixin.create({
 
   unknownProperty(key: string) {
     let content = contentFor(this);
-    if (content) {
-      return get(content, key);
-    }
+    return content ? get(content, key) : undefined;
   },
 
   setUnknownProperty(key: string, value: unknown) {

--- a/packages/@ember/debug/lib/deprecate.ts
+++ b/packages/@ember/debug/lib/deprecate.ts
@@ -116,6 +116,7 @@ if (DEBUG) {
     captureErrorForStack = () => {
       try {
         __fail__.fail();
+        return;
       } catch (e) {
         return e;
       }

--- a/packages/@ember/object/observable.ts
+++ b/packages/@ember/object/observable.ts
@@ -329,7 +329,7 @@ interface Observable {
     Remove an observer you have previously registered on this object. Pass
     the same key, target, and method you passed to `addObserver()` and your
     target will no longer receive notifications.
-    
+
     @method removeObserver
     @param {String} key The key to observe
     @param {Object} target The target object to invoke
@@ -400,7 +400,7 @@ interface Observable {
     This allows you to inspect the value of a computed property
     without accidentally invoking it if it is intended to be
     generated lazily.
-    
+
     @method cacheFor
     @param {String} keyName
     @return {Object} The cached value of the computed property, if any
@@ -526,10 +526,7 @@ const Observable = Mixin.create({
 
   cacheFor(keyName: string) {
     let meta = peekMeta(this);
-
-    if (meta !== null) {
-      return meta.valueFor(keyName);
-    }
+    return meta !== null ? meta.valueFor(keyName) : undefined;
   },
 });
 


### PR DESCRIPTION
Explicitly do a consistent return from a number of spots which TS 5.1 nightlies are catching, and which previous versions did not. In these cases, we explicitly return `undefined`, which is equivalent to the previous behavior.

Fixes a lint-style error with TS nightly.