### PR TITLE
Custom locations are a supported public API

### DIFF
--- a/types/preview/@ember/routing/router.d.ts
+++ b/types/preview/@ember/routing/router.d.ts
@@ -3,6 +3,7 @@ declare module '@ember/routing/router' {
   import Evented from '@ember/object/evented';
   import RouterDSL from '@ember/routing/-private/router-dsl';
   import Transition from '@ember/routing/transition';
+  import Location from '@ember/routing/location';
 
   /**
    * The `Ember.Router` class manages the application state and URLs. Refer to
@@ -21,7 +22,7 @@ declare module '@ember/routing/router' {
      *
      * @note the `'auto'` location is [deprecated](https://deprecations.emberjs.com/v4.x/#toc_deprecate-auto-location).
      */
-    location: 'history' | 'hash' | 'none' | 'auto';
+    location: 'history' | 'hash' | 'none' | 'auto' | Location | string;
     /**
      * Represents the URL of the root of the application, often '/'. This prefix is
      * assumed on all routes defined on this router.

--- a/types/preview/@ember/routing/router.d.ts
+++ b/types/preview/@ember/routing/router.d.ts
@@ -22,7 +22,7 @@ declare module '@ember/routing/router' {
      *
      * @note the `'auto'` location is [deprecated](https://deprecations.emberjs.com/v4.x/#toc_deprecate-auto-location).
      */
-    location: 'history' | 'hash' | 'none' | 'auto' | Location | string;
+    location: Location | string;
     /**
      * Represents the URL of the root of the application, often '/'. This prefix is
      * assumed on all routes defined on this router.


### PR DESCRIPTION
See docs at:

https://github.com/emberjs/ember.js/blob/60d2e0cddb353aea0d6e36a72fda971010d92355/packages/%40ember/routing/location.ts#L31-L33

If you create `app/locations/whatever.js` you can set Router.location to `"whatever"` to resolve it.

In addition to using the resolver in this way with a custom string, you can avoid stringly resolution by passing a Location instance directly.