### PR TITLE
Add private utility API that enables `ember-qunit` to detect leaking an Owner instance

### DIFF
--- a/bin/run-tests-browser-runner.js
+++ b/bin/run-tests-browser-runner.js
@@ -65,7 +65,10 @@ module.exports = class BrowserRunner {
   }
 
   async newBrowser() {
-    let browser = await puppeteer.launch({ dumpio: true });
+    let browser = await puppeteer.launch({
+      dumpio: true,
+      args: ['--js-flags=--expose-gc'],
+    });
     return browser;
   }
 

--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -732,3 +732,5 @@ export interface RegistryProxy extends BasicRegistry {
  *   APIs which are not exposed on `Owner` itself.
  */
 export interface InternalOwner extends RegistryProxy, ContainerProxy {}
+
+export { trackOwner, setupOwnerTracker, type OwnerTrackerCallback } from './leak-detector';

--- a/packages/@ember/-internals/owner/leak-detector.ts
+++ b/packages/@ember/-internals/owner/leak-detector.ts
@@ -1,0 +1,15 @@
+import type { InternalOwner } from './index';
+
+export type OwnerTrackerCallback = (owner: InternalOwner) => void;
+
+let ownerTrackerCallback: OwnerTrackerCallback | undefined;
+
+export function setupOwnerTracker(callback: OwnerTrackerCallback) {
+  ownerTrackerCallback = callback;
+}
+
+export function trackOwner(owner: InternalOwner) {
+  if (ownerTrackerCallback) {
+    ownerTrackerCallback(owner);
+  }
+}

--- a/packages/@ember/-internals/runtime/lib/mixins/container_proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/container_proxy.ts
@@ -4,7 +4,7 @@ import { schedule, join } from '@ember/runloop';
 */
 import type Container from '@ember/-internals/container/lib/container';
 import Mixin from '@ember/object/mixin';
-import type { ContainerProxy } from '@ember/-internals/owner';
+import { type ContainerProxy, trackOwner } from '@ember/-internals/owner';
 
 // This is defined as a separate interface so that it can be used in the definition of
 // `Owner` without also including the `__container__` property.
@@ -29,6 +29,12 @@ const ContainerProxyMixin = Mixin.create({
    @property {Ember.Container} __container__
    */
   __container__: null,
+
+  init() {
+    this._super();
+
+    trackOwner(this);
+  },
 
   ownerInjection() {
     return this.__container__.ownerInjection();

--- a/packages/@ember/owner/index.ts
+++ b/packages/@ember/owner/index.ts
@@ -99,4 +99,5 @@ export {
   KnownForTypeResult,
   Resolver,
   DIRegistry,
+  setupOwnerTracker as _setupOwnerTracker,
 } from '@ember/-internals/owner';

--- a/packages/internal-test-helpers/lib/ember-dev/setup-owner-leak-detection.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-owner-leak-detection.ts
@@ -1,0 +1,114 @@
+import { setupOwnerTracker, type InternalOwner } from '@ember/-internals/owner';
+
+declare global {
+  interface Config {
+    queue: unknown[];
+  }
+}
+
+export function setupOwnerLeakTracker() {
+  let OWNER_REFS: [WeakRef<InternalOwner>, string][] = [];
+
+  setupOwnerTracker((owner: InternalOwner) => {
+    OWNER_REFS.push([new WeakRef(owner), getTestName()]);
+  });
+
+  function getTestName() {
+    // the test named `ember-testing Adapters: Adapter is used by default (if
+    // QUnit is not available)` sets the `Qunit` global to undefined in order
+    // to confirm the test adapter functions properly without QUnit, this guard
+    // is specifically to avoid an error in that test case
+    if (typeof QUnit === 'undefined') {
+      return '(unknown test)';
+    }
+
+    const currentTest = QUnit.config.current;
+    return `${currentTest.module.name}: ${currentTest.testName}`;
+  }
+
+  let hasCheckedOwnerLeaks = false;
+
+  async function fullyGC() {
+    if (typeof gc !== 'function') {
+      throw new Error('Attempting to call `fullyGC` without launching with `--expose-gc`');
+    }
+
+    // Ignoring TS errors below for the `gc` style that we are using,
+    // modern chromiums accept an argument specifying type of gc (and
+    // to force it to be promise based)
+
+    // @ts-expect-error see above
+    await gc({ type: 'major', execution: 'async' });
+    // @ts-expect-error see above
+    await gc({ type: 'major', execution: 'async' });
+    // @ts-expect-error see above
+    await gc({ type: 'major', execution: 'async' });
+  }
+
+  async function checkForRetainedOwners() {
+    await fullyGC();
+
+    const testNameToRetainedOwner = new Map();
+    for (let [ownerRef, testName] of OWNER_REFS) {
+      const owner = ownerRef.deref();
+      if (owner !== undefined) {
+        let owners = testNameToRetainedOwner.get(testName);
+        if (owners === undefined) {
+          owners = [];
+          testNameToRetainedOwner.set(testName, owners);
+        }
+        owners.push(owner);
+      }
+    }
+
+    OWNER_REFS = [];
+
+    return testNameToRetainedOwner;
+  }
+
+  function getOwnerMetadata(owner: any) {
+    if (owner.mountPoint) {
+      return `Engine [mounted at \`/${owner.mountPoint}\`]`;
+    }
+    return `Application`;
+  }
+
+  // Due to details of how QUnit functions (see https://github.com/qunitjs/qunit/pull/1629)
+  // we cannot enqueue new tests if we use `runEnd` which is basically what we want (i.e. "when all tests are done run this callback")
+  //
+  // Instead we use `suiteEnd` and check `QUnit.config.queue` which indicates the number of tests remaining to be ran
+  // when `QUnit.config.queue` gets to `0` and `suiteEnd` is running we are finished with all tests **but** `runEnd` / `QUnit.done()` hasn't ran yet so we can still emit new tests
+  QUnit.moduleDone(() => {
+    if (QUnit.config.queue.length !== 0) {
+      return;
+    }
+
+    if (hasCheckedOwnerLeaks) return;
+    hasCheckedOwnerLeaks = true;
+
+    QUnit.module(`[OWNER LEAK DETECTION]`, function () {
+      const testBody = async function (assert: Assert) {
+        assert.expect(0);
+
+        await fullyGC();
+
+        const leakedOwners = await checkForRetainedOwners();
+        for (const [testName, owners] of leakedOwners) {
+          for (const owner of owners) {
+            assert.pushResult({
+              result: false,
+              expected: true,
+              actual: false,
+
+              message: `${testName}: Leaked ${getOwnerMetadata(owner)}`,
+            });
+          }
+        }
+      };
+      // Opts the user into the `OWNER LEAK DETECTION` module regardless of filter or module selected.
+      testBody.validTest = true;
+
+      QUnit.test('There should be zero leaked Owners', testBody);
+    });
+  });
+}

--- a/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/setup-qunit.ts
@@ -11,6 +11,7 @@ import { setupObserversCheck } from './observers';
 import { setupRunLoopCheck } from './run-loop';
 import type { DebugEnv } from './utils';
 import { setupWarningHelpers } from './warning';
+import { setupOwnerLeakTracker } from './setup-owner-leak-detection';
 
 declare global {
   let Ember: any;
@@ -106,4 +107,10 @@ export default function setupQUnit() {
 
     await QUnit.assert.rejects(promise, expected, message);
   };
+
+  if (typeof gc === 'undefined') {
+    // `gc` isn't available, no reason to do **anything** WRT leak detection
+    return;
+  }
+  setupOwnerLeakTracker();
 }

--- a/tsconfig/compiler-options.json
+++ b/tsconfig/compiler-options.json
@@ -22,6 +22,12 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": false,
 
+    "lib": [
+      "ES2017",
+      "ES2021.Weakref",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "newLine": "LF",
 
     "allowJs": true,


### PR DESCRIPTION
This PR introduces a simple internal utility API that can be leveraged by `ember-qunit` and `@ember/test-helpers` to allow applications to more easily detect memory leaks within their application. 

---

Example of running a test that intentionally holds on to the owner instance (e.g. "bad test"):

![Screenshot 2023-04-12 at 5 53 11 PM](https://user-images.githubusercontent.com/12637/231595205-4c0d20f1-d656-4787-bc85-d745cd97e8be.png)
![Screenshot 2023-04-12 at 5 56 46 PM](https://user-images.githubusercontent.com/12637/231595207-e2569fcf-1f79-46e0-986b-d551dd928042.png)
