### PR TITLE
[BREAKING BUGFIX beta] Drop support for Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -192,7 +192,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -285,7 +285,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - name: install dependencies
@@ -318,7 +318,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -352,7 +352,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@glimmer/component": "^1.1.2"
   },
   "engines": {
-    "node": ">= 14.*"
+    "node": ">= 16.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"

--- a/smoke-tests/ember-test-app/package.json
+++ b/smoke-tests/ember-test-app/package.json
@@ -62,7 +62,7 @@
     "webpack": "^5.74.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Node 14 is EOL'ed as of 2023-04-30, which will happen **before** 5.0.0 stable will be out, so IMO we should probably just land it now as part of 5.0.
