### PR TITLE
[BUGFIX beta] fix for TS 5.1 nightly narrowing change

### DIFF
--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -1850,7 +1850,7 @@ function buildRenderOptions(
   options?: PartialRenderOptions
 ): RenderOptions {
   let isDefaultRender = !nameOrOptions && !options;
-  let _name;
+  let _name: string;
   if (!isDefaultRender) {
     if (typeof nameOrOptions === 'object' && !options) {
       _name = route.templateName || route.routeName;
@@ -1860,7 +1860,11 @@ function buildRenderOptions(
         'The name in the given arguments is undefined or empty string',
         !isEmpty(nameOrOptions)
       );
-      _name = nameOrOptions!;
+      // SAFETY: the check for `nameOrOptions` above should be validating this,
+      // and as of TS 5.1.0-dev.2023-0417 it is *not*. This cast can go away if
+      // TS validates it correctly *or* if we refactor this entire function to
+      // be less wildly dynamic in its argument handling.
+      _name = nameOrOptions as string;
     }
   }
   assert(


### PR DESCRIPTION
The type here was `any` and *sort of* narrowing before; now it checks explicitly whether it is `string`. TS 5.1 seems to have a change (maybe a regression?) in how it narrows between the two branches, but previous versions simply fell back to `any` anyway rather than narrowing to the inferred types. This unblocks us for TS 5.1, but we should also rewrite this function handler entirely: if it were just two functions instead of using variadic function args, it would dramatically simplify *all* of this implementation (and almost certainly perform better, too!).