### PR TITLE
Add a couple of tests to test passing empty `queryParams` to `replaceWith`

### DIFF
--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -136,5 +136,29 @@ moduleFor(
           assert.deepEqual(this.state, ['/', '/child']);
         });
     }
+
+    ['@test RouterService#replaceWith with empty query params'](assert) {
+      assert.expect(1);
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.replaceWith('parent.child', { queryParams: {} });
+        })
+        .then(() => {
+          assert.deepEqual(this.state, ['/child']);
+        });
+    }
+
+    ['@test RouterService#replaceWith with `undefined` in query params'](assert) {
+      assert.expect(1);
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.replaceWith('parent.child', { queryParams: undefined });
+        })
+        .then(() => {
+          assert.deepEqual(this.state, ['/child']);
+        });
+    }
   }
 );


### PR DESCRIPTION
This is just #20042 rebased on `main` instead of `master`.

cc @wagenet 