### PR TITLE
[BUGFIX beta] preventDefault in SVG LinkTo

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -364,11 +364,14 @@ class LinkTo extends InternalComponent {
     }
 
     let element = event.currentTarget;
-    assert('[BUG] must be an <a> element', element instanceof HTMLAnchorElement);
+    assert(
+      '[BUG] must be an <a> element',
+      element instanceof HTMLAnchorElement || element instanceof SVGAElement
+    );
 
     let isSelf = element.target === '' || element.target === '_self';
 
-    if (isSelf) {
+    if (isSelf || element instanceof SVGAElement) {
       this.preventDefault(event);
     } else {
       return;


### PR DESCRIPTION
When wrapping `LinkTo` in an SVG element, the click `event.currentTarget` is not an `instanceof HTMLAnchorElement` but of `SVGAElement`. `preventDefault` is only triggered when `isSelf`, but it needs to be triggered when wrapped inside an SVG as well, otherwise clicking the element causes a reload.

Fix for https://github.com/emberjs/ember.js/issues/19891