### PR TITLE
Restore the stable LTS 4.4 engines.node declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "typescript": "~4.6.0"
   },
   "engines": {
-    "node": ">= 14.*"
+    "node": ">= 12.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/20405 changed `engines.node`. We can't do that within the LTS channel without breaking peope.