### PR TITLE
Revert CI changes to 4.4 LTS

### DIFF
--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -2,7 +2,7 @@ name: Alpha Releases
 
 on:
   schedule:
-    - cron: '0 20 * * 3' # weekly (Wednesday)
+    - cron:  '0 20 * * 3' # weekly (Wednesday)
 
 jobs:
   test:
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
       - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
       - beta
       - release
       # release branches
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -236,24 +236,13 @@ jobs:
   deploy-tag:
     name: Deploy tags to npm
     runs-on: ubuntu-latest
-    needs:
-      [
-        basic-test,
-        lint,
-        browserstack-test,
-        production-test,
-        production-debug-render-test,
-        extend-prototypes-test,
-        node-test,
-        blueprint-test,
-        browser-test,
-      ]
+    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - name: install dependencies
@@ -268,25 +257,14 @@ jobs:
   publish:
     name: Publish channel to s3
     runs-on: ubuntu-latest
-    needs:
-      [
-        basic-test,
-        lint,
-        browserstack-test,
-        production-test,
-        production-debug-render-test,
-        extend-prototypes-test,
-        node-test,
-        blueprint-test,
-        browser-test,
-      ]
+    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
     # Only run on pushes to branches that are not from the cron workflow
     if: github.event_name == 'push' && contains(github.ref, 'cron') != true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -302,25 +280,14 @@ jobs:
   publish-alpha:
     name: Publish alpha from default branch
     runs-on: ubuntu-latest
-    needs:
-      [
-        basic-test,
-        lint,
-        browserstack-test,
-        production-test,
-        production-debug-render-test,
-        extend-prototypes-test,
-        node-test,
-        blueprint-test,
-        browser-test,
-      ]
-    # Only run on pushes to main
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [basic-test, lint, browserstack-test, production-test, production-debug-render-test, extend-prototypes-test, node-test, blueprint-test, browser-test]
+    # Only run on pushes to master
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 12.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
@@ -334,3 +301,4 @@ jobs:
           S3_BUCKET_NAME: 'builds.emberjs.com'
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY}}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID}}
+

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: Cron
 
 on:
   schedule:
-    - cron: '0 7 * * *' # daily, 7am
+    - cron:  '0 7 * * *' # daily, 7am
 
 jobs:
   trigger-ci:
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - main
+          - master
           - beta
           - release
     steps:

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "typescript": "~4.6.0"
   },
   "engines": {
-    "node": ">= 14.*"
+    "node": ">= 12.*"
   },
   "ember-addon": {
     "after": "ember-cli-legacy-blueprints"

--- a/smoke-tests/ember-test-app/package.json
+++ b/smoke-tests/ember-test-app/package.json
@@ -63,7 +63,7 @@
     "webpack": "^5.65.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This reverts the more aggressive node CI changes and only bumps the node version in the smoke test app.