### PR TITLE
Backport "Don't run getters while applying mixins" to 4.8 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
@@ -1,0 +1,56 @@
+import EmberObject from '@ember/object';
+import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'runtime: Mixin Accessors',
+  class extends RenderingTestCase {
+    ['@test works with getters'](assert) {
+      let value = 'building';
+
+      let Base = EmberObject.extend({
+        get foo() {
+          if (value === 'building') {
+            throw Error('base should not be called yet');
+          }
+
+          return "base's foo";
+        },
+      });
+
+      // force Base to be finalized so its properties will contain `foo`
+      Base.proto();
+
+      class Child extends Base {
+        get foo() {
+          if (value === 'building') {
+            throw Error('child should not be called yet');
+          }
+
+          return "child's foo";
+        }
+      }
+
+      Child.proto();
+
+      let Grandchild = Child.extend({
+        get foo() {
+          if (value === 'building') {
+            throw Error('grandchild should not be called yet');
+          }
+
+          return value;
+        },
+      });
+
+      let instance = Grandchild.create();
+
+      value = 'done building';
+
+      assert.equal(instance.foo, 'done building', 'getter defined correctly');
+
+      value = 'changed value';
+
+      assert.equal(instance.foo, 'changed value', 'the value is a real getter, not a snapshot');
+    }
+  }
+);

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1930,11 +1930,11 @@ let NativeArray = Mixin.create(MutableArray, Observable, {
 });
 
 // Remove any methods implemented natively so we don't override them
-const ignore = ['length'];
-NativeArray.keys().forEach((methodName) => {
+const ignore: string[] = ['length'];
+NativeArray.keys().forEach((methodName: unknown): void => {
   // SAFETY: It's safe to read unknown properties from an object
-  if ((Array.prototype as any)[methodName]) {
-    ignore.push(methodName);
+  if (Reflect.has(Array.prototype, methodName as string)) {
+    ignore.push(methodName as string);
   }
 });
 
@@ -1963,7 +1963,7 @@ if (ENV.EXTEND_PROTOTYPES.Array) {
 
     if (isEmberArray(arr)) {
       // SAFETY: If it's a true native array and it is also an EmberArray then it should be an Ember NativeArray
-      return arr as NativeArray<T>;
+      return arr as unknown as NativeArray<T>;
     } else {
       // SAFETY: This will return an NativeArray but TS can't infer that.
       return NativeArray.apply(arr ?? []) as NativeArray<T>;

--- a/smoke-tests/ember-test-app/package.json
+++ b/smoke-tests/ember-test-app/package.json
@@ -63,7 +63,7 @@
     "webpack": "^5.65.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Backports #20388.

This change ensures that getters are never evaluated while applying mixins.

It relies on the fact that all getters (including undecorated ones) get converted into classic decorators when the mixin is originally created.