### PR TITLE
[BUGFIX LTS] Fix cyclic module crash

### DIFF
--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -17,8 +17,6 @@ import type Application from '@ember/application';
 import type { BootEnvironment } from '@ember/-internals/glimmer';
 import type { SimpleElement } from '@simple-dom/interface';
 
-const CEngine = Engine;
-
 export interface BootOptions {
   isBrowser?: boolean;
   shouldRender?: boolean;
@@ -202,17 +200,17 @@ class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerPro
     @return {EngineInstance,Error}
   */
   buildChildEngineInstance(name: string, options: EngineInstanceOptions = {}): EngineInstance {
-    let Engine = this.lookup(`engine:${name}`);
+    let ChildEngine = this.lookup(`engine:${name}`);
 
-    if (!Engine) {
+    if (!ChildEngine) {
       throw new Error(
         `You attempted to mount the engine '${name}', but it is not registered with its parent.`
       );
     }
 
-    assert('expected an Engine', Engine instanceof CEngine);
+    assert('expected an Engine', ChildEngine instanceof Engine);
 
-    let engineInstance = Engine.buildInstance(options);
+    let engineInstance = ChildEngine.buildInstance(options);
 
     setEngineParent(engineInstance, this);
 


### PR DESCRIPTION
`@ember/engine/index` and `@ember/engine/instance` have circular dependencies on each other.

This would be OK, except that `instance.ts` is eagerly copying a class off `index.ts`, at a point in time where it might not actually be available.

Whether this bug hits you depends on which side of the pair gets evaluated first. I only happened to hit it when testing an app with engines and fastboot on Ember 5. The exception looks like:

```
TypeError: Right-hand side of 'instanceof' is not an object
```

The fix is to not eagerly pull the class off the module.