### PR TITLE
[FEATURE] Create public import for uniqueId helper #20171 

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -481,3 +481,4 @@ export {
   setComponentManager,
 } from './lib/utils/managers';
 export { isSerializationFirstNode } from './lib/utils/serialization-first-node-helpers';
+export { uniqueId } from './lib/helpers/unique-id';

--- a/packages/@ember/-internals/glimmer/lib/helpers/unique-id.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/unique-id.ts
@@ -41,7 +41,7 @@ export default internalHelper((): Reference<string> => {
 // implementation details into an intimate API. It also ensures that the UUID
 // always starts with a letter, to avoid creating invalid IDs with a numeric
 // digit at the start.
-function uniqueId() {
+export function uniqueId(): string {
   // @ts-expect-error this one-liner abuses weird JavaScript semantics that
   // TypeScript (legitimately) doesn't like, but they're nonetheless valid and
   // specced.

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unique-id-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unique-id-test.js
@@ -17,8 +17,18 @@ moduleFor(
       this.assert = assert;
     }
     ['@test it can be invoked as a JS function']() {
-      let first = getValue(invokeHelper({}, uniqueId()));
-      let second = getValue(invokeHelper({}, uniqueId()));
+      let first = uniqueId();
+      let second = uniqueId();
+
+      this.assert.notStrictEqual(
+        first,
+        second,
+        `different invocations of uniqueId should produce different values`
+      );
+    }
+    ['@test it can be invoked via invokeHelper']() {
+      let first = getValue(invokeHelper({}, uniqueId));
+      let second = getValue(invokeHelper({}, uniqueId));
 
       this.assert.notStrictEqual(
         first,

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unique-id-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unique-id-test.js
@@ -1,6 +1,33 @@
-import { RenderingTestCase, strip, moduleFor, runTask } from 'internal-test-helpers';
+import {
+  AbstractTestCase,
+  RenderingTestCase,
+  strip,
+  moduleFor,
+  runTask,
+} from 'internal-test-helpers';
 import { setProperties } from '@ember/object';
+import { uniqueId, invokeHelper } from '@ember/helper';
+import { getValue } from '@glimmer/validator';
 
+moduleFor(
+  'Helpers test: {{unique-id}} JS',
+  class extends AbstractTestCase {
+    constructor(assert) {
+      super(assert);
+      this.assert = assert;
+    }
+    ['@test it can be invoked as a JS function']() {
+      let first = getValue(invokeHelper({}, uniqueId()));
+      let second = getValue(invokeHelper({}, uniqueId()));
+
+      this.assert.notStrictEqual(
+        first,
+        second,
+        `different invocations of uniqueId should produce different values`
+      );
+    }
+  }
+);
 moduleFor(
   'Helpers test: {{unique-id}}',
   class extends RenderingTestCase {

--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -11,6 +11,7 @@ import {
   get as glimmerGet,
   fn as glimmerFn,
 } from '@glimmer/runtime';
+import { uniqueId as glimmerUniqueId } from '@ember/-internals/glimmer';
 import { type Opaque } from '@ember/-internals/utility-types';
 
 /**
@@ -468,4 +469,26 @@ export interface GetHelper extends Opaque<'helper:get'> {}
  */
 export const fn = glimmerFn as FnHelper;
 export interface FnHelper extends Opaque<'helper:fn'> {}
+
+/**
+ * Use the {{uniqueId}} helper to generate a unique ID string suitable for use as
+ * an ID attribute in the DOM.
+ *
+ * Each invocation of {{uniqueId}} will return a new, unique ID string.
+ * You can use the `let` helper to create an ID that can be reused within a template.
+ *
+ * ```js
+ * import { uniqueId } from '@ember/helper';
+ *
+ * <template>
+ *   {{#let (uniqueId) as |emailId|}}
+ *     <label for={{emailId}}>Email address</label>
+ *     <input id={{emailId}} type="email" />
+ *   {{/let}}
+ * </template>
+ * ```
+ */
+export const uniqueId = glimmerUniqueId;
+export type UniqueIdHelper = typeof uniqueId;
+
 /* eslint-enable @typescript-eslint/no-empty-interface */

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -146,6 +146,7 @@ let allExports = [
   ['_hash', '@ember/helper', 'hash'],
   ['_get', '@ember/helper', 'get'],
   ['_concat', '@ember/helper', 'concat'],
+  ['_uniqueId', '@ember/helper', 'uniqueId'],
 
   // @ember/object
   ['Object', '@ember/object', 'default'],

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -146,7 +146,6 @@ let allExports = [
   ['_hash', '@ember/helper', 'hash'],
   ['_get', '@ember/helper', 'get'],
   ['_concat', '@ember/helper', 'concat'],
-  ['_uniqueId', '@ember/helper', 'uniqueId'],
 
   // @ember/object
   ['Object', '@ember/object', 'default'],

--- a/type-tests/@ember/helper-tests.ts
+++ b/type-tests/@ember/helper-tests.ts
@@ -9,6 +9,8 @@ import {
   GetHelper,
   hash,
   HashHelper,
+  uniqueId,
+  UniqueIdHelper,
 } from '@ember/helper';
 import { expectTypeOf } from 'expect-type';
 
@@ -17,3 +19,4 @@ expectTypeOf(concat).toEqualTypeOf<ConcatHelper>();
 expectTypeOf(fn).toEqualTypeOf<FnHelper>();
 expectTypeOf(get).toEqualTypeOf<GetHelper>();
 expectTypeOf(hash).toEqualTypeOf<HashHelper>();
+expectTypeOf(uniqueId).toEqualTypeOf<UniqueIdHelper>();


### PR DESCRIPTION
Rebases: https://github.com/emberjs/ember.js/pull/20171

Additional changes:
 - uses the _function_ `uniqueId`, rather than the helper, because this is better. We don't need the classic Helper infra ever since native functions became supported in 4.5 (this was pending feedback on #20171) 
 - added JSDoc to the new export as well so that documentation shows up in the API Reference site
 - the test that was added has been changed to _not_ pre-invoke uniqueId, because it's now just a function
 - one additional test ensuring the behavior, when used as a plain function, is the same as used via invokeHelper
 - Remove addition of `_invokeHelper` to the Ember global -- I don't think we don't want to keep adding to that object, because it makes future stuff and tree shaking harder (or forces us to have even more build time complexity)
 
 Resolves: https://github.com/emberjs/ember.js/issues/20165 
 
 Locally,
 
![image](https://github.com/emberjs/ember.js/assets/199018/0983240a-41bc-4ce5-bdaf-5ff35182d9c7)
![image](https://github.com/emberjs/ember.js/assets/199018/ac731605-8fb7-41c1-b7c4-33eda1c7d9e0)

