### PR TITLE
feat: Generate SLSA Build L3 provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           BROWSERSTACK_LOCAL_IDENTIFIER="$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
-          echo "BROWSERSTACK_LOCAL_IDENTIFIER=$BROWSERSTACK_LOCAL_IDENTIFIER" >> $GITHUB_ENV
+          echo "BROWSERSTACK_LOCAL_IDENTIFIER=$BROWSERSTACK_LOCAL_IDENTIFIER" >> "$GITHUB_ENV"
 
       - name: test:browserstack
         env:
@@ -284,7 +284,6 @@ jobs:
         node-test,
         blueprint-test,
         browser-test,
-        build,
       ]
     permissions:
       id-token: write # For signing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,9 +272,7 @@ jobs:
       - name: test
         run: yarn ember test -c testem.ci-browsers.js
 
-  deploy-tag:
-    name: Deploy tags to npm
-    runs-on: ubuntu-latest
+  build:
     needs:
       [
         basic-test,
@@ -286,7 +284,21 @@ jobs:
         node-test,
         blueprint-test,
         browser-test,
+        build,
       ]
+    permissions:
+      id-token: write # For signing
+      contents: read # For repo checkout.
+      actions: read # For getting workflow run info.
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'push' && (contains(github.ref, 'cron') != true || github.ref == 'refs/heads/main'))
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_nodejs_slsa3.yml@v1.7.0
+    with:
+      run-scripts: 'ci, build:publish'
+
+  deploy-tag:
+    name: Deploy tags to npm
+    runs-on: ubuntu-latest
+    needs: [build]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v3
@@ -295,30 +307,23 @@ jobs:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
-      - name: install dependencies
-        run: yarn install --frozen-lockfile --non-interactive
-      - name: build for publish
-        run: node bin/build-for-publishing.js
-      - name: publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: publish
+        id: publish
+        uses: slsa-framework/slsa-github-generator/actions/nodejs/publish@e55b76ce421082dfa4b34a6ac3c5e59de0f3bb58 # v1.7.0
+        with:
+          access: public
+          node-auth-token: ${{ secrets.NPM_AUTH_TOKEN }}
+          package-name: ${{ needs.build.outputs.package-name }}
+          package-download-name: ${{ needs.build.outputs.package-download-name }}
+          package-download-sha256: ${{ needs.build.outputs.package-download-sha256 }}
+          provenance-name: ${{ needs.build.outputs.provenance-name }}
+          provenance-download-name: ${{ needs.build.outputs.provenance-download-name }}
+          provenance-download-sha256: ${{ needs.build.outputs.provenance-download-sha256 }}
 
   publish:
     name: Publish channel to s3
     runs-on: ubuntu-latest
-    needs:
-      [
-        basic-test,
-        lint,
-        browserstack-test,
-        production-test,
-        production-debug-render-test,
-        extend-prototypes-test,
-        node-test,
-        blueprint-test,
-        browser-test,
-      ]
+    needs: [build]
     # Only run on pushes to branches that are not from the cron workflow
     if: github.event_name == 'push' && contains(github.ref, 'cron') != true
     steps:
@@ -329,8 +334,13 @@ jobs:
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
-      - name: build for publish
-        run: node bin/build-for-publishing.js
+      # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/2311): Use secure-download-package action.
+      - name: download tarball
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@e55b76ce421082dfa4b34a6ac3c5e59de0f3bb58 # v1.7.0
+        with:
+          name: ${{ needs.build.outputs.package-download-name }}
+          path: 'dist/${{ needs.build.outputs.package-name }}'
+          sha256: ${{ needs.build.outputs.package-download-sha256 }}
       - name: publish to s3
         run: node bin/publish-to-s3.mjs
         env:
@@ -341,18 +351,7 @@ jobs:
   publish-alpha:
     name: Publish alpha from default branch
     runs-on: ubuntu-latest
-    needs:
-      [
-        basic-test,
-        lint,
-        browserstack-test,
-        production-test,
-        production-debug-render-test,
-        extend-prototypes-test,
-        node-test,
-        blueprint-test,
-        browser-test,
-      ]
+    needs: [build]
     # Only run on pushes to main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
@@ -363,8 +362,13 @@ jobs:
           cache: yarn
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
-      - name: build for publish
-        run: node bin/build-for-publishing.js
+      # TODO(https://github.com/slsa-framework/slsa-github-generator/issues/2311): Use secure-download-package action.
+      - name: download tarball
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@e55b76ce421082dfa4b34a6ac3c5e59de0f3bb58 # v1.7.0
+        with:
+          name: ${{ needs.build.outputs.package-download-name }}
+          path: 'dist/${{ needs.build.outputs.package-name }}'
+          sha256: ${{ needs.build.outputs.package-download-sha256 }}
       - name: publish to s3
         run: node bin/publish-to-s3.mjs
         env:
@@ -394,8 +398,8 @@ jobs:
       - uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.FRAMEWORK_WEBHOOK }}
-          status: "Failure"
-          title: "Ember.js Nightly CI"
+          status: 'Failure'
+          title: 'Ember.js Nightly CI'
           color: 0xcc0000
-          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           username: GitHub Actions

--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -80,9 +80,12 @@ Promise.resolve()
       encoding: 'utf-8',
     });
 
-    // using npm pack here because `yarn pack` does not honor the `package.json`'s `files`
-    // property properly, and therefore the tarball generated is quite large (~7MB).
-    return exec('npm', ['pack']);
+    // After this script runs, SLSA Node.js Builder will run 'npm pack' to
+    // package the tarball.
+    //
+    // Incidentally we do not use `yarn pack` because it does not honor the
+    // `package.json`'s `files` property properly, and therefore the
+    // tarball generated is quite large (~7MB).
   })
   .then(
     // eslint-disable-next-line

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "url": "git+https://github.com/emberjs/ember.js.git"
   },
   "scripts": {
+    "ci": "yarn install --frozen-lockfile --non-interactive",
+    "build:publish": "node bin/build-for-publishing.js",
     "build:js": "ember build --environment production",
     "build:types": "node types/publish.mjs",
     "build": "npm-run-all build:*",


### PR DESCRIPTION
Fixes #20474 

This updates `ci.yml` to build the `ember-source` package using the [SLSA Node.js Builder](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/nodejs/README.md).

A new `build` job was added to build the package `tgz`. The `deploy-tag`, `publish`, and `publish-alpha` jobs will download the `tgz` and upload them to their respective destinations (npm registry, or S3) rather than building the `tgz` independently. This allows the package tarball be identical byte-for-byte and thus verifiable no matter where it is retrieved from.