### PR TITLE
Upgrade TS and configure TS CI accordingly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     needs: ['types']
     strategy:
       matrix:
-        ts-version: ['next']
+        ts-version: ['4.9', '5.0', 'next']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -394,8 +394,8 @@ jobs:
       - uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.FRAMEWORK_WEBHOOK }}
-          status: "Failure"
-          title: "Ember.js Nightly CI"
+          status: 'Failure'
+          title: 'Ember.js Nightly CI'
           color: 0xcc0000
-          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           username: GitHub Actions

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "simple-dom": "^1.4.0",
     "testem": "^3.10.1",
     "testem-failure-only-reporter": "^1.0.0",
-    "typescript": "4.9"
+    "typescript": "5.1"
   },
   "peerDependencies": {
     "@glimmer/component": "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11554,10 +11554,10 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@4.9:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
- Bump the development version to 5.1.
- Update the CI config to test against the other supported versions: currently 4.9 and 5.0, which we tested against implicitly previously by way of our tests against TS nightly releases.

This is a bit more important now that we are officially publishing stable types! Using 4.9 as our initially supported version is an easy choice: it is what we were already using, and it gives us a solid six months of TS releases as our initial support category. Folks may find it useful to review [the "rolling windows" policy][semver-ts-rw], since that is Ember's SemVer policy for TS.

[semver-ts-rw]: https://www.semver-ts.org/#rolling-support-windows