### PR TITLE
[BUGFIX LTS] Backport some stable type import locations

### DIFF
--- a/types/preview/@ember/-internals/runtime/lib/mixins/container_proxy.d.ts
+++ b/types/preview/@ember/-internals/runtime/lib/mixins/container_proxy.d.ts
@@ -1,0 +1,11 @@
+declare module '@ember/-internals/runtime/lib/mixins/container_proxy' {
+  import { ContainerProxy } from '@ember/-internals/owner';
+  import Mixin from '@ember/object/mixin';
+
+  /**
+   * Given a fullName return a factory manager.
+   */
+  interface ContainerProxyMixin extends ContainerProxy {}
+  const ContainerProxyMixin: Mixin;
+  export default ContainerProxyMixin;
+}

--- a/types/preview/@ember/-internals/runtime/lib/mixins/registry_proxy.d.ts
+++ b/types/preview/@ember/-internals/runtime/lib/mixins/registry_proxy.d.ts
@@ -1,0 +1,12 @@
+declare module '@ember/-internals/runtime/lib/mixins/registry_proxy' {
+  import { RegistryProxy } from '@ember/-internals/owner';
+  import Mixin from '@ember/object/mixin';
+
+  /**
+   * RegistryProxyMixin is used to provide public access to specific
+   * registry functionality.
+   */
+  interface RegistryProxyMixin extends RegistryProxy {}
+  const RegistryProxyMixin: Mixin;
+  export default RegistryProxyMixin;
+}

--- a/types/preview/@ember/engine/-private/container-proxy-mixin.d.ts
+++ b/types/preview/@ember/engine/-private/container-proxy-mixin.d.ts
@@ -1,11 +1,3 @@
 declare module '@ember/engine/-private/container-proxy-mixin' {
-  import { ContainerProxy } from '@ember/-internals/owner';
-  import Mixin from '@ember/object/mixin';
-
-  /**
-   * Given a fullName return a factory manager.
-   */
-  interface ContainerProxyMixin extends ContainerProxy {}
-  const ContainerProxyMixin: Mixin;
-  export default ContainerProxyMixin;
+  export type { default } from '@ember/-internals/runtime/lib/mixins/container_proxy';
 }

--- a/types/preview/@ember/engine/-private/registry-proxy-mixin.d.ts
+++ b/types/preview/@ember/engine/-private/registry-proxy-mixin.d.ts
@@ -1,12 +1,3 @@
 declare module '@ember/engine/-private/registry-proxy-mixin' {
-  import { RegistryProxy } from '@ember/-internals/owner';
-  import Mixin from '@ember/object/mixin';
-
-  /**
-   * RegistryProxyMixin is used to provide public access to specific
-   * registry functionality.
-   */
-  interface RegistryProxyMixin extends RegistryProxy {}
-  const RegistryProxyMixin: Mixin;
-  export default RegistryProxyMixin;
+  export type { default } from '@ember/-internals/runtime/lib/mixins/registry_proxy';
 }

--- a/types/preview/index.d.ts
+++ b/types/preview/index.d.ts
@@ -34,6 +34,9 @@
 import './ember';
 import './ember/-private/type-utils';
 
+import './@ember/-internals/runtime/lib/mixins/container_proxy';
+import './@ember/-internals/runtime/lib/mixins/registry_proxy';
+
 import './@ember/application';
 import './@ember/application/-private/event-dispatcher';
 import './@ember/application/-private/registry';


### PR DESCRIPTION
The `ContainerProxyMixin` and `RegistryProxyMixin` private types are used as "intimate API" by `@ember/test-helpers`, which aims to support both the preview and stable type definitions. Provide both these types in both their legacy locations (where they were published from until 4.10) and their correct locations. *Only* provide the types, however, since the runtime location has moved.