### PR TITLE
[BUGFIX stable] Fix model arg to a Route `serialize`

### DIFF
--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -335,7 +335,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     @since 1.0.0
     @public
   */
-  serialize(model: Model | undefined, params: string[]): { [key: string]: unknown } | undefined {
+  serialize(model: Model, params: string[]): { [key: string]: unknown } | undefined {
     if (params.length < 1 || !model) {
       return;
     }

--- a/type-tests/@ember/routing-test/route.ts
+++ b/type-tests/@ember/routing-test/route.ts
@@ -35,6 +35,27 @@ class ModelTest extends Route {
   }
 }
 
+class Model {
+  baseClass = true;
+}
+
+class Child extends Model {
+  baseClass = false;
+  extraStuff = true;
+}
+
+class FooRoute<T extends Model> extends Route<T> {
+  serialize(object: T): any {
+    return null;
+  }
+}
+
+class FooChildRoute extends FooRoute<Child> {
+  serialize(object: Child) {
+    return object.extraStuff;
+  }
+}
+
 class QPsTest extends Route {
   queryParams = {
     memberQp: { refreshModel: true },


### PR DESCRIPTION
Previously, the internal type here always explicitly added `| undefined` to the type of the `model` param. This was likely reasonable when the conversion first happened, since the type here was simply a minimal `IModel | undefined`. Since the param is now driven by the type param for the `Route`, though, and defaults to `unknown`, we can just use the `Model` type param directly, and the implementation handles it correctly since the was actually already, albeit invisibly, just `unknown`, since `unknown | undefined` === `unknown`.

Fixes #20487.