### PR TITLE
[BUGFIX stable] EmberComponent init can have no args

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -843,7 +843,7 @@ class Component<S = unknown>
   declare [IS_DISPATCHING_ATTRS]: boolean;
   declare [DIRTY_TAG]: DirtyableTag;
 
-  init(properties: object | undefined) {
+  init(properties?: object | undefined) {
     super.init(properties);
 
     // Handle methods from ViewMixin.

--- a/type-tests/@ember/component-test/component.ts
+++ b/type-tests/@ember/component-test/component.ts
@@ -20,6 +20,10 @@ const component1 = Component.extend({
 class AnotherComponent extends Component {
   name = '';
 
+  init() {
+    super.init();
+  }
+
   hello(name: string) {
     this.set('name', name);
     this.name = name;


### PR DESCRIPTION
Bitten by the Δ between `t: T | undefined` and `t?: T | undefined`, my very favorite.

Fixes #20483.