### PR TITLE
[BUGFIX LTS] Backport more types fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@babel/helper-module-imports": "^7.16.7",
     "@babel/plugin-transform-block-scoping": "^7.20.5",
     "@ember/edition-utils": "^1.2.0",
+    "@simple-dom/interface": "^1.4.0",
     "@glimmer/vm-babel-plugins": "0.84.2",
     "babel-plugin-debug-macros": "^0.3.4",
     "babel-plugin-filter-imports": "^4.0.0",

--- a/types/preview/@ember/application/index.d.ts
+++ b/types/preview/@ember/application/index.d.ts
@@ -1,14 +1,12 @@
 declare module '@ember/application' {
   import Engine from '@ember/engine';
-  import ApplicationInstance from '@ember/application/instance';
+  import ApplicationInstance, { BootOptions } from '@ember/application/instance';
   import EventDispatcher from '@ember/application/-private/event-dispatcher';
   import { EventDispatcherEvents } from '@ember/application/types';
   import Router from '@ember/routing/router';
   import Registry from '@ember/application/-private/registry';
   import { AnyFn } from 'ember/-private/type-utils';
-  import Owner, { Resolver } from '@ember/owner';
-  import type GlimmerComponent from '@glimmer/component';
-  import EmberObject from '@ember/object';
+  import Owner from '@ember/owner';
 
   // Shut off default exporting; we don't want anything but the *intended*
   // public API present.
@@ -83,10 +81,6 @@ declare module '@ember/application' {
      */
     eventDispatcher: EventDispatcher;
     /**
-     * Set this to provide an alternate class to `DefaultResolver`
-     */
-    resolver: Resolver | null;
-    /**
      * The root DOM element of the Application. This can be specified as an
      * element or a jQuery-compatible selector string.
      *
@@ -114,6 +108,8 @@ declare module '@ember/application' {
      * Create an ApplicationInstance for this Application.
      */
     buildInstance(options?: object): ApplicationInstance;
+
+    visit(url: string, options: BootOptions): Promise<ApplicationInstance>;
   }
 
   /**

--- a/types/preview/@ember/application/instance.d.ts
+++ b/types/preview/@ember/application/instance.d.ts
@@ -1,5 +1,17 @@
 declare module '@ember/application/instance' {
   import EngineInstance from '@ember/engine/instance';
+  import { SimpleElement } from '@simple-dom/interface';
+
+  export interface BootOptions {
+    isBrowser?: boolean;
+    shouldRender?: boolean;
+    document?: Document | null;
+    rootElement?: string | Element | SimpleElement | null;
+    location?: string | null;
+    // Private?
+    isInteractive?: boolean;
+    _renderMode?: string;
+  }
 
   /**
    * The `ApplicationInstance` encapsulates all of the stateful aspects of a


### PR DESCRIPTION
- Missing `visit` API (used by `@ember/test-helpers`)
- Missing dependency on `@simple-dom/interface` for `SimpleElement`