### PR TITLE
[BUGFIX stable] Fix the types for the mutation-methods of `NativeArray`

### DIFF
--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1899,7 +1899,7 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
 @module ember
 */
 
-type AnyArray<T> = EmberArray<T> | Array<T>;
+type AnyArray<T> = EmberArray<T> | Array<T> | ReadonlyArray<T>;
 
 /**
  * The final definition of NativeArray removes all native methods. This is the list of removed methods

--- a/packages/@ember/array/type-tests/index.test.ts
+++ b/packages/@ember/array/type-tests/index.test.ts
@@ -205,6 +205,10 @@ expectTypeOf(arr.without(foo)).toEqualTypeOf<NativeArray<Foo>>();
 // @ts-expect-error invalid type
 arr.without(1);
 
+expectTypeOf(arr.pushObjects(arr)).toEqualTypeOf<NativeArray<Foo>>();
+expectTypeOf(arr.pushObjects([foo] as Foo[])).toEqualTypeOf<NativeArray<Foo>>();
+expectTypeOf(arr.pushObjects([foo] as readonly Foo[])).toEqualTypeOf<NativeArray<Foo>>();
+
 expectTypeOf(isArray(arr)).toEqualTypeOf<boolean>();
 
 expectTypeOf(makeArray(arr)).toEqualTypeOf<NativeArray<Foo>>();


### PR DESCRIPTION
Similar to #20327. Not sure why that change wasn't ported to the stable types?

cc @chriskrycho 