### PR TITLE
[BUGFIX release] Remove use of `this.element` in `component-test` and `helper-test` blueprints

### DIFF
--- a/blueprints-js/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
+++ b/blueprints-js/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.js
@@ -12,7 +12,7 @@ module('<%= friendlyTestDescription %>', function (hooks) {
 
     await render(hbs`<%= selfCloseComponent(componentName) %>`);
 
-    assert.dom(this.element).hasText('');
+    assert.dom().hasText('');
 
     // Template block usage:
     await render(hbs`
@@ -21,7 +21,7 @@ module('<%= friendlyTestDescription %>', function (hooks) {
       <%= closeComponent(componentName) %>
     `);
 
-    assert.dom(this.element).hasText('template block text');
+    assert.dom().hasText('template block text');
   });
 });<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
 import { setupTest } from '<%= modulePrefix %>/tests/helpers';

--- a/blueprints-js/helper-test/qunit-rfc-232-files/__root__/__testType__/helpers/__name__-test.js
+++ b/blueprints-js/helper-test/qunit-rfc-232-files/__root__/__testType__/helpers/__name__-test.js
@@ -12,6 +12,6 @@ module('<%= friendlyTestName %>', function (hooks) {
 
     await render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom().hasText('1234');
   });
 });

--- a/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/qunit-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -12,7 +12,7 @@ module('<%= friendlyTestDescription %>', function (hooks) {
 
     await render(hbs`<%= selfCloseComponent(componentName) %>`);
 
-    assert.dom(this.element).hasText('');
+    assert.dom().hasText('');
 
     // Template block usage:
     await render(hbs`
@@ -21,7 +21,7 @@ module('<%= friendlyTestDescription %>', function (hooks) {
       <%= closeComponent(componentName) %>
     `);
 
-    assert.dom(this.element).hasText('template block text');
+    assert.dom().hasText('template block text');
   });
 });<% } else if (testType === 'unit') { %>import { module, test } from 'qunit';
 import { setupTest } from '<%= modulePrefix %>/tests/helpers';

--- a/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/helpers/__name__-test.ts
+++ b/blueprints/helper-test/qunit-rfc-232-files/__root__/__testType__/helpers/__name__-test.ts
@@ -12,6 +12,6 @@ module('<%= friendlyTestName %>', function (hooks) {
 
     await render(hbs`{{<%= dasherizedModuleName %> this.inputValue}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom().hasText('1234');
   });
 });

--- a/node-tests/fixtures/component-test/rfc232-addon.js
+++ b/node-tests/fixtures/component-test/rfc232-addon.js
@@ -12,7 +12,7 @@ module('Integration | Component | foo', function (hooks) {
 
     await render(hbs`<Foo />`);
 
-    assert.dom(this.element).hasText('');
+    assert.dom().hasText('');
 
     // Template block usage:
     await render(hbs`
@@ -21,6 +21,6 @@ module('Integration | Component | foo', function (hooks) {
       </Foo>
     `);
 
-    assert.dom(this.element).hasText('template block text');
+    assert.dom().hasText('template block text');
   });
 });

--- a/node-tests/fixtures/component-test/rfc232.js
+++ b/node-tests/fixtures/component-test/rfc232.js
@@ -12,7 +12,7 @@ module('Integration | Component | x-foo', function (hooks) {
 
     await render(hbs`<XFoo />`);
 
-    assert.dom(this.element).hasText('');
+    assert.dom().hasText('');
 
     // Template block usage:
     await render(hbs`
@@ -21,6 +21,6 @@ module('Integration | Component | x-foo', function (hooks) {
       </XFoo>
     `);
 
-    assert.dom(this.element).hasText('template block text');
+    assert.dom().hasText('template block text');
   });
 });

--- a/node-tests/fixtures/helper-test/rfc232-addon.js
+++ b/node-tests/fixtures/helper-test/rfc232-addon.js
@@ -12,6 +12,6 @@ module('Integration | Helper | foo', function (hooks) {
 
     await render(hbs`{{foo this.inputValue}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom().hasText('1234');
   });
 });

--- a/node-tests/fixtures/helper-test/rfc232.js
+++ b/node-tests/fixtures/helper-test/rfc232.js
@@ -12,6 +12,6 @@ module('Integration | Helper | foo/bar-baz', function (hooks) {
 
     await render(hbs`{{foo/bar-baz this.inputValue}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom().hasText('1234');
   });
 });


### PR DESCRIPTION
See https://github.com/emberjs/ember-qunit/blob/master/docs/migration.md#migrating-to-native-typescript-support-in-v610.