### PR TITLE
Adding stage3-compatible decorator implementations

### DIFF
--- a/packages/@ember/-internals/metal/lib/decorator-util.ts
+++ b/packages/@ember/-internals/metal/lib/decorator-util.ts
@@ -78,9 +78,21 @@ export type ClassAutoAccessorDecorator = (
   init?: (initialValue: unknown) => unknown;
 } | void;
 
+export type Decorator =
+  | ClassMethodDecorator
+  | ClassGetterDecorator
+  | ClassSetterDecorator
+  | ClassFieldDecorator
+  | ClassDecorator
+  | ClassAutoAccessorDecorator;
+
+export function isModernDecoratorArgs(args: unknown[]): args is Parameters<Decorator> {
+  return args.length === 2 && typeof args[1] === 'object' && args[1] != null && 'kind' in args[1];
+}
+
 // this is designed to turn the arguments into a discriminated union so you can
 // check the kind once and then have the right types for them.
-export function identify2023DecoratorArgs(args: unknown[]):
+export function identifyModernDecoratorArgs(args: Parameters<Decorator>):
   | {
       kind: 'method';
       value: Parameters<ClassMethodDecorator>[0];
@@ -110,15 +122,10 @@ export function identify2023DecoratorArgs(args: unknown[]):
       kind: 'accessor';
       value: Parameters<ClassAutoAccessorDecorator>[0];
       context: Parameters<ClassAutoAccessorDecorator>[1];
-    }
-  | undefined {
-  if (args.length !== 2 || typeof args[1] !== 'object' || args[1] == null || !('kind' in args[1])) {
-    return undefined;
-  }
-
+    } {
   return {
     kind: args[1].kind,
     value: args[0],
     context: args[1],
-  } as ReturnType<typeof identify2023DecoratorArgs>;
+  } as ReturnType<typeof identifyModernDecoratorArgs>;
 }

--- a/packages/@ember/-internals/metal/lib/decorator-util.ts
+++ b/packages/@ember/-internals/metal/lib/decorator-util.ts
@@ -1,0 +1,124 @@
+/*
+  Types and utilities for working with 2023-05 decorators -- the ones that are
+  currently (as of 2023-07-22) in Stage 3.
+*/
+
+export type ClassMethodDecorator = (
+  value: Function,
+  context: {
+    kind: 'method';
+    name: string | symbol;
+    access: { get(): unknown };
+    static: boolean;
+    private: boolean;
+    addInitializer(initializer: () => void): void;
+  }
+) => Function | void;
+
+export type ClassGetterDecorator = (
+  value: Function,
+  context: {
+    kind: 'getter';
+    name: string | symbol;
+    access: { get(): unknown };
+    static: boolean;
+    private: boolean;
+    addInitializer(initializer: () => void): void;
+  }
+) => Function | void;
+
+export type ClassSetterDecorator = (
+  value: Function,
+  context: {
+    kind: 'setter';
+    name: string | symbol;
+    access: { set(value: unknown): void };
+    static: boolean;
+    private: boolean;
+    addInitializer(initializer: () => void): void;
+  }
+) => Function | void;
+
+export type ClassFieldDecorator = (
+  value: undefined,
+  context: {
+    kind: 'field';
+    name: string | symbol;
+    access: { get(): unknown; set(value: unknown): void };
+    static: boolean;
+    private: boolean;
+  }
+) => (initialValue: unknown) => unknown | void;
+
+export type ClassDecorator = (
+  value: Function,
+  context: {
+    kind: 'class';
+    name: string | undefined;
+    addInitializer(initializer: () => void): void;
+  }
+) => Function | void;
+
+export type ClassAutoAccessorDecorator = (
+  value: {
+    get(): unknown;
+    set(value: unknown): void;
+  },
+  context: {
+    kind: 'accessor';
+    name: string | symbol;
+    access: { get(): unknown; set(value: unknown): void };
+    static: boolean;
+    private: boolean;
+    addInitializer(initializer: () => void): void;
+  }
+) => {
+  get?: () => unknown;
+  set?: (value: unknown) => void;
+  init?: (initialValue: unknown) => unknown;
+} | void;
+
+// this is designed to turn the arguments into a discriminated union so you can
+// check the kind once and then have the right types for them.
+export function identify2023DecoratorArgs(args: unknown[]):
+  | {
+      kind: 'method';
+      value: Parameters<ClassMethodDecorator>[0];
+      context: Parameters<ClassMethodDecorator>[1];
+    }
+  | {
+      kind: 'getter';
+      value: Parameters<ClassGetterDecorator>[0];
+      context: Parameters<ClassGetterDecorator>[1];
+    }
+  | {
+      kind: 'setter';
+      value: Parameters<ClassSetterDecorator>[0];
+      context: Parameters<ClassSetterDecorator>[1];
+    }
+  | {
+      kind: 'field';
+      value: Parameters<ClassFieldDecorator>[0];
+      context: Parameters<ClassFieldDecorator>[1];
+    }
+  | {
+      kind: 'class';
+      value: Parameters<ClassDecorator>[0];
+      context: Parameters<ClassDecorator>[1];
+    }
+  | {
+      kind: 'accessor';
+      value: Parameters<ClassAutoAccessorDecorator>[0];
+      context: Parameters<ClassAutoAccessorDecorator>[1];
+    }
+  | undefined {
+  if (args.length !== 2 || typeof args[1] !== 'object' || args[1] == null || !('kind' in args[1])) {
+    return undefined;
+  }
+
+  return {
+    kind: args[1].kind,
+    value: args[0],
+    context: args[1],
+  } as ReturnType<typeof identify2023DecoratorArgs>;
+}


### PR DESCRIPTION
(This should stay draft and not merge until we have some consensus on the ecosystem-spanning parts of the migration.)

This is an exploration to see how easy it is to make the ember-provided decorators work under both legacy decorators and stage3 decorators.

(I don't think it's hard!)

The first commit here implements `@tracked`. I tested it in an application with the configuration:

```js
 const app = new EmberApp(defaults, {
    'ember-cli-babel': {
      disableDecoratorTransforms: true,
    },
    babel: {
      plugins: [
        [
          '@babel/plugin-proposal-decorators',
          {
            version: '2023-05',
          },
        ],
      ],
    },
  });
```

With those settings, `@tracked foo` becomes a runtime error and will tell you to use `@tracked accessor foo` instead, and when you do it all works correctly.