### PR TITLE
Cleaning up unused module

### DIFF
--- a/packages/@ember/-internals/overrides/index.ts
+++ b/packages/@ember/-internals/overrides/index.ts
@@ -1,1 +1,0 @@
-export let onEmberGlobalAccess: any;


### PR DESCRIPTION
I think this only existed to support `Ember` global deprecation, and the rest of that code is removed.