### PR TITLE
[FEATURE] Add TypeScript support for looking up controllers in DI registry

### DIFF
--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -387,7 +387,7 @@ export { Controller as default, ControllerMixin };
   }
   ```
 
-  Then `@service` can check that the service is registered correctly, and APIs
+  Then `@inject` can check that the service is registered correctly, and APIs
   like `owner.lookup('controller:example')` can return `ExampleController`.
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -366,3 +366,29 @@ export function inject(
 }
 
 export { Controller as default, ControllerMixin };
+
+/**
+  A type registry for Ember `Controller`s. Meant to be declaration-merged so string
+  lookups resolve to the correct type.
+
+  Blueprints should include such a declaration merge for TypeScript:
+
+  ```ts
+  import Controller from '@ember/controller';
+
+  export default class ExampleController extends Controller {
+  // ...
+  }
+
+  declare module '@ember/controller' {
+    export interface Registry {
+      example: ExampleController;
+    }
+  }
+  ```
+
+  Then `@service` can check that the service is registered correctly, and APIs
+  like `owner.lookup('controller:example')` can return `ExampleController`.
+*/
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Registry extends Record<string, Controller | undefined> {}

--- a/packages/@ember/controller/owner-ext.d.ts
+++ b/packages/@ember/controller/owner-ext.d.ts
@@ -1,0 +1,11 @@
+// This module provides an 'extension' to the `@ember/owner` module from the
+// `@ember/controller` module. Our type publishing infrastructure will pass it
+// through unchanged, so end users will get this extension.
+
+import type { Registry } from '@ember/controller';
+
+declare module '@ember/owner' {
+  export interface DIRegistry {
+    controller: Registry;
+  }
+}

--- a/packages/@ember/controller/type-tests/index.test.ts
+++ b/packages/@ember/controller/type-tests/index.test.ts
@@ -72,3 +72,14 @@ expectTypeOf(inject()).toMatchTypeOf<PropertyDecorator>();
 
 // @ts-expect-error Doesn't allow invalid types
 inject(1);
+
+class ExampleController extends Controller {}
+
+declare module '@ember/controller' {
+    export interface Registry {
+        example: ExampleController;
+    }
+}
+
+expectTypeOf(owner.lookup('controller:example')).toEqualTypeOf<ExampleController>();
+expectTypeOf(owner.lookup('controller:non-registered')).toEqualTypeOf<Controller | undefined>();

--- a/type-tests/@ember/controller-test/octane.ts
+++ b/type-tests/@ember/controller-test/octane.ts
@@ -1,4 +1,6 @@
 import Controller, { ControllerQueryParam, inject } from '@ember/controller';
+import { expectTypeOf } from 'expect-type';
+import type Owner from '@ember/owner';
 
 class FirstController extends Controller {
   foo = 'bar';
@@ -36,3 +38,9 @@ declare module '@ember/controller' {
     second: InstanceType<typeof SecondController>;
   }
 }
+
+const owner = {} as Owner;
+
+expectTypeOf(owner.lookup('controller:first')).toEqualTypeOf<FirstController>();
+expectTypeOf(owner.lookup('controller:second')).toEqualTypeOf<InstanceType<typeof SecondController>>();
+expectTypeOf(owner.lookup('controller:non-registered')).toEqualTypeOf<Controller | undefined>();


### PR DESCRIPTION
This PR enables controller type discovery through `Owner::lookup` method:

```ts
declare module '@ember/controller' {
  interface Registry {
    foo: FooController;
  }
}

const fooController = this.owner.lookup('controller:foo'); // TS resolves fooController's type as FooController.
const barController = this.owner.lookup('controller:bar'); // If not specified via Registry interface, will resolve type as Controller | undefined
```

Complementary PR to `@types/ember__controller`: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66067