### PR TITLE
Fix `@module` comments

### DIFF
--- a/packages/@ember/routing/lib/controller_for.ts
+++ b/packages/@ember/routing/lib/controller_for.ts
@@ -3,7 +3,7 @@ import type { FactoryClass, InternalFactory } from '@ember/-internals/owner';
 import type { RegisterOptions } from '@ember/owner';
 
 /**
-  @module ember/routing
+  @module @ember/routing
 */
 
 /**

--- a/packages/@ember/routing/lib/generate_controller.ts
+++ b/packages/@ember/routing/lib/generate_controller.ts
@@ -5,7 +5,7 @@ import { assert, info } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
 /**
- @module ember/routing
+ @module @ember/routing
 */
 
 /**


### PR DESCRIPTION
Should fix this rogue `ember/routing` module:

<img width="251" alt="Screenshot 2023-08-17 at 10 05 48" src="https://github.com/emberjs/ember.js/assets/7403183/83cd54d0-9e39-4894-aced-9b54b7c1b5dc">