### PR TITLE
Don't rethrow string errors in handleTransitionReject

### DIFF
--- a/packages/@ember/application/instance.ts
+++ b/packages/@ember/application/instance.ts
@@ -262,7 +262,7 @@ class ApplicationInstance extends EngineInstance {
     };
 
     let handleTransitionReject = (error: any): unknown => {
-      if (error.error) {
+      if (error.error && error.error instanceof Error) {
         throw error.error;
       } else if (error.name === 'TransitionAborted' && router._routerMicrolib.activeTransition) {
         return router._routerMicrolib.activeTransition.then(


### PR DESCRIPTION
`handleTransitionReject` blindly rethrows `error.error` regardless of its type. While the code appears to assume that the error will be of type `TransitionError`, `handleTransitionReject` might be called with another error type.

Newer versions of EmberData will throw an error that has `error.error` (https://github.com/emberjs/data/blob/f0dd0d429052abe3ce49e4e87f3492691e62d523/ember-data-types/cache/document.ts#L59) and when this happens, this code is rethrowing the string/object error unexpectedly.

Based on https://github.com/tildeio/router.js/blob/9320c7b1c1e887e73afd3700cd0093b9f34c9e6b/lib/router/transition-state.ts#L124 it looks like the type for `TransitionError` should be `Error`, and generally it sames safe enough to rethrow as long as the `error.error` is itself an `Error`. :)