### PR TITLE
On internal-strict-modules, get linting passing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
   overrides: [
     {
       files: ['*.ts'],
+      excludedFiles: ['packages/ember/version.d.ts', 'vite.config.ts'],
 
       extends: ['plugin:@typescript-eslint/recommended'],
 
@@ -124,6 +125,7 @@ module.exports = {
       // matches all node-land files
       files: [
         '.eslintrc.js',
+        'makepkgs.js',
         'node-tests/**/*.js',
         'tests/node/**/*.js',
         'blueprints/**/*.js',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: wyvox/action/setup-pnpm@v3
+      - uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 16.x
       - name: linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: wyvox/action/setup-pnpm@v3
         with:
           node-version: 16.x
-          cache: yarn
-      - name: install dependencies
-        run: yarn install --frozen-lockfile --non-interactive
       - name: linting
-        run: yarn lint
+        run: pnpm lint
 
   types:
     name: Type Checking (current version)

--- a/makepkgs.js
+++ b/makepkgs.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+/* eslint-disable no-unused-vars */
 const fs = require('fs');
 const path = require('path');
 

--- a/packages/@ember/test/index.ts
+++ b/packages/@ember/test/index.ts
@@ -5,7 +5,7 @@ export let registerHelper: (typeof EmberTesting.Test)['registerHelper'];
 export let registerWaiter: (typeof EmberTesting.Test)['registerWaiter'];
 export let unregisterHelper: (typeof EmberTesting.Test)['unregisterHelper'];
 export let unregisterWaiter: (typeof EmberTesting.Test)['unregisterWaiter'];
-export let _impl: typeof EmberTesting | undefined;;
+export let _impl: typeof EmberTesting | undefined;
 
 let testingNotAvailableMessage = () => {
   throw new Error('Attempted to use test utilities, but `ember-testing` was not included');


### PR DESCRIPTION
Minimally gets linting green on Ci.

Like the other PR,
C.I. is not expected to pass on `internal-strict-modules`.