### PR TITLE
pnpm docs doesn't run the scripts entry named docs

### DIFF
--- a/bin/build-for-publishing.js
+++ b/bin/build-for-publishing.js
@@ -64,7 +64,7 @@ Promise.resolve()
   })
   .then(() => {
     // generate docs
-    return exec('pnpm', ['docs']).then(() => {
+    return exec('pnpm', ['run', 'docs']).then(() => {
       updateDocumentationVersion();
     });
   })


### PR DESCRIPTION
```
❯ pnpm docs --help
Open documentation for a package in a web browser

Usage:
npm docs [<pkgname> [<pkgname> ...]]

Options:
[--no-browser|--browser <browser>] [--registry <registry>]
[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
[-ws|--workspaces] [--include-workspace-root]

alias: home

Run "npm help docs" for more info
```