### PR TITLE
set isTracked on getter

### DIFF
--- a/packages/@ember/-internals/metal/lib/tracked.ts
+++ b/packages/@ember/-internals/metal/lib/tracked.ts
@@ -171,10 +171,11 @@ function descriptorForField([target, key, desc]: ElementDescriptor): DecoratorPr
     dirtyTagFor(this, SELF_TAG);
   }
 
+  get.isTracked = true;
+
   let newDesc = {
     enumerable: true,
     configurable: true,
-    isTracked: true,
 
     get,
     set,


### PR DESCRIPTION
Instead of the descriptor. It's just ignored by defineProperty.

This would make it useful for the inspector to detect tracked property without hacks 