### PR TITLE
[BUGFIX lts] Update ApplicationInstance#visit to use followRedirects()

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ember-router-generator": "^2.0.0",
     "inflection": "^2.0.1",
     "route-recognizer": "^0.3.4",
-    "router_js": "^8.0.5",
+    "router_js": "^8.0.6",
     "semver": "^7.5.2",
     "silent-error": "^1.1.1",
     "simple-html-tokenizer": "^0.5.11"

--- a/packages/@ember/-internals/package.json
+++ b/packages/@ember/-internals/package.json
@@ -69,7 +69,7 @@
     "ember-template-compiler": "workspace:*",
     "expect-type": "^0.15.0",
     "internal-test-helpers": "workspace:*",
-    "router_js": "^8.0.5",
+    "router_js": "^8.0.6",
     "rsvp": "^4.8.5"
   },
   "devDependencies": {

--- a/packages/@ember/application/instance.ts
+++ b/packages/@ember/application/instance.ts
@@ -263,11 +263,6 @@ class ApplicationInstance extends EngineInstance {
     let handleTransitionReject = (error: any): unknown => {
       if (error.error && error.error instanceof Error) {
         throw error.error;
-      } else if (error.name === 'TransitionAborted' && router._routerMicrolib.activeTransition) {
-        return router._routerMicrolib.activeTransition.then(
-          handleTransitionResolve,
-          handleTransitionReject
-        );
       } else if (error.name === 'TransitionAborted') {
         throw new Error(error.message);
       } else {
@@ -284,6 +279,7 @@ class ApplicationInstance extends EngineInstance {
     // getURL returns the set url with the rootURL stripped off
     return router
       .handleURL(location.getURL())
+      .followRedirects()
       .then(handleTransitionResolve, handleTransitionReject);
   }
 

--- a/packages/@ember/application/package.json
+++ b/packages/@ember/application/package.json
@@ -30,6 +30,6 @@
     "ember-template-compiler": "workspace:*",
     "expect-type": "^0.15.0",
     "internal-test-helpers": "workspace:*",
-    "router_js": "^8.0.5"
+    "router_js": "^8.0.6"
   }
 }

--- a/packages/@ember/engine/package.json
+++ b/packages/@ember/engine/package.json
@@ -27,6 +27,6 @@
     "dag-map": "^2.0.2",
     "expect-type": "^0.15.0",
     "internal-test-helpers": "workspace:*",
-    "router_js": "^8.0.5"
+    "router_js": "^8.0.6"
   }
 }

--- a/packages/@ember/routing/package.json
+++ b/packages/@ember/routing/package.json
@@ -37,6 +37,6 @@
     "dag-map": "^2.0.2",
     "expect-type": "^0.15.0",
     "internal-test-helpers": "workspace:*",
-    "router_js": "^8.0.5"
+    "router_js": "^8.0.6"
   }
 }

--- a/packages/ember-testing/package.json
+++ b/packages/ember-testing/package.json
@@ -27,6 +27,6 @@
     "backburner.js": "^2.7.0",
     "ember": "workspace:*",
     "internal-test-helpers": "workspace:*",
-    "router_js": "^8.0.5"
+    "router_js": "^8.0.6"
   }
 }

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -46,7 +46,7 @@
     "ember-testing": "workspace:*",
     "expect-type": "^0.15.0",
     "internal-test-helpers": "workspace:*",
-    "router_js": "^8.0.5",
+    "router_js": "^8.0.6",
     "rsvp": "^4.8.5"
   }
 }

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -698,7 +698,11 @@ moduleFor(
         // if we transition in this test we will receive failures
         // if the tests are run from a static file
         _doURLTransition() {
-          return RSVP.resolve('');
+          return {
+            followRedirects() {
+              return RSVP.resolve('');
+            },
+          };
         },
       });
 

--- a/packages/internal-test-helpers/package.json
+++ b/packages/internal-test-helpers/package.json
@@ -39,7 +39,7 @@
     "dag-map": "^2.0.2",
     "ember": "workspace:*",
     "ember-template-compiler": "workspace:*",
-    "router_js": "^8.0.5",
+    "router_js": "^8.0.6",
     "rsvp": "^4.8.5",
     "simple-html-tokenizer": "^0.5.11"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
       semver:
         specifier: ^7.5.2
@@ -395,7 +395,7 @@ importers:
         specifier: workspace:*
         version: link:../../internal-test-helpers
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
       rsvp:
         specifier: ^4.8.5
@@ -477,7 +477,7 @@ importers:
         specifier: workspace:*
         version: link:../../internal-test-helpers
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
 
   packages/@ember/array:
@@ -742,7 +742,7 @@ importers:
         specifier: workspace:*
         version: link:../../internal-test-helpers
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
 
   packages/@ember/enumerable:
@@ -1025,7 +1025,7 @@ importers:
         specifier: workspace:*
         version: link:../../internal-test-helpers
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
 
   packages/@ember/runloop:
@@ -2451,7 +2451,7 @@ importers:
         specifier: workspace:*
         version: link:../internal-test-helpers
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
       rsvp:
         specifier: ^4.8.5
@@ -2610,7 +2610,7 @@ importers:
         specifier: workspace:*
         version: link:../internal-test-helpers
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
 
   packages/internal-test-helpers:
@@ -2712,7 +2712,7 @@ importers:
         specifier: workspace:*
         version: link:../ember-template-compiler
       router_js:
-        specifier: ^8.0.5
+        specifier: ^8.0.6
         version: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
       rsvp:
         specifier: ^4.8.5


### PR DESCRIPTION
The current implementation of `Transition#followRedirects()` is identical to the logic here: it catches rejections, and then checks for any other `activeTransition`. Therefore, this commit introduces no change in behavior.

But, if/when https://github.com/tildeio/router.js/pull/335 lands, it will means we can take advantage of that fix for ApplicationInstance#visit.