### PR TITLE
[BUGFIX lts] Update backburner.js to 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@simple-dom/interface": "^1.4.0",
     "babel-plugin-debug-macros": "^0.3.4",
     "babel-plugin-filter-imports": "^4.0.0",
-    "backburner.js": "^2.7.0",
+    "backburner.js": "^2.8.0",
     "broccoli-concat": "^4.2.5",
     "broccoli-debug": "^0.6.4",
     "broccoli-file-creator": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ dependencies:
     specifier: ^4.0.0
     version: 4.0.0
   backburner.js:
-    specifier: ^2.7.0
-    version: 2.7.0
+    specifier: ^2.8.0
+    version: 2.8.0
   broccoli-concat:
     specifier: ^4.2.5
     version: 4.2.5
@@ -4315,8 +4315,8 @@ packages:
       underscore: 1.13.6
     dev: true
 
-  /backburner.js@2.7.0:
-    resolution: {integrity: sha512-eBZC6r7wT+YYAOKeru8IqgzOimz3VgyspXiZ1k6MI8i10zUdU8cnNII56rlnItQ89cHgQO3C/nPuFW3V9di+zg==}
+  /backburner.js@2.8.0:
+    resolution: {integrity: sha512-zYXY0KvpD7/CWeOLF576mV8S+bQsaIoj/GNLXXB+Eb8SJcQy5lqSjkRrZ0MZhdKUs9QoqmGNIEIe3NQfGiiscQ==}
     dev: false
 
   /balanced-match@1.0.2:


### PR DESCRIPTION
Ensure scheduleOnce works correctly following a cancelled job

This fixes the issue described in https://github.com/BackburnerJS/backburner.js/pull/402