### PR TITLE
[BUGFIX canary] Restore/deprecate outlet `TemplateFactory` support

### DIFF
--- a/packages/ember/tests/ember-test-helpers-test.js
+++ b/packages/ember/tests/ember-test-helpers-test.js
@@ -138,4 +138,124 @@ module('@ember/test-helpers emulation test', function () {
       });
     });
   });
+
+  module('v1.6.0', function () {
+    let EMPTY_TEMPLATE = compile('');
+
+    function settled() {
+      return new Promise(function (resolve) {
+        let watcher = setInterval(() => {
+          if (_getCurrentRunLoop() || _hasScheduledTimers()) {
+            return;
+          }
+
+          // Stop polling
+          clearInterval(watcher);
+
+          // Synchronously resolve the promise
+          run(null, resolve);
+        }, 10);
+      });
+    }
+
+    async function setupContext(context) {
+      // condensed version of https://github.com/emberjs/ember-test-helpers/blob/v1.6.0/addon-test-support/%40ember/test-helpers/build-owner.ts#L38
+      // without support for "custom resolver"
+      await context.application.boot();
+
+      context.owner = await context.application.buildInstance().boot();
+    }
+
+    function setupRenderingContext(context) {
+      let { owner } = context;
+      let OutletView = owner.factoryFor('view:-outlet');
+      let environment = owner.lookup('-environment:main');
+      let outletTemplateFactory = owner.lookup('template:-outlet');
+      let toplevelView = OutletView.create({ environment, template: outletTemplateFactory });
+
+      owner.register('-top-level-view:main', {
+        create() {
+          return toplevelView;
+        },
+      });
+
+      // initially render a simple empty template
+      return render(EMPTY_TEMPLATE, context).then(() => {
+        let rootElement = document.querySelector(owner.rootElement);
+        run(toplevelView, 'appendTo', rootElement);
+
+        context.element = rootElement;
+
+        return settled();
+      });
+    }
+
+    let templateId = 0;
+    function render(template, context) {
+      let { owner } = context;
+      let toplevelView = owner.lookup('-top-level-view:main');
+      templateId += 1;
+      let templateFullName = `template:-undertest-${templateId}`;
+      owner.register(templateFullName, template);
+
+      let outletState = {
+        render: {
+          owner,
+          into: undefined,
+          outlet: 'main',
+          name: 'application',
+          controller: undefined,
+          ViewClass: undefined,
+          template: owner.lookup('template:-outlet'),
+        },
+
+        outlets: {
+          main: {
+            render: {
+              owner,
+              into: undefined,
+              outlet: 'main',
+              name: 'index',
+              controller: context,
+              ViewClass: undefined,
+              template: owner.lookup(templateFullName),
+              outlets: {},
+            },
+            outlets: {},
+          },
+        },
+      };
+      toplevelView.setOutletState(outletState);
+
+      return settled();
+    }
+
+    module('setupRenderingContext', function (hooks) {
+      hooks.beforeEach(async function () {
+        expectDeprecation(
+          /The `template` property of `OutletState` should be a `Template` rather than a `TemplateFactory`/
+        );
+
+        this.application = Application.create({
+          rootElement: '#qunit-fixture',
+          autoboot: false,
+          Resolver: ModuleBasedTestResolver,
+        });
+
+        await setupContext(this);
+        await setupRenderingContext(this);
+      });
+
+      hooks.afterEach(function () {
+        run(this.owner, 'destroy');
+        run(this.application, 'destroy');
+      });
+
+      test('it basically works', async function (assert) {
+        await render(compile('Hi!'), this);
+
+        assert.equal(this.element.textContent, 'Hi!');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #20576

The test is a bit misleading in that, this is not actually restored to support the very old 1.6.0 version of ember-test-helpers. The issue is that while that particular spot of the invalid usage was fixed in 1.6.1, other similarly invalid patterns have popped up in the code since then. However, the old tests was probably a close enough approximation of the general problem.

This is not to avoid fixing the actual issue, but it's just that it was very difficult for us to support for a short time, and there may be other code that copied the same invalid pattern elsewhere.

We could probably backport this to all the way up to LTS if we want with minimal effort, since the code I brought back is basically the same as what was previously there, just with the deprecation.

See also https://github.com/emberjs/ember-test-helpers/pull/1445