### PR TITLE
[BUGFIX beta] Deprecate outlet `TemplateFactory` support

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -1,5 +1,5 @@
 import type { InternalOwner } from '@ember/-internals/owner';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import type { CapturedArguments, DynamicScope } from '@glimmer/interfaces';
 import { CurriedType } from '@glimmer/interfaces';
@@ -124,6 +124,36 @@ function stateFor(ref: Reference, outlet: OutletState | undefined): OutletDefini
   // and is no longer considered supported
   if (isTemplateFactory(template)) {
     template = template(render.owner);
+
+    if (DEBUG) {
+      let message =
+        'The `template` property of `OutletState` should be a ' +
+        '`Template` rather than a `TemplateFactory`. This is known to be a ' +
+        "problem in older versions of `@ember/test-helpers`. If you haven't " +
+        'done so already, try upgrading to the latest version.\n\n';
+
+      if (template.result === 'ok' && typeof template.moduleName === 'string') {
+        message +=
+          'The offending template has a moduleName `' +
+          template.moduleName +
+          '`, which might be helpful for identifying ' +
+          'source of this issue.\n\n';
+      }
+
+      message +=
+        'Please note that `OutletState` is a private API in Ember.js ' +
+        "and not meant to be used outside of the framework's internal code.";
+
+      deprecate(message, false, {
+        id: 'outlet-state-template-factory',
+        until: '5.9.0',
+        for: 'ember-source',
+        since: {
+          available: '5.5.0',
+          enabled: '5.5.0',
+        },
+      });
+    }
   }
 
   return {

--- a/packages/ember/tests/ember-test-helpers-test.js
+++ b/packages/ember/tests/ember-test-helpers-test.js
@@ -110,6 +110,10 @@ module('@ember/test-helpers emulation test', function () {
 
     module('setupRenderingContext', function (hooks) {
       hooks.beforeEach(async function () {
+        expectDeprecation(
+          /The `template` property of `OutletState` should be a `Template` rather than a `TemplateFactory`/
+        );
+
         this.application = Application.create({
           rootElement: '#qunit-fixture',
           autoboot: false,


### PR DESCRIPTION
Backport of #20577

The exact code itself will probably apply cleanly to LTS as well. Logistically I'm not sure if we need to bother. We probably want to release https://github.com/emberjs/ember-test-helpers/pull/1445 before merging this into the next beta, so people have something to upgrade _to_.