### PR TITLE
Mark `cached` as a `MethodDecorator` instead of `PropertyDecorator`

### DIFF
--- a/packages/@ember/-internals/metal/lib/cached.ts
+++ b/packages/@ember/-internals/metal/lib/cached.ts
@@ -93,7 +93,7 @@ import { createCache, getValue } from '@glimmer/validator';
   @for @glimmer/tracking
   @public
  */
-export const cached: PropertyDecorator = (...args: any[]) => {
+export const cached: MethodDecorator = (...args: any[]) => {
   const [target, key, descriptor] = args;
 
   // Error on `@cached()`, `@cached(...args)`, and `@cached propName = value;`


### PR DESCRIPTION
I believe that's more correct as `cached` uses/needs `descriptor` which is only available in `MethodDecorator`.

cc @dfreeman, @chriskrycho, @jamescdavis, @wagenet

Sorry for pinging so many people but I'm not sure who I should. :smile: Is there like a TypeScript team that I can mention?