### PR TITLE
Reducing internal usage of AMD loader

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,7 @@ module.exports = {
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-this-alias': 'off',
-        '@typescript-eslint/no-var-requires': 'warn',
+        '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
 
         // TODO: Enable and fix these rules

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -265,6 +265,7 @@ function templateCompilerBundle(emberPackages, transpileTree) {
       define('@ember/-internals/glimmer', ['exports'], function(e) {
         e.template = undefined;
       });
+      define('@ember/application', ['exports'], function(e) {});
     }
     
     (function (m) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -262,6 +262,9 @@ function templateCompilerBundle(emberPackages, transpileTree) {
           VERSION: ver.default,
         };
       });
+      define('@ember/-internals/glimmer', ['exports'], function(e) {
+        e.template = undefined;
+      });
     }
     
     (function (m) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -241,8 +241,15 @@ function templateCompilerBundle(emberPackages, transpileTree) {
 
   return concatBundle(new MergeTrees([templateCompilerFiles, emberHeaderFiles()]), {
     outputFile: 'ember-template-compiler.js',
-    footer:
-      '(function (m) { if (typeof module === "object" && module.exports) { module.exports = m } }(require("ember-template-compiler")));',
+    footer: `
+    try {
+      // in the browser, the ember-template-compiler.js and ember.js bundles find each other via globalThis.require.
+      require("@ember/template-compilation");
+    } catch (err) {
+      // in node, that coordination is a no-op
+      define("@ember/template-compilation", ["exports"], function(e) { e.__registerTemplateCompiler = function(){}; });
+    }
+    (function (m) { if (typeof module === "object" && module.exports) { module.exports = m } }(require("ember-template-compiler")));`,
   });
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -244,12 +244,33 @@ function templateCompilerBundle(emberPackages, transpileTree) {
     footer: `
     try {
       // in the browser, the ember-template-compiler.js and ember.js bundles find each other via globalThis.require.
-      require("@ember/template-compilation");
+      require('@ember/template-compilation');
     } catch (err) {
       // in node, that coordination is a no-op
-      define("@ember/template-compilation", ["exports"], function(e) { e.__registerTemplateCompiler = function(){}; });
+      define('@ember/template-compilation', ['exports'], function (e) {
+        e.__registerTemplateCompiler = function () {};
+      });
+      define('ember', [
+        'exports',
+        '@ember/-internals/environment',
+        '@ember/canary-features',
+        'ember/version',
+      ], function (e, env, fea, ver) {
+        e.default = {
+          ENV: env.ENV,
+          FEATURES: fea.FEATURES,
+          VERSION: ver.default,
+        };
+      });
     }
-    (function (m) { if (typeof module === "object" && module.exports) { module.exports = m } }(require("ember-template-compiler")));`,
+    
+    (function (m) {
+      if (typeof module === 'object' && module.exports) {
+        module.exports = m;
+      }
+    })(require('ember-template-compiler'));
+    
+      `,
   });
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,14 @@ module.exports = {
     return new MergeTrees([
       concatBundle(emberFiles, {
         outputFile: 'ember.js',
-        footer: `require('@ember/-internals/bootstrap')`,
+        footer: `
+        (function bootstrap() {
+          // Bootstrap Node module
+          if (typeof module === 'object' && typeof module.require === 'function') {
+            module.exports = require('ember').default;
+          }
+        })();
+        `,
       }),
 
       concatBundle(emberTestingFiles, {

--- a/packages/@ember/-internals/bootstrap/index.ts
+++ b/packages/@ember/-internals/bootstrap/index.ts
@@ -1,8 +1,0 @@
-import require from 'require';
-
-(function bootstrap() {
-  // Bootstrap Node module
-  if (typeof module === 'object' && typeof module.require === 'function') {
-    module.exports = require('ember').default;
-  }
-})();

--- a/packages/@ember/template-compilation/index.ts
+++ b/packages/@ember/template-compilation/index.ts
@@ -1,7 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import type { TemplateFactory } from '@glimmer/interfaces';
-
-export { compile as compileTemplate } from 'ember-template-compiler';
+import type * as ETC from 'ember-template-compiler';
 
 interface CommonOptions {
   moduleName?: string;
@@ -27,6 +26,16 @@ interface PrecompileTemplate {
   (templateString: string, options: StrictModeOptions): TemplateFactory;
 }
 
+export let __emberTemplateCompiler: undefined | typeof ETC;
+export const compileTemplate: typeof ETC.compile = (...args: Parameters<typeof ETC.compile>) => {
+  if (!__emberTemplateCompiler) {
+    throw new Error(
+      'Attempted to call `compileTemplate` without first loading the runtime template compiler.'
+    );
+  }
+  return __emberTemplateCompiler.compile(...args);
+};
+
 export let precompileTemplate: PrecompileTemplate;
 
 if (DEBUG) {
@@ -35,4 +44,8 @@ if (DEBUG) {
       'Attempted to call `precompileTemplate` at runtime, but this API is meant to be used at compile time. You should use `compileTemplate` instead.'
     );
   };
+}
+
+export function __registerTemplateCompiler(c: typeof ETC) {
+  __emberTemplateCompiler = c;
 }

--- a/packages/@ember/test/index.ts
+++ b/packages/@ember/test/index.ts
@@ -1,32 +1,28 @@
-import require, { has } from 'require';
-import { type Test as TestNS } from 'ember-testing';
+import type * as EmberTesting from 'ember-testing';
 
-export let registerAsyncHelper: (typeof TestNS)['registerAsyncHelper'];
-export let registerHelper: (typeof TestNS)['registerHelper'];
-export let registerWaiter: (typeof TestNS)['registerWaiter'];
-export let unregisterHelper: (typeof TestNS)['unregisterHelper'];
-export let unregisterWaiter: (typeof TestNS)['unregisterWaiter'];
+export let registerAsyncHelper: (typeof EmberTesting.Test)['registerAsyncHelper'];
+export let registerHelper: (typeof EmberTesting.Test)['registerHelper'];
+export let registerWaiter: (typeof EmberTesting.Test)['registerWaiter'];
+export let unregisterHelper: (typeof EmberTesting.Test)['unregisterHelper'];
+export let unregisterWaiter: (typeof EmberTesting.Test)['unregisterWaiter'];
+export let _impl: typeof EmberTesting | undefined;
 
-if (has('ember-testing')) {
-  // SAFETY: since `require` is opaque to TS, we need to inform it that this is
-  // the actual type of what we import. This `require` needs to stay in sync
-  // with the `import type` statement above. (This cast *increases* safety,
-  // because the result of `require` is `any`.)
-  let Test = require('ember-testing').Test as typeof TestNS;
+let testingNotAvailableMessage = () => {
+  throw new Error('Attempted to use test utilities, but `ember-testing` was not included');
+};
 
+registerAsyncHelper = testingNotAvailableMessage;
+registerHelper = testingNotAvailableMessage;
+registerWaiter = testingNotAvailableMessage;
+unregisterHelper = testingNotAvailableMessage;
+unregisterWaiter = testingNotAvailableMessage;
+
+export function registerTestImplementaiton(impl: typeof EmberTesting) {
+  let { Test } = impl;
   registerAsyncHelper = Test.registerAsyncHelper;
   registerHelper = Test.registerHelper;
   registerWaiter = Test.registerWaiter;
   unregisterHelper = Test.unregisterHelper;
   unregisterWaiter = Test.unregisterWaiter;
-} else {
-  let testingNotAvailableMessage = () => {
-    throw new Error('Attempted to use test utilities, but `ember-testing` was not included');
-  };
-
-  registerAsyncHelper = testingNotAvailableMessage;
-  registerHelper = testingNotAvailableMessage;
-  registerWaiter = testingNotAvailableMessage;
-  unregisterHelper = testingNotAvailableMessage;
-  unregisterWaiter = testingNotAvailableMessage;
+  _impl = impl;
 }

--- a/packages/ember-template-compiler/index.ts
+++ b/packages/ember-template-compiler/index.ts
@@ -1,36 +1,8 @@
-import { ENV } from '@ember/-internals/environment';
-import { FEATURES } from '@ember/canary-features';
-import * as _GlimmerSyntax from '@glimmer/syntax';
-import VERSION from 'ember/version';
-import require from 'require';
+export * from './lib/public-api';
+import * as ETC from './lib/public-api';
+import { __registerTemplateCompiler } from '@ember/template-compilation';
 
-export let _Ember: unknown;
-
-try {
-  _Ember = require('ember');
-} catch (e) {
-  _Ember = {
-    ENV,
-    FEATURES,
-    VERSION,
-  };
-}
-
-export { default as precompile } from './lib/system/precompile';
-export { default as compile } from './lib/system/compile';
-export {
-  default as compileOptions,
-  buildCompileOptions as _buildCompileOptions,
-  transformsFor as _transformsFor,
-} from './lib/system/compile-options';
-export { RESOLUTION_MODE_TRANSFORMS, STRICT_MODE_TRANSFORMS } from './lib/plugins';
-export { EmberPrecompileOptions } from './lib/types';
-
-export { preprocess as _preprocess, print as _print } from '@glimmer/syntax';
-export { precompile as _precompile } from '@glimmer/compiler';
-
-export { _GlimmerSyntax, VERSION };
-
+__registerTemplateCompiler(ETC);
 // used to bootstrap templates
 import './lib/system/bootstrap';
 

--- a/packages/ember-template-compiler/lib/public-api.ts
+++ b/packages/ember-template-compiler/lib/public-api.ts
@@ -1,20 +1,7 @@
-import { ENV } from '@ember/-internals/environment';
-import { FEATURES } from '@ember/canary-features';
-import * as _GlimmerSyntax from '@glimmer/syntax';
+export { default as _Ember } from 'ember';
+
 import VERSION from 'ember/version';
-import require from 'require';
-
-export let _Ember: unknown;
-
-try {
-  _Ember = require('ember');
-} catch (e) {
-  _Ember = {
-    ENV,
-    FEATURES,
-    VERSION,
-  };
-}
+import * as _GlimmerSyntax from '@glimmer/syntax';
 
 export { default as precompile } from './system/precompile';
 export { default as compile } from './system/compile';

--- a/packages/ember-template-compiler/lib/public-api.ts
+++ b/packages/ember-template-compiler/lib/public-api.ts
@@ -1,0 +1,32 @@
+import { ENV } from '@ember/-internals/environment';
+import { FEATURES } from '@ember/canary-features';
+import * as _GlimmerSyntax from '@glimmer/syntax';
+import VERSION from 'ember/version';
+import require from 'require';
+
+export let _Ember: unknown;
+
+try {
+  _Ember = require('ember');
+} catch (e) {
+  _Ember = {
+    ENV,
+    FEATURES,
+    VERSION,
+  };
+}
+
+export { default as precompile } from './system/precompile';
+export { default as compile } from './system/compile';
+export {
+  default as compileOptions,
+  buildCompileOptions as _buildCompileOptions,
+  transformsFor as _transformsFor,
+} from './system/compile-options';
+export { RESOLUTION_MODE_TRANSFORMS, STRICT_MODE_TRANSFORMS } from './plugins';
+export { EmberPrecompileOptions } from './types';
+
+export { preprocess as _preprocess, print as _print } from '@glimmer/syntax';
+export { precompile as _precompile } from '@glimmer/compiler';
+
+export { _GlimmerSyntax, VERSION };

--- a/packages/ember-template-compiler/lib/system/compile.ts
+++ b/packages/ember-template-compiler/lib/system/compile.ts
@@ -1,13 +1,10 @@
 /**
 @module ember
 */
-import require, { has } from 'require';
 import type { EmberPrecompileOptions } from '../types';
 import precompile from './precompile';
 import type { SerializedTemplateWithLazyBlock, TemplateFactory } from '@glimmer/interfaces';
-import type { templateFactory } from '@glimmer/opcode-compiler';
-
-let template: typeof templateFactory;
+import { template } from '@ember/-internals/glimmer';
 
 /**
   Uses HTMLBars `compile` function to process a string into a compiled template.
@@ -21,10 +18,6 @@ export default function compile(
   templateString: string,
   options: Partial<EmberPrecompileOptions> = {}
 ): TemplateFactory {
-  if (!template && has('@ember/-internals/glimmer')) {
-    template = require('@ember/-internals/glimmer').template;
-  }
-
   if (!template) {
     throw new Error(
       'Cannot call `compile` with only the template compiler loaded. Please load `ember.debug.js` or `ember.prod.js` prior to calling `compile`.'

--- a/packages/ember-template-compiler/lib/system/initializer.ts
+++ b/packages/ember-template-compiler/lib/system/initializer.ts
@@ -1,16 +1,11 @@
-import require, { has } from 'require';
 import bootstrap from './bootstrap';
+import * as emberEnv from '@ember/-internals/browser-environment';
+import * as emberGlimmer from '@ember/-internals/glimmer';
+import emberApp from '@ember/application';
 
 // Globals mode template compiler
-if (
-  has('@ember/application') &&
-  has('@ember/-internals/browser-environment') &&
-  has('@ember/-internals/glimmer')
-) {
-  let emberEnv = require('@ember/-internals/browser-environment');
-  let emberGlimmer = require('@ember/-internals/glimmer');
-  let emberApp = require('@ember/application');
-  let Application = emberApp.default;
+if (emberEnv && emberGlimmer && emberApp) {
+  let Application = emberApp;
   let { hasTemplate, setTemplate } = emberGlimmer;
   let { hasDOM } = emberEnv;
 

--- a/packages/ember-template-compiler/lib/system/initializer.ts
+++ b/packages/ember-template-compiler/lib/system/initializer.ts
@@ -1,11 +1,11 @@
 import bootstrap from './bootstrap';
 import * as emberEnv from '@ember/-internals/browser-environment';
 import * as emberGlimmer from '@ember/-internals/glimmer';
-import emberApp from '@ember/application';
+import * as emberApp from '@ember/application';
 
 // Globals mode template compiler
-if (emberEnv && emberGlimmer && emberApp) {
-  let Application = emberApp;
+if (emberApp.default) {
+  let Application = emberApp.default;
   let { hasTemplate, setTemplate } = emberGlimmer;
   let { hasDOM } = emberEnv;
 

--- a/packages/ember-testing/index.ts
+++ b/packages/ember-testing/index.ts
@@ -1,9 +1,5 @@
-export { default as Test } from './lib/test';
-export { default as Adapter } from './lib/adapters/adapter';
-export { default as setupForTesting } from './lib/setup_for_testing';
-export { default as QUnitAdapter } from './lib/adapters/qunit';
+export * from './lib/public-api';
+import * as EmberTesting from './lib/public-api';
+import { registerTestImplementaiton } from '@ember/test';
 
-import './lib/ext/application';
-import './lib/ext/rsvp'; // setup RSVP + run loop integration
-import './lib/helpers'; // adds helpers to helpers object in Test
-import './lib/initializers'; // to setup initializer
+registerTestImplementaiton(EmberTesting);

--- a/packages/ember-testing/lib/public-api.ts
+++ b/packages/ember-testing/lib/public-api.ts
@@ -1,0 +1,9 @@
+export { default as Test } from './test';
+export { default as Adapter } from './adapters/adapter';
+export { default as setupForTesting } from './setup_for_testing';
+export { default as QUnitAdapter } from './adapters/qunit';
+
+import './ext/application';
+import './ext/rsvp'; // setup RSVP + run loop integration
+import './helpers'; // adds helpers to helpers object in Test
+import './initializers'; // to setup initializer

--- a/packages/ember-testing/tests/reexports_test.js
+++ b/packages/ember-testing/tests/reexports_test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { confirmExport } from 'internal-test-helpers';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import * as emberTesting from 'ember-testing';
 
 class ReexportsTestCase extends AbstractTestCase {}
 
@@ -19,7 +20,7 @@ class ReexportsTestCase extends AbstractTestCase {}
   }
 
   ReexportsTestCase.prototype[`@test Ember.${path} exports correctly`] = function (assert) {
-    confirmExport(Ember, assert, path, moduleId, exportName);
+    confirmExport(Ember, assert, path, moduleId, exportName, emberTesting);
   };
 });
 

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -42,6 +42,7 @@
     "backburner.js": "^2.7.0",
     "dag-map": "^2.0.2",
     "ember-template-compiler": "workspace:*",
+    "ember-testing": "workspace:*",
     "expect-type": "^0.15.0",
     "internal-test-helpers": "workspace:*",
     "router_js": "^8.0.3",

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -8,14 +8,14 @@ moduleFor(
   class extends AbstractTestCase {
     [`@test Ember exports correctly`](assert) {
       allExports.forEach((reexport) => {
-        let [path, moduleId, exportName] = reexport;
+        let [path, moduleId, exportName, mod] = reexport;
 
         // default path === exportName if none present
         if (!exportName) {
           exportName = path;
         }
 
-        confirmExport(Ember, assert, path, moduleId, exportName);
+        confirmExport(Ember, assert, path, moduleId, exportName, mod);
       });
     }
 
@@ -35,319 +35,315 @@ moduleFor(
   }
 );
 
+import * as test0 from '@ember/application';
+import * as test1 from '@ember/application/instance';
+import * as test2 from '@ember/application/namespace';
+import * as test3 from '@ember/array';
+import * as test4 from '@ember/array/mutable';
+import * as test5 from '@ember/array/proxy';
+import * as test6 from '@ember/canary-features';
+import * as test7 from '@ember/component';
+import * as test8 from '@ember/component/helper';
+import * as test9 from '@ember/component/template-only';
+import * as test10 from '@ember/controller';
+import * as test11 from '@ember/debug';
+import * as test12 from '@ember/debug/container-debug-adapter';
+import * as test13 from '@ember/debug/data-adapter';
+import * as test14 from '@ember/destroyable';
+import * as test15 from '@ember/engine';
+import * as test16 from '@ember/engine/instance';
+import * as test17 from '@ember/enumerable';
+import * as test18 from '@ember/instrumentation';
+import * as test19 from '@ember/modifier';
+import * as test20 from '@ember/helper';
+import * as test21 from '@ember/object';
+import * as test22 from '@ember/object/compat';
+import * as test23 from '@ember/object/computed';
+import * as test24 from '@ember/object/core';
+import * as test25 from '@ember/object/evented';
+import * as test26 from '@ember/object/events';
+import * as test27 from '@ember/object/internals';
+import * as test28 from '@ember/object/mixin';
+import * as test29 from '@ember/object/observable';
+import * as test30 from '@ember/object/observers';
+import * as test31 from '@ember/object/promise-proxy-mixin';
+import * as test32 from '@ember/object/proxy';
+import * as test33 from '@ember/routing/hash-location';
+import * as test34 from '@ember/routing/history-location';
+import * as test35 from '@ember/routing/none-location';
+import * as test36 from '@ember/routing/route';
+import * as test37 from '@ember/routing/router';
+import * as test38 from '@ember/runloop';
+import * as test39 from '@ember/service';
+import * as test40 from '@ember/template';
+import * as test41 from '@ember/template-compilation';
+import * as test42 from '@ember/template-factory';
+import * as test43 from '@ember/test';
+import * as test44 from '@ember/test/adapter';
+import * as test45 from '@ember/utils';
+import * as test46 from '@ember/version';
+import * as test47 from '@glimmer/tracking';
+import * as test48 from '@glimmer/tracking/primitives/cache';
+import * as test49 from '@ember/-internals/environment';
+import * as test50 from '@ember/-internals/utils';
+import * as test51 from '@ember/-internals/container';
+import * as test52 from '@ember/-internals/metal';
+import * as test53 from '@ember/-internals/error-handling';
+import * as test54 from '@ember/-internals/meta';
+import * as test55 from '@ember/-internals/views';
+import * as test56 from '@ember/-internals/glimmer';
+import * as test57 from '@ember/-internals/runtime';
+import * as test58 from '@ember/-internals/routing';
+import * as test59 from 'backburner.js';
+import * as test60 from 'rsvp';
+
 let allExports = [
-  // @ember/application
-  ['Application', '@ember/application', 'default'],
-  ['getOwner', '@ember/application', 'getOwner'],
-  ['onLoad', '@ember/application', 'onLoad'],
-  ['runLoadHooks', '@ember/application', 'runLoadHooks'],
-  ['setOwner', '@ember/application', 'setOwner'],
-
-  // @ember/application/instance
-  ['ApplicationInstance', '@ember/application/instance', 'default'],
-
-  // @ember/application/namespace
-  ['Namespace', '@ember/application/namespace', 'default'],
-
-  // @ember/array
-  ['Array', '@ember/array', 'default'],
-  ['A', '@ember/array', 'A'],
-  ['NativeArray', '@ember/array', 'NativeArray'],
-  ['isArray', '@ember/array', 'isArray'],
-  ['makeArray', '@ember/array', 'makeArray'],
-
-  // @ember/array/mutable
-  ['MutableArray', '@ember/array/mutable', 'default'],
-
-  // @ember/array/proxy
-  ['ArrayProxy', '@ember/array/proxy', 'default'],
-
-  // @ember/canary-features
-  ['FEATURES.isEnabled', '@ember/canary-features', 'isEnabled'],
-
-  // @ember/component
-  ['Component', '@ember/component', 'default'],
-  ['_componentManagerCapabilities', '@ember/component', 'capabilities'],
-  ['_getComponentTemplate', '@ember/component', 'getComponentTemplate'],
-  ['_setComponentManager', '@ember/component', 'setComponentManager'],
-  ['_setComponentTemplate', '@ember/component', 'setComponentTemplate'],
-
-  // @ember/component/helper
-  ['Helper', '@ember/component/helper', 'default'],
-  ['Helper.helper', '@ember/component/helper', 'helper'],
-
-  // @ember/component/template-only
-  ['_templateOnlyComponent', '@ember/component/template-only', 'default'],
-
-  // @ember/controller
-  ['Controller', '@ember/controller', 'default'],
-  ['ControllerMixin', '@ember/controller', 'ControllerMixin'],
-  ['inject.controller', '@ember/controller', 'inject'],
-
-  // @ember/debug
-  ['deprecateFunc', '@ember/debug', 'deprecateFunc'],
-  ['deprecate', '@ember/debug', 'deprecate'],
-  ['assert', '@ember/debug', 'assert'],
-  ['debug', '@ember/debug', 'debug'],
-  ['inspect', '@ember/debug', 'inspect'],
-  ['Debug.registerDeprecationHandler', '@ember/debug', 'registerDeprecationHandler'],
-  ['Debug.registerWarnHandler', '@ember/debug', 'registerWarnHandler'],
-  ['runInDebug', '@ember/debug', 'runInDebug'],
-  ['warn', '@ember/debug', 'warn'],
-  ['testing', '@ember/debug', { get: 'isTesting', set: 'setTesting' }],
-  ['_captureRenderTree', '@ember/debug', 'captureRenderTree'],
-
-  // @ember/debug/container-debug-adapter
-  ['ContainerDebugAdapter', '@ember/debug/container-debug-adapter', 'default'],
-
-  // @ember/debug/data-adapter
-  ['DataAdapter', '@ember/debug/data-adapter', 'default'],
-
-  // @ember/destroyable
+  ['Application', '@ember/application', 'default', test0],
+  ['getOwner', '@ember/application', 'getOwner', test0],
+  ['onLoad', '@ember/application', 'onLoad', test0],
+  ['runLoadHooks', '@ember/application', 'runLoadHooks', test0],
+  ['setOwner', '@ember/application', 'setOwner', test0],
+  ['ApplicationInstance', '@ember/application/instance', 'default', test1],
+  ['Namespace', '@ember/application/namespace', 'default', test2],
+  ['Array', '@ember/array', 'default', test3],
+  ['A', '@ember/array', 'A', test3],
+  ['NativeArray', '@ember/array', 'NativeArray', test3],
+  ['isArray', '@ember/array', 'isArray', test3],
+  ['makeArray', '@ember/array', 'makeArray', test3],
+  ['MutableArray', '@ember/array/mutable', 'default', test4],
+  ['ArrayProxy', '@ember/array/proxy', 'default', test5],
+  ['FEATURES.isEnabled', '@ember/canary-features', 'isEnabled', test6],
+  ['Component', '@ember/component', 'default', test7],
+  ['_componentManagerCapabilities', '@ember/component', 'capabilities', test7],
+  ['_getComponentTemplate', '@ember/component', 'getComponentTemplate', test7],
+  ['_setComponentManager', '@ember/component', 'setComponentManager', test7],
+  ['_setComponentTemplate', '@ember/component', 'setComponentTemplate', test7],
+  ['Helper', '@ember/component/helper', 'default', test8],
+  ['Helper.helper', '@ember/component/helper', 'helper', test8],
+  ['_templateOnlyComponent', '@ember/component/template-only', 'default', test9],
+  ['Controller', '@ember/controller', 'default', test10],
+  ['ControllerMixin', '@ember/controller', 'ControllerMixin', test10],
+  ['inject.controller', '@ember/controller', 'inject', test10],
+  ['deprecateFunc', '@ember/debug', 'deprecateFunc', test11],
+  ['deprecate', '@ember/debug', 'deprecate', test11],
+  ['assert', '@ember/debug', 'assert', test11],
+  ['debug', '@ember/debug', 'debug', test11],
+  ['inspect', '@ember/debug', 'inspect', test11],
+  ['Debug.registerDeprecationHandler', '@ember/debug', 'registerDeprecationHandler', test11],
+  ['Debug.registerWarnHandler', '@ember/debug', 'registerWarnHandler', test11],
+  ['runInDebug', '@ember/debug', 'runInDebug', test11],
+  ['warn', '@ember/debug', 'warn', test11],
+  [
+    'testing',
+    '@ember/debug',
+    {
+      get: 'isTesting',
+      set: 'setTesting',
+    },
+    test11,
+  ],
+  ['_captureRenderTree', '@ember/debug', 'captureRenderTree', test11],
+  ['ContainerDebugAdapter', '@ember/debug/container-debug-adapter', 'default', test12],
+  ['DataAdapter', '@ember/debug/data-adapter', 'default', test13],
   DEBUG
-    ? ['_assertDestroyablesDestroyed', '@ember/destroyable', 'assertDestroyablesDestroyed']
+    ? ['_assertDestroyablesDestroyed', '@ember/destroyable', 'assertDestroyablesDestroyed', test14]
     : null,
-  ['_associateDestroyableChild', '@ember/destroyable', 'associateDestroyableChild'],
-  ['destroy', '@ember/destroyable', 'destroy'],
-  DEBUG ? ['_enableDestroyableTracking', '@ember/destroyable', 'enableDestroyableTracking'] : null,
-  ['_isDestroyed', '@ember/destroyable', 'isDestroyed'],
-  ['_isDestroying', '@ember/destroyable', 'isDestroying'],
-  ['_registerDestructor', '@ember/destroyable', 'registerDestructor'],
-  ['_unregisterDestructor', '@ember/destroyable', 'unregisterDestructor'],
-
-  // @ember/engine
-  ['Engine', '@ember/engine', 'default'],
-
-  // @ember/engine/instance
-  ['EngineInstance', '@ember/engine/instance', 'default'],
-
-  // @ember/enumerable
-  ['Enumerable', '@ember/enumerable', 'default'],
-
-  // @ember/instrumentation
-  ['instrument', '@ember/instrumentation', 'instrument'],
-  ['subscribe', '@ember/instrumentation', 'subscribe'],
-  ['Instrumentation.instrument', '@ember/instrumentation', 'instrument'],
-  ['Instrumentation.reset', '@ember/instrumentation', 'reset'],
-  ['Instrumentation.subscribe', '@ember/instrumentation', 'subscribe'],
-  ['Instrumentation.unsubscribe', '@ember/instrumentation', 'unsubscribe'],
-
-  // @ember/modifier
-  ['_modifierManagerCapabilities', '@ember/modifier', 'capabilities'],
-  ['_setModifierManager', '@ember/modifier', 'setModifierManager'],
-  ['_on', '@ember/modifier', 'on'],
-
-  // @ember/helper
-  ['_helperManagerCapabilities', '@ember/helper', 'capabilities'],
-  ['_setHelperManager', '@ember/helper', 'setHelperManager'],
-  ['_invokeHelper', '@ember/helper', 'invokeHelper'],
-  ['_fn', '@ember/helper', 'fn'],
-  ['_array', '@ember/helper', 'array'],
-  ['_hash', '@ember/helper', 'hash'],
-  ['_get', '@ember/helper', 'get'],
-  ['_concat', '@ember/helper', 'concat'],
-
-  // @ember/object
-  ['Object', '@ember/object', 'default'],
-  ['_action', '@ember/object', 'action'],
-  ['computed', '@ember/object', 'computed'],
-  ['defineProperty', '@ember/object', 'defineProperty'],
-  ['get', '@ember/object', 'get'],
-  ['getProperties', '@ember/object', 'getProperties'],
-  ['notifyPropertyChange', '@ember/object', 'notifyPropertyChange'],
-  ['observer', '@ember/object', 'observer'],
-  ['set', '@ember/object', 'set'],
-  ['setProperties', '@ember/object', 'setProperties'],
-  ['trySet', '@ember/object', 'trySet'],
-
-  // @ember/object/compat
-  ['_dependentKeyCompat', '@ember/object/compat', 'dependentKeyCompat'],
-
-  // @ember/object/computed
-  ['ComputedProperty', '@ember/object/computed', 'default'],
-  ['expandProperties', '@ember/object/computed', 'expandProperties'],
-
-  // @ember/object/core
-  ['CoreObject', '@ember/object/core', 'default'],
-
-  // @ember/object/evented
-  ['Evented', '@ember/object/evented', 'default'],
-  ['on', '@ember/object/evented', 'on'],
-
-  // @ember/object/events
-  ['addListener', '@ember/object/events', 'addListener'],
-  ['removeListener', '@ember/object/events', 'removeListener'],
-  ['sendEvent', '@ember/object/events', 'sendEvent'],
-
-  // @ember/object/internals
-  ['cacheFor', '@ember/object/internals', 'cacheFor'],
-  ['guidFor', '@ember/object/internals', 'guidFor'],
-
-  // @ember/object/mixin
-  ['Mixin', '@ember/object/mixin', 'default'],
-
-  // @ember/object/observable
-  ['Observable', '@ember/object/observable', 'default'],
-
-  // @ember/object/observers
-  ['addObserver', '@ember/object/observers', 'addObserver'],
-  ['removeObserver', '@ember/object/observers', 'removeObserver'],
-
-  // @ember/object/promise-proxy-mixin
-  ['PromiseProxyMixin', '@ember/object/promise-proxy-mixin', 'default'],
-
-  // @ember/object/proxy
-  ['ObjectProxy', '@ember/object/proxy', 'default'],
-
-  // @ember/routing/hash-location
-  ['HashLocation', '@ember/routing/hash-location', 'default'],
-
-  // @ember/routing/history-location
-  ['HistoryLocation', '@ember/routing/history-location', 'default'],
-
-  // @ember/routing/none-location
-  ['NoneLocation', '@ember/routing/none-location', 'default'],
-
-  // @ember/routing/route
-  ['Route', '@ember/routing/route', 'default'],
-
-  // @ember/routing/router
-  ['Router', '@ember/routing/router', 'default'],
-
-  // @ember/runloop
-  ['run', '@ember/runloop', 'run'],
-
-  // @ember/service
-  ['Service', '@ember/service', 'default'],
-  ['inject.service', '@ember/service', 'service'],
-
-  // @ember/template
-  [null, '@ember/template', 'htmlSafe'],
-  [null, '@ember/template', 'isHTMLSafe'],
-
-  // @ember/template-compilation
-  ['HTMLBars.compile', '@ember/template-compilation', 'compileTemplate'],
-
-  // @ember/template-factory
-  ['Handlebars.template', '@ember/template-factory', 'createTemplateFactory'],
-  ['HTMLBars.template', '@ember/template-factory', 'createTemplateFactory'],
-
-  // @ember/test
-  ['Test.registerAsyncHelper', '@ember/test', 'registerAsyncHelper'],
-  ['Test.registerHelper', '@ember/test', 'registerHelper'],
-  ['Test.registerWaiter', '@ember/test', 'registerWaiter'],
-  ['Test.unregisterHelper', '@ember/test', 'unregisterHelper'],
-  ['Test.unregisterWaiter', '@ember/test', 'unregisterWaiter'],
-
-  // @ember/test/adapter
-  ['Test.Adapter', '@ember/test/adapter', 'default'],
-
-  // @ember/utils
-  ['compare', '@ember/utils', 'compare'],
-  ['isBlank', '@ember/utils', 'isBlank'],
-  ['isEmpty', '@ember/utils', 'isEmpty'],
-  ['isEqual', '@ember/utils', 'isEqual'],
-  ['isNone', '@ember/utils', 'isNone'],
-  ['isPresent', '@ember/utils', 'isPresent'],
-  ['typeOf', '@ember/utils', 'typeOf'],
-
-  // @ember/version
-  ['VERSION', '@ember/version', 'VERSION'],
-
-  // @glimmer/tracking
-  ['_tracked', '@glimmer/tracking', 'tracked'],
-
-  // @glimmer/tracking/primitives/cache
-  ['_createCache', '@glimmer/tracking/primitives/cache', 'createCache'],
-  ['_cacheGetValue', '@glimmer/tracking/primitives/cache', 'getValue'],
-  ['_cacheIsConst', '@glimmer/tracking/primitives/cache', 'isConst'],
-
-  // @ember/-internals/environment
-  ['ENV', '@ember/-internals/environment', { get: 'getENV' }],
-  ['lookup', '@ember/-internals/environment', { get: 'getLookup', set: 'setLookup' }],
-
-  // @ember/-internals/utils
-  ['GUID_KEY', '@ember/-internals/utils'],
-  ['uuid', '@ember/-internals/utils'],
-  ['generateGuid', '@ember/-internals/utils'],
-  ['canInvoke', '@ember/-internals/utils'],
-  ['wrap', '@ember/-internals/utils'],
-  ['_Cache', '@ember/-internals/utils', 'Cache'],
-
-  // @ember/-internals/container
-  ['Registry', '@ember/-internals/container', 'Registry'],
-  ['Container', '@ember/-internals/container', 'Container'],
-
-  // @ember/-internals/metal
-  ['_descriptor', '@ember/-internals/metal', 'nativeDescDecorator'],
-  ['_setClassicDecorator', '@ember/-internals/metal', 'setClassicDecorator'],
-  ['_getPath', '@ember/-internals/metal'],
-  ['hasListeners', '@ember/-internals/metal'],
-  ['beginPropertyChanges', '@ember/-internals/metal'],
-  ['endPropertyChanges', '@ember/-internals/metal'],
-  ['changeProperties', '@ember/-internals/metal'],
-  ['libraries', '@ember/-internals/metal'],
+  ['_associateDestroyableChild', '@ember/destroyable', 'associateDestroyableChild', test14],
+  ['destroy', '@ember/destroyable', 'destroy', test14],
+  DEBUG
+    ? ['_enableDestroyableTracking', '@ember/destroyable', 'enableDestroyableTracking', test14]
+    : null,
+  ['_isDestroyed', '@ember/destroyable', 'isDestroyed', test14],
+  ['_isDestroying', '@ember/destroyable', 'isDestroying', test14],
+  ['_registerDestructor', '@ember/destroyable', 'registerDestructor', test14],
+  ['_unregisterDestructor', '@ember/destroyable', 'unregisterDestructor', test14],
+  ['Engine', '@ember/engine', 'default', test15],
+  ['EngineInstance', '@ember/engine/instance', 'default', test16],
+  ['Enumerable', '@ember/enumerable', 'default', test17],
+  ['instrument', '@ember/instrumentation', 'instrument', test18],
+  ['subscribe', '@ember/instrumentation', 'subscribe', test18],
+  ['Instrumentation.instrument', '@ember/instrumentation', 'instrument', test18],
+  ['Instrumentation.reset', '@ember/instrumentation', 'reset', test18],
+  ['Instrumentation.subscribe', '@ember/instrumentation', 'subscribe', test18],
+  ['Instrumentation.unsubscribe', '@ember/instrumentation', 'unsubscribe', test18],
+  ['_modifierManagerCapabilities', '@ember/modifier', 'capabilities', test19],
+  ['_setModifierManager', '@ember/modifier', 'setModifierManager', test19],
+  ['_on', '@ember/modifier', 'on', test19],
+  ['_helperManagerCapabilities', '@ember/helper', 'capabilities', test20],
+  ['_setHelperManager', '@ember/helper', 'setHelperManager', test20],
+  ['_invokeHelper', '@ember/helper', 'invokeHelper', test20],
+  ['_fn', '@ember/helper', 'fn', test20],
+  ['_array', '@ember/helper', 'array', test20],
+  ['_hash', '@ember/helper', 'hash', test20],
+  ['_get', '@ember/helper', 'get', test20],
+  ['_concat', '@ember/helper', 'concat', test20],
+  ['Object', '@ember/object', 'default', test21],
+  ['_action', '@ember/object', 'action', test21],
+  ['computed', '@ember/object', 'computed', test21],
+  ['defineProperty', '@ember/object', 'defineProperty', test21],
+  ['get', '@ember/object', 'get', test21],
+  ['getProperties', '@ember/object', 'getProperties', test21],
+  ['notifyPropertyChange', '@ember/object', 'notifyPropertyChange', test21],
+  ['observer', '@ember/object', 'observer', test21],
+  ['set', '@ember/object', 'set', test21],
+  ['setProperties', '@ember/object', 'setProperties', test21],
+  ['trySet', '@ember/object', 'trySet', test21],
+  ['_dependentKeyCompat', '@ember/object/compat', 'dependentKeyCompat', test22],
+  ['ComputedProperty', '@ember/object/computed', 'default', test23],
+  ['expandProperties', '@ember/object/computed', 'expandProperties', test23],
+  ['CoreObject', '@ember/object/core', 'default', test24],
+  ['Evented', '@ember/object/evented', 'default', test25],
+  ['on', '@ember/object/evented', 'on', test25],
+  ['addListener', '@ember/object/events', 'addListener', test26],
+  ['removeListener', '@ember/object/events', 'removeListener', test26],
+  ['sendEvent', '@ember/object/events', 'sendEvent', test26],
+  ['cacheFor', '@ember/object/internals', 'cacheFor', test27],
+  ['guidFor', '@ember/object/internals', 'guidFor', test27],
+  ['Mixin', '@ember/object/mixin', 'default', test28],
+  ['Observable', '@ember/object/observable', 'default', test29],
+  ['addObserver', '@ember/object/observers', 'addObserver', test30],
+  ['removeObserver', '@ember/object/observers', 'removeObserver', test30],
+  ['PromiseProxyMixin', '@ember/object/promise-proxy-mixin', 'default', test31],
+  ['ObjectProxy', '@ember/object/proxy', 'default', test32],
+  ['HashLocation', '@ember/routing/hash-location', 'default', test33],
+  ['HistoryLocation', '@ember/routing/history-location', 'default', test34],
+  ['NoneLocation', '@ember/routing/none-location', 'default', test35],
+  ['Route', '@ember/routing/route', 'default', test36],
+  ['Router', '@ember/routing/router', 'default', test37],
+  ['run', '@ember/runloop', 'run', test38],
+  ['Service', '@ember/service', 'default', test39],
+  ['inject.service', '@ember/service', 'service', test39],
+  [null, '@ember/template', 'htmlSafe', test40],
+  [null, '@ember/template', 'isHTMLSafe', test40],
+  ['HTMLBars.compile', '@ember/template-compilation', 'compileTemplate', test41],
+  ['Handlebars.template', '@ember/template-factory', 'createTemplateFactory', test42],
+  ['HTMLBars.template', '@ember/template-factory', 'createTemplateFactory', test42],
+  ['Test.registerAsyncHelper', '@ember/test', 'registerAsyncHelper', test43],
+  ['Test.registerHelper', '@ember/test', 'registerHelper', test43],
+  ['Test.registerWaiter', '@ember/test', 'registerWaiter', test43],
+  ['Test.unregisterHelper', '@ember/test', 'unregisterHelper', test43],
+  ['Test.unregisterWaiter', '@ember/test', 'unregisterWaiter', test43],
+  ['Test.Adapter', '@ember/test/adapter', 'default', test44],
+  ['compare', '@ember/utils', 'compare', test45],
+  ['isBlank', '@ember/utils', 'isBlank', test45],
+  ['isEmpty', '@ember/utils', 'isEmpty', test45],
+  ['isEqual', '@ember/utils', 'isEqual', test45],
+  ['isNone', '@ember/utils', 'isNone', test45],
+  ['isPresent', '@ember/utils', 'isPresent', test45],
+  ['typeOf', '@ember/utils', 'typeOf', test45],
+  ['VERSION', '@ember/version', 'VERSION', test46],
+  ['_tracked', '@glimmer/tracking', 'tracked', test47],
+  ['_createCache', '@glimmer/tracking/primitives/cache', 'createCache', test48],
+  ['_cacheGetValue', '@glimmer/tracking/primitives/cache', 'getValue', test48],
+  ['_cacheIsConst', '@glimmer/tracking/primitives/cache', 'isConst', test48],
+  [
+    'ENV',
+    '@ember/-internals/environment',
+    {
+      get: 'getENV',
+    },
+    test49,
+  ],
+  [
+    'lookup',
+    '@ember/-internals/environment',
+    {
+      get: 'getLookup',
+      set: 'setLookup',
+    },
+    test49,
+  ],
+  ['GUID_KEY', '@ember/-internals/utils', null, test50],
+  ['uuid', '@ember/-internals/utils', null, test50],
+  ['generateGuid', '@ember/-internals/utils', null, test50],
+  ['canInvoke', '@ember/-internals/utils', null, test50],
+  ['wrap', '@ember/-internals/utils', null, test50],
+  ['_Cache', '@ember/-internals/utils', 'Cache', test50],
+  ['Registry', '@ember/-internals/container', 'Registry', test51],
+  ['Container', '@ember/-internals/container', 'Container', test51],
+  ['_descriptor', '@ember/-internals/metal', 'nativeDescDecorator', test52],
+  ['_setClassicDecorator', '@ember/-internals/metal', 'setClassicDecorator', test52],
+  ['_getPath', '@ember/-internals/metal', null, test52],
+  ['hasListeners', '@ember/-internals/metal', null, test52],
+  ['beginPropertyChanges', '@ember/-internals/metal', null, test52],
+  ['endPropertyChanges', '@ember/-internals/metal', null, test52],
+  ['changeProperties', '@ember/-internals/metal', null, test52],
+  ['libraries', '@ember/-internals/metal', null, test52],
   [
     'BOOTED',
     '@ember/-internals/metal',
-    { get: 'isNamespaceSearchDisabled', set: 'setNamespaceSearchDisabled' },
+    {
+      get: 'isNamespaceSearchDisabled',
+      set: 'setNamespaceSearchDisabled',
+    },
+    test52,
   ],
-
-  // @ember/-internals/error-handling
-  ['onerror', '@ember/-internals/error-handling', { get: 'getOnerror', set: 'setOnerror' }],
-
-  // @ember/-internals/meta
-  ['meta', '@ember/-internals/meta'],
-
-  // @ember/-internals/views
-  ['ViewUtils.isSimpleClick', '@ember/-internals/views', 'isSimpleClick'],
-  ['ViewUtils.getElementView', '@ember/-internals/views', 'getElementView'],
-  ['ViewUtils.getViewElement', '@ember/-internals/views', 'getViewElement'],
-  ['ViewUtils.getViewBounds', '@ember/-internals/views', 'getViewBounds'],
-  ['ViewUtils.getViewClientRects', '@ember/-internals/views', 'getViewClientRects'],
-  ['ViewUtils.getViewBoundingClientRect', '@ember/-internals/views', 'getViewBoundingClientRect'],
-  ['ViewUtils.getRootViews', '@ember/-internals/views', 'getRootViews'],
-  ['ViewUtils.getChildViews', '@ember/-internals/views', 'getChildViews'],
-  ['ViewUtils.isSerializationFirstNode', '@ember/-internals/glimmer', 'isSerializationFirstNode'],
-  ['ComponentLookup', '@ember/-internals/views'],
-  ['EventDispatcher', '@ember/-internals/views'],
-
-  // @ember/-internals/glimmer
-  ['TEMPLATES', '@ember/-internals/glimmer', { get: 'getTemplates', set: 'setTemplates' }],
-  ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression'],
-  ['_Input', '@ember/-internals/glimmer', 'Input'],
-
-  // @ember/-internals/runtime
-  ['_RegistryProxyMixin', '@ember/-internals/runtime', 'RegistryProxyMixin'],
-  ['_ContainerProxyMixin', '@ember/-internals/runtime', 'ContainerProxyMixin'],
-  ['Comparable', '@ember/-internals/runtime'],
-  ['ActionHandler', '@ember/-internals/runtime'],
-  ['MutableEnumerable', '@ember/-internals/runtime'],
-  ['_ProxyMixin', '@ember/-internals/runtime'],
-
-  // @ember/-internals/routing
-  ['controllerFor', '@ember/-internals/routing'],
-  ['generateControllerFactory', '@ember/-internals/routing'],
-  ['generateController', '@ember/-internals/routing'],
-  ['RouterDSL', '@ember/-internals/routing'],
-
-  // backburner
-  ['_Backburner', 'backburner.js', 'default'],
-
-  // rsvp
-  [null, 'rsvp', 'default'],
-  [null, 'rsvp', 'Promise'],
-  [null, 'rsvp', 'all'],
-  [null, 'rsvp', 'allSettled'],
-  [null, 'rsvp', 'defer'],
-  [null, 'rsvp', 'denodeify'],
-  [null, 'rsvp', 'filter'],
-  [null, 'rsvp', 'hash'],
-  [null, 'rsvp', 'hashSettled'],
-  [null, 'rsvp', 'map'],
-  [null, 'rsvp', 'off'],
-  [null, 'rsvp', 'on'],
-  [null, 'rsvp', 'race'],
-  [null, 'rsvp', 'reject'],
-  [null, 'rsvp', 'resolve'],
+  [
+    'onerror',
+    '@ember/-internals/error-handling',
+    {
+      get: 'getOnerror',
+      set: 'setOnerror',
+    },
+    test53,
+  ],
+  ['meta', '@ember/-internals/meta', null, test54],
+  ['ViewUtils.isSimpleClick', '@ember/-internals/views', 'isSimpleClick', test55],
+  ['ViewUtils.getElementView', '@ember/-internals/views', 'getElementView', test55],
+  ['ViewUtils.getViewElement', '@ember/-internals/views', 'getViewElement', test55],
+  ['ViewUtils.getViewBounds', '@ember/-internals/views', 'getViewBounds', test55],
+  ['ViewUtils.getViewClientRects', '@ember/-internals/views', 'getViewClientRects', test55],
+  [
+    'ViewUtils.getViewBoundingClientRect',
+    '@ember/-internals/views',
+    'getViewBoundingClientRect',
+    test55,
+  ],
+  ['ViewUtils.getRootViews', '@ember/-internals/views', 'getRootViews', test55],
+  ['ViewUtils.getChildViews', '@ember/-internals/views', 'getChildViews', test55],
+  [
+    'ViewUtils.isSerializationFirstNode',
+    '@ember/-internals/glimmer',
+    'isSerializationFirstNode',
+    test56,
+  ],
+  ['ComponentLookup', '@ember/-internals/views', null, test55],
+  ['EventDispatcher', '@ember/-internals/views', null, test55],
+  [
+    'TEMPLATES',
+    '@ember/-internals/glimmer',
+    {
+      get: 'getTemplates',
+      set: 'setTemplates',
+    },
+    test56,
+  ],
+  ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression', test56],
+  ['_Input', '@ember/-internals/glimmer', 'Input', test56],
+  ['_RegistryProxyMixin', '@ember/-internals/runtime', 'RegistryProxyMixin', test57],
+  ['_ContainerProxyMixin', '@ember/-internals/runtime', 'ContainerProxyMixin', test57],
+  ['Comparable', '@ember/-internals/runtime', null, test57],
+  ['ActionHandler', '@ember/-internals/runtime', null, test57],
+  ['MutableEnumerable', '@ember/-internals/runtime', null, test57],
+  ['_ProxyMixin', '@ember/-internals/runtime', null, test57],
+  ['controllerFor', '@ember/-internals/routing', null, test58],
+  ['generateControllerFactory', '@ember/-internals/routing', null, test58],
+  ['generateController', '@ember/-internals/routing', null, test58],
+  ['RouterDSL', '@ember/-internals/routing', null, test58],
+  ['_Backburner', 'backburner.js', 'default', test59],
+  [null, 'rsvp', 'default', test60],
+  [null, 'rsvp', 'Promise', test60],
+  [null, 'rsvp', 'all', test60],
+  [null, 'rsvp', 'allSettled', test60],
+  [null, 'rsvp', 'defer', test60],
+  [null, 'rsvp', 'denodeify', test60],
+  [null, 'rsvp', 'filter', test60],
+  [null, 'rsvp', 'hash', test60],
+  [null, 'rsvp', 'hashSettled', test60],
+  [null, 'rsvp', 'map', test60],
+  [null, 'rsvp', 'off', test60],
+  [null, 'rsvp', 'on', test60],
+  [null, 'rsvp', 'race', test60],
+  [null, 'rsvp', 'reject', test60],
+  [null, 'rsvp', 'resolve', test60],
 ].filter(Boolean);

--- a/packages/internal-test-helpers/lib/confirm-export.ts
+++ b/packages/internal-test-helpers/lib/confirm-export.ts
@@ -1,5 +1,3 @@
-import require from 'require';
-
 function getDescriptor(obj: Record<string, unknown>, path: string) {
   let parts = path.split('.');
   let value: unknown = obj;
@@ -20,7 +18,8 @@ export default function confirmExport(
   assert: QUnit['assert'],
   path: string,
   moduleId: string,
-  exportName: string | { value: unknown; get: string; set: string }
+  exportName: string | { value: unknown; get: string; set: string },
+  mod: any
 ) {
   try {
     let desc: PropertyDescriptor | null | undefined;
@@ -33,21 +32,18 @@ export default function confirmExport(
     }
 
     if (desc == null) {
-      let mod = require(moduleId);
       assert.notEqual(
         mod[exportName as string],
         undefined,
         `${moduleId}#${exportName} is not \`undefined\``
       );
     } else if (typeof exportName === 'string') {
-      let mod = require(moduleId);
       let value = 'value' in desc ? desc.value : desc.get!.call(Ember);
       assert.equal(value, mod[exportName], `Ember.${path} is exported correctly`);
       assert.notEqual(mod[exportName], undefined, `Ember.${path} is not \`undefined\``);
     } else if ('value' in desc) {
       assert.equal(desc.value, exportName.value, `Ember.${path} is exported correctly`);
     } else {
-      let mod = require(moduleId);
       assert.equal(desc.get, mod[exportName.get], `Ember.${path} getter is exported correctly`);
       assert.notEqual(desc.get, undefined, `Ember.${path} getter is not undefined`);
 


### PR DESCRIPTION
There are several places where ember-source depends unnecessarily on details of the AMD loader:

 - [x] optionally loading the `ember-testing` implementation
 - [x] optionally loading the runtime template compiler

This PR replaces them with more direct forms of coordination via module-scoped state.

My overarching goal here is to eliminate all usage of `require` inside the actual ES module packages so they are true ES modules. 

In contrast, the traditional ember.js, ember-testing.js, and ember-template-compiler.js **bundles** will still use `require` as their implementation to maintain backward compatibility. Where we need to patch over the weirdness of this (from the perspective of actual compliant ES modules), we do so entirely within the build that produces the bundles.

This is a step toward the proposed strict-es-modules optional feature. This implementation cleanup is happening before advancing that RFC because this cleanup is good either way and does not make any public API changes. 