### PR TITLE
Improve link script for glimmer-vm packages

### DIFF
--- a/bin/link-glimmer-vm-packages.mjs
+++ b/bin/link-glimmer-vm-packages.mjs
@@ -1,15 +1,47 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
 import execa from 'execa';
+import glob from 'glob';
 
-const packageJsonPath = new URL('../package.json', import.meta.url).pathname;
-const packageJson = JSON.parse(await readFileSync(packageJsonPath, { encoding: 'utf8' }));
+const rootDir = new URL('..', import.meta.url).pathname;
+
+const packageJsonPaths = glob.sync('**/package.json', {
+  cwd: rootDir,
+  ignore: '**/node_modules/**',
+});
 
 function shouldLink(dep) {
-  return dep.startsWith('@glimmer/') && dep !== '@glimmer/component' && dep !== '@glimmer/env';
+  return (
+    dep.startsWith('@glimmer/') &&
+    dep !== '@glimmer/component' &&
+    dep !== '@glimmer/env' &&
+    dep !== '@glimmer/tracking'
+  );
 }
 
-for (const [dep] of Object.entries(packageJson.dependencies)) {
-  if (shouldLink(dep)) {
-    await execa('pnpm', ['link', '--global', dep], { stdio: 'inherit' });
+const link = packageJsonPaths.map(async (packageJsonPath) => {
+  const packagePath = path.dirname(packageJsonPath);
+
+  try {
+    const packageJson = JSON.parse(await readFileSync(packageJsonPath, { encoding: 'utf8' }));
+
+    for (const [dep] of Object.entries(packageJson.dependencies ?? {})) {
+      if (shouldLink(dep)) {
+        // eslint-disable-next-line no-console
+        console.log(`Linking ${chalk.yellow(dep)} from ${chalk.grey(packagePath)}`);
+        await execa('pnpm', ['link', '--global', dep], { cwd: packagePath });
+      }
+    }
+  } catch (error) {
+    let message = `Failed to link ${packagePath}`;
+
+    if (error instanceof Error) {
+      message += `\n\n${error.stack}`;
+    }
+
+    throw new Error(message);
   }
-}
+});
+
+await Promise.all(link);

--- a/bin/unlink-all.mjs
+++ b/bin/unlink-all.mjs
@@ -1,0 +1,18 @@
+import chalk from 'chalk';
+import execa from 'execa';
+import glob from 'glob';
+import path from 'node:path';
+
+const rootDir = new URL('..', import.meta.url).pathname;
+
+const packageJsonPaths = glob.sync('**/package.json', {
+  cwd: rootDir,
+  ignore: '**/node_modules/**',
+});
+
+for (const packageJsonPath of packageJsonPaths) {
+  const packagePath = path.dirname(packageJsonPath);
+  // eslint-disable-next-line no-console
+  console.log(`Unlinking ${chalk.grey(packagePath)}`);
+  await execa('pnpm', ['unlink'], { stdio: 'inherit', cwd: packagePath });
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "type-check:internals": "tsc --noEmit",
     "type-check:types": "pnpm build:types && tsc --noEmit --project type-tests",
-    "type-check": "npm-run-all type-check:*"
+    "type-check": "npm-run-all type-check:*",
+    "unlink:all": "node bin/unlink-all.mjs"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.16.7",


### PR DESCRIPTION
Since packages/** are real packages now, it is not sufficient to only link from the root (e.g. for TypeScript checking), and instead we will need to link each sub-package separately.

In the future, https://github.com/pnpm/rfcs/blob/main/text/0001-catalogs.md may help, but that is not yet implemented.