### PR TITLE
[BUGFIX internal] fix pnpm invocation for nightly TS run

### DIFF
--- a/.github/workflows/night-ts.yml
+++ b/.github/workflows/night-ts.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - run: pnpm add --save-dev typescript@next
+      - run: pnpm add --save-dev typescript@next --workspace-root
       - run: pnpm type-check
   notify:
     name: Notify Discord


### PR DESCRIPTION
pnpm long had a warning for installing to the root of a workspace without this explicit flag, and it has now become an error. In the current shape of the workspace, installing in the root is appropriate, particularly for this job. Accordingly, just add the flag. (This matches the configuration for [regular CI jobs](https://github.com/emberjs/ember.js/blob/b4e52451770e95eec8986578052baffb4f18a72d/.github/workflows/ci.yml#L52).