### PR TITLE
[FEATURE] Add explicit support TS 5.1, 5.2, and 5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     needs: ['types']
     strategy:
       matrix:
-        ts-version: ['4.9', '5.0', 'next']
+        ts-version: ['4.9', '5.0', '5.1', '5.2', '5.3', 'next']
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Ember has had implicit support for these since their release, and has tested against all of them successfully via the nightly job. Include them explicitly in the CI range so Ember does not *regress* against any of them. (They should also, separately, be added to a public list of supported versions, in line with [the semver-ts spec][spec].)

[spec]: https://www.semver-ts.org/2-conformance.html