### PR TITLE
[BUGFIX beta] internal templates should be strictMode

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/templates/empty.ts
+++ b/packages/@ember/-internals/glimmer/lib/templates/empty.ts
@@ -1,4 +1,5 @@
 import { precompileTemplate } from '@ember/template-compilation';
 export default precompileTemplate('', {
   moduleName: 'packages/@ember/-internals/glimmer/lib/templates/empty.hbs',
+  strictMode: true,
 });

--- a/packages/@ember/-internals/glimmer/lib/templates/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/templates/input.ts
@@ -1,4 +1,5 @@
 import { precompileTemplate } from '@ember/template-compilation';
+import { on } from '@ember/modifier';
 export default precompileTemplate(
   `<input
   {{!-- for compatibility --}}
@@ -17,5 +18,11 @@ export default precompileTemplate(
   {{on "paste" this.valueDidChange}}
   {{on "cut" this.valueDidChange}}
 />`,
-  { moduleName: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs' }
+  {
+    moduleName: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
+    strictMode: true,
+    scope() {
+      return { on };
+    },
+  }
 );

--- a/packages/@ember/-internals/glimmer/lib/templates/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/templates/link-to.ts
@@ -1,4 +1,6 @@
 import { precompileTemplate } from '@ember/template-compilation';
+import { on } from '@ember/modifier';
+
 export default precompileTemplate(
   `<a
   {{!-- for compatibility --}}
@@ -18,5 +20,11 @@ export default precompileTemplate(
 
   {{on 'click' this.click}}
 >{{yield}}</a>`,
-  { moduleName: 'packages/@ember/-internals/glimmer/lib/templates/link-to.hbs' }
+  {
+    moduleName: 'packages/@ember/-internals/glimmer/lib/templates/link-to.hbs',
+    strictMode: true,
+    scope() {
+      return { on };
+    },
+  }
 );

--- a/packages/@ember/-internals/glimmer/lib/templates/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/templates/outlet.ts
@@ -1,4 +1,10 @@
 import { precompileTemplate } from '@ember/template-compilation';
-export default precompileTemplate(`{{component (-outlet)}}`, {
+import { outletHelper } from '../syntax/outlet';
+
+export default precompileTemplate(`{{component (outletHelper)}}`, {
   moduleName: 'packages/@ember/-internals/glimmer/lib/templates/outlet.hbs',
+  strictMode: true,
+  scope() {
+    return { outletHelper };
+  },
 });

--- a/packages/@ember/-internals/glimmer/lib/templates/root.ts
+++ b/packages/@ember/-internals/glimmer/lib/templates/root.ts
@@ -1,4 +1,5 @@
 import { precompileTemplate } from '@ember/template-compilation';
 export default precompileTemplate(`{{component this}}`, {
   moduleName: 'packages/@ember/-internals/glimmer/lib/templates/root.hbs',
+  strictMode: true,
 });

--- a/packages/@ember/-internals/glimmer/lib/templates/textarea.ts
+++ b/packages/@ember/-internals/glimmer/lib/templates/textarea.ts
@@ -1,4 +1,6 @@
 import { precompileTemplate } from '@ember/template-compilation';
+import { on } from '@ember/modifier';
+
 export default precompileTemplate(
   `<textarea
   {{!-- for compatibility --}}
@@ -15,5 +17,11 @@ export default precompileTemplate(
   {{on "paste" this.valueDidChange}}
   {{on "cut" this.valueDidChange}}
 />`,
-  { moduleName: 'packages/@ember/-internals/glimmer/lib/templates/textarea.hbs' }
+  {
+    moduleName: 'packages/@ember/-internals/glimmer/lib/templates/textarea.hbs',
+    strictMode: true,
+    scope() {
+      return { on };
+    },
+  }
 );

--- a/packages/@ember/-internals/package.json
+++ b/packages/@ember/-internals/package.json
@@ -31,6 +31,7 @@
     "@ember/enumerable": "workspace:*",
     "@ember/helper": "workspace:*",
     "@ember/instrumentation": "workspace:*",
+    "@ember/modifier": "workspace:*",
     "@ember/object": "workspace:*",
     "@ember/owner": "workspace:*",
     "@ember/routing": "workspace:*",

--- a/packages/@ember/template-compilation/index.ts
+++ b/packages/@ember/template-compilation/index.ts
@@ -2,19 +2,6 @@ import { DEBUG } from '@glimmer/env';
 import type { TemplateFactory } from '@glimmer/interfaces';
 import type * as ETC from 'ember-template-compiler';
 
-interface CommonOptions {
-  moduleName?: string;
-}
-
-interface LooseModeOptions extends CommonOptions {
-  strictMode?: false;
-}
-
-interface StrictModeOptions extends CommonOptions {
-  strictMode: true;
-  scope: () => Record<string, unknown>;
-}
-
 // (UN)SAFETY: the public API is that people can import and use this (and indeed
 // it is emitted as part of Ember's build!), so we define it as having the type
 // which makes that work. However, in practice it is supplied by the build,
@@ -22,8 +9,14 @@ interface StrictModeOptions extends CommonOptions {
 // here is `undefined` in prod; in dev it is a function which throws a somewhat
 // nicer error. This is janky, but... here we are.
 interface PrecompileTemplate {
-  (templateString: string, options?: LooseModeOptions): TemplateFactory;
-  (templateString: string, options: StrictModeOptions): TemplateFactory;
+  (
+    templateString: string,
+    options?: {
+      strictMode?: boolean;
+      scope?: () => Record<string, unknown>;
+      moduleName?: string;
+    }
+  ): TemplateFactory;
 }
 
 export let __emberTemplateCompiler: undefined | typeof ETC;

--- a/packages/@ember/test/index.ts
+++ b/packages/@ember/test/index.ts
@@ -17,7 +17,7 @@ registerWaiter = testingNotAvailableMessage;
 unregisterHelper = testingNotAvailableMessage;
 unregisterWaiter = testingNotAvailableMessage;
 
-export function registerTestImplementaiton(impl: typeof EmberTesting) {
+export function registerTestImplementation(impl: typeof EmberTesting) {
   let { Test } = impl;
   registerAsyncHelper = Test.registerAsyncHelper;
   registerHelper = Test.registerHelper;

--- a/packages/ember-testing/index.ts
+++ b/packages/ember-testing/index.ts
@@ -1,5 +1,5 @@
 export * from './lib/public-api';
 import * as EmberTesting from './lib/public-api';
-import { registerTestImplementaiton } from '@ember/test';
+import { registerTestImplementation } from '@ember/test';
 
-registerTestImplementaiton(EmberTesting);
+registerTestImplementation(EmberTesting);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       '@ember/instrumentation':
         specifier: workspace:*
         version: link:../instrumentation
+      '@ember/modifier':
+        specifier: workspace:*
+        version: link:../modifier
       '@ember/object':
         specifier: workspace:*
         version: link:../object
@@ -9690,7 +9693,7 @@ packages:
       function-bind: 1.1.2
 
   /hawk@1.1.1:
-    resolution: {integrity: sha512-am8sVA2bCJIw8fuuVcKvmmNnGFUGW8spTkVtj2fXTEZVkfN42bwFZFtDem57eFi+NSxurJB8EQ7Jd3uCHLn8Vw==}
+    resolution: {integrity: sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=}
     engines: {node: '>=0.8.0'}
     deprecated: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
     requiresBuild: true

--- a/type-tests/@ember/template-compilation.ts
+++ b/type-tests/@ember/template-compilation.ts
@@ -15,9 +15,6 @@ precompileTemplate(`Hello World`, { strictMode: true, moduleName: 'hello', scope
 // Integration, since this is the primary use case for precompileTemplate
 expectTypeOf(setComponentTemplate(precompileTemplate(`Hello World`), templateOnly())).toBeObject();
 
-// @ts-expect-error scope is required when strictMode is true
-precompileTemplate(`Hello World`, { strictMode: true });
-
 // @ts-expect-error scope must be a function
 precompileTemplate(`Hello World`, { strictMode: true, scope: {} });
 
@@ -26,6 +23,3 @@ precompileTemplate(`Hello World`, { strictMode: true, scope: () => {} });
 
 // @ts-expect-error scope must return an object and arrays are not the kind of object we want
 precompileTemplate(`Hello World`, { strictMode: true, scope: () => [] });
-
-// @ts-expect-error scope has no purpose when strictMode is false
-precompileTemplate(`Hello World`, { strictMode: false, scope: () => ({}) });


### PR DESCRIPTION
As of https://github.com/emberjs/ember.js/pull/20587, the modules published under `dist/packages` act more like normal addon code,  in that their templates are published as calls to `precompileTemplate` rather than wire format.

But that makes this the first time that Embroider is seeing these templates, and because they are in loose mode and use the dynamic component helper they are un-analyzable.

This PR:
 - switches them to strict mode
 - fixes the declared types for `precompileTemplate`, which were a lie before. `scope` is allowed in non-strict mode. `scope` is optional even in strict mode
 - fixes a spelling error in a recently-introduced internal method, because I noticed it and it annoyed me.