### PR TITLE
Removing ts@next from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
     needs: ['types']
     strategy:
       matrix:
-        ts-version: ['4.9', '5.0', '5.1', '5.2', '5.3', 'next']
+        # I removed 'next' from this list because we're seeing buggy behavior in
+        # the so-far unreleased 5.4. -ef4
+        ts-version: ['4.9', '5.0', '5.1', '5.2', '5.3']
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup


### PR DESCRIPTION
We're seeing potentially-buggy behavior from the currently unreleased typescript. To unblock other PRs I'm taking it out of the CI matrix for the present.