### PR TITLE
[CLEANUP canary] Cleanup incorrect module usage

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -6,7 +6,7 @@ import {
   runTask,
 } from 'internal-test-helpers';
 
-import { DEBUG } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
 import { set } from '@ember/object';
 import { getOwner } from '@ember/-internals/owner';
 import Controller from '@ember/controller';

--- a/packages/@ember/-internals/glimmer/tests/utils/helpers.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/helpers.js
@@ -5,8 +5,6 @@ export {
   Helper,
   helper,
   Component,
-  InteractiveRenderer,
-  InertRenderer,
   htmlSafe,
   SafeString,
   DOMChanges,


### PR DESCRIPTION
These are places where Ember is importing things that don't actually exist. I found them while working toward strict-es-modules, since these become hard errors under those assumptions.