### PR TITLE
[CLEANUP canary] Remove final eager consumption of AMD loader

### DIFF
--- a/packages/ember/index.ts
+++ b/packages/ember/index.ts
@@ -506,8 +506,10 @@ namespace Ember {
     get define() {
       return (globalThis as any).define;
     },
-    // @ts-expect-error These properties don't appear as being defined
-    registry: typeof requirejs !== 'undefined' ? requirejs.entries : require.entries,
+    get registry() {
+      let g = globalThis as any;
+      return g.requirejs?.entries ?? g.require.entries;
+    },
   };
 
   // ------------------------------------------------------------------------ //


### PR DESCRIPTION
This is the last place where Ember treats the AMD loader as mandatory. After this change I have Ember's whole test suite passing with no AMD loader!