### PR TITLE
Replace master with main in links and text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Ember uses [StandardIssueLabels](https://github.com/wagenet/StandardIssueLabels)
 Think you've found a bug or have a new feature to suggest? Let us know!
 
 ## Reporting a Bug
-1. Update to the most recent master release if possible. We may have already
+1. Update to the most recent main release if possible. We may have already
 fixed your bug.
 
 2. Search for similar issues. It's possible somebody has encountered
@@ -53,7 +53,7 @@ might close the issue if we do not hear from you after two weeks since the
 original notice.
 
 * If you submit a feature request as an issue, you will be invited to follow the
-[instructions in this document](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#requesting-a-feature)
+[instructions in this document](https://github.com/emberjs/ember.js/blob/main/CONTRIBUTING.md#requesting-a-feature)
 and the issue will be closed
 * Issues that become inactive will be labeled accordingly
   to inform the original poster and Ember contributors that the issue
@@ -174,7 +174,7 @@ a test! If your change is a new feature, please
 [wrap it in a feature flag](https://guides.emberjs.com/release/contributing/adding-new-features/).
 
 4. Make sure to check out the
-   [JavaScript Style Guide](https://github.com/emberjs/ember.js/blob/master/STYLEGUIDE.md) and
+   [JavaScript Style Guide](https://github.com/emberjs/ember.js/blob/main/STYLEGUIDE.md) and
    ensure that your code complies with the rules. If you missed a rule or two, don't worry, our
    tests will warn you.
 
@@ -299,7 +299,7 @@ In general bug fixes are pulled into the beta branch. As such, the prefix is: `[
 
 For bugs related to canary features, follow the prefixing rules for features.
 
-The vast majority of bug fixes apply to the current stable or beta releases, so submit your PR against `emberjs:master` with one of the above mentioned BUGFIX tags.  (In the unusual case of a bug fix specifically for a past release, tag for that release `[BUGFIX release-1-13]` and submit the PR against the stable branch for that release: `emberjs:stable-1-13`.)
+The vast majority of bug fixes apply to the current stable or beta releases, so submit your PR against `emberjs:main` with one of the above mentioned BUGFIX tags.  (In the unusual case of a bug fix specifically for a past release, tag for that release `[BUGFIX release-1-13]` and submit the PR against the stable branch for that release: `emberjs:stable-1-13`.)
 
 ### Cleanup
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://codeclimate.com/github/emberjs/ember.js"><img src="https://codeclimate.com/github/emberjs/ember.js.svg" alt="Code Climate"></a>
   <a href="https://discord.gg/zT3asNS"><img src="https://img.shields.io/discord/480462759797063690.svg?logo=discord" alt="Discord Community Server"></a>
   <a href="https://help-wanted.emberjs.com/"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
-  <a href="https://github.com/emberjs/ember.js/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="GitHub license"></a>
+  <a href="https://github.com/emberjs/ember.js/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="GitHub license"></a>
 
 </p>
 
@@ -42,7 +42,7 @@ Find out more:
 
 ## Contributions
 
-See [CONTRIBUTING.md](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/emberjs/ember.js/blob/main/CONTRIBUTING.md)
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@
 ## Ember Notes on Point Releases (Not Release Notes)
 
 1. Check out `beta` branch and `git pull`
-1. Make sure any master commits that are conceptually `[{BUGFIX,DOC} {beta,release}]` are cherry-picked.
+1. Make sure any main commits that are conceptually `[{BUGFIX,DOC} {beta,release}]` are cherry-picked.
 1. `git push origin beta`, and `let ciBranch = kick off a CI build`
 1. `PRIOR_VERSION=v2.5.0-beta.1 ./bin/changelog.js | uniq | pbcopy`
 1. Open `CHANGELOG.md`, paste in the results of the previous script, and clean it up for human-readability.
@@ -26,10 +26,10 @@
     1. Revert [BUGFIX ...] -> [BUGFIX] Revert ...
     1. rm [DOC] (usually)
     1. rm other trivial things
-1. Backport CHANGELOG to master
+1. Backport CHANGELOG to main
 1. `await ciBranch`
     1. if CI succeeds, process
-    1. if CI fails and it's a fix that doesn't need to be on master (e.g. linting or merge conflicts accidentally checked in), fix and retry.
+    1. if CI fails and it's a fix that doesn't need to be on main (e.g. linting or merge conflicts accidentally checked in), fix and retry.
     1. otherwise, start over
 1. Update `package.json` and `VERSION` file to use new version number
 1. git add/commit -m "Release v2.5.0-beta.2."
@@ -123,7 +123,7 @@ end
 
 ## On to the Beta Release…
 
-1. Check out `master` branch and pull to get latest `canary` on your local machine
+1. Check out `main` branch and pull to get latest `canary` on your local machine
 1. `nombom` and run those tests!
 1. Branch locally to `beta`
     1. `git checkout -b beta`
@@ -137,7 +137,7 @@ end
 
 ### Changelog
 
-1. `PRIOR_VERSION=v2.4.0-beta.1^ HEAD=master ./bin/changelog.js | uniq | pbcopy`
+1. `PRIOR_VERSION=v2.4.0-beta.1^ HEAD=main ./bin/changelog.js | uniq | pbcopy`
 1. Clean up changelog. Make sure the changelog from the stable release you just did is included.
 
 #### Tag & Release

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -6,7 +6,7 @@
 
 /*
  * This script generates the template a changelog by comparing a current version
- * with master. Run this, copy what's logged into the `CHANGELOG.md` and update
+ * with main. Run this, copy what's logged into the `CHANGELOG.md` and update
  * the top section based on the changes listed in "Community Contributions"
  *
  * Usage:


### PR DESCRIPTION
Saw that clicking on "see CONTRIBUTING" made github tell me that master was renamed to main so I thought I would update the links to point to `main`.

This is my first time looking at this project so I apologize in advance if I changed something erroneously.