### PR TITLE
Enable noImplicitOverride and add override keyword to properties/functions that are overridden.

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/outlet.ts
@@ -226,7 +226,7 @@ export function createRootOutlet(outletView: OutletView): OutletComponentDefinit
         return 'div';
       }
 
-      getCapabilities(): InternalComponentCapabilities {
+      override getCapabilities(): InternalComponentCapabilities {
         return WRAPPED_CAPABILITIES;
       }
 

--- a/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/root.ts
@@ -29,7 +29,7 @@ class RootComponentManager extends CurlyComponentManager {
     this.component = component;
   }
 
-  create(
+  override create(
     _owner: Owner,
     _state: unknown,
     _args: Nullable<VMArguments>,

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -843,7 +843,7 @@ class Component<S = unknown>
   declare [IS_DISPATCHING_ATTRS]: boolean;
   declare [DIRTY_TAG]: DirtyableTag;
 
-  init(properties?: object | undefined) {
+  override init(properties?: object | undefined) {
     super.init(properties);
 
     // Handle methods from ViewMixin.
@@ -921,13 +921,13 @@ class Component<S = unknown>
     return this.__dispatcher;
   }
 
-  on<Target>(
+  override on<Target>(
     name: string,
     target: Target,
     method: string | ((this: Target, ...args: any[]) => void)
   ): this;
-  on(name: string, method: ((...args: any[]) => void) | string): this;
-  on(name: string, target: any, method?: any) {
+  override on(name: string, method: ((...args: any[]) => void) | string): this;
+  override on(name: string, target: any, method?: any) {
     this._dispatcher?.setupHandlerForEmberEvent(name);
     // The `on` method here comes from the Evented mixin. Since this mixin
     // is applied to the parent of this class, however, we are still able
@@ -1177,7 +1177,7 @@ class Component<S = unknown>
 
   static isComponentFactory = true;
 
-  static toString() {
+  static override toString() {
     return '@ember/component';
   }
 }

--- a/packages/@ember/-internals/glimmer/lib/components/abstract-input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/abstract-input.ts
@@ -101,7 +101,7 @@ class ForkedValue implements Value {
 }
 
 export default abstract class AbstractInput extends InternalComponent {
-  validateArguments(): void {
+  override validateArguments(): void {
     assert(
       `The ${this.constructor} component does not take any positional arguments`,
       this.args.positional.length === 0
@@ -159,7 +159,7 @@ export default abstract class AbstractInput extends InternalComponent {
     }
   }
 
-  protected listenerFor(name: string): EventListener {
+  protected override listenerFor(name: string): EventListener {
     let listener = super.listenerFor(name);
 
     if (this.isVirtualEventListener(name, listener)) {

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -160,14 +160,14 @@ if (hasDOM) {
   @public
 */
 class _Input extends AbstractInput {
-  static toString(): string {
+  static override toString(): string {
     return 'Input';
   }
 
   /**
    * The HTML class attribute.
    */
-  get class(): string {
+  override get class(): string {
     if (this.isCheckbox) {
       return 'ember-checkbox ember-view';
     } else {
@@ -237,7 +237,7 @@ class _Input extends AbstractInput {
     this._checked.set(checked);
   }
 
-  @action change(event: Event): void {
+  @action override change(event: Event): void {
     if (this.isCheckbox) {
       this.checkedDidChange(event);
     } else {
@@ -245,7 +245,7 @@ class _Input extends AbstractInput {
     }
   }
 
-  @action input(event: Event): void {
+  @action override input(event: Event): void {
     if (!this.isCheckbox) {
       super.input(event);
     }
@@ -257,7 +257,7 @@ class _Input extends AbstractInput {
     this.checked = element.checked;
   }
 
-  protected isSupportedArgument(name: string): boolean {
+  protected override isSupportedArgument(name: string): boolean {
     let supportedArguments = [
       'type',
       'value',

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -275,13 +275,13 @@ function isQueryParams(value: unknown): value is QueryParams {
 **/
 
 class _LinkTo extends InternalComponent {
-  static toString(): string {
+  static override toString(): string {
     return 'LinkTo';
   }
 
   @service('-routing') private declare routing: RoutingService<Route>;
 
-  validateArguments(): void {
+  override validateArguments(): void {
     assert(
       'You attempted to use the <LinkTo> component within a routeless engine, this is not supported. ' +
         'If you are using the ember-engines addon, use the <LinkToExternal> component instead. ' +
@@ -305,7 +305,7 @@ class _LinkTo extends InternalComponent {
     super.validateArguments();
   }
 
-  get class(): string {
+  override get class(): string {
     let classes = 'ember-view';
 
     if (this.isActive) {
@@ -566,7 +566,7 @@ class _LinkTo extends InternalComponent {
     event.preventDefault();
   }
 
-  protected isSupportedArgument(name: string): boolean {
+  protected override isSupportedArgument(name: string): boolean {
     let supportedArguments = [
       'route',
       'model',

--- a/packages/@ember/-internals/glimmer/lib/components/textarea.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/textarea.ts
@@ -141,25 +141,25 @@ import { type OpaqueInternalComponentConstructor, opaquify } from './internal';
   @public
 **/
 class _Textarea extends AbstractInput {
-  static toString(): string {
+  static override toString(): string {
     return 'Textarea';
   }
 
-  get class(): string {
+  override get class(): string {
     return 'ember-text-area ember-view';
   }
 
   // See abstract-input.ts for why these are needed
 
-  @action change(event: Event): void {
+  @action override change(event: Event): void {
     super.change(event);
   }
 
-  @action input(event: Event): void {
+  @action override input(event: Event): void {
     super.input(event);
   }
 
-  protected isSupportedArgument(name: string): boolean {
+  protected override isSupportedArgument(name: string): boolean {
     let supportedArguments = ['type', 'value', 'enter', 'insert-newline', 'escape-press'];
     return supportedArguments.indexOf(name) !== -1 || super.isSupportedArgument(name);
   }

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -128,7 +128,7 @@ export default class Helper<S = unknown> extends FrameworkObject {
   // here to preserve the type param.
   private declare [SIGNATURE]: S;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
     this[RECOMPUTE_TAG] = createTag();
 

--- a/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/iterator.ts
@@ -179,7 +179,7 @@ class ObjectIterator extends BoundedIterator {
     return this.values[position];
   }
 
-  memoFor(position: number): unknown {
+  override memoFor(position: number): unknown {
     return this.keys[position];
   }
 }

--- a/packages/@ember/-internals/glimmer/lib/views/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/views/outlet.ts
@@ -27,7 +27,7 @@ const TOP_LEVEL_NAME = '-top-level';
 export default class OutletView {
   static extend(injections: any): typeof OutletView {
     return class extends OutletView {
-      static create(options: any) {
+      static override create(options: any) {
         if (options) {
           return super.create(Object.assign({}, injections, options));
         } else {

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -61,7 +61,7 @@ if (ENV._DEBUG_RENDER_TREE) {
         ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = true;
       }
 
-      teardown() {
+      override teardown() {
         super.teardown();
         ENV._TEMPLATE_ONLY_GLIMMER_COMPONENTS = this._TEMPLATE_ONLY_GLIMMER_COMPONENTS;
       }
@@ -85,7 +85,7 @@ if (ENV._DEBUG_RENDER_TREE) {
         });
 
         class PassThroughRoute extends Route {
-          model({ model }: { model: string }) {
+          override model({ model }: { model: string }) {
             return model;
           }
         }
@@ -197,9 +197,9 @@ if (ENV._DEBUG_RENDER_TREE) {
           'engine:foo',
           class extends Engine {
             isFooEngine = true;
-            Resolver = ModuleBasedTestResolver;
+            override Resolver = ModuleBasedTestResolver;
 
-            init(properties: object | undefined) {
+            override init(properties: object | undefined) {
               super.init(properties);
               this.register(
                 'template:application',
@@ -222,7 +222,7 @@ if (ENV._DEBUG_RENDER_TREE) {
               );
             }
 
-            buildInstance(options?: EngineInstanceOptions): EngineInstance {
+            override buildInstance(options?: EngineInstanceOptions): EngineInstance {
               let instance: EngineInstance & {
                 isFooEngineInstance?: boolean;
               } = super.buildInstance(options);
@@ -235,9 +235,9 @@ if (ENV._DEBUG_RENDER_TREE) {
         this.add(
           'engine:bar',
           class extends Engine {
-            Resolver = ModuleBasedTestResolver;
+            override Resolver = ModuleBasedTestResolver;
 
-            init(properties: object | undefined) {
+            override init(properties: object | undefined) {
               super.init(properties);
               this.register(
                 'template:application',
@@ -260,7 +260,7 @@ if (ENV._DEBUG_RENDER_TREE) {
               );
             }
 
-            buildInstance(options?: EngineInstanceOptions): EngineInstance {
+            override buildInstance(options?: EngineInstanceOptions): EngineInstance {
               let instance: EngineInstance & {
                 isBarEngineInstance?: boolean;
               } = super.buildInstance(options);
@@ -593,9 +593,9 @@ if (ENV._DEBUG_RENDER_TREE) {
           'engine:foo',
           class extends Engine {
             isFooEngine = true;
-            Resolver = ModuleBasedTestResolver;
+            override Resolver = ModuleBasedTestResolver;
 
-            init(properties: object | undefined) {
+            override init(properties: object | undefined) {
               super.init(properties);
               this.register(
                 'template:application',
@@ -626,7 +626,7 @@ if (ENV._DEBUG_RENDER_TREE) {
               );
             }
 
-            buildInstance(options?: EngineInstanceOptions): EngineInstance {
+            override buildInstance(options?: EngineInstanceOptions): EngineInstance {
               return (instance = super.buildInstance(options));
             }
           }

--- a/packages/@ember/-internals/metal/lib/alias.ts
+++ b/packages/@ember/-internals/metal/lib/alias.ts
@@ -67,7 +67,7 @@ export class AliasedProperty extends ComputedDescriptor {
     this.altKey = altKey;
   }
 
-  setup(obj: object, keyName: string, propertyDesc: PropertyDescriptor, meta: Meta): void {
+  override setup(obj: object, keyName: string, propertyDesc: PropertyDescriptor, meta: Meta): void {
     assert(`Setting alias '${keyName}' on self`, this.altKey !== keyName);
     super.setup(obj, keyName, propertyDesc, meta);
     CHAIN_PASS_THROUGH.add(this);

--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -319,7 +319,12 @@ export class ComputedProperty extends ComputedDescriptor {
     }
   }
 
-  setup(obj: object, keyName: string, propertyDesc: DecoratorPropertyDescriptor, meta: Meta) {
+  override setup(
+    obj: object,
+    keyName: string,
+    propertyDesc: DecoratorPropertyDescriptor,
+    meta: Meta
+  ) {
     super.setup(obj, keyName, propertyDesc, meta);
 
     assert(
@@ -543,7 +548,7 @@ export class ComputedProperty extends ComputedDescriptor {
   }
 
   /* called before property is overridden */
-  teardown(obj: object, keyName: string, meta: Meta): void {
+  override teardown(obj: object, keyName: string, meta: Meta): void {
     if (meta.revisionFor(keyName) !== undefined) {
       meta.setRevisionFor(keyName, undefined);
       meta.setValueFor(keyName, undefined);
@@ -554,7 +559,7 @@ export class ComputedProperty extends ComputedDescriptor {
 }
 
 class AutoComputedProperty extends ComputedProperty {
-  get(obj: object, keyName: string): unknown {
+  override get(obj: object, keyName: string): unknown {
     let meta = metaFor(obj);
     let tagMeta = tagMetaFor(obj);
 

--- a/packages/@ember/-internals/views/lib/system/event_dispatcher.ts
+++ b/packages/@ember/-internals/views/lib/system/event_dispatcher.ts
@@ -348,7 +348,7 @@ export default class EventDispatcher extends EmberObject {
     this.lazyEvents.delete(event);
   }
 
-  destroy() {
+  override destroy() {
     if (this._didSetup === false) {
       return;
     }
@@ -368,7 +368,7 @@ export default class EventDispatcher extends EmberObject {
     return this._super(...arguments);
   }
 
-  toString() {
+  override toString() {
     return '(EventDispatcher)';
   }
 }

--- a/packages/@ember/-internals/views/lib/views/core_view.ts
+++ b/packages/@ember/-internals/views/lib/views/core_view.ts
@@ -46,7 +46,7 @@ class CoreView extends FrameworkObject.extend(Evented, ActionHandler) {
   */
   declare parentView: View | null;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
 
     // Handle methods from Evented

--- a/packages/@ember/application/index.ts
+++ b/packages/@ember/application/index.ts
@@ -218,7 +218,7 @@ class Application extends Engine {
     @return {Ember.Registry} the built registry
     @private
   */
-  static buildRegistry(namespace: Application) {
+  static override buildRegistry(namespace: Application) {
     let registry = super.buildRegistry(namespace);
 
     commonSetupRegistry(registry);
@@ -228,12 +228,15 @@ class Application extends Engine {
     return registry;
   }
 
-  static initializer = buildInitializerMethod<'initializers', Application>(
+  static override initializer = buildInitializerMethod<'initializers', Application>(
     'initializers',
     'initializer'
   );
 
-  static instanceInitializer = buildInitializerMethod<'instanceInitializers', ApplicationInstance>(
+  // There is a bug with prettier when the line length overflows here, prettier tries
+  // wrapping the type incorrectly.
+  // prettier-ignore
+  static override instanceInitializer = buildInitializerMethod<'instanceInitializers', ApplicationInstance>(
     'instanceInitializers',
     'instance initializer'
   );
@@ -404,7 +407,7 @@ class Application extends Engine {
 
   declare _booted: boolean;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
 
     this.rootElement ??= 'body';
@@ -447,7 +450,7 @@ class Application extends Engine {
     @method buildInstance
     @return {ApplicationInstance} the application instance
   */
-  buildInstance(options: EngineInstanceOptions = {}): ApplicationInstance {
+  override buildInstance(options: EngineInstanceOptions = {}): ApplicationInstance {
     assert(
       'You cannot build new instances of this application since it has already been destroyed',
       !this.isDestroyed
@@ -960,7 +963,7 @@ class Application extends Engine {
   }
 
   // This method must be moved to the application instance object
-  willDestroy() {
+  override willDestroy() {
     super.willDestroy();
 
     if (_loaded['application'] === this) {

--- a/packages/@ember/application/instance.ts
+++ b/packages/@ember/application/instance.ts
@@ -61,7 +61,7 @@ class ApplicationInstance extends EngineInstance {
 
   declare customEvents: Record<string, string | null> | null;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
 
     this.application._watchInstance(this);
@@ -90,7 +90,7 @@ class ApplicationInstance extends EngineInstance {
 
     @private
   */
-  _bootSync(options?: BootOptions) {
+  override _bootSync(options?: BootOptions) {
     if (this._booted) {
       return this;
     }
@@ -120,7 +120,7 @@ class ApplicationInstance extends EngineInstance {
     return this;
   }
 
-  setupRegistry(options: BootOptions) {
+  override setupRegistry(options: BootOptions) {
     (this.constructor as typeof ApplicationInstance).setupRegistry(this.__registry__, options);
   }
 
@@ -288,7 +288,7 @@ class ApplicationInstance extends EngineInstance {
       .then(handleTransitionResolve, handleTransitionReject);
   }
 
-  willDestroy() {
+  override willDestroy() {
     super.willDestroy();
     this.application._unwatchInstance(this);
   }
@@ -299,7 +299,7 @@ class ApplicationInstance extends EngineInstance {
    @param {Registry} registry
    @param {BootOptions} options
   */
-  static setupRegistry(registry: Registry, options: BootOptions | _BootOptions = {}) {
+  static override setupRegistry(registry: Registry, options: BootOptions | _BootOptions = {}) {
     let coptions = options instanceof _BootOptions ? options : new _BootOptions(options);
 
     registry.register('-environment:main', coptions.toEnvironment(), {

--- a/packages/@ember/application/namespace.ts
+++ b/packages/@ember/application/namespace.ts
@@ -42,12 +42,12 @@ class Namespace extends EmberObject {
 
   declare isNamespace: true;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
     addNamespace(this);
   }
 
-  toString(): string {
+  override toString(): string {
     let existing_name = get(this, 'name') || get(this, 'modulePrefix');
     if (existing_name) {
       assert("name wasn't a string", typeof existing_name === 'string');
@@ -66,7 +66,7 @@ class Namespace extends EmberObject {
     processNamespace(this);
   }
 
-  destroy() {
+  override destroy() {
     removeNamespace(this);
     return super.destroy();
   }

--- a/packages/@ember/application/type-tests/index.test.ts
+++ b/packages/@ember/application/type-tests/index.test.ts
@@ -8,12 +8,12 @@ import { expectTypeOf } from 'expect-type';
 declare let owner: Owner;
 
 class App extends Application {
-  rootElement = '#ember-application';
-  customEvents = {
+  override rootElement = '#ember-application';
+  override customEvents = {
     mouseenter: null,
     paste: 'paste',
   };
-  ready(): this {
+  override ready(): this {
     // I'm ready!
     return this;
   }

--- a/packages/@ember/array/proxy.ts
+++ b/packages/@ember/array/proxy.ts
@@ -200,7 +200,7 @@ class ArrayProxy<T> extends EmberObject implements PropertyDidChange {
   /** @internal */
   _arrTag: Tag | null = null;
 
-  init(props: object | undefined) {
+  override init(props: object | undefined) {
     super.init(props);
 
     setCustomTagFor(this, customTagForArrayProxy);
@@ -210,7 +210,7 @@ class ArrayProxy<T> extends EmberObject implements PropertyDidChange {
     this._revalidate();
   }
 
-  willDestroy() {
+  override willDestroy() {
     this._removeArrangedContentArrayObserver();
   }
 

--- a/packages/@ember/component/type-tests/helper/index.test.ts
+++ b/packages/@ember/component/type-tests/helper/index.test.ts
@@ -13,21 +13,21 @@ let helper = new Helper(owner);
 expectTypeOf(helper).toMatchTypeOf<FrameworkObject>();
 
 class MyHelper extends Helper {
-  compute([cents]: [number], { currency }: { currency: string }) {
+  override compute([cents]: [number], { currency }: { currency: string }) {
     return `${currency}${cents * 0.01}`;
   }
 }
 new MyHelper(owner);
 
 class NoHash extends Helper {
-  compute([cents]: [number]): string {
+  override compute([cents]: [number]): string {
     return `${cents * 0.01}`;
   }
 }
 new NoHash(owner);
 
 class NoParams extends Helper {
-  compute(): string {
+  override compute(): string {
     return 'hello';
   }
 }

--- a/packages/@ember/debug/data-adapter.ts
+++ b/packages/@ember/debug/data-adapter.ts
@@ -444,7 +444,7 @@ export default class DataAdapter<T> extends EmberObject {
     @private
     @method willDestroy
   */
-  willDestroy() {
+  override willDestroy() {
     this._super(...arguments);
 
     this.typeWatchers.forEach((watcher) => watcher.release());

--- a/packages/@ember/engine/index.ts
+++ b/packages/@ember/engine/index.ts
@@ -330,7 +330,7 @@ class Engine extends Namespace.extend(RegistryProxyMixin) {
   */
   declare Resolver: ResolverClass;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
     this.buildRegistry();
   }

--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -82,7 +82,7 @@ class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerPro
 
   _booted = false;
 
-  init(properties: object | undefined) {
+  override init(properties: object | undefined) {
     super.init(properties);
 
     // Ensure the guid gets setup for this instance

--- a/packages/@ember/helper/type-tests/invoke-helper.test.ts
+++ b/packages/@ember/helper/type-tests/invoke-helper.test.ts
@@ -8,7 +8,7 @@ import { expectTypeOf } from 'expect-type';
 // NOTE: The types should probably be stricter, but they're from glimmer itself
 
 class PlusOne extends Helper {
-  compute([number]: [number]) {
+  override compute([number]: [number]) {
     return number + 1;
   }
 }

--- a/packages/@ember/object/-internals.ts
+++ b/packages/@ember/object/-internals.ts
@@ -32,7 +32,7 @@ if (DEBUG) {
   FrameworkObject = class DebugFrameworkObject extends EmberObject {
     [INIT_WAS_CALLED] = false;
 
-    init(properties: object | undefined) {
+    override init(properties: object | undefined) {
       super.init(properties);
       this[INIT_WAS_CALLED] = true;
     }

--- a/packages/@ember/routing/hash-location.ts
+++ b/packages/@ember/routing/hash-location.ts
@@ -41,7 +41,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
   private _location?: Location;
   declare location: Location;
 
-  init(): void {
+  override init(): void {
     this.location = this._location ?? window.location;
     this._hashchangeHandler = undefined;
   }
@@ -163,7 +163,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
     @private
     @method willDestroy
   */
-  willDestroy(): void {
+  override willDestroy(): void {
     this._removeEventListener();
   }
 

--- a/packages/@ember/routing/history-location.ts
+++ b/packages/@ember/routing/history-location.ts
@@ -88,7 +88,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     return getHash(this.location);
   }
 
-  init(): void {
+  override init(): void {
     this._super(...arguments);
 
     let base = document.querySelector('base');
@@ -275,7 +275,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
     @private
     @method willDestroy
   */
-  willDestroy(): void {
+  override willDestroy(): void {
     this._removeEventListener();
   }
 

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -1516,7 +1516,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     once(this._router, '_setOutlets');
   }
 
-  willDestroy() {
+  override willDestroy() {
     this.teardownViews();
   }
 

--- a/packages/@ember/routing/router-service.ts
+++ b/packages/@ember/routing/router-service.ts
@@ -80,7 +80,7 @@ class RouterService extends Service.extend(Evented) {
     return (this[ROUTER] = _router);
   }
 
-  willDestroy() {
+  override willDestroy() {
     super.willDestroy();
 
     this[ROUTER] = undefined;

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -829,7 +829,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     }
   }
 
-  willDestroy() {
+  override willDestroy() {
     if (this._toplevelView) {
       this._toplevelView.destroy();
       this._toplevelView = null;

--- a/packages/@ember/routing/type-tests/route/overrides.test.ts
+++ b/packages/@ember/routing/type-tests/route/overrides.test.ts
@@ -9,38 +9,38 @@ let owner = {} as Owner;
 class Foo {}
 
 class MyRoute extends Route<Foo> {
-  resetController(_controller: Controller, _isExiting: boolean, _transition: Transition): this {
+  override resetController(_controller: Controller, _isExiting: boolean, _transition: Transition): this {
     return this;
   }
 
   @action
-  willTransition(_transition: Transition) {}
+  override willTransition(_transition: Transition) {}
 
   @action
-  didTransition() {}
+  override didTransition() {}
 
   @action
-  loading(_transition: Transition, _route: Route<Foo>) {}
+  override loading(_transition: Transition, _route: Route<Foo>) {}
 
-  activate(_transition: Transition): void {}
+  override activate(_transition: Transition): void {}
 
-  deactivate(_transition?: Transition): void {}
+  override deactivate(_transition?: Transition): void {}
 
-  beforeModel(_transition: Transition): void {}
+  override beforeModel(_transition: Transition): void {}
 
-  afterModel(_transition: Transition): void {}
+  override afterModel(_transition: Transition): void {}
 
-  redirect(_transition: Transition): void {}
+  override redirect(_transition: Transition): void {}
 
-  model(_params: Record<string, unknown>, _transition: Transition): Foo | Promise<Foo> {
+  override model(_params: Record<string, unknown>, _transition: Transition): Foo | Promise<Foo> {
     return new Foo();
   }
 
-  setupController(_controller: Controller, _context: Foo, _transition?: Transition): void {}
+  override setupController(_controller: Controller, _context: Foo, _transition?: Transition): void {}
 
-  buildRouteInfoMetadata(): void {}
+  override buildRouteInfoMetadata(): void {}
 
-  serialize(_model: Foo | undefined, _params: string[]): { [key: string]: unknown } {
+  override serialize(_model: Foo | undefined, _params: string[]): { [key: string]: unknown } {
     return {};
   }
 }

--- a/packages/@ember/routing/type-tests/route/query-params.test.ts
+++ b/packages/@ember/routing/type-tests/route/query-params.test.ts
@@ -5,7 +5,7 @@ import Route from '@ember/routing/route';
 let owner = {} as Owner;
 
 class MyRoute extends Route {
-  queryParams = {
+  override queryParams = {
     page: {
       refreshModel: false,
       replace: false,

--- a/packages/@ember/routing/type-tests/route/send.test.ts
+++ b/packages/@ember/routing/type-tests/route/send.test.ts
@@ -6,7 +6,7 @@ class MyRoute extends Route {
   @action
   topLevel(_foo: number, _opt?: boolean) {}
 
-  actions = {
+  override actions = {
     nested(_foo: string, _opt?: number) {},
   };
 }

--- a/packages/ember-testing/lib/test/promise.ts
+++ b/packages/ember-testing/lib/test/promise.ts
@@ -16,7 +16,7 @@ export default class TestPromise<T> extends RSVP.Promise<T> {
     lastPromise = this;
   }
 
-  then<TResult1 = T, TResult2 = never>(
+  override then<TResult1 = T, TResult2 = never>(
     onFulfilled?: OnFulfilled<T, TResult1> | null,
     onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
     label?: string

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -61,7 +61,7 @@ class DeprecationAssert extends DebugAssert {
     super('deprecate', env);
   }
 
-  inject(): void {
+  override inject(): void {
     let w = window as ExtendedWindow;
     w.expectNoDeprecation = expectNoDeprecation = this.expectNoDeprecation.bind(this);
     w.expectNoDeprecationAsync = expectNoDeprecationAsync =
@@ -72,7 +72,7 @@ class DeprecationAssert extends DebugAssert {
     super.inject();
   }
 
-  restore(): void {
+  override restore(): void {
     super.restore();
     let w = window as ExtendedWindow;
     w.expectNoDeprecation = undefined;

--- a/packages/internal-test-helpers/lib/ember-dev/warning.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/warning.ts
@@ -35,7 +35,7 @@ class WarningAssert extends DebugAssert {
     super('warn', env);
   }
 
-  inject() {
+  override inject() {
     // Expects no warning to happen within a function, or if no function is
     // passed, from the time of calling until the end of the test.
     //
@@ -101,7 +101,7 @@ class WarningAssert extends DebugAssert {
     w.ignoreWarning = ignoreWarning;
   }
 
-  restore() {
+  override restore() {
     super.restore();
     let w = window as ExtendedWindow;
     w.expectWarning = null;

--- a/packages/internal-test-helpers/lib/test-cases/abstract-application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/abstract-application.ts
@@ -59,7 +59,7 @@ export default abstract class AbstractApplicationTestCase extends AbstractTestCa
     this._element = element;
   }
 
-  afterEach() {
+  override afterEach() {
     runDestroy(this.applicationInstance);
     runDestroy(this.application);
 

--- a/packages/internal-test-helpers/lib/test-cases/application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/application.ts
@@ -31,7 +31,7 @@ export default abstract class ApplicationTestCase extends TestResolverApplicatio
     return MyApplication.create(myOptions);
   }
 
-  get applicationOptions() {
+  override get applicationOptions() {
     return Object.assign(super.applicationOptions, {
       autoboot: false,
     });

--- a/packages/internal-test-helpers/lib/test-cases/autoboot-application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/autoboot-application.ts
@@ -23,7 +23,7 @@ export default abstract class AutobootApplicationTestCase extends TestResolverAp
     return application;
   }
 
-  visit(url: string) {
+  override visit(url: string) {
     return this.application.boot().then(() => {
       return this.applicationInstance!.visit(url);
     });

--- a/packages/internal-test-helpers/lib/test-cases/query-param.ts
+++ b/packages/internal-test-helpers/lib/test-cases/query-param.ts
@@ -20,7 +20,7 @@ export default abstract class QueryParamTestCase extends ApplicationTestCase {
     this.add(
       'location:test',
       class extends NoneLocation {
-        setURL(path: string) {
+        override setURL(path: string) {
           if (testCase.expectedReplaceURL) {
             testCase.assert.ok(false, 'pushState occurred but a replaceState was expected');
           }
@@ -67,7 +67,7 @@ export default abstract class QueryParamTestCase extends ApplicationTestCase {
     return this.applicationInstance!.lookup(`route:${name}`);
   }
 
-  get routerOptions() {
+  override get routerOptions() {
     return {
       location: 'test',
     };

--- a/packages/internal-test-helpers/lib/test-cases/rendering.ts
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.ts
@@ -116,7 +116,7 @@ export default abstract class RenderingTestCase extends AbstractTestCase {
     }
   }
 
-  afterEach() {
+  override afterEach() {
     try {
       if (this.component) {
         runDestroy(this.component);

--- a/packages/internal-test-helpers/lib/test-cases/router-non-application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/router-non-application.ts
@@ -101,7 +101,7 @@ export default class RouterNonApplicationTestCase extends AbstractTestCase {
     }
   }
 
-  afterEach() {
+  override afterEach() {
     try {
       if (this.component) {
         runDestroy(this.component);

--- a/packages/internal-test-helpers/lib/test-cases/test-resolver-application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/test-resolver-application.ts
@@ -7,7 +7,7 @@ import type { InternalFactory } from '@ember/-internals/owner';
 export default abstract class TestResolverApplicationTestCase extends AbstractApplicationTestCase {
   abstract resolver?: Resolver;
 
-  get applicationOptions() {
+  override get applicationOptions() {
     return Object.assign(super.applicationOptions, {
       Resolver: ModuleBasedResolver,
     });

--- a/tsconfig/compiler-options.json
+++ b/tsconfig/compiler-options.json
@@ -22,6 +22,7 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": false,
     "isolatedModules": true,
+    "noImplicitOverride": true,
 
     "newLine": "LF",
 


### PR DESCRIPTION
 Fixes GH-20604

This enables `noImplicitOverride` in TypeScript and adds the `override` keyword to all properties and functions that have been overridden.