### PR TITLE
Update the `@since` version for `getOwner` and `setOwner`

### DIFF
--- a/packages/@ember/-internals/owner/index.ts
+++ b/packages/@ember/-internals/owner/index.ts
@@ -550,7 +550,7 @@ export function getOwner(object: object): InternalOwner | undefined {
   @for @ember/owner
   @param {Object} object An object instance.
   @param {Owner} object The new owner object of the object instance.
-  @since 2.3.0
+  @since 4.10.0
   @public
 */
 export function setOwner(object: object, owner: Owner): void {

--- a/packages/@ember/owner/index.ts
+++ b/packages/@ember/owner/index.ts
@@ -77,7 +77,7 @@ import { type default as Owner, getOwner as internalGetOwner } from '@ember/-int
   @for @ember/owner
   @param {Object} object An object with an owner.
   @return {Object} An owner object.
-  @since 2.3.0
+  @since 4.10.0
   @public
 */
 // SAFETY: the cast here is necessary, instead of using an assignment, because


### PR DESCRIPTION
The `@ember/owner` package was introduced in v4.10, but the `@since` value was still refering to the `@ember/application` version.