### PR TITLE
Remove `escapeExpression` from `@ember/template`

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -456,7 +456,7 @@ export {
   type FunctionBasedHelper,
   type FunctionBasedHelperInstance,
 } from './lib/helper';
-export { SafeString, escapeExpression, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export { SafeString, htmlSafe, isHTMLSafe } from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/ember/barrel.ts
+++ b/packages/ember/barrel.ts
@@ -603,6 +603,7 @@ Reflect.set(Ember, 'RSVP', _RSVP);
 
 interface EmberHandlebars {
   template: typeof template;
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   Utils: {};
   compile?: typeof compile;
   precompile?: typeof precompile;

--- a/packages/ember/barrel.ts
+++ b/packages/ember/barrel.ts
@@ -603,9 +603,7 @@ Reflect.set(Ember, 'RSVP', _RSVP);
 
 interface EmberHandlebars {
   template: typeof template;
-  Utils: {
-    escapeExpression: typeof escapeExpression;
-  };
+  Utils: {};
   compile?: typeof compile;
   precompile?: typeof precompile;
 }
@@ -671,9 +669,7 @@ applicationRunLoadHooks('Ember.Application', EmberApplication);
 
 let EmberHandlebars: EmberHandlebars = {
   template,
-  Utils: {
-    escapeExpression,
-  },
+  Utils: {},
 };
 
 let EmberHTMLBars: EmberHTMLBars = {

--- a/packages/ember/barrel.ts
+++ b/packages/ember/barrel.ts
@@ -56,7 +56,6 @@ import {
   componentCapabilities,
   modifierCapabilities,
   setComponentManager,
-  escapeExpression,
   getTemplates,
   setTemplates,
   template,

--- a/packages/ember/tests/reexports_test.js
+++ b/packages/ember/tests/reexports_test.js
@@ -339,7 +339,6 @@ let allExports = [
     },
     test56,
   ],
-  ['Handlebars.Utils.escapeExpression', '@ember/-internals/glimmer', 'escapeExpression', test56],
   ['_Input', '@ember/-internals/glimmer', 'Input', test56],
   ['_RegistryProxyMixin', '@ember/-internals/runtime', 'RegistryProxyMixin', test57],
   ['_ContainerProxyMixin', '@ember/-internals/runtime', 'ContainerProxyMixin', test57],


### PR DESCRIPTION
Co-Authored-By: @chriskrycho

Rebase of: https://github.com/emberjs/ember.js/pull/20360


This also gets a mention here: https://github.com/emberjs/rfcs/pull/1003 :sweat_smile: (for migration docs)