### PR TITLE
[failing test] add test for adding/removing/re-adding modifier with `if`

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -267,6 +267,37 @@ moduleFor(
 
       this.assertCounts({ adds: 1, removes: 1 });
     }
+
+    [`@test can be set or unset dynamically multiple times on an element`](assert) {
+      let wasCalled = false;
+      let toggle = () => (wasCalled = !wasCalled);
+
+      this.render(
+        '<button {{(if this.bindClick (modifier this.on "click" this.toggle))}}></button>',
+        {
+          bindClick: false,
+          toggle,
+          on,
+        }
+      );
+
+      this.$('button').click();
+      assert.false(wasCalled);
+
+      runTask(() => this.context.set('bindClick', true));
+
+      this.$('button').click();
+      assert.true(wasCalled);
+
+      wasCalled = false;
+      runTask(() => this.context.set('bindClick', false));
+      this.$('button').click();
+      assert.false(wasCalled);
+
+      runTask(() => this.context.set('bindClick', true));
+      this.$('button').click();
+      assert.true(wasCalled);
+    }
   }
 );
 


### PR DESCRIPTION
This test currently fails if the modifier is inside an `(if)` statement, and if the condition changes from true -> false -> true.

It seems like somehow when the 3rd re-render to true happens, the `modifier` helper gets a clone of the first two positional arguments (the event name and the callback). The `modifier` helper gets 4 arguments when it should only be getting two. See the screenshot to see that the first two arguments are the same as the last two arguments:

<img width="763" alt="Screenshot 2024-01-24 at 21 13 54" src="https://github.com/emberjs/ember.js/assets/1275021/fd5845d6-b6d7-4633-bfb3-c49aeb8dfe1c">

This should work, but on 3.28.12 throws the following error message:

```
Uncaught (in promise) Error: You can only pass two positional arguments (event name and callback) to the `on` modifier, but you provided 4. Consider using the `fn` helper to provide additional arguments to the `on` callback.
    at OnModifierState.updateFromArgs (runtime.js:7277:1)
    at OnModifierManager.install (runtime.js:7486:1)
    at runtime.js:4840:1
    at track (validator.js:820:1)
    at TransactionImpl.commit (runtime.js:4839:1)
    at EnvironmentImpl.commit (runtime.js:4936:1)
    at inTransaction (runtime.js:4961:1)
    at Renderer._renderRoots (index.js:7779:1)
    at Renderer._renderRootsTransaction (index.js:7831:1)
    at Renderer._revalidate (index.js:7873:1)
```