### PR TITLE
Implement RFC#1006, Deprecate `(action)` and `{{action}}` 

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -97,6 +97,15 @@ export const DEPRECATIONS = {
     until: '6.0.0',
     url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-implicit-route-model',
   }),
+  DEPRECATE_TEMPLATE_ACTION: deprecation({
+    id: 'template-action',
+    url: 'https://deprecations.emberjs.com/id/template-action',
+    until: '6.0.0',
+    for: 'ember-source',
+    since: {
+      available: '5.9.0',
+    },
+  }),
 };
 
 export function deprecateUntil(message: string, deprecation: DeprecationObject) {

--- a/packages/@ember/-internals/glimmer/lib/helpers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/action.ts
@@ -4,6 +4,7 @@
 import { get } from '@ember/-internals/metal';
 import type { AnyFn } from '@ember/-internals/utility-types';
 import { assert } from '@ember/debug';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import { flaggedInstrument } from '@ember/instrumentation';
 import { join } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
@@ -278,6 +279,10 @@ export const ACTIONS = new WeakSet();
   @public
 */
 export default internalHelper((args: CapturedArguments): Reference<Function> => {
+  deprecateUntil(
+    `Usage of the \`(action)\` helper is deprecated. Migrate to native functions and function invocation.`,
+    DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION
+  );
   let { named, positional } = args;
   // The first two argument slots are reserved.
   // pos[0] is the context (or `this`)

--- a/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/action.ts
@@ -1,4 +1,5 @@
 import type { InternalOwner } from '@ember/-internals/owner';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import { uuid } from '@ember/-internals/utils';
 import { ActionManager, EventDispatcher, isSimpleClick } from '@ember/-internals/views';
 import { assert } from '@ember/debug';
@@ -204,6 +205,10 @@ class ActionModifierManager implements InternalModifierManager<ActionState, obje
   }
 
   install(actionState: ActionState): void {
+    deprecateUntil(
+      `Usage of the \`{{action}}\` modifier is deprecated. Migrate to native functions and function invocation.`,
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION
+    );
     let { element, actionId, positional } = actionState;
 
     let actionName;

--- a/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
@@ -4,6 +4,7 @@ import Controller from '@ember/controller';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
 
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 const originalDebug = getDebugFunction('debug');
 const noop = function () {};
@@ -14,6 +15,11 @@ moduleFor(
     constructor() {
       setDebugFunction('debug', noop);
       super(...arguments);
+
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
     }
 
     teardown() {
@@ -23,7 +29,7 @@ moduleFor(
     ['@test actions in top level template application template target application controller'](
       assert
     ) {
-      assert.expect(1);
+      assert.expect(2);
 
       this.add(
         'controller:application',
@@ -47,7 +53,7 @@ moduleFor(
     }
 
     ['@test actions in nested outlet template target their controller'](assert) {
-      assert.expect(1);
+      assert.expect(2);
 
       this.add(
         'controller:application',

--- a/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/actions-test.js
@@ -1,4 +1,10 @@
-import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
+import {
+  testUnless,
+  moduleFor,
+  ApplicationTestCase,
+  RenderingTestCase,
+  runTask,
+} from 'internal-test-helpers';
 
 import Controller from '@ember/controller';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
@@ -26,9 +32,9 @@ moduleFor(
       setDebugFunction('debug', originalDebug);
     }
 
-    ['@test actions in top level template application template target application controller'](
-      assert
-    ) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} actions in top level template application template target application controller`](assert) {
       assert.expect(2);
 
       this.add(
@@ -52,7 +58,9 @@ moduleFor(
       });
     }
 
-    ['@test actions in nested outlet template target their controller'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} actions in nested outlet template target their controller`](assert) {
       assert.expect(2);
 
       this.add(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -4,6 +4,7 @@ import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'inter
 import { isEmpty } from '@ember/utils';
 import { A as emberA } from '@ember/array';
 
+import { DEPRECATIONS } from '../../../../deprecations';
 import { Component } from '../../utils/helpers';
 
 moduleFor(
@@ -757,6 +758,11 @@ moduleFor(
     }
 
     ['@test renders with dot path and updates attributes'](assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.registerComponent('my-nested-component', {
         ComponentClass: Component.extend({
           didReceiveAttrs() {
@@ -839,6 +845,14 @@ moduleFor(
     ['@test parameters in a contextual component are mutable when value is a param'](assert) {
       // This checks that a `(mut)` is added to parameters and attributes to
       // contextual components when it is a param.
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.registerComponent('change-button', {
         ComponentClass: Component.extend().reopenClass({
@@ -889,6 +903,10 @@ moduleFor(
     }
 
     ['@test GH#13494 tagless blockless component with property binding'](assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.registerComponent('outer-component', {
         ComponentClass: Component.extend({
           message: 'hello',
@@ -1442,6 +1460,14 @@ class MutableParamTestGenerator {
   generate({ title, setup }) {
     return {
       [`@test parameters in a contextual component are mutable when value is a ${title}`](assert) {
+        expectDeprecation(
+          /Usage of the `\(action\)` helper is deprecated./,
+          DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+        );
+        expectDeprecation(
+          /Usage of the `\{\{action\}\}` modifier is deprecated./,
+          DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+        );
         this.registerComponent('change-button', {
           ComponentClass: Component.extend().reopenClass({
             positionalParams: ['val'],

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -2,6 +2,7 @@ import { DEBUG } from '@glimmer/env';
 import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'internal-test-helpers';
 
 import { isEmpty } from '@ember/utils';
+import { action } from '@ember/object';
 import { A as emberA } from '@ember/array';
 
 import { DEPRECATIONS } from '../../../../deprecations';
@@ -758,11 +759,6 @@ moduleFor(
     }
 
     ['@test renders with dot path and updates attributes'](assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       this.registerComponent('my-nested-component', {
         ComponentClass: Component.extend({
           didReceiveAttrs() {
@@ -779,18 +775,16 @@ moduleFor(
 
       this.registerComponent('my-action-component', {
         ComponentClass: Component.extend({
-          actions: {
-            changeValue() {
-              this.incrementProperty('myProp');
-            },
-          },
+          changeValue: action(function () {
+            this.incrementProperty('myProp');
+          }),
         }),
         template: strip`
         {{#my-component my-attr=this.myProp as |api|}}
           {{api.my-nested-component}}
         {{/my-component}}
         <br>
-        <button onclick={{action 'changeValue'}}>Change value</button>`,
+        <button onclick={{this.changeValue}}>Change value</button>`,
       });
 
       this.render('{{my-action-component myProp=this.model.myProp}}', {
@@ -845,21 +839,12 @@ moduleFor(
     ['@test parameters in a contextual component are mutable when value is a param'](assert) {
       // This checks that a `(mut)` is added to parameters and attributes to
       // contextual components when it is a param.
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       this.registerComponent('change-button', {
         ComponentClass: Component.extend().reopenClass({
           positionalParams: ['val'],
         }),
         template: strip`
-        <button {{action (action (mut this.val) 10)}} class="my-button">
+        <button {{on "click" (fn (mut this.val) 10)}} class="my-button">
           Change to 10
         </button>`,
       });
@@ -903,22 +888,16 @@ moduleFor(
     }
 
     ['@test GH#13494 tagless blockless component with property binding'](assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       this.registerComponent('outer-component', {
         ComponentClass: Component.extend({
           message: 'hello',
-          actions: {
-            change() {
-              this.set('message', 'goodbye');
-            },
-          },
+          change: action(function () {
+            this.set('message', 'goodbye');
+          }),
         }),
         template: strip`
         message: {{this.message}}{{inner-component message=this.message}}
-        <button onclick={{action "change"}} />`,
+        <button onclick={{this.change}} />`,
       });
 
       this.registerComponent('inner-component', {
@@ -1460,20 +1439,12 @@ class MutableParamTestGenerator {
   generate({ title, setup }) {
     return {
       [`@test parameters in a contextual component are mutable when value is a ${title}`](assert) {
-        expectDeprecation(
-          /Usage of the `\(action\)` helper is deprecated./,
-          DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-        );
-        expectDeprecation(
-          /Usage of the `\{\{action\}\}` modifier is deprecated./,
-          DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-        );
         this.registerComponent('change-button', {
           ComponentClass: Component.extend().reopenClass({
             positionalParams: ['val'],
           }),
           template: strip`
-          <button {{action (action (mut this.val) 10)}} class="my-button">
+          <button {{on "click" (fn (mut this.val) 10)}} class="my-button">
             Change to 10
           </button>`,
         });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -5,7 +5,6 @@ import { isEmpty } from '@ember/utils';
 import { action } from '@ember/object';
 import { A as emberA } from '@ember/array';
 
-import { DEPRECATIONS } from '../../../../deprecations';
 import { Component } from '../../utils/helpers';
 
 moduleFor(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -20,6 +20,7 @@ import { A as emberA } from '@ember/array';
 
 import { Component, compile, htmlSafe } from '../../utils/helpers';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Components test: curly components',
@@ -1427,6 +1428,11 @@ moduleFor(
       assert
     ) {
       let componentInstance = null;
+
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.registerComponent('non-block', {
         ComponentClass: Component.extend({
@@ -3149,6 +3155,11 @@ moduleFor(
     ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.registerComponent('display-toggle', {
         ComponentClass: Component.extend({
           actions: {
@@ -3174,7 +3185,12 @@ moduleFor(
     }
 
     ['@test returning `true` from an action bubbles to the `target` if specified'](assert) {
-      assert.expect(4);
+      assert.expect(5);
+
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.registerComponent('display-toggle', {
         ComponentClass: Component.extend({

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -7,8 +7,10 @@ import {
   equalsElement,
   runTask,
   runLoopSettled,
+  testUnless,
 } from 'internal-test-helpers';
 
+import { action } from '@ember/object';
 import { run } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import { tracked } from '@ember/-internals/metal';
@@ -1429,11 +1431,6 @@ moduleFor(
     ) {
       let componentInstance = null;
 
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       this.registerComponent('non-block', {
         ComponentClass: Component.extend({
           counter: computed({
@@ -1447,25 +1444,23 @@ moduleFor(
             componentInstance = this;
           },
 
-          actions: {
-            click() {
-              let currentCounter = this.get('counter');
+          myClick: action(function () {
+            let currentCounter = this.get('counter');
 
-              assert.equal(currentCounter, 0, 'the current `counter` value is correct');
+            assert.equal(currentCounter, 0, 'the current `counter` value is correct');
 
-              let newCounter = currentCounter + 1;
-              this.set('counter', newCounter);
+            let newCounter = currentCounter + 1;
+            this.set('counter', newCounter);
 
-              assert.equal(
-                this.get('counter'),
-                newCounter,
-                "getting the newly set `counter` property works; it's equal to the value we just set and not `undefined`"
-              );
-            },
-          },
+            assert.equal(
+              this.get('counter'),
+              newCounter,
+              "getting the newly set `counter` property works; it's equal to the value we just set and not `undefined`"
+            );
+          }),
         }),
         template: `
-          <button {{action "click"}}>foobar</button>
+          <button {{on "click" this.myClick}}>foobar</button>
         `,
       });
 
@@ -3152,7 +3147,9 @@ moduleFor(
       runTask(() => set(this.context, 'foo', 5));
     }
 
-    ['@test returning `true` from an action does not bubble if `target` is not specified (GH#14275)'](
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} returning \`true\` from an action does not bubble if \`target\` is not specified (GH#14275)`](
       assert
     ) {
       expectDeprecation(
@@ -3184,7 +3181,9 @@ moduleFor(
       runTask(() => this.$('button').click());
     }
 
-    ['@test returning `true` from an action bubbles to the `target` if specified'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} returning \`true\` from an action bubbles to the \`target\` if specified`](assert) {
       assert.expect(5);
 
       expectDeprecation(

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -5,6 +5,7 @@ import { set, computed } from '@ember/object';
 
 import { Component } from '../../utils/helpers';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Components test: dynamic components',
@@ -448,6 +449,11 @@ moduleFor(
           },
         }),
       });
+
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       let actionTriggered = 0;
       this.registerComponent('outer-component', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -1,5 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask, testUnless } from 'internal-test-helpers';
 
 import { set, computed } from '@ember/object';
 
@@ -430,7 +430,9 @@ moduleFor(
       this.assertText('foo-bar Caracas Caracas arepas!');
     }
 
-    ['@test component helper with actions'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} component helper with actions`](assert) {
       this.registerComponent('inner-component', {
         template: 'inner-component {{yield}}',
         ComponentClass: Component.extend({

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -1,12 +1,5 @@
-import {
-  moduleFor,
-  RenderingTestCase,
-  runDestroy,
-  runTask,
-  testUnless,
-} from 'internal-test-helpers';
-import { set } from '@ember/object';
-import { DEPRECATIONS } from '../../../../deprecations';
+import { moduleFor, RenderingTestCase, runDestroy, runTask } from 'internal-test-helpers';
+import { action, set } from '@ember/object';
 
 class InputRenderingTest extends RenderingTestCase {
   $input() {
@@ -287,24 +280,16 @@ moduleFor(
       // this.assertSelectionRange(8, 8); //NOTE: this fails in IE, the range is 0 -> 0 (TEST_SUITE=sauce)
     }
 
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
-    )} sends an action with \`<Input @enter={{action "foo"}} />\` when <enter> is pressed`](
+    [`@test sends an action with \`<Input @enter={{this.foo}} />\` when <enter> is pressed`](
       assert
     ) {
-      assert.expect(3);
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      assert.expect(2);
 
-      this.render(`<Input @enter={{action 'foo'}} />`, {
-        actions: {
-          foo(value, event) {
-            assert.ok(true, 'action was triggered');
-            assert.ok(event instanceof Event, 'Native event was passed');
-          },
-        },
+      this.render(`<Input @enter={{this.foo}} />`, {
+        foo: action(function (value, event) {
+          assert.ok(true, 'action was triggered');
+          assert.ok(event instanceof Event, 'Native event was passed');
+        }),
       });
 
       this.triggerEvent('keyup', {
@@ -327,24 +312,16 @@ moduleFor(
       });
     }
 
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
-    )} sends an action with \`<Input @escape-press={{action "foo"}} />\` when <escape> is pressed`](
+    ['@test sends an action with `<Input @escape-press={{this.foo}} />` when <escape> is pressed'](
       assert
     ) {
-      assert.expect(3);
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      assert.expect(2);
 
-      this.render(`<Input @escape-press={{action 'foo'}} />`, {
-        actions: {
-          foo(value, event) {
-            assert.ok(true, 'action was triggered');
-            assert.ok(event instanceof Event, 'Native event was passed');
-          },
-        },
+      this.render(`<Input @escape-press={{this.foo}} />`, {
+        foo: action(function (value, event) {
+          assert.ok(true, 'action was triggered');
+          assert.ok(event instanceof Event, 'Native event was passed');
+        }),
       });
 
       this.triggerEvent('keyup', { key: 'Escape' });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -1,5 +1,6 @@
 import { moduleFor, RenderingTestCase, runDestroy, runTask } from 'internal-test-helpers';
 import { set } from '@ember/object';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 class InputRenderingTest extends RenderingTestCase {
   $input() {
@@ -283,7 +284,11 @@ moduleFor(
     ['@test sends an action with `<Input @enter={{action "foo"}} />` when <enter> is pressed'](
       assert
     ) {
-      assert.expect(2);
+      assert.expect(3);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.render(`<Input @enter={{action 'foo'}} />`, {
         actions: {
@@ -300,7 +305,11 @@ moduleFor(
     }
 
     ['@test sends `insert-newline` when <enter> is pressed'](assert) {
-      assert.expect(2);
+      assert.expect(3);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.render(`<Input @insert-newline={{action 'foo'}} />`, {
         actions: {
@@ -319,7 +328,11 @@ moduleFor(
     ['@test sends an action with `<Input @escape-press={{action "foo"}} />` when <escape> is pressed'](
       assert
     ) {
-      assert.expect(2);
+      assert.expect(3);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.render(`<Input @escape-press={{action 'foo'}} />`, {
         actions: {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -1,4 +1,10 @@
-import { moduleFor, RenderingTestCase, runDestroy, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  runDestroy,
+  runTask,
+  testUnless,
+} from 'internal-test-helpers';
 import { set } from '@ember/object';
 import { DEPRECATIONS } from '../../../../deprecations';
 
@@ -281,7 +287,9 @@ moduleFor(
       // this.assertSelectionRange(8, 8); //NOTE: this fails in IE, the range is 0 -> 0 (TEST_SUITE=sauce)
     }
 
-    ['@test sends an action with `<Input @enter={{action "foo"}} />` when <enter> is pressed'](
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} sends an action with \`<Input @enter={{action "foo"}} />\` when <enter> is pressed`](
       assert
     ) {
       assert.expect(3);
@@ -305,18 +313,12 @@ moduleFor(
     }
 
     ['@test sends `insert-newline` when <enter> is pressed'](assert) {
-      assert.expect(3);
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      assert.expect(2);
 
-      this.render(`<Input @insert-newline={{action 'foo'}} />`, {
-        actions: {
-          foo(value, event) {
-            assert.ok(true, 'action was triggered');
-            assert.ok(event instanceof Event, 'Native event was passed');
-          },
+      this.render(`<Input @insert-newline={{this.foo}} />`, {
+        foo(value, event) {
+          assert.ok(true, 'action was triggered');
+          assert.ok(event instanceof Event, 'Native event was passed');
         },
       });
 
@@ -325,7 +327,9 @@ moduleFor(
       });
     }
 
-    ['@test sends an action with `<Input @escape-press={{action "foo"}} />` when <escape> is pressed'](
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} sends an action with \`<Input @escape-press={{action "foo"}} />\` when <escape> is pressed`](
       assert
     ) {
       assert.expect(3);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -1,4 +1,10 @@
-import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
+import {
+  RenderingTestCase,
+  moduleFor,
+  runDestroy,
+  runTask,
+  testUnless,
+} from 'internal-test-helpers';
 
 import { set } from '@ember/object';
 import { DEPRECATIONS } from '../../../../deprecations';
@@ -150,9 +156,9 @@ moduleFor(
       // this.assertSelectionRange(8, 8); //NOTE: this fails in IE, the range is 0 -> 0 (TEST_SUITE=sauce)
     }
 
-    ['@test sends an action with `{{input enter=(action "foo")}}` when <enter> is pressed'](
-      assert
-    ) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} sends an action with \`{{input enter=(action "foo")}}\` when <enter> is pressed`](assert) {
       assert.expect(3);
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
@@ -174,18 +180,11 @@ moduleFor(
     }
 
     ['@test sends `insert-newline` when <enter> is pressed'](assert) {
-      assert.expect(3);
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
-      this.render(`{{input insert-newline=(action 'foo')}}`, {
-        actions: {
-          foo(value, event) {
-            assert.ok(true, 'action was triggered');
-            assert.ok(event instanceof Event, 'Native event was passed');
-          },
+      assert.expect(2);
+      this.render(`{{input insert-newline=this.foo}}`, {
+        foo(value, event) {
+          assert.ok(true, 'action was triggered');
+          assert.ok(event instanceof Event, 'Native event was passed');
         },
       });
 
@@ -197,18 +196,11 @@ moduleFor(
     ['@test sends an action with `{{input escape-press=(action "foo")}}` when <escape> is pressed'](
       assert
     ) {
-      assert.expect(3);
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
-      this.render(`{{input escape-press=(action 'foo')}}`, {
-        actions: {
-          foo(value, event) {
-            assert.ok(true, 'action was triggered');
-            assert.ok(event instanceof Event, 'Native event was passed');
-          },
+      assert.expect(2);
+      this.render(`{{input escape-press=this.foo}}`, {
+        foo(value, event) {
+          assert.ok(true, 'action was triggered');
+          assert.ok(event instanceof Event, 'Native event was passed');
         },
       });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -1,13 +1,6 @@
-import {
-  RenderingTestCase,
-  moduleFor,
-  runDestroy,
-  runTask,
-  testUnless,
-} from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
-import { set } from '@ember/object';
-import { DEPRECATIONS } from '../../../../deprecations';
+import { action, set } from '@ember/object';
 
 class InputRenderingTest extends RenderingTestCase {
   $input() {
@@ -156,22 +149,14 @@ moduleFor(
       // this.assertSelectionRange(8, 8); //NOTE: this fails in IE, the range is 0 -> 0 (TEST_SUITE=sauce)
     }
 
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
-    )} sends an action with \`{{input enter=(action "foo")}}\` when <enter> is pressed`](assert) {
-      assert.expect(3);
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+    ['@test sends an action with `{{input enter=this.foo}}` when <enter> is pressed'](assert) {
+      assert.expect(2);
 
-      this.render(`{{input enter=(action 'foo')}}`, {
-        actions: {
-          foo(value, event) {
-            assert.ok(true, 'action was triggered');
-            assert.ok(event instanceof Event, 'Native event was passed');
-          },
-        },
+      this.render(`{{input enter=this.foo}}`, {
+        foo: action(function (value, event) {
+          assert.ok(true, 'action was triggered');
+          assert.ok(event instanceof Event, 'Native event was passed');
+        }),
       });
 
       this.triggerEvent('keyup', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -1,6 +1,7 @@
 import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/object';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 class InputRenderingTest extends RenderingTestCase {
   $input() {
@@ -152,7 +153,11 @@ moduleFor(
     ['@test sends an action with `{{input enter=(action "foo")}}` when <enter> is pressed'](
       assert
     ) {
-      assert.expect(2);
+      assert.expect(3);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.render(`{{input enter=(action 'foo')}}`, {
         actions: {
@@ -169,7 +174,11 @@ moduleFor(
     }
 
     ['@test sends `insert-newline` when <enter> is pressed'](assert) {
-      assert.expect(2);
+      assert.expect(3);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.render(`{{input insert-newline=(action 'foo')}}`, {
         actions: {
@@ -188,7 +197,11 @@ moduleFor(
     ['@test sends an action with `{{input escape-press=(action "foo")}}` when <escape> is pressed'](
       assert
     ) {
-      assert.expect(2);
+      assert.expect(3);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.render(`{{input escape-press=(action 'foo')}}`, {
         actions: {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -13,7 +13,6 @@ import { service } from '@ember/service';
 import Engine from '@ember/engine';
 import { DEBUG } from '@glimmer/env';
 import { compile } from '../../../utils/helpers';
-import { DEPRECATIONS } from '../../../../../deprecations';
 
 // IE includes the host name
 function normalizeUrl(url) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -13,6 +13,7 @@ import { service } from '@ember/service';
 import Engine from '@ember/engine';
 import { DEBUG } from '@glimmer/env';
 import { compile } from '../../../utils/helpers';
+import { DEPRECATIONS } from '../../../../../deprecations';
 
 // IE includes the host name
 function normalizeUrl(url) {
@@ -1027,6 +1028,10 @@ moduleFor(
     }
 
     async ['@test it defaults to bubbling'](assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.addTemplate(
         'about',
         `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -1028,14 +1028,10 @@ moduleFor(
     }
 
     async ['@test it defaults to bubbling'](assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       this.addTemplate(
         'about',
         `
-        <div {{action this.hide}}>
+        <div {{on "click" this.hide}}>
           <LinkTo id='about-contact' @route='about.contact'>About</LinkTo>
         </div>
         {{outlet}}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -13,6 +13,7 @@ import { service } from '@ember/service';
 import Engine from '@ember/engine';
 import { DEBUG } from '@glimmer/env';
 import { compile } from '../../../utils/helpers';
+import { DEPRECATIONS } from '../../../../../deprecations';
 
 // IE includes the host name
 function normalizeUrl(url) {
@@ -1097,6 +1098,11 @@ moduleFor(
     }
 
     async ['@test it defaults to bubbling'](assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.addTemplate(
         'about',
         `

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -13,7 +13,6 @@ import { service } from '@ember/service';
 import Engine from '@ember/engine';
 import { DEBUG } from '@glimmer/env';
 import { compile } from '../../../utils/helpers';
-import { DEPRECATIONS } from '../../../../../deprecations';
 
 // IE includes the host name
 function normalizeUrl(url) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -1098,15 +1098,10 @@ moduleFor(
     }
 
     async ['@test it defaults to bubbling'](assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       this.addTemplate(
         'about',
         `
-        <div {{action this.hide}}>
+        <div {{on "click" this.hide}}>
           <div id="about-contact">{{#link-to route='about.contact'}}About{{/link-to}}</div>
         </div>
         {{outlet}}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -137,25 +137,20 @@ moduleFor(
     }
 
     '@test tracked properties that are uninitialized do not throw an error'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class CountComponent extends Component {
+        @tracked count;
 
-      let CountComponent = Component.extend({
-        count: tracked(),
-
-        increment() {
+        increment = () => {
           if (!this.count) {
             this.count = 0;
           }
           this.count++;
-        },
-      });
+        };
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.count}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.count}}</button>',
       });
 
       this.render('<Counter />');
@@ -168,22 +163,17 @@ moduleFor(
     }
 
     '@test tracked properties rerender when updated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class CountComponent extends Component {
+        @tracked count = 0;
 
-      let CountComponent = Component.extend({
-        count: tracked({ value: 0 }),
-
-        increment() {
+        increment = () => {
           this.count++;
-        },
-      });
+        };
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.count}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.count}}</button>',
       });
 
       this.render('<Counter />');
@@ -196,26 +186,21 @@ moduleFor(
     }
 
     '@test tracked properties rerender when updated outside of a runloop'(assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       let done = assert.async();
 
-      let CountComponent = Component.extend({
-        count: tracked({ value: 0 }),
+      class CountComponent extends Component {
+        @tracked count = 0;
 
-        increment() {
+        increment = () => {
           setTimeout(() => {
             this.count++;
           }, 100);
-        },
-      });
+        };
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.count}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.count}}</button>',
       });
 
       this.render('<Counter />');
@@ -232,26 +217,19 @@ moduleFor(
     }
 
     '@test nested tracked properties rerender when updated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class Counter {
+        @tracked count = 0;
+      }
 
-      let Counter = EmberObject.extend({
-        count: tracked({ value: 0 }),
-      });
+      class CountComponent extends Component {
+        counter = new Counter();
 
-      let CountComponent = Component.extend({
-        counter: Counter.create(),
-
-        increment() {
-          this.counter.count++;
-        },
-      });
+        increment = () => this.counter.count++;
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.counter.count}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.counter.count}}</button>',
       });
 
       this.render('<Counter />');
@@ -264,23 +242,16 @@ moduleFor(
     }
 
     '@test array properties rerender when updated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class NumListComponent extends Component {
+        @tracked numbers = A([1, 2, 3]);
 
-      let NumListComponent = Component.extend({
-        numbers: tracked({ initializer: () => A([1, 2, 3]) }),
-
-        addNumber() {
-          this.numbers.pushObject(4);
-        },
-      });
+        addNumber = () => this.numbers.pushObject(4);
+      }
 
       this.registerComponent('num-list', {
         ComponentClass: NumListComponent,
         template: strip`
-            <button {{action this.addNumber}}>
+            <button {{on "click" this.addNumber}}>
               {{#each this.numbers as |num|}}{{num}}{{/each}}
             </button>
           `,
@@ -296,28 +267,19 @@ moduleFor(
     }
 
     '@test getters update when dependent properties are invalidated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class CountComponent extends Component {
+        @tracked count = 0;
 
-      let CountComponent = Component.extend({
-        count: tracked({ value: 0 }),
+        get countAlias() {
+          return this.count;
+        }
 
-        countAlias: descriptor({
-          get() {
-            return this.count;
-          },
-        }),
-
-        increment() {
-          this.count++;
-        },
-      });
+        increment = () => this.count++;
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.countAlias}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.countAlias}}</button>',
       });
 
       this.render('<Counter />');
@@ -330,36 +292,28 @@ moduleFor(
     }
 
     '@test getters update when dependent computeds are invalidated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class CountComponent extends Component {
+        @tracked _count = 0;
 
-      let CountComponent = Component.extend({
-        _count: 0,
-
-        count: computed({
+        @computed({
           get() {
             return this._count;
           },
-
-          set(key, value) {
+          set(_key, value) {
             return (this._count = value);
           },
-        }),
+        })
+        count;
 
         get countAlias() {
           return this.count;
-        },
-
-        increment() {
-          this.set('count', this.count + 1);
-        },
-      });
+        }
+        increment = () => this.set('count', this.count + 1);
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.countAlias}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.countAlias}}</button>',
       });
 
       this.render('<Counter />');
@@ -376,32 +330,23 @@ moduleFor(
     }
 
     '@test nested getters update when dependent properties are invalidated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class Counter {
+        @tracked count = 0;
 
-      let Counter = EmberObject.extend({
-        count: tracked({ value: 0 }),
+        get countAlias() {
+          return this.count;
+        }
+      }
 
-        countAlias: descriptor({
-          get() {
-            return this.count;
-          },
-        }),
-      });
+      class CountComponent extends Component {
+        counter = new Counter();
 
-      let CountComponent = Component.extend({
-        counter: Counter.create(),
-
-        increment() {
-          this.counter.count++;
-        },
-      });
+        increment = () => this.counter.count++;
+      }
 
       this.registerComponent('counter', {
         ComponentClass: CountComponent,
-        template: '<button {{action this.increment}}>{{this.counter.countAlias}}</button>',
+        template: '<button {{on "click" this.increment}}>{{this.counter.countAlias}}</button>',
       });
 
       this.render('<Counter />');
@@ -414,32 +359,25 @@ moduleFor(
     }
 
     '@test tracked object passed down through components updates correctly'(assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class Person {
+        @tracked first = 'Rob';
+        @tracked last = 'Jackson';
 
-      let Person = EmberObject.extend({
-        first: tracked({ value: 'Rob' }),
-        last: tracked({ value: 'Jackson' }),
+        get full() {
+          return `${this.first} ${this.last}`;
+        }
+      }
 
-        full: descriptor({
-          get() {
-            return `${this.first} ${this.last}`;
-          },
-        }),
-      });
+      class ParentComponent extends Component {
+        person = new Person();
+      }
 
-      let ParentComponent = Component.extend({
-        person: Person.create(),
-      });
-
-      let ChildComponent = Component.extend({
-        updatePerson() {
+      class ChildComponent extends Component {
+        updatePerson = () => {
           this.person.first = 'Kris';
           this.person.last = 'Selden';
-        },
-      });
+        };
+      }
 
       this.registerComponent('parent', {
         ComponentClass: ParentComponent,
@@ -453,7 +391,7 @@ moduleFor(
         ComponentClass: ChildComponent,
         template: strip`
             <div id="child">{{this.person.full}}</div>
-            <button onclick={{action this.updatePerson}}></button>
+            <button onclick={{this.updatePerson}}></button>
           `,
       });
 
@@ -469,31 +407,23 @@ moduleFor(
     }
 
     '@test yielded getters update correctly'() {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class PersonComponent extends Component {
+        @tracked first = 'Rob';
+        @tracked last = 'Jackson';
 
-      let PersonComponent = Component.extend({
-        first: tracked({ value: 'Rob' }),
-        last: tracked({ value: 'Jackson' }),
-
-        full: descriptor({
-          get() {
-            return `${this.first} ${this.last}`;
-          },
-        }),
-
-        updatePerson() {
+        get full() {
+          return `${this.first} ${this.last}`;
+        }
+        updatePerson = () => {
           this.first = 'Kris';
           this.last = 'Selden';
-        },
-      });
+        };
+      }
 
       this.registerComponent('person', {
         ComponentClass: PersonComponent,
         template: strip`
-            {{yield this.full (action this.updatePerson)}}
+            {{yield this.full this.updatePerson}}
           `,
       });
 
@@ -513,35 +443,27 @@ moduleFor(
     }
 
     '@test yielded nested getters update correctly'() {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+      class Person {
+        @tracked first = 'Rob';
+        @tracked last = 'Jackson';
 
-      let Person = EmberObject.extend({
-        first: tracked({ value: 'Rob' }),
-        last: tracked({ value: 'Jackson' }),
+        get full() {
+          return `${this.first} ${this.last}`;
+        }
+      }
+      class PersonComponent extends Component {
+        person = new Person();
 
-        full: descriptor({
-          get() {
-            return `${this.first} ${this.last}`;
-          },
-        }),
-      });
-
-      let PersonComponent = Component.extend({
-        person: Person.create(),
-
-        updatePerson() {
+        updatePerson = () => {
           this.person.first = 'Kris';
           this.person.last = 'Selden';
-        },
-      });
+        };
+      }
 
       this.registerComponent('person', {
         ComponentClass: PersonComponent,
         template: strip`
-            {{yield this.person (action this.updatePerson)}}
+            {{yield this.person this.updatePerson}}
           `,
       });
 
@@ -643,11 +565,6 @@ moduleFor(
     '@test downstream property changes do not invalidate upstream component getters/arguments'(
       assert
     ) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       let outerRenderCount = 0;
       let innerRenderCount = 0;
 
@@ -666,9 +583,9 @@ moduleFor(
           return this.args.count + this.count;
         }
 
-        updateInnerCount() {
+        updateInnerCount = () => {
           this.count++;
-        }
+        };
       }
 
       this.registerComponent('outer', {
@@ -678,7 +595,7 @@ moduleFor(
 
       this.registerComponent('inner', {
         ComponentClass: InnerComponent,
-        template: '<button {{action this.updateInnerCount}}>{{this.combinedCounts}}</button>',
+        template: '<button {{on "click" this.updateInnerCount}}>{{this.combinedCounts}}</button>',
       });
 
       this.render('<Outer @count={{this.count}}/>', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -8,6 +8,7 @@ import { Promise } from 'rsvp';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Component Tracked Properties',
@@ -136,6 +137,11 @@ moduleFor(
     }
 
     '@test tracked properties that are uninitialized do not throw an error'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let CountComponent = Component.extend({
         count: tracked(),
 
@@ -162,6 +168,11 @@ moduleFor(
     }
 
     '@test tracked properties rerender when updated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let CountComponent = Component.extend({
         count: tracked({ value: 0 }),
 
@@ -185,6 +196,11 @@ moduleFor(
     }
 
     '@test tracked properties rerender when updated outside of a runloop'(assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let done = assert.async();
 
       let CountComponent = Component.extend({
@@ -216,6 +232,11 @@ moduleFor(
     }
 
     '@test nested tracked properties rerender when updated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let Counter = EmberObject.extend({
         count: tracked({ value: 0 }),
       });
@@ -243,6 +264,11 @@ moduleFor(
     }
 
     '@test array properties rerender when updated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let NumListComponent = Component.extend({
         numbers: tracked({ initializer: () => A([1, 2, 3]) }),
 
@@ -270,6 +296,11 @@ moduleFor(
     }
 
     '@test getters update when dependent properties are invalidated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let CountComponent = Component.extend({
         count: tracked({ value: 0 }),
 
@@ -299,6 +330,11 @@ moduleFor(
     }
 
     '@test getters update when dependent computeds are invalidated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let CountComponent = Component.extend({
         _count: 0,
 
@@ -340,6 +376,11 @@ moduleFor(
     }
 
     '@test nested getters update when dependent properties are invalidated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let Counter = EmberObject.extend({
         count: tracked({ value: 0 }),
 
@@ -373,6 +414,11 @@ moduleFor(
     }
 
     '@test tracked object passed down through components updates correctly'(assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let Person = EmberObject.extend({
         first: tracked({ value: 'Rob' }),
         last: tracked({ value: 'Jackson' }),
@@ -423,6 +469,11 @@ moduleFor(
     }
 
     '@test yielded getters update correctly'() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let PersonComponent = Component.extend({
         first: tracked({ value: 'Rob' }),
         last: tracked({ value: 'Jackson' }),
@@ -462,6 +513,11 @@ moduleFor(
     }
 
     '@test yielded nested getters update correctly'() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let Person = EmberObject.extend({
         first: tracked({ value: 'Rob' }),
         last: tracked({ value: 'Jackson' }),
@@ -587,6 +643,11 @@ moduleFor(
     '@test downstream property changes do not invalidate upstream component getters/arguments'(
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let outerRenderCount = 0;
       let innerRenderCount = 0;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -2,13 +2,12 @@ import EmberObject from '@ember/object';
 import { A } from '@ember/array';
 import ArrayProxy from '@ember/array/proxy';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
-import { tracked, nativeDescDecorator as descriptor } from '@ember/-internals/metal';
+import { tracked } from '@ember/-internals/metal';
 import { computed, get, set } from '@ember/object';
 import { Promise } from 'rsvp';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 import { Component } from '../../utils/helpers';
-import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Component Tracked Properties',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -11,7 +11,6 @@ import {
 } from '@ember/-internals/views';
 
 import { Component } from '../../utils/helpers';
-import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'View tree tests',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -1,5 +1,6 @@
 import { moduleFor, ApplicationTestCase, RenderingTestCase, runTask } from 'internal-test-helpers';
 
+import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
 import {
   getRootViews,
@@ -40,20 +41,13 @@ moduleFor(
         template: '[{{this.id}}] {{#if this.isExpanded}}{{yield}}{{/if}}',
       });
 
-      let ToggleController = Controller.extend({
-        isExpanded: true,
+      class ToggleController extends Controller {
+        @tracked isExpanded = true;
 
-        actions: {
-          toggle: function () {
-            this.toggleProperty('isExpanded');
-          },
-        },
-      });
-
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
+        toggle = () => {
+          this.toggleProperty('isExpanded');
+        };
+      }
 
       this.add('controller:application', ToggleController);
 
@@ -70,7 +64,7 @@ moduleFor(
         {{/x-toggle}}
       {{/x-toggle}}
 
-      <button id="toggle-application" {{action "toggle"}}>Toggle</button>
+      <button id="toggle-application" {{on "click" this.toggle}}>Toggle</button>
 
       {{#if this.isExpanded}}
         {{x-toggle id="root-3"}}
@@ -82,9 +76,9 @@ moduleFor(
 
       this.add(
         'controller:index',
-        ToggleController.extend({
-          isExpanded: false,
-        })
+        class extends ToggleController {
+          @tracked isExpanded = false;
+        }
       );
 
       this.addTemplate(
@@ -100,7 +94,7 @@ moduleFor(
         {{/x-toggle}}
       {{/x-toggle}}
 
-      <button id="toggle-index" {{action "toggle"}}>Toggle</button>
+      <button id="toggle-index" {{on "click" this.toggle}}>Toggle</button>
 
       {{#if this.isExpanded}}
         {{x-toggle id="root-6"}}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/utils-test.js
@@ -10,6 +10,7 @@ import {
 } from '@ember/-internals/views';
 
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'View tree tests',
@@ -48,6 +49,11 @@ moduleFor(
           },
         },
       });
+
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
 
       this.add('controller:application', ToggleController);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -2,7 +2,6 @@ import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { Component } from '../utils/helpers';
 import { _getCurrentRunLoop } from '@ember/runloop';
-import { DEPRECATIONS } from '../../../deprecations';
 
 let canDataTransfer = Boolean(document.createEvent('HTMLEvents').dataTransfer);
 

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -2,6 +2,7 @@ import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { Component } from '../utils/helpers';
 import { _getCurrentRunLoop } from '@ember/runloop';
+import { DEPRECATIONS } from '../../../deprecations';
 
 let canDataTransfer = Boolean(document.createEvent('HTMLEvents').dataTransfer);
 
@@ -134,6 +135,11 @@ moduleFor(
     }
 
     ['@test case insensitive events'](assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let receivedEvent;
 
       this.registerComponent('x-bar', {
@@ -153,6 +159,10 @@ moduleFor(
     }
 
     ['@test case sensitive events'](assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let receivedEvent;
 
       this.registerComponent('x-bar', {

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -135,11 +135,6 @@ moduleFor(
     }
 
     ['@test case insensitive events'](assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       let receivedEvent;
 
       this.registerComponent('x-bar', {
@@ -148,7 +143,7 @@ moduleFor(
             receivedEvent = event;
           },
         }),
-        template: `<button id="is-done" onclick={{action this.clicked}}>my button</button>`,
+        template: `<button id="is-done" onclick={{this.clicked}}>my button</button>`,
       });
 
       this.render(`{{x-bar}}`);
@@ -159,10 +154,6 @@ moduleFor(
     }
 
     ['@test case sensitive events'](assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       let receivedEvent;
 
       this.registerComponent('x-bar', {
@@ -171,7 +162,7 @@ moduleFor(
             receivedEvent = event;
           },
         }),
-        template: `<button id="is-done" onClick={{action this.clicked}}>my button</button>`,
+        template: `<button id="is-done" onClick={{this.clicked}}>my button</button>`,
       });
 
       this.render(`{{x-bar}}`);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -4,11 +4,17 @@ import { _getCurrentRunLoop } from '@ember/runloop';
 import { set, computed } from '@ember/object';
 
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Helpers test: closure {{action}}',
   class extends RenderingTestCase {
     ['@test action should be called']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let outerActionCalled = false;
       let component;
 
@@ -47,6 +53,11 @@ moduleFor(
     }
 
     ['@test an error is triggered when bound action function is undefined']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.registerComponent('inner-component', {
         template: 'inner',
       });
@@ -60,6 +71,11 @@ moduleFor(
     }
 
     ['@test an error is triggered when bound action being passed in is a non-function']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.registerComponent('inner-component', {
         template: 'inner',
       });
@@ -76,6 +92,15 @@ moduleFor(
     }
 
     ['@test [#12718] a nice error is shown when a bound action function is undefined and it is passed as @foo']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.registerComponent('inner-component', {
         template:
           '<button id="inner-button" {{action (action @external-action)}}>Click me</button>',
@@ -91,6 +116,11 @@ moduleFor(
     }
 
     ['@test action value is returned']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let expectedValue = 'terrible tom';
       let returnedValue;
       let innerComponent;
@@ -131,6 +161,11 @@ moduleFor(
     }
 
     ['@test action should be called on the correct scope']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let innerComponent;
       let outerComponent;
       let actualComponent;
@@ -177,6 +212,11 @@ moduleFor(
     }
 
     ['@test arguments to action are passed, curry']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let first = 'mitch';
       let second = 'martin';
       let third = 'matt';
@@ -226,6 +266,11 @@ moduleFor(
     }
 
     ['@test `this` can be passed as an argument']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let value = {};
       let component;
       let innerComponent;
@@ -271,6 +316,11 @@ moduleFor(
     }
 
     ['@test arguments to action are bound']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let value = 'lazy leah';
 
       let innerComponent;
@@ -328,6 +378,11 @@ moduleFor(
     }
 
     ['@test array arguments are passed correctly to action']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let first = 'foo';
       let second = [3, 5];
       let third = [4, 9];
@@ -388,6 +443,11 @@ moduleFor(
     }
 
     ['@test mut values can be wrapped in actions, are settable']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let newValue = 'trollin trek';
 
       let innerComponent;
@@ -431,6 +491,11 @@ moduleFor(
     }
 
     ['@test mut values can be wrapped in actions, are settable with a curry']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let newValue = 'trollin trek';
 
       let innerComponent;
@@ -474,6 +539,11 @@ moduleFor(
     }
 
     ['@test action can create closures over actions']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let first = 'raging robert';
       let second = 'mild machty';
       let returnValue = 'butch brian';
@@ -526,6 +596,11 @@ moduleFor(
     }
 
     ['@test provides a helpful error if an action is not present']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let InnerComponent = Component.extend({});
 
       let OuterComponent = Component.extend({
@@ -554,6 +629,11 @@ moduleFor(
     }
 
     ['@test provides a helpful error if actions hash is not present']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let InnerComponent = Component.extend({});
 
       let OuterComponent = Component.extend({});
@@ -574,6 +654,11 @@ moduleFor(
     }
 
     ['@test action can create closures over actions with target']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let innerComponent;
       let actionCalled = false;
 
@@ -619,6 +704,11 @@ moduleFor(
     }
 
     ['@test value can be used with action over actions']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let newValue = 'yelping yehuda';
 
       let innerComponent;
@@ -667,6 +757,11 @@ moduleFor(
     }
 
     ['@test action will read the value of a first property']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let newValue = 'irate igor';
 
       let innerComponent;
@@ -710,6 +805,11 @@ moduleFor(
     }
 
     ['@test action will read the value of a curried first argument property']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let newValue = 'kissing kris';
 
       let innerComponent;
@@ -754,6 +854,11 @@ moduleFor(
     }
 
     ['@test action closure does not get auto-mut wrapped'](assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let first = 'raging robert';
       let second = 'mild machty';
       let returnValue = 'butch brian';
@@ -823,6 +928,11 @@ moduleFor(
     }
 
     ['@test action should be called within a run loop']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let innerComponent;
       let capturedRunLoop;
 
@@ -864,6 +974,11 @@ moduleFor(
     }
 
     ['@test closure action with `(mut undefinedThing)` works properly [GH#13959]']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let component;
 
       let ExampleComponent = Component.extend({
@@ -914,6 +1029,11 @@ moduleFor(
     ['@test closure actions does not cause component hooks to fire unnecessarily [GH#14305] [GH#14654]'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let clicked = 0;
       let didReceiveAttrsFired = 0;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/closure-action-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask, testUnless } from 'internal-test-helpers';
 
 import { _getCurrentRunLoop } from '@ember/runloop';
 import { set, computed } from '@ember/object';
@@ -9,7 +9,7 @@ import { DEPRECATIONS } from '../../../../deprecations';
 moduleFor(
   'Helpers test: closure {{action}}',
   class extends RenderingTestCase {
-    ['@test action should be called']() {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved)} action should be called`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -52,7 +52,9 @@ moduleFor(
       this.assert.ok(outerActionCalled, 'the action was called');
     }
 
-    ['@test an error is triggered when bound action function is undefined']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} an error is triggered when bound action function is undefined`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -70,7 +72,9 @@ moduleFor(
       }, /Action passed is null or undefined in \(action[^)]*\) from .*\./);
     }
 
-    ['@test an error is triggered when bound action being passed in is a non-function']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} an error is triggered when bound action being passed in is a non-function`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -91,7 +95,9 @@ moduleFor(
       }, /An action could not be made for `.*` in .*\. Please confirm that you are using either a quoted action name \(i\.e\. `\(action '.*'\)`\) or a function available in .*\./);
     }
 
-    ['@test [#12718] a nice error is shown when a bound action function is undefined and it is passed as @foo']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} [#12718] a nice error is shown when a bound action function is undefined and it is passed as @foo`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -115,7 +121,7 @@ moduleFor(
       }, /Action passed is null or undefined in \(action[^)]*\) from .*\./);
     }
 
-    ['@test action value is returned']() {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved)} action value is returned`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -160,7 +166,9 @@ moduleFor(
       this.assert.equal(returnedValue, expectedValue, 'action can return to caller');
     }
 
-    ['@test action should be called on the correct scope']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action should be called on the correct scope`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -211,7 +219,9 @@ moduleFor(
       this.assert.ok(actualComponent.isOuterComponent, 'action has the correct context');
     }
 
-    ['@test arguments to action are passed, curry']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} arguments to action are passed, curry`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -265,7 +275,9 @@ moduleFor(
       );
     }
 
-    ['@test `this` can be passed as an argument']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} \`this\` can be passed as an argument`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -315,7 +327,9 @@ moduleFor(
       this.assert.strictEqual(value, component, 'the component is passed at `this`');
     }
 
-    ['@test arguments to action are bound']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} arguments to action are bound`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -377,7 +391,9 @@ moduleFor(
       this.assert.strictEqual(actualArg, value, 'action has the correct first arg');
     }
 
-    ['@test array arguments are passed correctly to action']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} array arguments are passed correctly to action`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -442,7 +458,9 @@ moduleFor(
       this.assert.equal(actualThird, third, 'action has the correct third arg');
     }
 
-    ['@test mut values can be wrapped in actions, are settable']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} mut values can be wrapped in actions, are settable`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -490,7 +508,9 @@ moduleFor(
       this.assert.equal(outerComponent.get('outerMut'), newValue, 'mut value is set');
     }
 
-    ['@test mut values can be wrapped in actions, are settable with a curry']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} mut values can be wrapped in actions, are settable with a curry`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -538,7 +558,9 @@ moduleFor(
       this.assert.equal(outerComponent.get('outerMut'), newValue, 'mut value is set');
     }
 
-    ['@test action can create closures over actions']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action can create closures over actions`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -595,7 +617,9 @@ moduleFor(
       this.assert.equal(actualSecond, second, 'second argument is correct');
     }
 
-    ['@test provides a helpful error if an action is not present']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} provides a helpful error if an action is not present`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -628,7 +652,9 @@ moduleFor(
       }, /An action named 'doesNotExist' was not found in /);
     }
 
-    ['@test provides a helpful error if actions hash is not present']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} provides a helpful error if actions hash is not present`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -653,7 +679,9 @@ moduleFor(
       }, /An action named 'doesNotExist' was not found in /);
     }
 
-    ['@test action can create closures over actions with target']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action can create closures over actions with target`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -703,7 +731,9 @@ moduleFor(
       this.assert.ok(actionCalled, 'action called on otherComponent');
     }
 
-    ['@test value can be used with action over actions']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} value can be used with action over actions`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -756,7 +786,9 @@ moduleFor(
       this.assert.equal(actualValue, newValue, 'value is read');
     }
 
-    ['@test action will read the value of a first property']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action will read the value of a first property`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -804,7 +836,9 @@ moduleFor(
       this.assert.equal(actualValue, newValue, 'property is read');
     }
 
-    ['@test action will read the value of a curried first argument property']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action will read the value of a curried first argument property`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -853,7 +887,9 @@ moduleFor(
       this.assert.equal(actualValue, newValue, 'property is read');
     }
 
-    ['@test action closure does not get auto-mut wrapped'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action closure does not get auto-mut wrapped`](assert) {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -927,7 +963,9 @@ moduleFor(
       this.assert.equal(actualReturnedValue, returnValue, 'return value is present');
     }
 
-    ['@test action should be called within a run loop']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action should be called within a run loop`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -973,7 +1011,9 @@ moduleFor(
       this.assert.ok(capturedRunLoop, 'action is called within a run loop');
     }
 
-    ['@test closure action with `(mut undefinedThing)` works properly [GH#13959]']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} closure action with \`(mut undefinedThing)\` works properly [GH#13959]`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1026,7 +1066,9 @@ moduleFor(
       this.assertText('Click me');
     }
 
-    ['@test closure actions does not cause component hooks to fire unnecessarily [GH#14305] [GH#14654]'](
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} closure actions does not cause component hooks to fire unnecessarily [GH#14305] [GH#14654]`](
       assert
     ) {
       expectDeprecation(

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, strip, runTask, testUnless } from 'internal-test-helpers';
 
 import EmberObject, { set } from '@ember/object';
 import { A as emberA } from '@ember/array';
@@ -31,7 +31,9 @@ function getActionIds(element) {
 moduleFor(
   'Helpers test: element action',
   class extends RenderingTestCase {
-    ['@test it can call an action on its enclosing component']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it can call an action on its enclosing component`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -73,7 +75,9 @@ moduleFor(
       this.assert.equal(fooCallCount, 2, 'foo has been called 2 times');
     }
 
-    ['@test it can call an action with parameters']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it can call an action with parameters`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -125,7 +129,9 @@ moduleFor(
       this.assert.deepEqual(fooArgs, ['a', 'b'], 'foo has been called with an updated value');
     }
 
-    ['@test it should output a marker attribute with a guid']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should output a marker attribute with a guid`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -147,7 +153,9 @@ moduleFor(
       );
     }
 
-    ['@test it should allow alternative events to be handled']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should allow alternative events to be handled`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -177,7 +185,9 @@ moduleFor(
       this.assert.ok(showCalled, 'show action was called on mouseUp');
     }
 
-    ['@test inside a yield, the target points at the original target']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} inside a yield, the target points at the original target`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -226,7 +236,9 @@ moduleFor(
       this.assert.notOk(innerWatted, 'the inner target was not watted');
     }
 
-    ['@test it should allow a target to be specified']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should allow a target to be specified`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -267,7 +279,9 @@ moduleFor(
       this.assert.equal(targetWatted, true, 'the specified target was watted');
     }
 
-    ['@test it should lazily evaluate the target']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should lazily evaluate the target`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -322,7 +336,9 @@ moduleFor(
       this.assert.equal(secondEdit, 1);
     }
 
-    ['@test it should register an event handler']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should register an event handler`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -367,7 +383,9 @@ moduleFor(
       );
     }
 
-    ['@test it handles whitelisted bound modifier keys']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it handles whitelisted bound modifier keys`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -414,7 +432,9 @@ moduleFor(
       );
     }
 
-    ['@test it handles whitelisted bound modifier keys with current value']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it handles whitelisted bound modifier keys with current value`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -462,7 +482,9 @@ moduleFor(
       this.assert.equal(editHandlerWasCalled, false, 'the event handler was not called');
     }
 
-    ['@test should be able to use action more than once for the same event within a view']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} should be able to use action more than once for the same event within a view`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -536,7 +558,9 @@ moduleFor(
       this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
-    ['@test the event should not bubble if `bubbles=false` is passed']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} the event should not bubble if \`bubbles=false\` is passed`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -602,7 +626,9 @@ moduleFor(
       this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
-    ['@test the event should not bubble if `bubbles=false` is passed bound']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} the event should not bubble if \`bubbles=false\` is passed bound`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -669,7 +695,9 @@ moduleFor(
       this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
-    ['@test the bubbling depends on the bound parameter']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} the bubbling depends on the bound parameter`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -723,7 +751,9 @@ moduleFor(
       this.assert.equal(originalHandlerWasCalled, true, 'the click handler was called');
     }
 
-    ['@test multiple actions with bubbles=false for same event are called but prevent bubbling']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} multiple actions with bubbles=false for same event are called but prevent bubbling`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -767,7 +797,9 @@ moduleFor(
       this.assert.notOk(eventHandlerWasCalled, 'event did not bubble up');
     }
 
-    ['@test it should work properly in an #each block']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should work properly in an #each block`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -799,7 +831,9 @@ moduleFor(
       this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
     }
 
-    ['@test it should work properly in a {{#let foo as |bar|}} block']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should work properly in a {{#let foo as |bar|}} block`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -831,7 +865,9 @@ moduleFor(
       this.assert.equal(editHandlerWasCalled, true, 'the event handler was called');
     }
 
-    ['@test it should unregister event handlers when an element action is removed'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should unregister event handlers when an element action is removed`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -881,7 +917,9 @@ moduleFor(
       assert.ok(ActionManager.registeredActions[actionId], 'A new action is registered');
     }
 
-    ['@test it should capture events from child elements and allow them to trigger the action']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should capture events from child elements and allow them to trigger the action`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -914,7 +952,9 @@ moduleFor(
       );
     }
 
-    ['@test it should allow bubbling of events from action helper to original parent event']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should allow bubbling of events from action helper to original parent event`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -951,7 +991,9 @@ moduleFor(
       );
     }
 
-    ['@test it should not bubble an event from action helper to original parent event if `bubbles=false` is passed']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should not bubble an event from action helper to original parent event if \`bubbles=false\` is passed`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -986,7 +1028,9 @@ moduleFor(
       this.assert.notOk(originalHandlerWasCalled, 'the parent handler was not called');
     }
 
-    ['@test it should allow "send" as the action name (#594)']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should allow "send" as the action name (#594)`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1016,7 +1060,9 @@ moduleFor(
       this.assert.ok(sendHandlerWasCalled, 'the event handler was called');
     }
 
-    ['@test it should send the view, event, and current context to the action']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should send the view, event, and current context to the action`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1072,7 +1118,9 @@ moduleFor(
       this.assert.strictEqual(passedContext, aContext, 'the parameter is passed along');
     }
 
-    ['@test it should only trigger actions for the event they were registered on']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should only trigger actions for the event they were registered on`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1110,7 +1158,9 @@ moduleFor(
       this.assert.notOk(editHandlerWasCalled, 'the event handler was not called on mouseover');
     }
 
-    ['@test it should allow multiple contexts to be specified']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should allow multiple contexts to be specified`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1147,7 +1197,9 @@ moduleFor(
       );
     }
 
-    ['@test it should allow multiple contexts to be specified mixed with string args']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should allow multiple contexts to be specified mixed with string args`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1183,7 +1235,9 @@ moduleFor(
       );
     }
 
-    ['@test it should not trigger action with special clicks']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should not trigger action with special clicks`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1239,7 +1293,9 @@ moduleFor(
       checkClick('button', 4, false);
     }
 
-    ['@test it can trigger actions for keyboard events']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it can trigger actions for keyboard events`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1269,7 +1325,9 @@ moduleFor(
       this.assert.ok(showCalled, 'the action was called with keyup');
     }
 
-    ['@test a quoteless parameter should allow dynamic lookup of the actionName']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} a quoteless parameter should allow dynamic lookup of the actionName`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1333,7 +1391,9 @@ moduleFor(
       );
     }
 
-    ['@test a quoteless string parameter should resolve actionName, including path']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} a quoteless string parameter should resolve actionName, including path`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1398,7 +1458,9 @@ moduleFor(
       );
     }
 
-    ['@test a quoteless function parameter should be called, including arguments']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} a quoteless function parameter should be called, including arguments`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1431,7 +1493,9 @@ moduleFor(
       this.assert.equal(incomingArg, arg, 'argument passed');
     }
 
-    ['@test a quoteless parameter that does not resolve to a value asserts']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} a quoteless parameter that does not resolve to a value asserts`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1453,7 +1517,9 @@ moduleFor(
       }, 'You specified a quoteless path, `this.ohNoeNotValid`, to the {{action}} helper ' + 'which did not resolve to an action name (a string). ' + 'Perhaps you meant to use a quoted actionName? (e.g. {{action "ohNoeNotValid"}}).');
     }
 
-    ['@test allows multiple actions on a single element']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} allows multiple actions on a single element`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1497,7 +1563,9 @@ moduleFor(
       this.assert.ok(doubleClickActionWasCalled, 'the doubleClicked action was called');
     }
 
-    ['@test allows multiple actions for same event on a single element']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} allows multiple actions for same event on a single element`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1536,7 +1604,9 @@ moduleFor(
       this.assert.ok(clickAction2WasCalled, 'the second clicked action was called');
     }
 
-    ['@test it should respect preventDefault option if provided']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should respect preventDefault option if provided`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1564,7 +1634,9 @@ moduleFor(
       this.assert.equal(event.defaultPrevented, false, 'should not preventDefault');
     }
 
-    ['@test it should respect preventDefault option if provided bound']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should respect preventDefault option if provided bound`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1606,7 +1678,9 @@ moduleFor(
       this.assert.equal(event.defaultPrevented, true, 'should preventDefault');
     }
 
-    ['@test it should target the proper component when `action` is in yielded block [GH #12409]']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it should target the proper component when \`action\` is in yielded block [GH #12409]`]() {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1664,7 +1738,9 @@ moduleFor(
       this.assert.ok(innerClickCalled, 'the click was triggered');
     }
 
-    ['@test element action with (mut undefinedThing) works properly']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} element action with (mut undefinedThing) works properly`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1717,7 +1793,9 @@ moduleFor(
       this.assertText('Click me');
     }
 
-    ['@test it supports non-registered actions [GH#14888]']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} it supports non-registered actions [GH#14888]`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1742,7 +1820,9 @@ moduleFor(
       });
     }
 
-    ["@test action handler that shifts element attributes doesn't trigger multiple invocations"]() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} action handler that shifts element attributes doesn't trigger multiple invocations`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-action-test.js
@@ -5,6 +5,7 @@ import { A as emberA } from '@ember/array';
 import { ActionManager } from '@ember/-internals/views';
 
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 function getActionAttributes(element) {
   let attributes = element.attributes;
@@ -31,6 +32,11 @@ moduleFor(
   'Helpers test: element action',
   class extends RenderingTestCase {
     ['@test it can call an action on its enclosing component']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let fooCallCount = 0;
 
       let ExampleComponent = Component.extend({
@@ -68,6 +74,11 @@ moduleFor(
     }
 
     ['@test it can call an action with parameters']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let fooArgs = [];
       let component;
 
@@ -115,6 +126,11 @@ moduleFor(
     }
 
     ['@test it should output a marker attribute with a guid']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.render('<button {{action "show"}}>me the money</button>');
 
       let button = this.$('button');
@@ -132,6 +148,11 @@ moduleFor(
     }
 
     ['@test it should allow alternative events to be handled']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let showCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -157,6 +178,11 @@ moduleFor(
     }
 
     ['@test inside a yield, the target points at the original target']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let targetWatted = false;
       let innerWatted = false;
 
@@ -201,6 +227,11 @@ moduleFor(
     }
 
     ['@test it should allow a target to be specified']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let targetWatted = false;
 
       let TargetComponent = Component.extend({
@@ -237,6 +268,11 @@ moduleFor(
     }
 
     ['@test it should lazily evaluate the target']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let firstEdit = 0;
       let secondEdit = 0;
       let component;
@@ -287,6 +323,11 @@ moduleFor(
     }
 
     ['@test it should register an event handler']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let shortcutHandlerWasCalled = false;
 
@@ -327,6 +368,11 @@ moduleFor(
     }
 
     ['@test it handles whitelisted bound modifier keys']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let shortcutHandlerWasCalled = false;
 
@@ -369,6 +415,11 @@ moduleFor(
     }
 
     ['@test it handles whitelisted bound modifier keys with current value']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let component;
 
@@ -412,6 +463,11 @@ moduleFor(
     }
 
     ['@test should be able to use action more than once for the same event within a view']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let deleteHandlerWasCalled = false;
       let originalHandlerWasCalled = false;
@@ -481,6 +537,11 @@ moduleFor(
     }
 
     ['@test the event should not bubble if `bubbles=false` is passed']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let deleteHandlerWasCalled = false;
       let originalHandlerWasCalled = false;
@@ -542,6 +603,11 @@ moduleFor(
     }
 
     ['@test the event should not bubble if `bubbles=false` is passed bound']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let deleteHandlerWasCalled = false;
       let originalHandlerWasCalled = false;
@@ -604,6 +670,11 @@ moduleFor(
     }
 
     ['@test the bubbling depends on the bound parameter']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let originalHandlerWasCalled = false;
       let component;
@@ -653,6 +724,11 @@ moduleFor(
     }
 
     ['@test multiple actions with bubbles=false for same event are called but prevent bubbling']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let clickAction1WasCalled = false;
       let clickAction2WasCalled = false;
       let eventHandlerWasCalled = false;
@@ -692,6 +768,11 @@ moduleFor(
     }
 
     ['@test it should work properly in an #each block']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -719,6 +800,11 @@ moduleFor(
     }
 
     ['@test it should work properly in a {{#let foo as |bar|}} block']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -746,6 +832,11 @@ moduleFor(
     }
 
     ['@test it should unregister event handlers when an element action is removed'](assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let ExampleComponent = Component.extend({
         actions: {
           edit() {},
@@ -791,6 +882,11 @@ moduleFor(
     }
 
     ['@test it should capture events from child elements and allow them to trigger the action']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -819,6 +915,11 @@ moduleFor(
     }
 
     ['@test it should allow bubbling of events from action helper to original parent event']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let originalHandlerWasCalled = false;
 
@@ -851,6 +952,11 @@ moduleFor(
     }
 
     ['@test it should not bubble an event from action helper to original parent event if `bubbles=false` is passed']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
       let originalHandlerWasCalled = false;
 
@@ -881,6 +987,11 @@ moduleFor(
     }
 
     ['@test it should allow "send" as the action name (#594)']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let sendHandlerWasCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -906,6 +1017,11 @@ moduleFor(
     }
 
     ['@test it should send the view, event, and current context to the action']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let passedTarget;
       let passedContext;
       let targetThis;
@@ -957,6 +1073,11 @@ moduleFor(
     }
 
     ['@test it should only trigger actions for the event they were registered on']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let editHandlerWasCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -990,6 +1111,11 @@ moduleFor(
     }
 
     ['@test it should allow multiple contexts to be specified']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let passedContexts;
       let models = [EmberObject.create(), EmberObject.create()];
 
@@ -1022,6 +1148,11 @@ moduleFor(
     }
 
     ['@test it should allow multiple contexts to be specified mixed with string args']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let passedContexts;
       let model = EmberObject.create();
 
@@ -1053,6 +1184,11 @@ moduleFor(
     }
 
     ['@test it should not trigger action with special clicks']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let showCalled = false;
       let component;
 
@@ -1104,6 +1240,11 @@ moduleFor(
     }
 
     ['@test it can trigger actions for keyboard events']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let showCalled = false;
 
       let ExampleComponent = Component.extend({
@@ -1129,6 +1270,11 @@ moduleFor(
     }
 
     ['@test a quoteless parameter should allow dynamic lookup of the actionName']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let lastAction;
       let actionOrder = [];
       let component;
@@ -1188,6 +1334,11 @@ moduleFor(
     }
 
     ['@test a quoteless string parameter should resolve actionName, including path']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let lastAction;
       let actionOrder = [];
       let component;
@@ -1248,6 +1399,11 @@ moduleFor(
     }
 
     ['@test a quoteless function parameter should be called, including arguments']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let submitCalled = false;
       let incomingArg;
 
@@ -1276,6 +1432,11 @@ moduleFor(
     }
 
     ['@test a quoteless parameter that does not resolve to a value asserts']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let ExampleComponent = Component.extend({
         actions: {
           ohNoeNotValid() {},
@@ -1293,6 +1454,11 @@ moduleFor(
     }
 
     ['@test allows multiple actions on a single element']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let clickActionWasCalled = false;
       let doubleClickActionWasCalled = false;
 
@@ -1332,6 +1498,11 @@ moduleFor(
     }
 
     ['@test allows multiple actions for same event on a single element']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let clickAction1WasCalled = false;
       let clickAction2WasCalled = false;
 
@@ -1366,6 +1537,11 @@ moduleFor(
     }
 
     ['@test it should respect preventDefault option if provided']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let ExampleComponent = Component.extend({
         actions: {
           show() {},
@@ -1389,6 +1565,11 @@ moduleFor(
     }
 
     ['@test it should respect preventDefault option if provided bound']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let component;
 
       let ExampleComponent = Component.extend({
@@ -1426,6 +1607,11 @@ moduleFor(
     }
 
     ['@test it should target the proper component when `action` is in yielded block [GH #12409]']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let outerActionCalled = false;
       let innerClickCalled = false;
 
@@ -1479,6 +1665,11 @@ moduleFor(
     }
 
     ['@test element action with (mut undefinedThing) works properly']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let component;
 
       let ExampleComponent = Component.extend({
@@ -1527,6 +1718,11 @@ moduleFor(
     }
 
     ['@test it supports non-registered actions [GH#14888]']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       this.render(
         `
       {{#if this.show}}
@@ -1547,6 +1743,11 @@ moduleFor(
     }
 
     ["@test action handler that shifts element attributes doesn't trigger multiple invocations"]() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let actionCount = 0;
       let ExampleComponent = Component.extend({
         selected: false,

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -2,7 +2,6 @@ import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { Component } from '../../utils/helpers';
-import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Helpers test: {{fn}}',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -136,13 +136,12 @@ moduleFor(
     }
 
     '@test can use `this` if bound prior to passing to fn'(assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-      this.render(`{{stash stashedFn=(fn (action this.myFunc) this.arg1)}}`, {
+      this.render(`{{stash stashedFn=(fn this.myFunc2 this.arg1)}}`, {
         myFunc(arg1) {
           return `arg1: ${arg1}, arg2: ${this.arg2}`;
+        },
+        get myFunc2() {
+          return this.myFunc.bind(this);
         },
 
         arg1: 'foo',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -2,6 +2,7 @@ import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Helpers test: {{fn}}',
@@ -135,6 +136,10 @@ moduleFor(
     }
 
     '@test can use `this` if bound prior to passing to fn'(assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.render(`{{stash stashedFn=(fn (action this.myFunc) this.arg1)}}`, {
         myFunc(arg1) {
           return `arg1: ${arg1}, arg2: ${this.arg2}`;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -3,6 +3,7 @@ import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { set, get } from '@ember/object';
 
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Helpers test: {{readonly}}',
@@ -37,7 +38,12 @@ moduleFor(
     }
 
     '@test passing an action to {{readonly}} avoids mutable cell wrapping'(assert) {
-      assert.expect(4);
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
+      assert.expect(5);
       let outer, inner;
 
       this.registerComponent('x-inner', {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/readonly-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask, testUnless } from 'internal-test-helpers';
 
 import { set, get } from '@ember/object';
 
@@ -37,7 +37,9 @@ moduleFor(
       // No U-R
     }
 
-    '@test passing an action to {{readonly}} avoids mutable cell wrapping'(assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} passing an action to {{readonly}} avoids mutable cell wrapping`](assert) {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -10,7 +10,6 @@ import Service, { service } from '@ember/service';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { Component } from '../../utils/helpers';
-import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Helper Tracked Properties',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -16,24 +16,19 @@ moduleFor(
   'Helper Tracked Properties',
   class extends RenderingTestCase {
     '@test tracked properties rerender when updated'(assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       let computeCount = 0;
 
-      let PersonComponent = Component.extend({
-        name: tracked({ value: 'bob' }),
-
-        updateName() {
+      class PersonComponent extends Component {
+        @tracked name = 'bob';
+        updateName = () => {
           this.name = 'sal';
-        },
-      });
+        };
+      }
 
       this.registerComponent('person', {
         ComponentClass: PersonComponent,
         template: strip`
-            <button onclick={{action this.updateName}}>
+            <button onclick={{this.updateName}}>
               {{hello-world this.name}}
             </button>
           `,
@@ -97,32 +92,25 @@ moduleFor(
     }
 
     '@test getters update when dependent properties are invalidated'(assert) {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       let computeCount = 0;
 
-      let PersonComponent = Component.extend({
-        first: tracked({ value: 'Rob' }),
-        last: tracked({ value: 'Jackson' }),
+      class PersonComponent extends Component {
+        @tracked first = 'Rob';
+        @tracked last = 'Jackson';
+        get full() {
+          return `${this.first} ${this.last}`;
+        }
 
-        full: descriptor({
-          get() {
-            return `${this.first} ${this.last}`;
-          },
-        }),
-
-        updatePerson() {
+        updatePerson = () => {
           this.first = 'Kris';
           this.last = 'Selden';
-        },
-      });
+        };
+      }
 
       this.registerComponent('person', {
         ComponentClass: PersonComponent,
         template: strip`
-            <button onclick={{action this.updatePerson}}>
+            <button onclick={{this.updatePerson}}>
               {{hello-world this.full}}
             </button>
           `,
@@ -153,22 +141,18 @@ moduleFor(
     }
 
     '@test array properties rerender when updated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-      let NumListComponent = Component.extend({
-        numbers: tracked({ initializer: () => A([1, 2, 3]) }),
+      class NumListComponent extends Component {
+        @tracked numbers = A([1, 2, 3]);
 
-        addNumber() {
+        addNumber = () => {
           this.numbers.pushObject(4);
-        },
-      });
+        };
+      }
 
       this.registerComponent('num-list', {
         ComponentClass: NumListComponent,
         template: strip`
-            <button {{action this.addNumber}}>
+            <button {{on "click" this.addNumber}}>
               {{join this.numbers}}
             </button>
           `,
@@ -188,10 +172,6 @@ moduleFor(
     }
 
     '@test custom ember array properties rerender when updated'() {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       let CustomArray = EmberObject.extend(MutableArray, {
         init() {
           this._super(...arguments);
@@ -216,18 +196,18 @@ moduleFor(
         },
       });
 
-      let NumListComponent = Component.extend({
-        numbers: tracked({ initializer: () => CustomArray.create() }),
+      class NumListComponent extends Component {
+        @tracked numbers = CustomArray.create();
 
-        addNumber() {
+        addNumber = () => {
           this.numbers.pushObject(4);
-        },
-      });
+        };
+      }
 
       this.registerComponent('num-list', {
         ComponentClass: NumListComponent,
         template: strip`
-            <button {{action this.addNumber}}>
+            <button {{on "click" this.addNumber}}>
               {{join this.numbers}}
             </button>
           `,

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -10,11 +10,16 @@ import Service, { service } from '@ember/service';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { Component } from '../../utils/helpers';
+import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Helper Tracked Properties',
   class extends RenderingTestCase {
     '@test tracked properties rerender when updated'(assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let computeCount = 0;
 
       let PersonComponent = Component.extend({
@@ -92,6 +97,10 @@ moduleFor(
     }
 
     '@test getters update when dependent properties are invalidated'(assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let computeCount = 0;
 
       let PersonComponent = Component.extend({
@@ -144,6 +153,10 @@ moduleFor(
     }
 
     '@test array properties rerender when updated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let NumListComponent = Component.extend({
         numbers: tracked({ initializer: () => A([1, 2, 3]) }),
 
@@ -175,6 +188,10 @@ moduleFor(
     }
 
     '@test custom ember array properties rerender when updated'() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let CustomArray = EmberObject.extend(MutableArray, {
         init() {
           this._super(...arguments);

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -1,4 +1,5 @@
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../deprecations';
 
 import { set } from '@ember/object';
 
@@ -202,6 +203,10 @@ moduleFor(
     }
 
     ['@test GH18211 input checked attribute, without a value, works with the action helper']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.render(`<input type="checkbox" checked {{action "someAction"}}>`, {
         actions: { someAction() {} },
       });
@@ -209,6 +214,10 @@ moduleFor(
     }
 
     ['@test GH18211 input checked attribute, with a value, works with the action helper']() {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.render(`<input type="checkbox" checked={{true}} {{action "someAction"}}>`, {
         actions: { someAction() {} },
       });
@@ -216,6 +225,10 @@ moduleFor(
     }
 
     ['@test GH18211 input checked attribute, without a value, works with attributes with values']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.render(`<input type="checkbox" checked click={{action "someAction"}}>`, {
         actions: { someAction() {} },
       });
@@ -223,6 +236,10 @@ moduleFor(
     }
 
     ['@test GH18211 input checked attribute, without a value, works with event attributes']() {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.render(`<input type="checkbox" checked onclick={{action "someAction"}}>`, {
         actions: { someAction() {} },
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
+import { testUnless, RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { DEPRECATIONS } from '../../../deprecations';
 
 import { set } from '@ember/object';
@@ -202,7 +202,9 @@ moduleFor(
       this.assertValue('hola', 'Value is used');
     }
 
-    ['@test GH18211 input checked attribute, without a value, works with the action helper']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} GH18211 input checked attribute, without a value, works with the action helper`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -213,7 +215,9 @@ moduleFor(
       this.assertPropertyHasValue('checked', true);
     }
 
-    ['@test GH18211 input checked attribute, with a value, works with the action helper']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} GH18211 input checked attribute, with a value, works with the action helper`]() {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -225,24 +229,12 @@ moduleFor(
     }
 
     ['@test GH18211 input checked attribute, without a value, works with attributes with values']() {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-      this.render(`<input type="checkbox" checked click={{action "someAction"}}>`, {
-        actions: { someAction() {} },
-      });
+      this.render(`<input type="checkbox" checked>`, {});
       this.assertPropertyHasValue('checked', true);
     }
 
     ['@test GH18211 input checked attribute, without a value, works with event attributes']() {
-      expectDeprecation(
-        /Usage of the `\(action\)` helper is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-      this.render(`<input type="checkbox" checked onclick={{action "someAction"}}>`, {
-        actions: { someAction() {} },
-      });
+      this.render(`<input type="checkbox" checked>`, {});
       this.assertPropertyHasValue('checked', true);
     }
 

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import EmberObject from '@ember/object';
 import { RSVP, onerrorDefault } from '@ember/-internals/runtime';
 import { later } from '@ember/runloop';
+import { action } from '@ember/object';
 import Application from '@ember/application';
 import ApplicationInstance from '@ember/application/instance';
 import Engine from '@ember/engine';
@@ -15,7 +16,6 @@ import Route from '@ember/routing/route';
 import { Component, helper, isSerializationFirstNode } from '@ember/-internals/glimmer';
 import { compile } from 'ember-template-compiler';
 import { ENV } from '@ember/-internals/environment';
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 function expectAsyncError() {
   RSVP.off('error');
@@ -626,10 +626,6 @@ moduleFor(
     }
 
     [`@test Ember Islands-style setup`](assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       let xFooInitCalled = false;
       let xFooDidInsertElementCalled = false;
 
@@ -708,7 +704,7 @@ moduleFor(
         'components/x-bar',
         `
         <h1>X-Bar</h1>
-        <button {{action "incrementCounter"}}>Join {{this.counter.value}} others in clicking me!</button>
+        <button {{on "click" this.incrementCounter}}>Join {{this.counter.value}} others in clicking me!</button>
         `
       );
 
@@ -717,11 +713,9 @@ moduleFor(
         Component.extend({
           counter: service('sharedCounter'),
 
-          actions: {
-            incrementCounter() {
-              this.get('counter').increment();
-            },
-          },
+          incrementCounter: action(function () {
+            this.get('counter').increment();
+          }),
 
           init() {
             this._super();

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -15,6 +15,7 @@ import Route from '@ember/routing/route';
 import { Component, helper, isSerializationFirstNode } from '@ember/-internals/glimmer';
 import { compile } from 'ember-template-compiler';
 import { ENV } from '@ember/-internals/environment';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 function expectAsyncError() {
   RSVP.off('error');
@@ -625,6 +626,10 @@ moduleFor(
     }
 
     [`@test Ember Islands-style setup`](assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let xFooInitCalled = false;
       let xFooDidInsertElementCalled = false;
 

--- a/packages/@ember/canary-features/index.ts
+++ b/packages/@ember/canary-features/index.ts
@@ -62,5 +62,5 @@ export function isEnabled(feature: string): boolean {
 
 //   return value;
 // }
-
+//
 // export const FLAG_NAME = featureValue(FEATURES.FLAG_NAME);

--- a/packages/@ember/object/tests/action_test.js
+++ b/packages/@ember/object/tests/action_test.js
@@ -1,17 +1,12 @@
 import { Component } from '@ember/-internals/glimmer';
 import EmberObject, { action } from '@ember/object';
-import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, testUnless } from 'internal-test-helpers';
 import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   '@action decorator',
   class extends RenderingTestCase {
     '@test action decorator works with ES6 class'(assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       class FooComponent extends Component {
         @action
         foo() {
@@ -21,7 +16,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooComponent,
-        template: "<button {{action 'foo'}}>Click Me!</button>",
+        template: "<button {{on 'click' this.foo}}>Click Me!</button>",
       });
 
       this.render('{{foo-bar}}');
@@ -54,7 +49,9 @@ moduleFor(
       assert.equal(typeof bar.actions.bar, 'function', 'bar has bar action');
     }
 
-    '@test actions are properly merged through traditional and ES6 prototype hierarchy'(assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} actions are properly merged through traditional and ES6 prototype hierarchy`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -107,11 +104,6 @@ moduleFor(
     }
 
     '@test action decorator super works with native class methods'(assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       class FooComponent extends Component {
         foo() {
           assert.ok(true, 'called!');
@@ -127,7 +119,7 @@ moduleFor(
 
       this.registerComponent('bar-bar', {
         ComponentClass: BarComponent,
-        template: "<button {{action 'foo'}}>Click Me!</button>",
+        template: "<button {{on 'click' this.foo}}>Click Me!</button>",
       });
 
       this.render('{{bar-bar}}');
@@ -136,11 +128,6 @@ moduleFor(
     }
 
     '@test action decorator super works with traditional class methods'(assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       let FooComponent = Component.extend({
         foo() {
           assert.ok(true, 'called!');
@@ -156,7 +143,7 @@ moduleFor(
 
       this.registerComponent('bar-bar', {
         ComponentClass: BarComponent,
-        template: "<button {{action 'foo'}}>Click Me!</button>",
+        template: "<button {{on 'click' this.foo}}>Click Me!</button>",
       });
 
       this.render('{{bar-bar}}');
@@ -259,11 +246,6 @@ moduleFor(
     }
 
     '@test action decorator can be used as a classic decorator with strings'(assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
-
       let FooComponent = Component.extend({
         foo: action(function () {
           assert.ok(true, 'called!');
@@ -272,7 +254,7 @@ moduleFor(
 
       this.registerComponent('foo-bar', {
         ComponentClass: FooComponent,
-        template: "<button {{action 'foo'}}>Click Me!</button>",
+        template: "<button {{on 'click' this.foo}}>Click Me!</button>",
       });
 
       this.render('{{foo-bar}}');

--- a/packages/@ember/object/tests/action_test.js
+++ b/packages/@ember/object/tests/action_test.js
@@ -1,11 +1,17 @@
 import { Component } from '@ember/-internals/glimmer';
 import EmberObject, { action } from '@ember/object';
 import { moduleFor, RenderingTestCase, strip } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   '@action decorator',
   class extends RenderingTestCase {
     '@test action decorator works with ES6 class'(assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       class FooComponent extends Component {
         @action
         foo() {
@@ -49,7 +55,11 @@ moduleFor(
     }
 
     '@test actions are properly merged through traditional and ES6 prototype hierarchy'(assert) {
-      assert.expect(4);
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+      assert.expect(5);
 
       let FooComponent = Component.extend({
         actions: {
@@ -97,6 +107,11 @@ moduleFor(
     }
 
     '@test action decorator super works with native class methods'(assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       class FooComponent extends Component {
         foo() {
           assert.ok(true, 'called!');
@@ -121,6 +136,11 @@ moduleFor(
     }
 
     '@test action decorator super works with traditional class methods'(assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let FooComponent = Component.extend({
         foo() {
           assert.ok(true, 'called!');
@@ -239,6 +259,11 @@ moduleFor(
     }
 
     '@test action decorator can be used as a classic decorator with strings'(assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let FooComponent = Component.extend({
         foo: action(function () {
           assert.ok(true, 'called!');

--- a/packages/ember/tests/component_context_test.js
+++ b/packages/ember/tests/component_context_test.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { Component } from '@ember/-internals/glimmer';
 import { moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'Application Lifecycle - Component Context',
@@ -186,6 +187,10 @@ moduleFor(
     ['@test Components trigger actions in the parents context when called from within a block'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.addTemplate(
         'application',
         `
@@ -219,6 +224,10 @@ moduleFor(
     ['@test Components trigger actions in the components context when called from within its template'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.addTemplate(
         'application',
         `

--- a/packages/ember/tests/component_context_test.js
+++ b/packages/ember/tests/component_context_test.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { Component } from '@ember/-internals/glimmer';
-import { moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
+import { testUnless, moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
 import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
@@ -184,9 +184,9 @@ moduleFor(
       });
     }
 
-    ['@test Components trigger actions in the parents context when called from within a block'](
-      assert
-    ) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Components trigger actions in the parents context when called from within a block`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -221,7 +221,9 @@ moduleFor(
       });
     }
 
-    ['@test Components trigger actions in the components context when called from within its template'](
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Components trigger actions in the components context when called from within its template`](
       assert
     ) {
       expectDeprecation(

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, runTask, testUnless } from 'internal-test-helpers';
 import { Component } from '@ember/-internals/glimmer';
 import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
@@ -14,7 +14,9 @@ import { DEPRECATIONS } from '@ember/-internals/deprecations';
 moduleFor(
   'Template scoping examples',
   class extends ApplicationTestCase {
-    ['@test Actions inside an outlet go to the associated controller'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Actions inside an outlet go to the associated controller`](assert) {
       expectDeprecation(
         /Usage of the `\(action\)` helper is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 import { Component } from '@ember/-internals/glimmer';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 /*
  In Ember 1.x, controllers subtly affect things like template scope
@@ -14,6 +15,10 @@ moduleFor(
   'Template scoping examples',
   class extends ApplicationTestCase {
     ['@test Actions inside an outlet go to the associated controller'](assert) {
+      expectDeprecation(
+        /Usage of the `\(action\)` helper is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.add(
         'controller:index',
         Controller.extend({

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -3,6 +3,7 @@ import Application from '@ember/application';
 import { Component } from '@ember/-internals/glimmer';
 import { getOwner } from '@ember/-internals/owner';
 import { resolve } from 'rsvp';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'View Integration',
@@ -82,6 +83,10 @@ moduleFor(
     }
 
     [`@test booting multiple applications can properly handle events`](assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let actions = [];
       this.addFactoriesToResolver(actions, this.resolver);
       this.addFactoriesToResolver(actions, this.secondResolver);

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -3,7 +3,7 @@ import Application from '@ember/application';
 import { Component } from '@ember/-internals/glimmer';
 import { getOwner } from '@ember/-internals/owner';
 import { resolve } from 'rsvp';
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
+import { action } from '@ember/object';
 
 moduleFor(
   'View Integration',
@@ -49,12 +49,10 @@ moduleFor(
       resolver.add(
         'component:special-button',
         Component.extend({
-          actions: {
-            doStuff() {
-              let rootElement = getOwner(this).application.rootElement;
-              actions.push(rootElement);
-            },
-          },
+          doStuff: action(function () {
+            let rootElement = getOwner(this).application.rootElement;
+            actions.push(rootElement);
+          }),
         })
       );
 
@@ -73,7 +71,7 @@ moduleFor(
         'template:components/special-button',
         this.compile(
           `
-        <button class='do-stuff' {{action 'doStuff'}}>Button</button>
+        <button class='do-stuff' {{on "click" this.doStuff}}>Button</button>
       `,
           {
             moduleName: 'my-app/templates/components/special-button.hbs',
@@ -83,10 +81,6 @@ moduleFor(
     }
 
     [`@test booting multiple applications can properly handle events`](assert) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       let actions = [];
       this.addFactoriesToResolver(actions, this.resolver);
       this.addFactoriesToResolver(actions, this.secondResolver);

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -6,6 +6,7 @@ import Route from '@ember/routing/route';
 import NoneLocation from '@ember/routing/none-location';
 import HistoryLocation from '@ember/routing/history-location';
 import Controller from '@ember/controller';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import EmberObject, { set } from '@ember/object';
 import {
   moduleFor,
@@ -296,6 +297,10 @@ moduleFor(
     async ['@test Events are triggered on the controller if a matching action name is implemented'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let done = assert.async();
 
       this.router.map(function () {
@@ -342,6 +347,10 @@ moduleFor(
     async ['@test Events are triggered on the current state when defined in `actions` object'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let done = assert.async();
 
       this.router.map(function () {
@@ -378,6 +387,10 @@ moduleFor(
     async ['@test Events defined in `actions` object are triggered on the current state when routes are nested'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let done = assert.async();
 
       this.router.map(function () {
@@ -419,7 +432,11 @@ moduleFor(
     }
 
     ['@test Events can be handled by inherited event handlers'](assert) {
-      assert.expect(4);
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+      assert.expect(5);
 
       let SuperRoute = Route.extend({
         actions: {
@@ -471,6 +488,10 @@ moduleFor(
     async ['@test Actions are not triggered on the controller if a matching action name is implemented as a method'](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let done = assert.async();
 
       this.router.map(function () {
@@ -515,6 +536,10 @@ moduleFor(
     }
 
     async ['@test actions can be triggered with multiple arguments'](assert) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       let done = assert.async();
       this.router.map(function () {
         this.route('root', { path: '/' }, function () {
@@ -1213,7 +1238,11 @@ moduleFor(
     }
 
     ['@test Actions can be handled by inherited action handlers'](assert) {
-      assert.expect(4);
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+      assert.expect(5);
 
       let SuperRoute = Route.extend({
         actions: {

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -15,6 +15,7 @@ import {
   ModuleBasedTestResolver,
   runDestroy,
   runTask,
+  testUnless,
 } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 import { addObserver } from '@ember/-internals/metal';
@@ -294,9 +295,9 @@ moduleFor(
       return promise;
     }
 
-    async ['@test Events are triggered on the controller if a matching action name is implemented'](
-      assert
-    ) {
+    async [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Events are triggered on the controller if a matching action name is implemented`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -344,9 +345,9 @@ moduleFor(
       document.getElementById('qunit-fixture').querySelector('a').click();
     }
 
-    async ['@test Events are triggered on the current state when defined in `actions` object'](
-      assert
-    ) {
+    async [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Events are triggered on the current state when defined in \`actions\` object`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -384,7 +385,9 @@ moduleFor(
       document.getElementById('qunit-fixture').querySelector('a').click();
     }
 
-    async ['@test Events defined in `actions` object are triggered on the current state when routes are nested'](
+    async [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Events defined in \`actions\` object are triggered on the current state when routes are nested`](
       assert
     ) {
       expectDeprecation(
@@ -431,7 +434,9 @@ moduleFor(
       document.getElementById('qunit-fixture').querySelector('a').click();
     }
 
-    ['@test Events can be handled by inherited event handlers'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Events can be handled by inherited event handlers`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -485,7 +490,9 @@ moduleFor(
       });
     }
 
-    async ['@test Actions are not triggered on the controller if a matching action name is implemented as a method'](
+    async [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Actions are not triggered on the controller if a matching action name is implemented as a method`](
       assert
     ) {
       expectDeprecation(
@@ -535,7 +542,9 @@ moduleFor(
       document.getElementById('qunit-fixture').querySelector('a').click();
     }
 
-    async ['@test actions can be triggered with multiple arguments'](assert) {
+    async [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} actions can be triggered with multiple arguments`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
@@ -1237,7 +1246,9 @@ moduleFor(
       return this.visit('/nork').then(() => this.visit('/dork'));
     }
 
-    ['@test Actions can be handled by inherited action handlers'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved
+    )} Actions can be handled by inherited action handlers`](assert) {
       expectDeprecation(
         /Usage of the `\{\{action\}\}` modifier is deprecated./,
         DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { dasherize } from '@ember/-internals/string';
-import EmberObject, { get, computed } from '@ember/object';
+import EmberObject, { action, get, computed } from '@ember/object';
 import { RSVP } from '@ember/-internals/runtime';
 import { A as emberA } from '@ember/array';
 import { run } from '@ember/runloop';
@@ -8,7 +8,6 @@ import { peekMeta } from '@ember/-internals/meta';
 import { tracked } from '@ember/-internals/metal';
 import Route from '@ember/routing/route';
 import { PARAMS_SYMBOL } from 'router_js';
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import { service } from '@ember/service';
 
 import { QueryParamTestCase, moduleFor, getTextOf, runLoopSettled } from 'internal-test-helpers';
@@ -744,22 +743,16 @@ moduleFor(
     async ['@test queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  '](
       assert
     ) {
-      expectDeprecation(
-        /Usage of the `\{\{action\}\}` modifier is deprecated./,
-        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
-      );
       this.addTemplate(
         'application',
-        '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{this.foo}}</span>{{outlet}}'
+        '<button id="test-button" {{on "click" this.increment}}>Increment</button><span id="test-value">{{this.foo}}</span>{{outlet}}'
       );
 
       this.setSingleQPController('application', 'foo', 1, {
-        actions: {
-          increment() {
-            this.incrementProperty('foo');
-            this.send('refreshRoute');
-          },
-        },
+        increment: action(function () {
+          this.incrementProperty('foo');
+          this.send('refreshRoute');
+        }),
       });
 
       this.add(

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -8,6 +8,7 @@ import { peekMeta } from '@ember/-internals/meta';
 import { tracked } from '@ember/-internals/metal';
 import Route from '@ember/routing/route';
 import { PARAMS_SYMBOL } from 'router_js';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import { service } from '@ember/service';
 
 import { QueryParamTestCase, moduleFor, getTextOf, runLoopSettled } from 'internal-test-helpers';
@@ -743,6 +744,10 @@ moduleFor(
     async ['@test queryParams are updated when a controller property is set and the route is refreshed. Issue #13263  '](
       assert
     ) {
+      expectDeprecation(
+        /Usage of the `\{\{action\}\}` modifier is deprecated./,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
       this.addTemplate(
         'application',
         '<button id="test-button" {{action \'increment\'}}>Increment</button><span id="test-value">{{this.foo}}</span>{{outlet}}'


### PR DESCRIPTION
RFC: https://github.com/emberjs/rfcs/pull/1006
~~Pending: https://github.com/emberjs/rfcs/pull/1006~~

I was was going through implementing the _removal_ of all this code in a [later PR (for v6)](https://github.com/emberjs/ember.js/pull/20659), I (re?)learned that by deprecating `(action)` and `{{action}}` we shadow-deprecate the `actions: {}` hash in classic.

Should that have its own deprecation RFC?