### PR TITLE
Add (failing) tests for Query Parameter + Router Service related issues

### DIFF
--- a/packages/ember/tests/routing/router_service_test/replaceWith_test.js
+++ b/packages/ember/tests/routing/router_service_test/replaceWith_test.js
@@ -1,7 +1,8 @@
 import NoneLocation from '@ember/routing/none-location';
-import { RouterTestCase, moduleFor } from 'internal-test-helpers';
+import { RouterTestCase, moduleFor, runLoopSettled } from 'internal-test-helpers';
 import { InternalTransition as Transition } from 'router_js';
 import Controller from '@ember/controller';
+import Route from '@ember/routing/route';
 
 moduleFor(
   'Router Service - replaceWith',
@@ -135,6 +136,46 @@ moduleFor(
         .then(() => {
           assert.deepEqual(this.state, ['/', '/child']);
         });
+    }
+
+    async ['@test RouterService#replaceWith with `refreshModel: true` query param does not always refresh'](
+      assert
+    ) {
+      assert.expect(3);
+
+      let parentBeforeModelCount = 0;
+
+      this.add(
+        'route:parent',
+        Route.extend({
+          beforeModel() {
+            parentBeforeModelCount++;
+          },
+          queryParams: {
+            foo: {
+              refreshModel: true,
+            },
+          },
+        })
+      );
+
+      this.add(
+        'controller:parent',
+        Controller.extend({
+          queryParams: ['foo'],
+          foo: 'default',
+        })
+      );
+
+      await this.visit('/child');
+
+      assert.equal(parentBeforeModelCount, 1, 'parent.beforeModel called once');
+
+      this.routerService.replaceWith('parent.sister');
+      await runLoopSettled();
+
+      assert.equal(this.routerService.get('currentURL'), '/sister', 'transitioned');
+      assert.equal(parentBeforeModelCount, 1, 'parent.beforeModel still called only once');
     }
   }
 );

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -5,7 +5,7 @@ import NoneLocation from '@ember/routing/none-location';
 import Controller from '@ember/controller';
 import { run } from '@ember/runloop';
 import { get } from '@ember/object';
-import { RouterTestCase, moduleFor } from 'internal-test-helpers';
+import { RouterTestCase, moduleFor, runLoopSettled } from 'internal-test-helpers';
 import { InternalTransition as Transition } from 'router_js';
 
 moduleFor(
@@ -422,6 +422,46 @@ moduleFor(
       return this.visit('/child?url_sort=a').then(() => {
         assert.equal(this.routerService.get('currentURL'), '/?url_sort=a');
       });
+    }
+
+    async ['@test RouterService#transitionTo with `refreshModel: true` query param does not always refresh'](
+      assert
+    ) {
+      assert.expect(3);
+
+      let parentBeforeModelCount = 0;
+
+      this.add(
+        'route:parent',
+        Route.extend({
+          beforeModel() {
+            parentBeforeModelCount++;
+          },
+          queryParams: {
+            foo: {
+              refreshModel: true,
+            },
+          },
+        })
+      );
+
+      this.add(
+        'controller:parent',
+        Controller.extend({
+          queryParams: ['foo'],
+          foo: 'default',
+        })
+      );
+
+      await this.visit('/child');
+
+      assert.equal(parentBeforeModelCount, 1, 'parent.beforeModel called once');
+
+      this.routerService.transitionTo('parent.sister');
+      await runLoopSettled();
+
+      assert.equal(this.routerService.get('currentURL'), '/sister', 'transitioned');
+      assert.equal(parentBeforeModelCount, 1, 'parent.beforeModel still called only once');
     }
   }
 );


### PR DESCRIPTION
This adds failing tests for at least 2 types of query parameter + router service related issues.

- Ancestor model hooks are unnecessarily called if there is a query parameter with `refresh: true` and a default value
- A query parameter transition happening during the afterModel of the initial transition will currently fail/crash. This happens both with and without a route specified.
- A query parameter transition happening during the afterModel of followup transitions succeeds (same implementation, just not on the initial transition). This happens both with and without a route specified.

This includes the tests from https://github.com/emberjs/ember.js/pull/18579 since it seems closely related.

I may add more failing tests for cases as I encounter them.