### PR TITLE
[FEATURE] Assert on deprecations in ember-source that have an until older or equal to the current ember-source version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,29 @@ jobs:
           TEST_SUITE: each-package
         run: pnpm test
 
+  deprecations-broken-test:
+    name: Debug and Prebuilt (All Tests by Package + Canary Features) with Deprecations as Errors
+    runs-on: ubuntu-latest
+    needs: [basic-test, lint, types]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - name: build
+        env:
+          DISABLE_SOURCE_MAPS: true
+          BROCCOLI_ENV: production
+        run: pnpm ember build
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: test
+        env:
+          TEST_SUITE: each-package
+          OVERRIDE_DEPRECATION_VERSION: '15.0.0' # Throws on all deprecations with an until before or equal to this version
+        run: pnpm test
+
   browserstack-test:
     name: Browserstack Tests (Safari, Edge)
     runs-on: ubuntu-latest

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -39,6 +39,10 @@ function run(queryString) {
     queryString = `${queryString}&debugrendertree`;
   }
 
+  if (process.env.OVERRIDE_DEPRECATION_VERSION) {
+    queryString = `${queryString}&overridedeprecationversion=${process.env.OVERRIDE_DEPRECATION_VERSION}`;
+  }
+
   let url = 'http://localhost:' + PORT + '/tests/?' + queryString;
   return runInBrowser(url, 3);
 }

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -1,0 +1,22 @@
+import type { DeprecationOptions } from '@ember/debug/lib/deprecate';
+import { ENV } from '@ember/-internals/environment';
+
+function isEnabled(options: DeprecationOptions) {
+  return Object.hasOwnProperty.call(options.since, 'enabled') || ENV._DEPRECATIONS_ENABLED;
+}
+
+function deprecation(options: DeprecationOptions) {
+  return {
+    options,
+    test: !isEnabled(options),
+  };
+}
+export const DEPRECATIONS = {
+  DEPRECATE_IMPLICIT_ROUTE_MODEL: deprecation({
+    id: 'deprecate-implicit-route-model',
+    for: 'ember-source',
+    since: { available: '5.3.0', enabled: '5.3.0' },
+    until: '6.0.0',
+    url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-implicit-route-model',
+  }),
+};

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -9,6 +9,7 @@ function deprecation(options: DeprecationOptions) {
   return {
     options,
     test: !isEnabled(options),
+    isEnabled: isEnabled(options),
   };
 }
 export const DEPRECATIONS = {

--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -159,6 +159,19 @@ export const ENV = {
   _NO_IMPLICIT_ROUTE_MODEL: false,
 
   /**
+   Override the version of ember-source used to determine when deprecations "break".
+   This is used internally by Ember to test with deprecated features "removed".
+   This is never intended to be set by projects.
+
+   @property _OVERRIDE_DEPRECATION_VERSION
+   @for EmberENV
+   @type string | null
+   @default null
+   @private
+   */
+  _OVERRIDE_DEPRECATION_VERSION: null,
+
+  /**
     Controls the maximum number of scheduled rerenders without "settling". In general,
     applications should not need to modify this environment variable, but please
     open an issue so that we can determine if a better default value is needed.
@@ -201,6 +214,8 @@ export const ENV = {
       (ENV as Record<string, unknown>)[flag] = EmberENV[flag] !== false;
     } else if (defaultValue === false) {
       (ENV as Record<string, unknown>)[flag] = EmberENV[flag] === true;
+    } else {
+      (ENV as Record<string, unknown>)[flag] = EmberENV[flag];
     }
   }
 

--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -129,6 +129,19 @@ export const ENV = {
   _DEBUG_RENDER_TREE: DEBUG,
 
   /**
+   Whether to force all deprecations to be enabled. This is used internally by
+   Ember to enable deprecations in tests. It is not intended to be set in
+   projects.
+
+   @property _DEPRECATIONS_ENABLED
+   @for EmberENV
+   @type Boolean
+   @default false
+   @private
+   */
+  _DEPRECATIONS_ENABLED: false,
+
+  /**
     Whether the app defaults to using async observers.
 
     This is not intended to be set directly, as the implementation may change in

--- a/packages/@ember/-internals/metal/tests/properties_test.js
+++ b/packages/@ember/-internals/metal/tests/properties_test.js
@@ -20,10 +20,15 @@ moduleFor(
     ['@test enables access to deprecated property and returns the value of the new property'](
       assert
     ) {
-      assert.expect(3);
+      assert.expect(5);
       let obj = { foo: 'bar' };
 
-      deprecateProperty(obj, 'baz', 'foo', { id: 'baz-deprecation', until: 'some.version' });
+      deprecateProperty(obj, 'baz', 'foo', {
+        id: 'baz-deprecation',
+        until: 'some.version',
+        for: 'test',
+        since: '1.0.0',
+      });
 
       expectDeprecation();
       assert.equal(obj.baz, obj.foo, 'baz and foo are equal');
@@ -48,10 +53,15 @@ moduleFor(
     ['@test enables setter to deprecated property and updates the value of the new property'](
       assert
     ) {
-      assert.expect(3);
+      assert.expect(5);
       let obj = { foo: 'bar' };
 
-      deprecateProperty(obj, 'baz', 'foo', { id: 'baz-deprecation', until: 'some.version' });
+      deprecateProperty(obj, 'baz', 'foo', {
+        id: 'baz-deprecation',
+        until: 'some.version',
+        for: 'test',
+        since: '1.0.0',
+      });
 
       expectDeprecation();
       obj.baz = 'bloop';

--- a/packages/@ember/debug/lib/deprecate.ts
+++ b/packages/@ember/debug/lib/deprecate.ts
@@ -81,9 +81,9 @@ let missingOptionsIdDeprecation: string;
 let missingOptionDeprecation: MissingOptionDeprecateFunc = () => '';
 let deprecate: DeprecateFunc = () => {};
 
-let numEmberVersion = parseFloat(VERSION);
+let numEmberVersion = parseFloat(ENV._OVERRIDE_DEPRECATION_VERSION ?? VERSION);
 function emberVersionGte(until: string) {
-  const significantUntil = until.replaceAll(/(\.0+)/g, '');
+  let significantUntil = until.replaceAll(/(\.0+)/g, '');
   return numEmberVersion >= parseFloat(significantUntil);
 }
 
@@ -280,4 +280,5 @@ export {
   missingOptionsDeprecation,
   missingOptionsIdDeprecation,
   missingOptionDeprecation,
+  emberVersionGte,
 };

--- a/packages/@ember/debug/lib/deprecate.ts
+++ b/packages/@ember/debug/lib/deprecate.ts
@@ -1,5 +1,6 @@
 import { ENV } from '@ember/-internals/environment';
 import { DEBUG } from '@glimmer/env';
+import { VERSION } from '@ember/version';
 
 import { assert } from '../index';
 import type { HandlerCallback } from './handlers';
@@ -79,6 +80,12 @@ let missingOptionsDeprecation: string;
 let missingOptionsIdDeprecation: string;
 let missingOptionDeprecation: MissingOptionDeprecateFunc = () => '';
 let deprecate: DeprecateFunc = () => {};
+
+let numEmberVersion = parseFloat(VERSION);
+function emberVersionGte(until: string) {
+  const significantUntil = until.replaceAll(/(\.0+)/g, '');
+  return numEmberVersion >= parseFloat(significantUntil);
+}
 
 if (DEBUG) {
   registerHandler = function registerHandler(handler: HandlerCallback<DeprecationOptions>): void {
@@ -255,6 +262,12 @@ if (DEBUG) {
     assert(missingOptionDeprecation(options!.id, 'until'), Boolean(options!.until));
     assert(missingOptionDeprecation(options!.id, 'for'), Boolean(options!.for));
     assert(missingOptionDeprecation(options!.id, 'since'), Boolean(options!.since));
+    assert(
+      `This API was removed in ${options!.for} ${
+        options!.until
+      }. The deprecation message was: ${formatMessage(message, options)}`,
+      !(options!.for === 'ember-source' && emberVersionGte(options!.until))
+    );
 
     invoke('deprecate', message, test, options);
   };

--- a/packages/@ember/debug/package.json
+++ b/packages/@ember/debug/package.json
@@ -18,6 +18,7 @@
     "@ember/routing": "workspace:*",
     "@ember/runloop": "workspace:*",
     "@ember/utils": "workspace:*",
+    "@ember/version": "workspace:*",
     "@glimmer/destroyable": "0.87.1",
     "@glimmer/env": "^0.1.7",
     "@glimmer/manager": "0.87.1",

--- a/packages/@ember/debug/tests/main_test.js
+++ b/packages/@ember/debug/tests/main_test.js
@@ -210,6 +210,53 @@ moduleFor(
       assert.ok(true, 'deprecations were not thrown');
     }
 
+    ['@test deprecate throws when ember-source version is past `until`'](assert) {
+      assert.expect(1);
+
+      ENV.RAISE_ON_DEPRECATION = false;
+
+      assert.throws(
+        () =>
+          deprecate('Old long gone api is deprecated', false, {
+            id: 'test',
+            until: '3.0.0',
+            for: 'ember-source',
+            since: { available: '1.0.0', enabled: '1.0.0' },
+          }),
+        'Error: Assertion Failed: This API was removed in ember-source 3.0.0. Old long gone api is deprecated'
+      );
+    }
+
+    ['@test deprecate does not throw when `for` is not ember-source'](assert) {
+      assert.expect(1);
+
+      ENV.RAISE_ON_DEPRECATION = false;
+
+      deprecate('Deprecation is thrown', false, {
+        id: 'test',
+        until: '3.0.0',
+        for: 'ember-data',
+        since: { available: '1.0.0', enabled: '1.0.0' },
+      });
+
+      assert.ok(true, 'assertion on until was not thrown');
+    }
+
+    ['@test deprecate does not throw when `until` is not past for ember-source'](assert) {
+      assert.expect(1);
+
+      ENV.RAISE_ON_DEPRECATION = false;
+
+      deprecate('Deprecation is thrown', false, {
+        id: 'test',
+        until: '30.0.0',
+        for: 'ember-source',
+        since: { available: '1.0.0', enabled: '1.0.0' },
+      });
+
+      assert.ok(true, 'assertion on until was not thrown');
+    }
+
     ['@test assert throws if second argument is falsy'](assert) {
       assert.expect(3);
 

--- a/packages/@ember/object/tests/computed/computed_macros_test.js
+++ b/packages/@ember/object/tests/computed/computed_macros_test.js
@@ -475,22 +475,42 @@ moduleFor(
       defineProperty(
         obj,
         'barAlias',
-        deprecatingAlias('bar', { id: 'bar-deprecation', until: 'some.version' })
+        deprecatingAlias('bar', {
+          id: 'bar-deprecation',
+          until: 'some.version',
+          for: 'test',
+          since: '1.0.0',
+        })
       );
       defineProperty(
         obj,
         'bazAlias',
-        deprecatingAlias('baz', { id: 'baz-deprecation', until: 'some.version' })
+        deprecatingAlias('baz', {
+          id: 'baz-deprecation',
+          until: 'some.version',
+          for: 'test',
+          since: '1.0.0',
+        })
       );
       defineProperty(
         obj,
         'quzAlias',
-        deprecatingAlias('quz', { id: 'quz-deprecation', until: 'some.version' })
+        deprecatingAlias('quz', {
+          id: 'quz-deprecation',
+          until: 'some.version',
+          for: 'test',
+          since: '1.0.0',
+        })
       );
       defineProperty(
         obj,
         'bayAlias',
-        deprecatingAlias('bay', { id: 'bay-deprecation', until: 'some.version' })
+        deprecatingAlias('bay', {
+          id: 'bay-deprecation',
+          until: 'some.version',
+          for: 'test',
+          since: '1.0.0',
+        })
       );
 
       expectDeprecation(function () {

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -19,6 +19,7 @@ import type { AnyFn } from '@ember/-internals/utility-types';
 import Controller from '@ember/controller';
 import type { ControllerQueryParamType } from '@ember/controller';
 import { assert, deprecate, info, isTesting } from '@ember/debug';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import EngineInstance from '@ember/engine/instance';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { once } from '@ember/runloop';
@@ -1258,14 +1259,8 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     deprecate(
       `The implicit model loading behavior for routes is deprecated. ` +
         `Please define an explicit model hook for ${this.fullRouteName}.`,
-      false,
-      {
-        id: 'deprecate-implicit-route-model',
-        for: 'ember-source',
-        since: { available: '5.3.0', enabled: '5.3.0' },
-        until: '6.0.0',
-        url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-implicit-route-model',
-      }
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.test,
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.options
     );
 
     const store = 'store' in this ? this.store : get(this, '_store');

--- a/packages/@ember/routing/tests/system/route_test.js
+++ b/packages/@ember/routing/tests/system/route_test.js
@@ -74,7 +74,7 @@ moduleFor(
           assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
         },
         /The implicit model loading behavior for routes is deprecated./,
-        DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.test
+        DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.isEnabled
       );
 
       runDestroy(owner);

--- a/packages/@ember/routing/tests/system/route_test.js
+++ b/packages/@ember/routing/tests/system/route_test.js
@@ -35,7 +35,7 @@ moduleFor(
     }
 
     ['@test default store utilizes the container to acquire the model factory'](assert) {
-      assert.expect(5);
+      assert.expect(7);
 
       let Post = EmberObject.extend();
       let post = {};
@@ -67,14 +67,10 @@ moduleFor(
       let owner = buildOwner(ownerOptions);
       setOwner(route, owner);
 
-      expectDeprecation(
-        () =>
-          ignoreAssertion(() => {
-            assert.equal(route.model({ post_id: 1 }), post);
-            assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
-          }),
-        /The implicit model loading behavior for routes is deprecated./
-      );
+      expectDeprecation(() => {
+        assert.equal(route.model({ post_id: 1 }), post);
+        assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+      }, /The implicit model loading behavior for routes is deprecated./);
 
       runDestroy(owner);
     }

--- a/packages/@ember/routing/tests/system/route_test.js
+++ b/packages/@ember/routing/tests/system/route_test.js
@@ -1,4 +1,5 @@
 import { setOwner } from '@ember/-internals/owner';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import { ENV } from '@ember/-internals/environment';
 import { runDestroy, buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import Service, { service } from '@ember/service';
@@ -67,10 +68,14 @@ moduleFor(
       let owner = buildOwner(ownerOptions);
       setOwner(route, owner);
 
-      expectDeprecation(() => {
-        assert.equal(route.model({ post_id: 1 }), post);
-        assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
-      }, /The implicit model loading behavior for routes is deprecated./);
+      expectDeprecation(
+        () => {
+          assert.equal(route.model({ post_id: 1 }), post);
+          assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+        },
+        /The implicit model loading behavior for routes is deprecated./,
+        DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.test
+      );
 
       runDestroy(owner);
     }

--- a/packages/internal-test-helpers/lib/ember-dev/assertion.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/assertion.ts
@@ -5,7 +5,7 @@ import { callWithStub, checkTest } from './utils';
 type ExpectAssertionFunc = (func: () => void, expectedMessage: Message) => void;
 type IgnoreAssertionFunc = (func: () => void) => void;
 
-type ExtendedWindow = Window &
+export type ExtendedWindow = Window &
   typeof globalThis & {
     expectAssertion: ExpectAssertionFunc | null;
     ignoreAssertion: IgnoreAssertionFunc | null;

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -177,6 +177,8 @@ class DeprecationAssert extends DebugAssert {
         tracker.expectCall(message, ['id', 'until']);
       });
     } else {
+      let { assert } = QUnit.config.current;
+      assert.ok(true, 'Balance assertion counts');
       this.expectNoDeprecation(func);
     }
   }

--- a/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/method-call-tracker.ts
@@ -41,9 +41,6 @@ export default class MethodCallTracker {
     let methodName = this._methodName;
 
     this._originalMethod = env.getDebugFunction(methodName);
-    if (methodName === 'deprecate') {
-      this._originalHandlers = HANDLERS['deprecate'];
-    }
 
     env.setDebugFunction(methodName, (message, test, options) => {
       let resultOfTest = checkTest(test);
@@ -51,7 +48,10 @@ export default class MethodCallTracker {
       this._actuals.push([message, resultOfTest, options]);
 
       if (methodName === 'deprecate') {
-        HANDLERS['deprecate'] = () => {};
+        if (!this._originalHandlers) {
+          this._originalHandlers = HANDLERS['deprecate'];
+          HANDLERS['deprecate'] = () => {};
+        }
         if (emberVersionGte((options as DeprecationOptions).until)) {
           let w = window as ExtendedWindow;
           w.expectAssertion?.(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,6 +709,9 @@ importers:
       '@ember/utils':
         specifier: workspace:*
         version: link:../utils
+      '@ember/version':
+        specifier: workspace:*
+        version: link:../version
       '@glimmer/destroyable':
         specifier: 0.87.1
         version: 0.87.1

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -14,6 +14,7 @@ module.exports = {
     '_RERENDER_LOOP_LIMIT',
     '_TEMPLATE_ONLY_GLIMMER_COMPONENTS',
     '_OVERRIDE_DEPRECATION_VERSION',
+    '_DEPRECATIONS_ENABLED',
     'Input',
     'LinkTo',
     'Textarea',

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -13,6 +13,7 @@ module.exports = {
     '_NO_IMPLICIT_ROUTE_MODEL',
     '_RERENDER_LOOP_LIMIT',
     '_TEMPLATE_ONLY_GLIMMER_COMPONENTS',
+    '_OVERRIDE_DEPRECATION_VERSION',
     'Input',
     'LinkTo',
     'Textarea',

--- a/tests/index.html
+++ b/tests/index.html
@@ -54,6 +54,10 @@
         if (QUnit.urlParams.debugrendertree) {
           EmberENV['_DEBUG_RENDER_TREE'] = true;
         }
+
+        if (QUnit.urlParams.overridedeprecationversion) {
+          EmberENV['_OVERRIDE_DEPRECATION_VERSION'] = QUnit.urlParams.overridedeprecationversion;
+        }
       })();
     </script>
 


### PR DESCRIPTION
- [ ] String.prototype.replaceAll apparently only since Safari 13ish
- [ ] What is going on with `@ember/version` module in Node tests and in Smoke tests?
- [ ] Throwing on the `until` will only happen in development due to deprecation stripping
- [ ] What to do about `expectDeprecation`? Other than the above issues this works fine without modifying any tests or test helpers because Ember's own tests do not exercise `deprecate` but completely stub it. The modifications here to test files and helpers are an attempt to allow the test suite to run both with deprecations all throwing and as they are default. These changes keep getting grosser. To the point I think either we need to rework `expectDeprecation` and/or add an `internalDeprecate` that is used internally by Ember that will not be stripped in production builds. 