### PR TITLE
[FEATURE] Make deprecations throw when the `until` for `ember-source` has passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,29 @@ jobs:
           ALL_DEPRECATIONS_ENABLED: true
         run: pnpm test
 
+  deprecations-broken-test:
+    name: Debug and Prebuilt (All Tests by Package + Canary Features) with Deprecations as Errors
+    runs-on: ubuntu-latest
+    needs: [ basic-test, lint, types ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - name: build
+        env:
+          DISABLE_SOURCE_MAPS: true
+          BROCCOLI_ENV: production
+        run: pnpm ember build
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: test
+        env:
+          TEST_SUITE: each-package
+          OVERRIDE_DEPRECATION_VERSION: '15.0.0' # Throws on all deprecations with an until before or equal to this version
+        run: pnpm test
+
   browserstack-test:
     name: Browserstack Tests (Safari, Edge)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,13 +309,13 @@ can be constructed in advance of the deprecation being added to the
 [deprecation app](https://github.com/ember-learn/deprecation-app) by following 
 this format: `https://deprecations.emberjs.com/deprecations/{{id}}`.
 
-`deprecate` should then be called using the entry from the `DEPRECATIONS` object.
+`deprecateUntil` (internal to Ember) should then be called using the entry from the `DEPRECATIONS` object.
 
 ```ts
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 //...
 
-deprecate(message, DEPRECATIONS.MY_DEPRECATION.test, DEPRECATIONS.MY_DEPRECATION.options);
+deprecateUntil(message, DEPRECATIONS.MY_DEPRECATION);
 
 ```
 

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -43,6 +43,10 @@ function run(queryString) {
     queryString = `${queryString}&alldeprecationsenabled=${process.env.ALL_DEPRECATIONS_ENABLED}`;
   }
 
+  if (process.env.OVERRIDE_DEPRECATION_VERSION) {
+    queryString = `${queryString}&overridedeprecationversion=${process.env.OVERRIDE_DEPRECATION_VERSION}`;
+  }
+
   let url = 'http://localhost:' + PORT + '/tests/?' + queryString;
   return runInBrowser(url, 3);
 }

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -8,9 +8,11 @@ function isEnabled(options: DeprecationOptions) {
 }
 
 let numEmberVersion = parseFloat(ENV._OVERRIDE_DEPRECATION_VERSION ?? VERSION);
-function emberVersionGte(until: string) {
-  let significantUntil = until.replaceAll(/(\.0+)/g, '');
-  return numEmberVersion >= parseFloat(significantUntil);
+
+/* until must only be a minor version or major version */
+export function emberVersionGte(until: string, emberVersion = numEmberVersion) {
+  let significantUntil = until.replace(/(\.0+)/g, '');
+  return emberVersion >= parseFloat(significantUntil);
 }
 
 export function isRemoved(options: DeprecationOptions) {

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -1,8 +1,27 @@
 import type { DeprecationOptions } from '@ember/debug/lib/deprecate';
 import { ENV } from '@ember/-internals/environment';
+import { VERSION } from '@ember/version';
+import { deprecate, assert } from '@ember/debug';
 
 function isEnabled(options: DeprecationOptions) {
   return Object.hasOwnProperty.call(options.since, 'enabled') || ENV._ALL_DEPRECATIONS_ENABLED;
+}
+
+let numEmberVersion = parseFloat(ENV._OVERRIDE_DEPRECATION_VERSION ?? VERSION);
+function emberVersionGte(until: string) {
+  let significantUntil = until.replaceAll(/(\.0+)/g, '');
+  return numEmberVersion >= parseFloat(significantUntil);
+}
+
+export function isRemoved(options: DeprecationOptions) {
+  return emberVersionGte(options.until);
+}
+
+interface DeprecationObject {
+  options: DeprecationOptions;
+  test: boolean;
+  isEnabled: boolean;
+  isRemoved: boolean;
 }
 
 function deprecation(options: DeprecationOptions) {
@@ -10,6 +29,7 @@ function deprecation(options: DeprecationOptions) {
     options,
     test: !isEnabled(options),
     isEnabled: isEnabled(options),
+    isRemoved: isRemoved(options),
   };
 }
 
@@ -39,7 +59,7 @@ function deprecation(options: DeprecationOptions) {
   import { DEPRECATIONS } from '@ember/-internals/deprecations';
   //...
 
-  deprecate(message, DEPRECATIONS.MY_DEPRECATION.test, DEPRECATIONS.MY_DEPRECATION.options);
+  deprecateUntil(message, DEPRECATIONS.MY_DEPRECATION);
   ```
 
   `expectDeprecation` should also use the DEPRECATIONS object, but it should be noted
@@ -55,6 +75,17 @@ function deprecation(options: DeprecationOptions) {
     DEPRECATIONS.MY_DEPRECATION.isEnabled
   );
   ```
+
+  Tests can be conditionally run based on whether a deprecation is enabled or not:
+
+  ```ts
+    [`${testUnless(DEPRECATIONS.MY_DEPRECATION.isRemoved)} specific deprecated feature tested only in this test`]
+  ```
+
+  This test will be skipped when the MY_DEPRECATION is removed.
+  When adding a deprecation, we need to guard all the code that will eventually be removed, including tests.
+  For tests that are not specifically testing the deprecated feature, we need to figure out how to
+  test the behavior without encountering the deprecated feature, just as users would.
  */
 export const DEPRECATIONS = {
   DEPRECATE_IMPLICIT_ROUTE_MODEL: deprecation({
@@ -65,3 +96,17 @@ export const DEPRECATIONS = {
     url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-implicit-route-model',
   }),
 };
+
+export function deprecateUntil(message: string, deprecation: DeprecationObject) {
+  const { options } = deprecation;
+  assert(
+    'deprecateUntil must only be called for ember-source',
+    Boolean(options.for === 'ember-source')
+  );
+  if (deprecation.isRemoved) {
+    throw new Error(
+      `The API deprecated by ${options.id} was removed in ember-source ${options.until}. The message was: ${message}. Please see ${options.url} for more details.`
+    );
+  }
+  deprecate(message, deprecation.test, options);
+}

--- a/packages/@ember/-internals/deprecations/tests/index-test.js
+++ b/packages/@ember/-internals/deprecations/tests/index-test.js
@@ -1,5 +1,5 @@
 import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
-import { deprecateUntil, isRemoved } from '../index';
+import { deprecateUntil, isRemoved, emberVersionGte } from '../index';
 import { ENV } from '@ember/-internals/environment';
 
 let originalEnvValue;
@@ -91,6 +91,46 @@ moduleFor(
         isRemoved(options),
         false,
         'isRemoved is false until the until has passed'
+      );
+    }
+
+    ['@test emberVersionGte returns whether the ember version is greater than or equal to the provided version'](
+      assert
+    ) {
+      assert.strictEqual(
+        emberVersionGte('3.0.0', parseFloat('5.0.0')),
+        true,
+        '5.0.0 is after 3.0.0'
+      );
+      assert.strictEqual(
+        emberVersionGte('30.0.0', parseFloat('5.0.0')),
+        false,
+        '5.0.0 is before 30.0.0'
+      );
+      assert.strictEqual(
+        emberVersionGte('5.0.0-beta.1', parseFloat('5.0.0')),
+        true,
+        '5.0.0 is after 5.0.0-beta.1'
+      );
+      assert.strictEqual(
+        emberVersionGte('5.0.1', parseFloat('5.0.0-beta.1')),
+        false,
+        '5.0.0-beta.1 is before 5.0.1'
+      );
+      assert.strictEqual(
+        emberVersionGte('5.0.0-alpha.abcde', parseFloat('5.0.0')),
+        true,
+        '5.0.0 is after 5.0.0-alpha'
+      );
+      assert.strictEqual(
+        emberVersionGte('5.9.0', parseFloat('5.8.9')),
+        false,
+        '5.8.9 is before 5.9.0'
+      );
+      assert.strictEqual(
+        emberVersionGte('5.10.0', parseFloat('5.9.2')),
+        true,
+        '5.10.1 is after 5.9.2'
       );
     }
   }

--- a/packages/@ember/-internals/deprecations/tests/index-test.js
+++ b/packages/@ember/-internals/deprecations/tests/index-test.js
@@ -1,0 +1,97 @@
+import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
+import { deprecateUntil, isRemoved } from '../index';
+import { ENV } from '@ember/-internals/environment';
+
+let originalEnvValue;
+
+moduleFor(
+  '@ember/-internals/deprecations',
+  class extends AbstractTestCase {
+    constructor() {
+      super();
+      originalEnvValue = ENV.RAISE_ON_DEPRECATION;
+      ENV.RAISE_ON_DEPRECATION = false;
+    }
+
+    teardown() {
+      ENV.RAISE_ON_DEPRECATION = originalEnvValue;
+    }
+
+    ['@test deprecateUntil throws when deprecation has been removed'](assert) {
+      assert.expect(1);
+
+      let MY_DEPRECATION = {
+        options: {
+          id: 'test',
+          until: '3.0.0',
+          for: 'ember-source',
+          url: 'http://example.com/deprecations/test',
+          since: {
+            available: '1.0.0',
+            enabled: '1.0.0',
+          },
+        },
+        isRemoved: true,
+      };
+
+      assert.throws(
+        () => deprecateUntil('Old long gone api is deprecated', MY_DEPRECATION),
+        /Error: The API deprecated by test was removed in ember-source 3.0.0. The message was: Old long gone api is deprecated. Please see http:\/\/example.com\/deprecations\/test for more details./,
+        'deprecateUntil throws when isRemoved is true on deprecation'
+      );
+    }
+
+    ['@test deprecateUntil does not throw when isRemoved is false on deprecation'](assert) {
+      assert.expect(1);
+
+      let MY_DEPRECATION = {
+        options: {
+          id: 'test',
+          until: '3.0.0',
+          for: 'ember-source',
+          url: 'http://example.com/deprecations/test',
+          since: {
+            available: '1.0.0',
+            enabled: '1.0.0',
+          },
+        },
+        isRemoved: false,
+      };
+
+      deprecateUntil('Deprecation is thrown', MY_DEPRECATION);
+
+      assert.ok(true, 'exception on until was not thrown');
+    }
+    ['@test isRemoved is true when until has passed current ember version'](assert) {
+      assert.expect(1);
+
+      let options = {
+        id: 'test',
+        until: '3.0.0',
+        for: 'ember-source',
+        url: 'http://example.com/deprecations/test',
+        since: { available: '1.0.0', enabled: '1.0.0' },
+      };
+
+      assert.strictEqual(isRemoved(options), true, 'isRemoved is true when until has passed');
+    }
+
+    ['@test isRemoved is false before until has passed current ember version'](assert) {
+      assert.expect(1);
+
+      let options = {
+        id: 'test',
+        until: '30.0.0',
+        for: 'ember-source',
+        url: 'http://example.com/deprecations/test',
+        since: { available: '1.0.0', enabled: '1.0.0' },
+      };
+
+      assert.strictEqual(
+        isRemoved(options),
+        false,
+        'isRemoved is false until the until has passed'
+      );
+    }
+  }
+);

--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -142,6 +142,18 @@ export const ENV = {
   _ALL_DEPRECATIONS_ENABLED: false,
 
   /**
+   Override the version of ember-source used to determine when deprecations "break".
+   This is used internally by Ember to test with deprecated features "removed".
+   This is never intended to be set by projects.
+   @property _OVERRIDE_DEPRECATION_VERSION
+   @for EmberENV
+   @type string | null
+   @default null
+   @private
+   */
+  _OVERRIDE_DEPRECATION_VERSION: null,
+
+  /**
     Whether the app defaults to using async observers.
 
     This is not intended to be set directly, as the implementation may change in
@@ -214,6 +226,8 @@ export const ENV = {
       (ENV as Record<string, unknown>)[flag] = EmberENV[flag] !== false;
     } else if (defaultValue === false) {
       (ENV as Record<string, unknown>)[flag] = EmberENV[flag] === true;
+    } else {
+      (ENV as Record<string, unknown>)[flag] = EmberENV[flag];
     }
   }
 

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -18,8 +18,8 @@ import { isProxy, lookupDescriptor } from '@ember/-internals/utils';
 import type { AnyFn } from '@ember/-internals/utility-types';
 import Controller from '@ember/controller';
 import type { ControllerQueryParamType } from '@ember/controller';
-import { assert, deprecate, info, isTesting } from '@ember/debug';
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
+import { assert, info, isTesting } from '@ember/debug';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import EngineInstance from '@ember/engine/instance';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { once } from '@ember/runloop';
@@ -1256,11 +1256,10 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     if (ENV._NO_IMPLICIT_ROUTE_MODEL) {
       return;
     }
-    deprecate(
+    deprecateUntil(
       `The implicit model loading behavior for routes is deprecated. ` +
         `Please define an explicit model hook for ${this.fullRouteName}.`,
-      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.test,
-      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.options
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL
     );
 
     const store = 'store' in this ? this.store : get(this, '_store');

--- a/packages/@ember/routing/tests/system/route_test.js
+++ b/packages/@ember/routing/tests/system/route_test.js
@@ -1,7 +1,13 @@
 import { setOwner } from '@ember/-internals/owner';
 import { ENV } from '@ember/-internals/environment';
 import { DEPRECATIONS } from '@ember/-internals/deprecations';
-import { runDestroy, buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import {
+  runDestroy,
+  buildOwner,
+  moduleFor,
+  testUnless,
+  AbstractTestCase,
+} from 'internal-test-helpers';
 import Service, { service } from '@ember/service';
 import EmberObject from '@ember/object';
 import EmberRoute from '@ember/routing/route';
@@ -35,7 +41,9 @@ moduleFor(
       ENV._NO_IMPLICIT_ROUTE_MODEL = this._NO_IMPLICIT_ROUTE_MODEL;
     }
 
-    ['@test default store utilizes the container to acquire the model factory'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.isRemoved
+    )} default store utilizes the container to acquire the model factory`](assert) {
       assert.expect(5);
 
       let Post = EmberObject.extend();
@@ -69,11 +77,10 @@ moduleFor(
       setOwner(route, owner);
 
       expectDeprecation(
-        () =>
-          ignoreAssertion(() => {
-            assert.equal(route.model({ post_id: 1 }), post);
-            assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
-          }),
+        () => {
+          assert.equal(route.model({ post_id: 1 }), post);
+          assert.equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+        },
         /The implicit model loading behavior for routes is deprecated./,
         DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.isEnabled
       );
@@ -97,7 +104,9 @@ moduleFor(
       assert.true(calledFind, 'store.find was called');
     }
 
-    ["@test assert if 'store.find' method is not found"]() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.isRemoved
+    )} assert if 'store.find' method is not found`]() {
       runDestroy(route);
 
       let owner = buildOwner();
@@ -134,7 +143,9 @@ moduleFor(
       runDestroy(owner);
     }
 
-    ['@test asserts if model class is not found']() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.isRemoved
+    )} asserts if model class is not found`]() {
       runDestroy(route);
 
       let owner = buildOwner();
@@ -161,7 +172,9 @@ moduleFor(
       runDestroy(owner);
     }
 
-    ["@test 'store' does not need to be injected"](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_IMPLICIT_ROUTE_MODEL.isRemoved
+    )} 'store' does not need to be injected`](assert) {
       runDestroy(route);
 
       let owner = buildOwner();

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -201,28 +201,21 @@ moduleFor(
     }
 
     ["@test The Special page returning an error invokes SpecialRoute's error handler"](assert) {
+      assert.expect(2);
+
       this.router.map(function () {
         this.route('home', { path: '/' });
-        this.route('special', { path: '/specials/:menu_item_id' });
+        this.route('special', { path: '/specials/:menu_item' });
       });
 
-      let menuItem, promise, resolve;
-
-      let MenuItem = EmberObject.extend();
-      MenuItem.reopenClass({
-        find(id) {
-          menuItem = MenuItem.create({ id: id });
-          promise = new RSVP.Promise((res) => (resolve = res));
-
-          return promise;
-        },
-      });
-
-      this.add('model:menu_item', MenuItem);
+      let resolve;
 
       this.add(
         'route:special',
         Route.extend({
+          model() {
+            return new RSVP.Promise((res) => (resolve = res));
+          },
           setup() {
             throw new Error('Setup error');
           },
@@ -239,11 +232,9 @@ moduleFor(
         })
       );
 
-      ignoreDeprecation(() => {
-        runTask(() => handleURLRejectsWith(this, assert, 'specials/1', 'Setup error'));
-      });
+      runTask(() => handleURLRejectsWith(this, assert, 'specials/1', 'Setup error'));
 
-      resolve(menuItem);
+      resolve();
     }
 
     ["@test ApplicationRoute's default error handler can be overridden"](assert) {

--- a/packages/internal-test-helpers/index.ts
+++ b/packages/internal-test-helpers/index.ts
@@ -18,6 +18,7 @@ export {
   defineSimpleHelper,
   defineSimpleModifier,
 } from './lib/define-template-values';
+export { testIf, testUnless } from './lib/conditional-test';
 export { default as compile } from './lib/compile';
 export { equalsElement, classes, styles, regex } from './lib/matchers';
 export { runAppend, runDestroy, runTask, runTaskNext, runLoopSettled } from './lib/run';

--- a/packages/internal-test-helpers/lib/conditional-test.ts
+++ b/packages/internal-test-helpers/lib/conditional-test.ts
@@ -1,0 +1,9 @@
+function testIf(condition: boolean) {
+  return condition ? '@test' : '@skip';
+}
+
+function testUnless(condition: boolean) {
+  return testIf(!condition);
+}
+
+export { testIf, testUnless };

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -14,6 +14,7 @@ module.exports = {
     '_RERENDER_LOOP_LIMIT',
     '_TEMPLATE_ONLY_GLIMMER_COMPONENTS',
     '_ALL_DEPRECATIONS_ENABLED',
+    '_OVERRIDE_DEPRECATION_VERSION',
     'Input',
     'LinkTo',
     'Textarea',

--- a/tests/index.html
+++ b/tests/index.html
@@ -58,6 +58,10 @@
         if (QUnit.urlParams.alldeprecationsenabled) {
           EmberENV['_ALL_DEPRECATIONS_ENABLED'] = QUnit.urlParams.alldeprecationsenabled;
         }
+
+        if (QUnit.urlParams.overridedeprecationversion) {
+          EmberENV['_OVERRIDE_DEPRECATION_VERSION'] = QUnit.urlParams.overridedeprecationversion;
+        }
       })();
     </script>
 


### PR DESCRIPTION
- Add a new `deprecateUntil` that checks whether a deprecation has been removed and throws if it has. This explicitly uses `throw` and not assert so that it will remain in production builds. This function should be used internally in ember-source in place of `deprecate`.
- Add utilities `testIf` and `testUnless` to guard tests based on whether a deprecation has been removed. Uses this for the existing deprecation on @ember/routing
- Add a query param to tests `overridedeprecationversion` that takes a version to be the current version for removing deprecation purposes
- Add a CI build to use the above to test with deprecations broken

For https://rfcs.emberjs.com/id/0830-evolving-embers-major-version-process