### PR TITLE
Consider deprecations enabled if they are past the until.

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -30,7 +30,7 @@ function deprecation(options: DeprecationOptions) {
   return {
     options,
     test: !isEnabled(options),
-    isEnabled: isEnabled(options),
+    isEnabled: isEnabled(options) || isRemoved(options),
     isRemoved: isRemoved(options),
   };
 }


### PR DESCRIPTION
This helps limit the explosion of test scenarios.