### PR TITLE
[BUGFIX beta] use correct syntax for computed.test.ts

### DIFF
--- a/packages/@ember/object/type-tests/computed.test.ts
+++ b/packages/@ember/object/type-tests/computed.test.ts
@@ -12,7 +12,7 @@ class Foo {
     return `${this.firstName} ${this.lastName}`;
   }
 
-  @computed('firstName', 'lastName').readOnly()
+  @(computed('firstName', 'lastName').readOnly())
   get readonlyFullName() {
     return `${this.firstName} ${this.lastName}`;
   }

--- a/type-tests/@ember/object-test/computed.ts
+++ b/type-tests/@ember/object-test/computed.ts
@@ -57,7 +57,7 @@ class Person extends EmberObject {
     return `${this.get('firstName')} ${this.get('lastName')}`;
   }
 
-  @computed('fullName').readOnly()
+  @(computed('fullName').readOnly())
   get fullNameReadonly() {
     return this.get('fullName');
   }
@@ -73,7 +73,7 @@ class Person extends EmberObject {
     this.set('lastName', last);
   }
 
-  @computed().meta({ foo: 'bar' }).readOnly()
+  @(computed().meta({ foo: 'bar' }).readOnly())
   get combinators() {
     return this.get('firstName');
   }

--- a/type-tests/ember/computed.ts
+++ b/type-tests/ember/computed.ts
@@ -23,7 +23,7 @@ class Person extends Ember.Object {
     return `${this.get('firstName')} ${this.get('lastName')}`;
   }
 
-  @Ember.computed('fullName').readOnly()
+  @(Ember.computed('fullName').readOnly())
   get fullNameReadonly() {
     return this.get('fullName');
   }
@@ -39,7 +39,7 @@ class Person extends Ember.Object {
     this.set('lastName', last);
   }
 
-  @Ember.computed().meta({ foo: 'bar' }).readOnly()
+  @(Ember.computed().meta({ foo: 'bar' }).readOnly())
   get combinators() {
     return this.get('firstName');
   }


### PR DESCRIPTION
I thought this syntax didn’t work *before*, but possibly it was just a warning. In any case, I believe this should fix the failures with nightly TS runs. cc. @jamescdavis @gitKrystan @wagenet