### PR TITLE
Address a missed deprecation introduced in #20658

### DIFF
--- a/packages/ember-template-compiler/lib/plugins/assert-against-attrs.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-against-attrs.ts
@@ -107,11 +107,13 @@ export default function assertAgainstAttrs(env: EmberASTPluginEnvironment): ASTP
 }
 
 function isAttrs(node: AST.PathExpression, symbols: string[]) {
-  let name = node.parts[0];
-  return node.head.type === 'VarHead' && name === 'attrs' && symbols.indexOf(name) === -1;
+  return (
+    node.head.type === 'VarHead' &&
+    node.head.name === 'attrs' &&
+    symbols.indexOf(node.head.name) === -1
+  );
 }
 
 function isThisDotAttrs(node: AST.PathExpression) {
-  let name = node.parts[0];
-  return node.head.type === 'ThisHead' && name === 'attrs';
+  return node.head.type === 'ThisHead' && node.tail[0] === 'attrs';
 }


### PR DESCRIPTION
It wasn't a "real" Ember deprecation so didn't go through the infra that would have caused a test failure, just spewing a lot of logs to the console.