### PR TITLE
[BUGFIX beta] honour preventDefault() in LinkTo

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -361,7 +361,7 @@ class _LinkTo extends InternalComponent {
   }
 
   @action click(event: Event): void {
-    if (!isSimpleClick(event)) {
+    if (event.defaultPrevented || !isSimpleClick(event)) {
       return;
     }
 


### PR DESCRIPTION
There was some discussion around this in https://github.com/emberjs/ember.js/issues/19861 but to me the current behaviour definitely seems like more of a bug than a feature. 

If `<LinkTo>` is a replacement for `<a>` then all behaviour should be carried over, I don't think the component should be opinionated about conventional/appropriate uses for the tag.