### PR TITLE
CI Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: build
-        env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
         run: pnpm ember build
       - name: Upload build
         uses: actions/upload-artifact@v3
@@ -87,9 +84,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: build
-        env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
         run: pnpm ember build
       - name: Upload build
         uses: actions/upload-artifact@v3
@@ -110,9 +104,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: build
-        env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
         run: pnpm ember build
       - name: Upload build
         uses: actions/upload-artifact@v3
@@ -134,8 +125,6 @@ jobs:
       - uses: ./.github/actions/setup
       - name: build
         env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
           SHOULD_TRANSPILE: true
         run: pnpm ember build
 
@@ -178,28 +167,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: build
-        env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
         run: pnpm ember build -prod
       - name: test
         run: pnpm test
 
-  production-debug-render-test:
-    name: Production (All Tests + Canary Features with Debug Render Tree)
-    runs-on: ubuntu-latest
-    needs: [basic-test, lint, types]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - name: build
-        env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
-          DEBUG_RENDER_TREE: true
-        run: pnpm ember build -prod
-      - name: test
-        run: pnpm test
 
   extend-prototypes-test:
     name: Extend Prototypes
@@ -226,8 +197,6 @@ jobs:
       - uses: ./.github/actions/setup
       - name: build
         env:
-          DISABLE_SOURCE_MAPS: true
-          BROCCOLI_ENV: production
           SHOULD_TRANSPILE_FOR_NODE: true
         run: pnpm ember build -prod
       - name: test
@@ -271,7 +240,6 @@ jobs:
         lint,
         browserstack-test,
         production-test,
-        production-debug-render-test,
         extend-prototypes-test,
         node-test,
         blueprint-test,
@@ -297,7 +265,6 @@ jobs:
         lint,
         browserstack-test,
         production-test,
-        production-debug-render-test,
         extend-prototypes-test,
         node-test,
         blueprint-test,
@@ -326,7 +293,6 @@ jobs:
         lint,
         browserstack-test,
         production-test,
-        production-debug-render-test,
         extend-prototypes-test,
         node-test,
         blueprint-test,
@@ -357,7 +323,6 @@ jobs:
         lint,
         browserstack-test,
         production-test,
-        production-debug-render-test,
         extend-prototypes-test,
         node-test,
         blueprint-test,

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -35,10 +35,6 @@ function getBrowserRunner() {
 }
 
 function run(queryString) {
-  if (process.env.DEBUG_RENDER_TREE) {
-    queryString = `${queryString}&debugrendertree`;
-  }
-
   if (process.env.ALL_DEPRECATIONS_ENABLED) {
     queryString = `${queryString}&alldeprecationsenabled=${process.env.ALL_DEPRECATIONS_ENABLED}`;
   }
@@ -66,7 +62,6 @@ function generateTestsFor(packageName) {
   }
 
   testFunctions.push(() => run('package=' + packageName));
-  testFunctions.push(() => run('package=' + packageName + '&edition=classic'));
   testFunctions.push(() => run('package=' + packageName + '&prebuilt=true'));
   testFunctions.push(() => run('package=' + packageName + '&enableoptionalfeatures=true'));
 }
@@ -87,7 +82,6 @@ function generateEachPackageTests() {
 
 function generateStandardTests() {
   testFunctions.push(() => run(''));
-  testFunctions.push(() => run('edition=classic'));
   testFunctions.push(() => run('enableoptionalfeatures=true'));
 }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -23,12 +23,8 @@
       (function() {
         window.EmberENV = window.EmberENV || {};
 
-        // Determine edition, and apply correct EmberENV settings
-        var edition = QUnit.urlParams.edition || 'octane';
-
-        if (edition === 'octane') {
-          EmberENV._DEFAULT_ASYNC_OBSERVERS = true;
-        }
+        // Test under octane defaults
+        EmberENV._DEFAULT_ASYNC_OBSERVERS = true;
 
         // Test for "hooks in EmberENV.EMBER_LOAD_HOOKS['hookName'] get executed"
         EmberENV.EMBER_LOAD_HOOKS = EmberENV.EMBER_LOAD_HOOKS || {};
@@ -48,10 +44,6 @@
         }
 
         EmberENV['RAISE_ON_DEPRECATION'] = true;
-
-        if (QUnit.urlParams.debugrendertree) {
-          EmberENV['_DEBUG_RENDER_TREE'] = true;
-        }
 
         if (QUnit.urlParams.alldeprecationsenabled) {
           EmberENV['_ALL_DEPRECATIONS_ENABLED'] = QUnit.urlParams.alldeprecationsenabled;


### PR DESCRIPTION
 - I searched through our entire dependency graph and couldn't find anything consuming `DISABLE_SOURCE_MAPS` or `BROCCOLI_ENV`. I think they are entirely vestigial.

 - `DEBUG_RENDER_TREE` was being set in an irrelevant place, because it doesn't take effect during the build, it takes effect during the test run. But when I tried to enable it there, I found that it never has any effect anyway. The issue is that DEBUG_RENDER_TREE is always enabled in dev mode, and even when the test suite is built in prod mode it still loads ember-template-compiler.js, which always includes dev-mode code that forces DEBUG_RENDER_TREE to on. So there's no way to run the test suite with DEBUG_RENDER_TREE off, so there's no need to have an extra test that tries to turn it on.
 
 - `edition=classic`: we dropped this at ember 4, but we're still doing extra test runs for it.