### PR TITLE
Cleanup warning noise from eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,26 @@ module.exports = {
         '@typescript-eslint/no-this-alias': 'off',
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            // these are the settings recommneded by typescript-eslint to follow
+            // typescript's own default unused variable naming policies.
+            args: 'all',
+            argsIgnorePattern: '^_',
+            caughtErrors: 'all',
+            caughtErrorsIgnorePattern: '^_',
+            destructuredArrayIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+            ignoreRestSiblings: true,
+          },
+        ],
+
+        // these default to 'warn' in @typescript-eslint/recommended. But
+        // warnings just get ignored and allowed to generate noise. We should
+        // either commit to makign them errors or leave them off.
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
 
         // TODO: Enable and fix these rules
         // Typescript provides better types with these rules enabled

--- a/packages/@ember/-internals/container/lib/container.ts
+++ b/packages/@ember/-internals/container/lib/container.ts
@@ -48,7 +48,7 @@ if (DEBUG) {
         };
       })();
     }
-  } catch (e) {
+  } catch (_e) {
     // ignore
   }
 }

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -28,7 +28,7 @@ if (hasDOM) {
       try {
         INPUT_ELEMENT.type = type;
         isValid = INPUT_ELEMENT.type === type;
-      } catch (e) {
+      } catch (_e) {
         isValid = false;
       } finally {
         INPUT_ELEMENT.type = 'text';

--- a/packages/@ember/-internals/glimmer/lib/components/internal.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/internal.ts
@@ -91,12 +91,10 @@ export default class InternalComponent {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected isSupportedArgument(_name: string): boolean {
     return false;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected onUnsupportedArgument(_name: string): void {}
 
   toString(): string {

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -371,7 +371,6 @@ export function helper<S>(
 export function helper(
   helperFn: (positional: unknown[], named: object) => unknown
   // At the implementation site, we don't care about the actual underlying type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): FunctionBasedHelper<any> {
   // SAFETY: this is completely lies, in two ways:
   //

--- a/packages/@ember/-internals/metal/lib/namespace_search.ts
+++ b/packages/@ember/-internals/metal/lib/namespace_search.ts
@@ -163,7 +163,7 @@ function tryIsNamespace(lookup: { [k: string]: any }, prop: string): Namespace |
       obj.isNamespace &&
       obj
     );
-  } catch (e) {
+  } catch (_e) {
     // continue
   }
 }

--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -311,8 +311,8 @@ const ControllerMixin = Mixin.create(ActionHandler, {
   @uses Ember.ControllerMixin
   @public
 */
-interface Controller<T = unknown> extends FrameworkObject, ControllerMixin<T> {}
-class Controller<T = unknown> extends FrameworkObject.extend(ControllerMixin) {}
+interface Controller<_T = unknown> extends FrameworkObject, ControllerMixin<_T> {}
+class Controller<_T = unknown> extends FrameworkObject.extend(ControllerMixin) {}
 
 /**
   Creates a property that lazily looks up another controller in the container.

--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -62,7 +62,6 @@ class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerPro
   // This is effectively an "abstract" method: it defines the contract a
   // subclass (e.g. `ApplicationInstance`) must follow to implement this
   // behavior, but an `EngineInstance` has no behavior of its own here.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static setupRegistry(_registry: Registry, _options?: BootOptions) {}
 
   /**

--- a/packages/internal-test-helpers/lib/system/synthetic-events.ts
+++ b/packages/internal-test-helpers/lib/system/synthetic-events.ts
@@ -137,7 +137,7 @@ function buildMouseEvent(type: string, options: MouseEventInit = {}) {
   let event;
   try {
     event = new MouseEvent(type, { ...DEFAULT_EVENT_OPTIONS, ...options });
-  } catch (e) {
+  } catch (_e) {
     event = buildBasicEvent(type, options);
   }
   return event;
@@ -147,7 +147,7 @@ function buildKeyboardEvent(type: string, options: KeyboardEventInit = {}) {
   let event;
   try {
     event = new KeyboardEvent(type, { ...DEFAULT_EVENT_OPTIONS, ...options });
-  } catch (e) {
+  } catch (_e) {
     event = buildBasicEvent(type, options);
   }
   return event;


### PR DESCRIPTION
We inherit several default rules at the "warn" level. IMO it's useless to leave rules at "warn", because people just ignore them and live with an increasing amount of noise.

As evidence I cite the 716 warnings that one must currently scroll through to find an actual lint failure.

This change turns unused-vars into errors, while enabling underscore-based exceptions that follow typescript's own defaults for its internal unused-vars rule.

And it disables no-explicit-any and no-non-null-assertion. These features are in the language for a reason. Idiomatic javascript that gains types after-the-fact needs these features, which is why we need them all over the place. If somebody else thinks these rules are good, I'm all in favor of enabling them **as errors** so they actually get followed, but then you've gotta do the project to refactor all the types to not need them so much.