### PR TITLE
rationalize test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: pnpm type-check
 
   basic-test:
-    name: Debug and Prebuilt (All Tests by Package + Canary Features)
+    name: Basic Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -72,48 +72,51 @@ jobs:
           name: dist
           path: dist
       - name: test
-        env:
-          TEST_SUITE: each-package
         run: pnpm test
 
-  deprecations-enabled-test:
-    name: Debug and Prebuilt (All Tests by Package + Canary Features) with all Deprecations enabled
+  variant-tests:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: [basic-test, lint, types]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - name: build
-        run: pnpm ember build
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist
-      - name: test
-        env:
-          TEST_SUITE: each-package
-          ALL_DEPRECATIONS_ENABLED: true
-        run: pnpm test
+    strategy:
+      matrix:
+        include:
+          - name: "All deprecations enabled"
+            ALL_DEPRECATIONS_ENABLED: "true"
+          - name: "All deprecations enabled, with optional features"
+            ALL_DEPRECATIONS_ENABLED: "true"
+            ENABLE_OPTIONAL_FEATURES: "true"
+          - name: "Deprecations as errors"
+            OVERRIDE_DEPRECATION_VERSION: "15.0.0"
+          - name: "Deprecations as errors, with optional features"
+            OVERRIDE_DEPRECATION_VERSION: "15.0.0"
+            ENABLE_OPTIONAL_FEATURES: "true"
+          - name: "Production build"
+            BUILD: "-prod"
+          - name: "Production build, with optional features"
+            BUILD: "-prod"
+            ENABLE_OPTIONAL_FEATURES: "true"
+          - name: "Extend prototypes"
+            EXTEND_PROTOTYPES: "true"
+          - name: "Extend prototypes, with optional features"
+            EXTEND_PROTOTYPES: "true"
+            ENABLE_OPTIONAL_FEATURES: "true"
+          - name: "Prebuilt"
+            PREBUILT: "true"
 
-  deprecations-broken-test:
-    name: Debug and Prebuilt (All Tests by Package + Canary Features) with Deprecations as Errors
-    runs-on: ubuntu-latest
-    needs: [ basic-test, lint, types ]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: build
-        run: pnpm ember build
-      - name: Upload build
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist
+        run: pnpm ember build ${{ matrix.BUILD }}
       - name: test
         env:
-          TEST_SUITE: each-package
-          OVERRIDE_DEPRECATION_VERSION: '15.0.0' # Throws on all deprecations with an until before or equal to this version
+          ALL_DEPRECATIONS_ENABLED: ${{ matrix.ALL_DEPRECATIONS_ENABLED }}
+          OVERRIDE_DEPRECATION_VERSION: ${{ matrix.OVERRIDE_DEPRECATION_VERSION }}
+          EXTEND_PROTOTYPES: ${{ matrix.EXTEND_PROTOTYPES }}
+          ENABLE_OPTIONAL_FEATURES: ${{ matrix.ENABLE_OPTIONAL_FEATURES }}
+          PREBUIlT: ${{ matrix.PREBUILT }}
+
         run: pnpm test
 
   browserstack-test:
@@ -158,35 +161,6 @@ jobs:
           pnpm install
           pnpm link ../..
           pnpm test
-
-  production-test:
-    name: Production (All Tests + Canary Features)
-    runs-on: ubuntu-latest
-    needs: [basic-test, lint, types]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - name: build
-        run: pnpm ember build -prod
-      - name: test
-        run: pnpm test
-
-
-  extend-prototypes-test:
-    name: Extend Prototypes
-    runs-on: ubuntu-latest
-    needs: [basic-test, lint, types]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist
-      - name: test
-        env:
-          TEST_SUITE: extend-prototypes
-        run: pnpm test
 
   node-test:
     name: Node.js Tests
@@ -238,9 +212,8 @@ jobs:
       [
         basic-test,
         lint,
+        variant-tests,
         browserstack-test,
-        production-test,
-        extend-prototypes-test,
         node-test,
         blueprint-test,
         browser-test,
@@ -263,9 +236,8 @@ jobs:
       [
         basic-test,
         lint,
+        variant-tests,
         browserstack-test,
-        production-test,
-        extend-prototypes-test,
         node-test,
         blueprint-test,
         browser-test,
@@ -291,9 +263,8 @@ jobs:
       [
         basic-test,
         lint,
+        variant-tests,
         browserstack-test,
-        production-test,
-        extend-prototypes-test,
         node-test,
         blueprint-test,
         browser-test,
@@ -321,9 +292,8 @@ jobs:
       [
         basic-test,
         lint,
+        variant-tests,
         browserstack-test,
-        production-test,
-        extend-prototypes-test,
         node-test,
         blueprint-test,
         browser-test,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,32 +124,9 @@ Pull requests should pass the Ember.js unit tests. Do the following to run these
 
 3. To run all tests, visit <http://localhost:4200/>.
 
-4. To test a specific package, visit `http://localhost:4200/tests/index.html?package=PACKAGE_NAME`. Replace
-`PACKAGE_NAME` with the name of the package you want to test. For
-example:
-
-  * [Ember.js Internals](http://localhost:4200/tests/index.html?package=@ember/-internals)
+4. To test a specific package, use the interactive QUnit filters on the page.
 
 To test multiple packages, you can separate them with commas.
-
-## From the CLI
-
-Run `pnpm test` to run a basic test suite or run `TEST_SUITE=all pnpm test` to
-run a more comprehensive suite.
-
-## From ember-cli
-
-1. `ember test --server`
-
-2. Connect the browsers you want.
-
-To run a specific browser, you can use the `--launch` flag
-
-* `ember test --server --launch SL_Firefox_Current`
-* `ember test --launch SL_Firefox_Current`
-* `ember test --launch SL_Firefox_Current,Chrome`
-
-To test multiple launchers, you can separate them with commas.
 
 # Pull Requests
 
@@ -245,12 +222,11 @@ Within the [CI workflow](https://github.com/emberjs/ember.js/blob/main/.github/w
 
 * `Linting` runs `pnpm lint` to check for code style issues.
 * `Type Checking` runs `pnpm type-check` to check for TypeScript type errors. This also runs against several version of TypeScript that are supported.
-* `Basic Test` / `each-package` test suite is closest to what you normally run locally on your machine. This is also run with all deprecations enabled -- that is, a deprecation that has been added but is not yet up to it's enabled version will be forced "on" and the test suite is required to pass both ways.
-* `Production` test suite runs tests against a production build. This also runs with the "Debug Render Tree" feature enabled.
+* `Basic Test` test suite is closest to what you normally run locally on your machine. 
+* `Variant Tests` run the test suite under different combinations of settings. See documentation in run-tests.js for the meaning of each setting.
 * `BrowserStack` and `Browser Tests` test suites run tests against various supported browsers.
 * `Blueprint Tests` runs tests for the Ember CLI blueprints provided by Ember in this package.
 * `Smoke Test` builds and runs a simple app.
-* `Extend Prototypes` runs the `extend-prototypes` test suite.
 * `Node.js Tests` runs tests for the node-side code in this package.
 
 Each commit to canary and beta publishes to the relevant channel on S3. These 

--- a/tests/index.html
+++ b/tests/index.html
@@ -36,27 +36,27 @@
 
 
         // Handle extending prototypes
-        EmberENV['EXTEND_PROTOTYPES'] = !!QUnit.urlParams.extendprototypes;
+        EmberENV['EXTEND_PROTOTYPES'] = !!QUnit.urlParams.EXTEND_PROTOTYPES;
 
         // Handle testing feature flags
-        if (QUnit.urlParams.enableoptionalfeatures) {
+        if (QUnit.urlParams.ENABLE_OPTIONAL_FEATURES) {
           EmberENV.ENABLE_OPTIONAL_FEATURES = true;
         }
 
         EmberENV['RAISE_ON_DEPRECATION'] = true;
 
-        if (QUnit.urlParams.alldeprecationsenabled) {
-          EmberENV['_ALL_DEPRECATIONS_ENABLED'] = QUnit.urlParams.alldeprecationsenabled;
+        if (QUnit.urlParams.ALL_DEPRECATIONS_ENABLED) {
+          EmberENV['_ALL_DEPRECATIONS_ENABLED'] = QUnit.urlParams.ALL_DEPRECATIONS_ENABLED;
         }
 
-        if (QUnit.urlParams.overridedeprecationversion) {
-          EmberENV['_OVERRIDE_DEPRECATION_VERSION'] = QUnit.urlParams.overridedeprecationversion;
+        if (QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION) {
+          EmberENV['_OVERRIDE_DEPRECATION_VERSION'] = QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION;
         }
       })();
     </script>
 
     <script>
-      if (QUnit.urlParams.prebuilt) {
+      if (QUnit.urlParams.PREBUILT) {
         loadScript('../ember.debug.js');
       } else {
         loadScript('./ember.js');
@@ -97,9 +97,9 @@
         // Hide skipped tests
         QUnit.config.urlConfig.push({ id: 'hideskipped', label: "Hide skipped tests"});
         // Handle testing feature flags
-        QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features"});
+        QUnit.config.urlConfig.push({ id: 'ENABLE_OPTIONAL_FEATURES', label: "Enable Opt Features"});
         // Handle extending prototypes
-        QUnit.config.urlConfig.push({ id: 'extendprototypes', label: 'Extend Prototypes'});
+        QUnit.config.urlConfig.push({ id: 'EXTEND_PROTOTYPES', label: 'Extend Prototypes'});
 
         QUnit.config.urlConfig.push('forceskip');
 


### PR DESCRIPTION
This surfaces all variants of our test suite in one github actions matrix.

Previously, each job you'd see in ci.yml actually invoked some combination of other jobs that were governed by run-tests.js. Now all the possible test suite variants are handled in one flat list and we can choose the list of combinations we want to test, and see each of their results independently in github actions output.

I did not completely reproduce the old behavior. We *could*, but I think some of what it was testing was more by accident than intentional. The "prebuilt" variant for example is worth testing, but not under every possible other flag. It gets built with the exact same pipeline we use for the not-prebuilt stuff.

This change also eliminates the per-package filtering that was being managed by run-tests.js. For interactive use, we have perfectly adequate filtering via qunit's UI. For CI runs, the splitting into packages only to re-concatenate them in series was actively counter-productive.