### PR TITLE
Fix running tests with all deprecations enabled.

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -788,13 +788,7 @@ if (ENV._DEBUG_RENDER_TREE) {
         ]);
       }
 
-      async [`${testUnless(
-        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-      )} template-only components`]() {
-        expectDeprecation(
-          /resolved templates/,
-          DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
-        );
+      async [`@test template-only components`]() {
         this.addTemplate(
           'application',
           strip`

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -1,10 +1,8 @@
 import {
   ApplicationTestCase,
   ModuleBasedTestResolver,
-  expectDeprecation,
   moduleFor,
   strip,
-  testUnless,
 } from 'internal-test-helpers';
 
 import { ENV } from '@ember/-internals/environment';
@@ -24,7 +22,6 @@ import type { SimpleElement, SimpleNode } from '@simple-dom/interface';
 import type { EmberPrecompileOptions } from 'ember-template-compiler';
 import { compile } from 'ember-template-compiler';
 import { runTask } from 'internal-test-helpers/lib/run';
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import templateOnly from '@ember/component/template-only';
 
 interface CapturedBounds {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -1,4 +1,11 @@
-import { moduleFor, RenderingTestCase, strip, runTask, testUnless } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  strip,
+  runTask,
+  testUnless,
+  expectDeprecation,
+} from 'internal-test-helpers';
 
 import { set } from '@ember/object';
 
@@ -284,6 +291,11 @@ class AbstractAppendTest extends RenderingTestCase {
   )} lifecycle hooks during component append`](assert) {
     let hooks = [];
 
+    expectDeprecation(
+      /resolved templates/,
+      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
+    );
+
     let oldRegisterComponent = this.registerComponent;
     let componentsByName = {};
 
@@ -531,6 +543,11 @@ class AbstractAppendTest extends RenderingTestCase {
     DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
   )} appending, updating and destroying a single component`](assert) {
     let willDestroyCalled = 0;
+
+    expectDeprecation(
+      /separately resolved templates/,
+      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
+    );
 
     this.registerComponent('x-parent', {
       ComponentClass: Component.extend({

--- a/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
@@ -31,8 +31,6 @@ moduleFor(
     [`${testUnless(
       DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
     )} it takes precedence over resolver`]() {
-      expectDeprecation('', DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled);
-
       this.registerComponent('foo-bar', {
         ComponentClass: setComponentTemplate(compile('hello'), Component.extend()),
         resolveableTemplate: 'noooooo!',

--- a/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
@@ -1,11 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import {
-  expectDeprecation,
-  moduleFor,
-  RenderingTestCase,
-  runTask,
-  testUnless,
-} from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask, testUnless } from 'internal-test-helpers';
 
 import { setComponentTemplate, getComponentTemplate } from '@glimmer/manager';
 import { Component, compile } from '../../utils/helpers';

--- a/packages/@ember/-internals/glimmer/tests/integration/components/strict-mode-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/strict-mode-test.js
@@ -6,6 +6,7 @@ import {
   defineSimpleHelper,
   defineSimpleModifier,
   testUnless,
+  expectDeprecation,
 } from 'internal-test-helpers';
 
 import { Input, Textarea } from '@ember/component';
@@ -268,6 +269,11 @@ moduleFor(
     [`${testUnless(DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved)} Can use action helper`](
       assert
     ) {
+      expectDeprecation(
+        /Migrate to native functions/,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let called = 0;
 
       let Foo = defineComponent(
@@ -294,6 +300,11 @@ moduleFor(
     [`${testUnless(DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isRemoved)} Can use action modifier`](
       assert
     ) {
+      expectDeprecation(
+        /Migrate to native functions/,
+        DEPRECATIONS.DEPRECATE_TEMPLATE_ACTION.isEnabled
+      );
+
       let called = 0;
 
       let Foo = defineComponent(

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -15,6 +15,7 @@ import Engine, { getEngineParent } from '@ember/engine';
 
 import { backtrackingMessageFor } from '../utils/debug-stack';
 import { compile, Component } from '../utils/helpers';
+import { setComponentTemplate } from '@glimmer/manager';
 
 moduleFor(
   '{{mount}} single param assertion',
@@ -142,18 +143,22 @@ moduleFor(
         },
       });
 
-      this.engineRegistrations['template:components/component-with-backtracking-set'] = compile(
-        '[component {{this.person.name}}]',
-        {
-          moduleName: 'my-app/templates/components/component-with-backtracking-set.hbs',
-        }
-      );
-      this.engineRegistrations['component:component-with-backtracking-set'] = Component.extend({
+      let ComponentWithBacktrackingSet = Component.extend({
         init() {
           this._super(...arguments);
           this.set('person.name', 'Ben');
         },
       });
+
+      setComponentTemplate(
+        compile('[component {{this.person.name}}]', {
+          moduleName: 'my-app/templates/components/component-with-backtracking-set.hbs',
+        }),
+        ComponentWithBacktrackingSet
+      );
+
+      this.engineRegistrations['component:component-with-backtracking-set'] =
+        ComponentWithBacktrackingSet;
 
       let expectedBacktrackingMessage = backtrackingMessageFor('name', 'Person \\(Ben\\)', {
         renderTree: ['application', 'route-with-mount', 'chat', 'this.person.name'],

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -128,7 +128,10 @@ moduleFor(
     [`${testUnless(
       DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
     )} each template is only compiled once`]() {
-      expectDeprecation(/msg here/, DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled);
+      expectDeprecation(
+        /resolved templates/,
+        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
+      );
       // static layout
       this.registerComponent('component-one', { resolveableTemplate: 'One' });
 

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -2,7 +2,13 @@ import Application from '@ember/application';
 import Controller from '@ember/controller';
 import { Component } from '@ember/-internals/glimmer';
 import { compile } from 'ember-template-compiler';
-import { moduleFor, testUnless, ApplicationTestCase, defineComponent } from 'internal-test-helpers';
+import {
+  moduleFor,
+  testUnless,
+  ApplicationTestCase,
+  defineComponent,
+  expectDeprecation,
+} from 'internal-test-helpers';
 import { DEBUG } from '@glimmer/env';
 import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import templateOnly from '@ember/component/template-only';
@@ -83,6 +89,10 @@ moduleFor(
     )} Late-registered components can be rendered with template registered on the container`](
       assert
     ) {
+      expectDeprecation(
+        /resolved templates/,
+        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
+      );
       this.addTemplate(
         'application',
         `<div id='wrapper'>hello world {{sally-rutherford}}-{{#sally-rutherford}}!!!{{/sally-rutherford}}</div>`
@@ -119,6 +129,11 @@ moduleFor(
     )} Late-registered components can be rendered with ONLY the template registered on the container`](
       assert
     ) {
+      expectDeprecation(
+        /resolved templates/,
+        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
+      );
+
       this.addTemplate(
         'application',
         `<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>`

--- a/packages/ember/tests/routing/router_service_test/non_application_test_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test_test.js
@@ -82,20 +82,22 @@ moduleFor(
 
       this.addTemplate('parent.index', '{{foo-bar}}');
 
+      let FooBar = Component.extend({
+        routerService: service('router'),
+        layout: this.compile('foo-bar'),
+        init() {
+          this._super(...arguments);
+          componentInstance = this;
+        },
+        actions: {
+          transitionToSister() {
+            get(this, 'routerService').transitionTo('parent.sister');
+          },
+        },
+      });
+
       this.addComponent('foo-bar', {
-        ComponentClass: Component.extend({
-          routerService: service('router'),
-          init() {
-            this._super(...arguments);
-            componentInstance = this;
-          },
-          actions: {
-            transitionToSister() {
-              get(this, 'routerService').transitionTo('parent.sister');
-            },
-          },
-        }),
-        template: `foo-bar`,
+        ComponentClass: FooBar,
       });
 
       this.render('{{foo-bar}}');

--- a/tests/index.html
+++ b/tests/index.html
@@ -46,7 +46,7 @@
         EmberENV['RAISE_ON_DEPRECATION'] = true;
 
         if (QUnit.urlParams.ALL_DEPRECATIONS_ENABLED) {
-          EmberENV['_ALL_DEPRECATIONS_ENABLED'] = QUnit.urlParams.ALL_DEPRECATIONS_ENABLED;
+          EmberENV['_ALL_DEPRECATIONS_ENABLED'] = true;
         }
 
         if (QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -109,6 +109,11 @@
           label: 'Deprecation Version',
         });
 
+        QUnit.config.urlConfig.push({
+          id: 'ALL_DEPRECATIONS_ENABLED',
+          label: 'Enable All Deprecations',
+        });
+
 
         if (QUnit.config.seed) {
           QUnit.config.reorder = false;


### PR DESCRIPTION
The refactor to put the QUnit parameter directly into the EmberENV instead of using process.env to set the QUnit parameter resulted in the property being a string instead of a boolean