### PR TITLE
Bugfix: new loader feature was missing cache update

### DIFF
--- a/packages/loader/lib/index.js
+++ b/packages/loader/lib/index.js
@@ -74,7 +74,7 @@ var define, require;
 
     var result = callback.apply(this, reified);
     if (!deps.includes('exports') || result !== undefined) {
-      exports = result;
+      exports = seen[name] = result;
     }
 
     return exports;

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -34,6 +34,14 @@ QUnit.module('ember-template-compiler.js', function () {
       assert.notEqual(typeof templateCompiler._Ember.ENV, null, '_Ember.ENV is not null');
     });
 
+    QUnit.test('_Ember.ENV (private API used by ember-cli-htmlbars) is stable', function (assert) {
+      assert.strictEqual(
+        templateCompiler._Ember.ENV,
+        templateCompiler._Ember.ENV,
+        '_Ember.ENV is stable'
+      );
+    });
+
     QUnit.test(
       'can access _Ember.FEATURES (private API used by ember-cli-htmlbars)',
       function (assert) {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/20675 included a small addition to the basic AMD loader that ships inside ember-source for use in node. I added the ability to register a whole preexisting module.

But when using that feature, we don't stick the results into the seen cache, so subsequent requests will see an empty module.