### PR TITLE
Update matchers.ts DOM text reinterpreted as HTML

### DIFF
--- a/packages/internal-test-helpers/lib/matchers.ts
+++ b/packages/internal-test-helpers/lib/matchers.ts
@@ -164,8 +164,8 @@ export function equalsElement(
 
     if (content !== null) {
       assert.pushResult({
-        result: element.innerHTML === content,
-        actual: element.innerHTML,
+        result: element.innerText === content,
+        actual: element.innerText,
         expected: content,
         message: `The element had '${content}' as its content`,
       });


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.

