### PR TITLE
Bugfix: restore publishing of internals entrypoints

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -135,7 +135,10 @@ function packages() {
   });
 
   // add only the entrypoints of the rolledUpPackages
-  entryFiles = [...entryFiles, ...glob.sync(`{${rolledUpPackages().join(',')}}/index.{js,ts}`)];
+  entryFiles = [
+    ...entryFiles,
+    ...glob.sync(`{${rolledUpPackages().join(',')}}/index.{js,ts}`, { cwd: 'packages' }),
+  ];
 
   return Object.fromEntries(
     entryFiles.map((filename) => [filename.replace(/\.[jt]s$/, ''), filename])


### PR DESCRIPTION
This is a followup bugfix to https://github.com/emberjs/ember.js/pull/20675.

That PR inadvertently stopped publishing entrypoints for certain internal packages, when consuming ember as separate modules. These packages are not public API, but they're used, so we need to keep them.

A symptom of what breaks here is ember-data importing `@ember/-internals/metal`, when building with Embroider's strictEmberSource option.