### PR TITLE
Update deprecation links for `template-action` & `component-template-resolving`

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -111,7 +111,7 @@ export const DEPRECATIONS = {
   }),
   DEPRECATE_TEMPLATE_ACTION: deprecation({
     id: 'template-action',
-    url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-template-action',
+    url: 'https://deprecations.emberjs.com/id/deprecate-template-action',
     until: '6.0.0',
     for: 'ember-source',
     since: {
@@ -121,7 +121,7 @@ export const DEPRECATIONS = {
   }),
   DEPRECATE_COMPONENT_TEMPLATE_RESOLVING: deprecation({
     id: 'component-template-resolving',
-    url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-component-template-resolving',
+    url: 'https://deprecations.emberjs.com/id/deprecate-component-template-resolving',
     until: '6.0.0',
     for: 'ember-source',
     since: {

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -111,7 +111,7 @@ export const DEPRECATIONS = {
   }),
   DEPRECATE_TEMPLATE_ACTION: deprecation({
     id: 'template-action',
-    url: 'https://deprecations.emberjs.com/id/template-action',
+    url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-template-action',
     until: '6.0.0',
     for: 'ember-source',
     since: {
@@ -121,7 +121,7 @@ export const DEPRECATIONS = {
   }),
   DEPRECATE_COMPONENT_TEMPLATE_RESOLVING: deprecation({
     id: 'component-template-resolving',
-    url: 'https://deprecations.emberjs.com/id/component-template-resolving',
+    url: 'https://deprecations.emberjs.com/v5.x/#toc_deprecate-component-template-resolving',
     until: '6.0.0',
     for: 'ember-source',
     since: {


### PR DESCRIPTION
The deprecation pages are now online, so we can update the urls in deprecation.

- https://deprecations.emberjs.com/id/deprecate-template-action
- https://deprecations.emberjs.com/id/deprecate-component-template-resolving