### PR TITLE
Deprecate array prototype extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: smoke-tests/scenarios
         run: |
           matrix_json=$(pnpm scenario-tester list --require @swc-node/register --files "*-test.ts" --matrix "pnpm run test --filter %s"   )
-          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT        
+          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
 
   types:
     name: Type Checking (current version)
@@ -105,9 +105,11 @@ jobs:
             ENABLE_OPTIONAL_FEATURES: "true"
           - name: "Extend prototypes"
             EXTEND_PROTOTYPES: "true"
+            RAISE_ON_DEPRECATION: "false"
           - name: "Extend prototypes, with optional features"
             EXTEND_PROTOTYPES: "true"
             ENABLE_OPTIONAL_FEATURES: "true"
+            RAISE_ON_DEPRECATION: "false"
 
     steps:
       - uses: actions/checkout@v3
@@ -120,6 +122,7 @@ jobs:
           OVERRIDE_DEPRECATION_VERSION: ${{ matrix.OVERRIDE_DEPRECATION_VERSION }}
           EXTEND_PROTOTYPES: ${{ matrix.EXTEND_PROTOTYPES }}
           ENABLE_OPTIONAL_FEATURES: ${{ matrix.ENABLE_OPTIONAL_FEATURES }}
+          RAISE_ON_DEPRECATION: ${{ matrix.RAISE_ON_DEPRECATION }}
 
         run: pnpm test
 

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
 'use strict';
 
-/* 
+/*
   Test Variants
 
   These are all accepted as environment variables when running `ember test` or
-  as query params when directly invoking the test suite in the browser. 
+  as query params when directly invoking the test suite in the browser.
 */
 const variants = [
   // When true, even deprecations that are not yet at the "enabled" version will
@@ -25,6 +25,9 @@ const variants = [
   // This enables all canary feature flags for unreleased feature within Ember
   // itself.
   'ENABLE_OPTIONAL_FEATURES',
+
+  // Throw on unexpected deprecations. Defaults to true if not set explicitly.
+  'RAISE_ON_DEPRECATION',
 ];
 
 const chalk = require('chalk');

--- a/index.html
+++ b/index.html
@@ -32,15 +32,17 @@
         EmberENV.ENABLE_OPTIONAL_FEATURES = true;
       }
 
-      EmberENV['RAISE_ON_DEPRECATION'] = true;
+      EmberENV['RAISE_ON_DEPRECATION'] = QUnit.urlParams.RAISE_ON_DEPRECATION
+        ? QUnit.urlParams.RAISE_ON_DEPRECATION === 'true'
+        : true;
 
       if (QUnit.urlParams.ALL_DEPRECATIONS_ENABLED) {
-          EmberENV['_ALL_DEPRECATIONS_ENABLED'] = true;
-        }
+        EmberENV['_ALL_DEPRECATIONS_ENABLED'] = true;
+      }
 
-        if (QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION) {
-          EmberENV['_OVERRIDE_DEPRECATION_VERSION'] = QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION;
-        }
+      if (QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION) {
+        EmberENV['_OVERRIDE_DEPRECATION_VERSION'] = QUnit.urlParams.OVERRIDE_DEPRECATION_VERSION;
+      }
     </script>
 
     <script type="module">

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -129,6 +129,16 @@ export const DEPRECATIONS = {
       enabled: '5.10.0',
     },
   }),
+  DEPRECATE_ARRAY_PROTOTYPE_EXTENSIONS: deprecation({
+    id: 'deprecate-array-prototype-extensions',
+    url: 'https://deprecations.emberjs.com/id/deprecate-deprecate-array-prototype-extensions',
+    until: '6.0.0',
+    for: 'ember-source',
+    since: {
+      available: '5.10.0',
+      enabled: '5.10.0',
+    },
+  }),
 };
 
 export function deprecateUntil(message: string, deprecation: DeprecationObject) {

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -154,3 +154,14 @@ export function deprecateUntil(message: string, deprecation: DeprecationObject) 
   }
   deprecate(message, deprecation.test, options);
 }
+
+const { EXTEND_PROTOTYPES } = ENV as {
+  EXTEND_PROTOTYPES: { Array?: boolean };
+};
+
+if (EXTEND_PROTOTYPES.Array !== false) {
+  deprecateUntil(
+    'Array prototype extensions are deprecated. Follow the deprecation guide for migration instructions, and set EmberENV.EXTEND_PROTOTYPES to false in your config/environment.js',
+    DEPRECATIONS.DEPRECATE_ARRAY_PROTOTYPE_EXTENSIONS
+  );
+}

--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -1,3 +1,4 @@
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import { DEBUG } from '@glimmer/env';
 import global from './global';
 
@@ -202,6 +203,14 @@ export const ENV = {
   }
 
   let { EXTEND_PROTOTYPES } = EmberENV;
+
+  if (EXTEND_PROTOTYPES !== false) {
+    deprecateUntil(
+      'Array prototype extensions are deprecated. Follow the deprecation guide for migration instructions, and set EmberENV.EXTEND_PROTOTYPES to false in your config/environment.js',
+      DEPRECATIONS.DEPRECATE_ARRAY_PROTOTYPE_EXTENSIONS
+    );
+  }
+
   if (EXTEND_PROTOTYPES !== undefined) {
     if (typeof EXTEND_PROTOTYPES === 'object' && EXTEND_PROTOTYPES !== null) {
       ENV.EXTEND_PROTOTYPES.Array = EXTEND_PROTOTYPES.Array !== false;

--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -1,4 +1,3 @@
-import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import { DEBUG } from '@glimmer/env';
 import global from './global';
 
@@ -203,14 +202,6 @@ export const ENV = {
   }
 
   let { EXTEND_PROTOTYPES } = EmberENV;
-
-  if (EXTEND_PROTOTYPES !== false) {
-    deprecateUntil(
-      'Array prototype extensions are deprecated. Follow the deprecation guide for migration instructions, and set EmberENV.EXTEND_PROTOTYPES to false in your config/environment.js',
-      DEPRECATIONS.DEPRECATE_ARRAY_PROTOTYPE_EXTENSIONS
-    );
-  }
-
   if (EXTEND_PROTOTYPES !== undefined) {
     if (typeof EXTEND_PROTOTYPES === 'object' && EXTEND_PROTOTYPES !== null) {
       ENV.EXTEND_PROTOTYPES.Array = EXTEND_PROTOTYPES.Array !== false;


### PR DESCRIPTION
As per [RFC848](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions).

This was a bit trickier than I actually expected, here is what I did and failed to do:
* The RFC says the deprecation should trigger when `EmberENV.EXTEND_PROTOTYPES` is not false. But given that there is some data munging happening [here](https://github.com/emberjs/ember.js/blob/f2940aaf714e9b17b143b6426a91d4fb65c5f70f/packages/%40ember/-internals/environment/lib/env.ts#L205-L211) that is turning `EXTEND_PROTOTYPES: false` to become `EXTEND_PROTOTYPES: { Array: false }`, which I was not eager to change, the deprecation is skipped for both of these. I think that is ok?
* I tried to add the deprecation to the [env.ts](https://github.com/emberjs/ember.js/blob/f2940aaf714e9b17b143b6426a91d4fb65c5f70f/packages/%40ember/-internals/environment/lib/env.ts#L205) file where the `EXTEND_PROTOTYPES` config is evaluated (1st commit)
* this didn't work, as it was causing a circular module dependency between that module and `deprecations/index.ts`, so I moved the deprecation call to the latter. Not ideal, but I had no better idea. (2nd commit)
* I have no test that is asserting for the deprecation to be issued, because with that implementation the deprecation is triggered when the module is loaded, so way before any test could call `expectDeprecation`. Any idea how to add a test here?
* Given that I was not able to silence the deprecation by a `expectDeprecation`, I added `RAISE_ON_DEPRECATION=false` to the test matrix scenarios that have `EXTEND_PROTOTYPES` to make them be able to actually run. (3rd commit)