### PR TITLE
Revert "Merge pull request #20700 from mkszepp/fix-deprecation-links"

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -111,7 +111,7 @@ export const DEPRECATIONS = {
   }),
   DEPRECATE_TEMPLATE_ACTION: deprecation({
     id: 'template-action',
-    url: 'https://deprecations.emberjs.com/id/deprecate-template-action',
+    url: 'https://deprecations.emberjs.com/id/template-action',
     until: '6.0.0',
     for: 'ember-source',
     since: {
@@ -121,7 +121,7 @@ export const DEPRECATIONS = {
   }),
   DEPRECATE_COMPONENT_TEMPLATE_RESOLVING: deprecation({
     id: 'component-template-resolving',
-    url: 'https://deprecations.emberjs.com/id/deprecate-component-template-resolving',
+    url: 'https://deprecations.emberjs.com/id/component-template-resolving',
     until: '6.0.0',
     for: 'ember-source',
     since: {


### PR DESCRIPTION
This reverts commit 199218e6b46ee74d926990c5b6749c1437063ca0, reversing changes made to f2940aaf714e9b17b143b6426a91d4fb65c5f70f.

Corrected this on the deprecation-app side by renaming the files there to match the deprecation ids (as was intended) https://github.com/ember-learn/deprecation-app/pull/1382