### PR TITLE
feat: support custom transitioning classes for LinkTo

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -511,14 +511,18 @@ class _LinkTo extends InternalComponent {
       isMissing(className) || typeof className === 'string' || typeof className === 'boolean'
     );
 
+    let defaultClassNames = {
+      active: 'active',
+      loading: 'loading',
+      disabled: 'disabled',
+      transitioningIn: 'ember-transitioning-in',
+      transitioningOut: 'ember-transitioning-out',
+    } as const
+
     if (className === true || isMissing(className)) {
-      return ` ${state}`;
+      return ` ${defaultClassNames[state]}`;
     } else if (className) {
       return ` ${className}`;
-    } else if (className === 'transitioningIn') {
-      return ' ember-transitioning-in';
-    } else if (className === 'transitioningOut') {
-      return ' ember-transitioning-out';
     } else {
       return '';
     }

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -312,10 +312,10 @@ class _LinkTo extends InternalComponent {
       classes += this.classFor('active');
 
       if (this.willBeActive === false) {
-        classes += ' ember-transitioning-out';
+        classes += this.classFor('transitioningOut');
       }
     } else if (this.willBeActive) {
-      classes += ' ember-transitioning-in';
+      classes += this.classFor('transitioningIn');
     }
 
     if (this.isLoading) {
@@ -503,7 +503,7 @@ class _LinkTo extends InternalComponent {
     return owner instanceof EngineInstance ? owner.mountPoint : undefined;
   }
 
-  private classFor(state: 'active' | 'loading' | 'disabled'): string {
+  private classFor(state: 'active' | 'loading' | 'disabled' | 'transitioningIn' | 'transitioningOut'): string {
     let className = this.named(`${state}Class`);
 
     assert(
@@ -515,6 +515,10 @@ class _LinkTo extends InternalComponent {
       return ` ${state}`;
     } else if (className) {
       return ` ${className}`;
+    } else if (className === 'transitioningIn') {
+      return ' ember-transitioning-in';
+    } else if (className === 'transitioningOut') {
+      return ' ember-transitioning-out';
     } else {
       return '';
     }
@@ -578,6 +582,8 @@ class _LinkTo extends InternalComponent {
       'activeClass',
       'loadingClass',
       'disabledClass',
+      'transitioningInClass',
+      'transitioningOutClass',
     ];
 
     return supportedArguments.indexOf(name) !== -1 || super.isSupportedArgument(name);


### PR DESCRIPTION
It has long been an issue that async model hooks with loading substates causes ember applications to feel sluggish for transitions. The LinkTo doesn't change until the full transition is complete

See this issue from 2014 https://github.com/emberjs/ember.js/issues/4908

For my applications, for many years now, I've avoided them wherever possible, opting to use ember-concurrency tasks or reactiveweb tracked functions instead. Instant transitions & allows for much greater control over loading state etc.

I came up against a situation where I needed to use an async model hook for a kinda slow request, and wasn't happy about how slow it made the page feel, particularly due to the LinkTo. I ended up delving into LinkTo source code and found out about `ember-transitioning-in` and `ember-transitioning-out` - if only I had known years ago!

I think it's important that more users know about these classes, and that that's why their pages feel slow when they use async model hooks. By making `transitioningInClass` and `transitioningOutClass` customizable, this should help with visibility a lot, ideally accompanying an API reference update as well.

---

Alternatively, as mentioned in that issue, should the LinkTo active class be updated to be eager? This is probably a better solution, but I understand that might have wider impacts. The change proposed in this PR shouldn't cause any breaking changes.

---

The PR I linked has a good gif demonstrating the "slow" LinkTo update, but here's a new demonstration video that shows it as well. Note how long it takes the "Reports" side nav item to update to active/blue after I click it

https://github.com/emberjs/ember.js/assets/1049837/ed8b02e6-4249-4968-b355-1c49323641dd
