### PR TITLE
[BUGFIX release] Don't publish empty modules

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -58,6 +58,7 @@ function esmConfig() {
       resolveTS(),
       version(),
       resolvePackages(exposedDependencies(), hiddenDependencies()),
+      pruneEmptyBundles(),
     ],
   };
 }
@@ -443,7 +444,7 @@ function templateCompilerConfig() {
   });
   config.output.globals = (id) => {
     return `(() => {
-      try { 
+      try {
         return require('${id}');
       } catch (err) {
         return ${externals[id]}
@@ -451,4 +452,17 @@ function templateCompilerConfig() {
     })()`;
   };
   return config;
+}
+
+function pruneEmptyBundles() {
+  return {
+    name: 'prune-empty-bundles',
+    generateBundle(options, bundles) {
+      for (let [key, bundle] of Object.entries(bundles)) {
+        if (bundle.code.trim() === '') {
+          delete bundles[key];
+        }
+      }
+    },
+  };
 }


### PR DESCRIPTION
The ES modules build (which is only used by embroider, not classic builds) includes several empty modules. They're type-only, and result in empty files after transpiling typescript.

This isn't necessarily wrong but it's unnecessary and it can trigger bugs in systems that are trying to use the presence of import/export to detect ESM format.