### PR TITLE
[BUGFIX release] Remove unintentional duplication from ember-testing bundle

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
         extensions: ['.js', '.ts'],
         configFile: resolve(dirname(fileURLToPath(import.meta.url)), './babel.test.config.mjs'),
       }),
-      resolvePackages(exposedDependencies(), hiddenDependencies()),
+      resolvePackages({ ...exposedDependencies(), ...hiddenDependencies() }),
       viteResolverBug(),
       version(),
     ],


### PR DESCRIPTION
Working on a fix for https://github.com/emberjs/ember.js/issues/20724

The ember-testing bundle is inlining copies of other ember packages that cause state to duplicate, which is most noticeable in breaking legacy test waiters.

- [x] Next step here is to sort out the AMD/ESM compat for the external references between the bundles.