### PR TITLE
Bump barrel file deprecations until 7.0.0

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -96,7 +96,7 @@ export const DEPRECATIONS = {
       id: `deprecate-import-${dasherize(importName).toLowerCase()}-from-ember`,
       for: 'ember-source',
       since: { available: '5.10.0' },
-      until: '6.0.0',
+      until: '7.0.0',
       url: `https://deprecations.emberjs.com/id/import-${dasherize(
         importName
       ).toLowerCase()}-from-ember`,


### PR DESCRIPTION
While we landed this deprecations successfully into ember-source we didn't manage to ship the necessary updates to other first-party packages to enable this deprecation at 6.0.0. Bumping to 7.0.0.