### PR TITLE
[TYPES] Directly assign a boolean value in deprecated-features

### DIFF
--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -3,4 +3,5 @@
 // These versions should be the version that the deprecation was _introduced_,
 // not the version that the feature will be removed.
 
-export const ASSIGN = !!'4.0.0-beta.1';
+/** Introduced in 4.0.0-beta.1 */
+export const ASSIGN = true;

--- a/packages/@ember/deprecated-features/index.ts
+++ b/packages/@ember/deprecated-features/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-implicit-coercion */
-
 // These versions should be the version that the deprecation was _introduced_,
 // not the version that the feature will be removed.
 


### PR DESCRIPTION
Nightly TS rightly complains that `!!'4.0.0-beta.1'` is always true. Instead, we just use a boolean and add a comment telling when it was introduced.