### PR TITLE
add v2 addon metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "keywords": [
     "ember-addon"
   ],
+  "exports": {
+    "./*": "./dist/packages/*",
+    "./dist/ember-template-compiler.js": "./dist/ember-template-compiler.js",
+    "./package.json": "./package.json"
+  },
   "homepage": "https://emberjs.com/",
   "bugs": {
     "url": "https://github.com/emberjs/ember.js/issues"
@@ -174,7 +179,8 @@
     "node": ">= 18.*"
   },
   "ember-addon": {
-    "after": "ember-cli-legacy-blueprints"
+    "after": "ember-cli-legacy-blueprints",
+    "type": "addon"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
This adds v2-addon-style metadata to the package.json at publication. Our build already produces everything needed to be a valid v2 addon, other than this metadata.

This PR doesn't actually flip the final switch though (by adding `version: 2` to the metdata). So it's safe and nonbreaking. This just gets us one step closer.

And it's helpful because embroider users will be able to opt in to treating ember-source as v2 even before we force it to be v2 for everyone.