### PR TITLE
attempting to fix metadata in alpha releases

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -502,7 +502,11 @@ function pruneEmptyBundles() {
 function packageMeta() {
   let renamedModules = Object.fromEntries(
     glob
-      .sync('**/*.js', { cwd: 'dist/packages', ignore: ['shared-chunks/**'], nodir: true })
+      .sync('**/*.js', {
+        cwd: new URL('dist/packages', import.meta.url).pathname,
+        ignore: ['shared-chunks/**'],
+        nodir: true,
+      })
       .map((name) => {
         return [name, 'ember-source/' + name];
       })


### PR DESCRIPTION
The alpha release CI is publishing with empty renamed-modules. I'm not quite sure why. This will eliminate the possibility that it's a CWD problem.