### PR TITLE
Fix object key 'ember-adodn' in rollup.config

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -516,7 +516,7 @@ function packageMeta() {
       );
       let pkg = JSON.parse(readFileSync('package.json'));
       if (!pkg['ember-addon']) {
-        pkg['ember-adodn'] = {};
+        pkg['ember-addon'] = {};
       }
       pkg['ember-addon']['renamed-modules'] = renamedModules;
       writeFileSync('package.json', JSON.stringify(pkg, null, 2));


### PR DESCRIPTION
rollup.config was added here with incorrect key https://github.com/emberjs/ember.js/commit/0909c98987334a09de31dd07099037b1a2b6ae9e#diff-47407fecafdf5f5cd55403c3de457833ddf9b6fab45253c04e1dc4c7cb4495b1R518