### PR TITLE
Prepare to implement tracked storage, RFC#669

### DIFF
--- a/packages/@glimmer/tracking/primitives/storage.ts
+++ b/packages/@glimmer/tracking/primitives/storage.ts
@@ -1,0 +1,32 @@
+/**
+ * https://rfcs.emberjs.com/id/0669-tracked-storage-primitive
+ *
+ * See, in particular:
+ *  https://rfcs.emberjs.com/id/0669-tracked-storage-primitive#re-implementing-tracked-with-storage
+ *
+ * This was an earlier iteration of "Cells" from starbeam.
+ *
+ * Ultimately, these functions could (and maybe should)
+ * be re-exports from Glimmer and/or Starbeam
+ */
+
+export function createStorage<T>(
+  initialValue?: T,
+  isEqual?: (oldValue: T, newValue: T) => boolean
+): Storage<T> {
+  throw new Error('Not Implemented');
+}
+
+/**
+ * This function receives a tracked storage instance, and returns the value it contains, consuming it so that it entangles with any currently active autotracking contexts.
+ */
+export function getValue<T>(storage: Storage<T>): T {
+  throw new Error('Not Implemented');
+}
+
+/**
+ * This function receives a tracked storage instance and a value, and sets the value of the tracked storage to the passed value if it is not equal to the previous value. If the value is set, it will dirty the storage, causing any tracked computations which consumed the stored value to recompute. If the value was not changed, then it does not set the value or dirty it.
+ */
+export function setValue<T>(storage: Storage<T>, value: T): void {
+  throw new Error('Not Implemented');
+}


### PR DESCRIPTION
Motivation here is that I want to stop folks from using https://github.com/ember-polyfills/ember-tracked-storage-polyfill (and swap its implementation to use the real implementation (here, hopefully)

----------------

This doesn't make sense to continue work on until 
- https://github.com/emberjs/ember.js/pull/20751

lands -- because I don't really want to continue the fake-glimmer packages we have in `@ember/-internals/metal`

Additionally, this RFC, https://rfcs.emberjs.com/id/0669-tracked-storage-primitive#re-implementing-tracked-with-storage, kinda just likes like Starbeam concepts, so it should be super easy:
```js
export function trackedStorage(...) {
  return Cell(...);
}

export function getValue(cell) {
  return cell.current;
}

export function setValue(cell, value) {
  return cell.set(value);
}
```
ez