### PR TITLE
Initial implementation of renderComponent

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -1,11 +1,10 @@
 import { ENV } from '@ember/-internals/environment';
-import { get, set, _getProp, _setProp } from '@ember/-internals/metal';
-import type { InternalOwner } from '@ember/-internals/owner';
+import { _getProp, _setProp, get, set } from '@ember/-internals/metal';
 import { getDebugName } from '@ember/-internals/utils';
 import { constructStyleDeprecationMessage } from '@ember/-internals/views';
-import { assert, deprecate, warn } from '@ember/debug';
 import type { DeprecationOptions } from '@ember/debug';
-import { schedule, _backburner } from '@ember/runloop';
+import { assert, deprecate, warn } from '@ember/debug';
+import { _backburner, schedule } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import setGlobalContext from '@glimmer/global-context';
 import type { EnvironmentDelegate } from '@glimmer/runtime';
@@ -131,7 +130,7 @@ const VM_ASSERTION_OVERRIDES: { id: string; message: string }[] = [];
 export class EmberEnvironmentDelegate implements EnvironmentDelegate {
   public enableDebugTooling: boolean = ENV._DEBUG_RENDER_TREE;
 
-  constructor(public owner: InternalOwner, public isInteractive: boolean) {}
+  constructor(public owner: object, public isInteractive: boolean) {}
 
   onTransactionCommit(): void {}
 }

--- a/packages/@ember/-internals/glimmer/lib/renderer/strict-resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer/strict-resolver.ts
@@ -1,0 +1,40 @@
+import type {
+  CompileTimeResolver as VMCompileTimeResolver,
+  InternalComponentManager,
+  Nullable,
+  ResolvedComponentDefinition,
+  RuntimeResolver as VMRuntimeResolver,
+} from '@glimmer/interfaces';
+import { BUILTIN_HELPERS, BUILTIN_KEYWORD_HELPERS } from '../resolver';
+
+///////////
+
+/**
+ * Resolution for non built ins is now handled by the vm as we are using strict mode
+ */
+export class StrictResolver implements VMRuntimeResolver, VMCompileTimeResolver {
+  lookupHelper(name: string, _owner: object): Nullable<object> {
+    return BUILTIN_HELPERS[name] ?? null;
+  }
+
+  lookupBuiltInHelper(name: string): Nullable<object> {
+    return BUILTIN_KEYWORD_HELPERS[name] ?? null;
+  }
+
+  lookupModifier(_name: string, _owner: object): Nullable<object> {
+    return null;
+  }
+
+  lookupComponent(
+    _name: string,
+    _owner: object
+  ): Nullable<
+    ResolvedComponentDefinition<object, unknown, InternalComponentManager<unknown, object>>
+  > {
+    return null;
+  }
+
+  lookupBuiltInModifier(_name: string): Nullable<object> {
+    return null;
+  }
+}

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -120,7 +120,7 @@ function lookupComponentPair(
   }
 }
 
-const BUILTIN_KEYWORD_HELPERS: Record<string, object> = {
+export const BUILTIN_KEYWORD_HELPERS: Record<string, object> = {
   action,
   mut,
   readonly,
@@ -135,7 +135,7 @@ const BUILTIN_KEYWORD_HELPERS: Record<string, object> = {
   '-in-el-null': inElementNullCheckHelper,
 };
 
-const BUILTIN_HELPERS: Record<string, object> = {
+export const BUILTIN_HELPERS: Record<string, object> = {
   ...BUILTIN_KEYWORD_HELPERS,
   array,
   concat,

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -1,0 +1,284 @@
+import {
+  AbstractStrictTestCase,
+  assertClassicComponentElement,
+  assertHTML,
+  buildOwner,
+  clickElement,
+  defComponent,
+  defineComponent,
+  defineSimpleHelper,
+  defineSimpleModifier,
+  moduleFor,
+  type ClassicComponentShape,
+} from 'internal-test-helpers';
+
+import { Input, Textarea } from '@ember/component';
+import { array, concat, fn, get, hash, on } from '@glimmer/runtime';
+import GlimmerishComponent from '../../utils/glimmerish-component';
+
+import { run } from '@ember/runloop';
+import { associateDestroyableChild } from '@glimmer/destroyable';
+import type { RenderResult } from '@glimmer/interfaces';
+import { renderComponent } from '../../../lib/renderer';
+
+class RenderComponentTestCase extends AbstractStrictTestCase {
+  component: RenderResult | undefined;
+  owner: object;
+
+  constructor(assert: QUnit['assert']) {
+    super(assert);
+
+    this.owner = buildOwner({});
+    associateDestroyableChild(this, this.owner);
+  }
+
+  get element() {
+    return document.querySelector('#qunit-fixture')!;
+  }
+
+  renderComponent(
+    component: object,
+    options: { expect: string } | { classic: ClassicComponentShape }
+  ) {
+    let { owner } = this;
+
+    run(() => {
+      this.component = renderComponent(component, {
+        owner,
+        env: { document: document, isInteractive: true, hasDOM: true },
+        into: this.element,
+      });
+      if (this.component) {
+        associateDestroyableChild(this, this.component);
+      }
+    });
+
+    if ('expect' in options) {
+      assertHTML(options.expect);
+    } else {
+      assertClassicComponentElement(options.classic);
+    }
+
+    this.assertStableRerender();
+  }
+}
+
+moduleFor(
+  'Strict Mode - renderComponent',
+  class extends RenderComponentTestCase {
+    '@test Can use a component in scope'() {
+      let Foo = defComponent('Hello, world!');
+      let Root = defComponent('<Foo/>', { scope: { Foo } });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use a custom helper in scope (in append position)'() {
+      let foo = defineSimpleHelper(() => 'Hello, world!');
+      let Root = defComponent('{{foo}}', { scope: { foo } });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use a custom modifier in scope'() {
+      let foo = defineSimpleModifier((element) => (element.innerHTML = 'Hello, world!'));
+      let Root = defComponent('<div {{foo}}></div>', { scope: { foo } });
+
+      this.renderComponent(Root, { expect: '<div>Hello, world!</div>' });
+    }
+
+    '@test Can shadow keywords'() {
+      let ifComponent = defineComponent({}, 'Hello, world!');
+      let Bar = defComponent('{{#if}}{{/if}}', { scope: { if: ifComponent } });
+
+      this.renderComponent(Bar, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use constant values in ambiguous helper/component position'() {
+      let value = 'Hello, world!';
+
+      let Root = defComponent('{{value}}', { scope: { value } });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use inline if and unless in strict mode templates'() {
+      let Root = defComponent('{{if true "foo" "bar"}}{{unless true "foo" "bar"}}');
+
+      this.renderComponent(Root, { expect: 'foobar' });
+    }
+
+    '@test Can use a dynamic component definition'() {
+      let Foo = defComponent('Hello, world!');
+      let Root = defComponent('<this.Foo/>', {
+        component: class extends GlimmerishComponent {
+          Foo = Foo;
+        },
+      });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use a dynamic component definition (curly)'() {
+      let Foo = defComponent('Hello, world!');
+      let Root = defComponent('{{this.Foo}}', {
+        component: class extends GlimmerishComponent {
+          Foo = Foo;
+        },
+      });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use a dynamic helper definition'() {
+      let foo = defineSimpleHelper(() => 'Hello, world!');
+      let Root = defComponent('{{this.foo}}', {
+        component: class extends GlimmerishComponent {
+          foo = foo;
+        },
+      });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use a curried dynamic helper'() {
+      let foo = defineSimpleHelper((value) => value);
+      let Foo = defComponent('{{@value}}');
+      let Root = defComponent('<Foo @value={{helper foo "Hello, world!"}}/>', {
+        scope: { Foo, foo },
+      });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use a curried dynamic modifier'() {
+      let foo = defineSimpleModifier((element, [text]) => (element.innerHTML = text));
+      let Foo = defComponent('<div {{@value}}></div>');
+      let Root = defComponent('<Foo @value={{modifier foo "Hello, world!"}}/>', {
+        scope: { Foo, foo },
+      });
+
+      this.renderComponent(Root, { expect: '<div>Hello, world!</div>' });
+    }
+  }
+);
+
+moduleFor(
+  'Strict Mode - renderComponent - built ins',
+  class extends RenderComponentTestCase {
+    '@test Can use Input'() {
+      let Root = defComponent('<Input/>', { scope: { Input } });
+
+      this.renderComponent(Root, {
+        classic: {
+          tagName: 'input',
+          attrs: {
+            type: 'text',
+            class: 'ember-text-field ember-view',
+          },
+        },
+      });
+    }
+
+    '@test Can use Textarea'() {
+      let Root = defComponent('<Textarea/>', { scope: { Textarea } });
+
+      this.renderComponent(Root, {
+        classic: {
+          tagName: 'textarea',
+          attrs: {
+            class: 'ember-text-area ember-view',
+          },
+        },
+      });
+    }
+
+    '@test Can use hash'() {
+      let Root = defComponent(
+        '{{#let (hash value="Hello, world!") as |hash|}}{{hash.value}}{{/let}}',
+        { scope: { hash } }
+      );
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use array'() {
+      let Root = defComponent('{{#each (array "Hello, world!") as |value|}}{{value}}{{/each}}', {
+        scope: { array },
+      });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use concat'() {
+      let Root = defComponent('{{(concat "Hello" ", " "world!")}}', { scope: { concat } });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use get'() {
+      let Root = defComponent(
+        '{{#let (hash value="Hello, world!") as |hash|}}{{(get hash "value")}}{{/let}}',
+        { scope: { hash, get } }
+      );
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+    }
+
+    '@test Can use on and fn'(assert: Assert) {
+      let handleClick = (value: unknown) => {
+        assert.step('handleClick');
+        assert.equal(value, 123);
+      };
+
+      let Root = defComponent('<button {{on "click" (fn handleClick 123)}}>Click</button>', {
+        scope: { on, fn, handleClick },
+      });
+
+      this.renderComponent(Root, { expect: '<button>Click</button>' });
+
+      clickElement('button');
+
+      assert.verifySteps(['handleClick']);
+    }
+
+    // Ember currently uses AST plugins to implement certain features that
+    // glimmer-vm does not natively provide, such as {{#each-in}}, {{outlet}}
+    // {{mount}} and some features in {{#in-element}}. These rewrites the AST
+    // and insert private keywords e.g. `{{#each (-each-in)}}`. These tests
+    // ensures we have _some_ basic coverage for those features in strict mode.
+    //
+    // Ultimately, our test coverage for strict mode is quite inadequate. This
+    // is particularly important as we expect more apps to start adopting the
+    // feature. Ideally we would run our entire/most of our test suite against
+    // both strict and resolution modes, and these things would be implicitly
+    // covered elsewhere, but until then, these coverage are essential.
+
+    '@test Can use each-in'() {
+      let obj = {
+        foo: 'FOO',
+        bar: 'BAR',
+      };
+
+      let Root = defComponent('{{#each-in obj as |k v|}}[{{k}}:{{v}}]{{/each-in}}', {
+        scope: { obj },
+      });
+
+      this.renderComponent(Root, { expect: '[foo:FOO][bar:BAR]' });
+    }
+
+    '@test Can use in-element'() {
+      let getElement = (id: string) => document.getElementById(id);
+
+      let Foo = defComponent(
+        '{{#in-element (getElement "in-element-test")}}before{{/in-element}}after',
+        { scope: { getElement } }
+      );
+      let Root = defComponent('[<div id="in-element-test" />][<Foo/>]', { scope: { Foo } });
+
+      this.renderComponent(Root, {
+        expect: '[<div id="in-element-test">before</div>][<!---->after]',
+      });
+    }
+  }
+);

--- a/packages/@ember/-internals/views/lib/mixins/view_support.ts
+++ b/packages/@ember/-internals/views/lib/mixins/view_support.ts
@@ -7,6 +7,7 @@ import { matches } from '../system/utils';
 import type { View } from '@ember/-internals/glimmer/lib/renderer';
 import type { SimpleElement } from '@simple-dom/interface';
 import type CoreView from '../views/core_view';
+import type Component from '@ember/component';
 
 function K(this: unknown) {
   return this;
@@ -195,7 +196,7 @@ const ViewMixin = Mixin.create({
    @return {Ember.View} receiver
    @private
    */
-  appendTo(selector: string | Element | SimpleElement) {
+  appendTo(this: Component, selector: string | Element | SimpleElement) {
     let target;
 
     if (hasDOM) {

--- a/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.ts
@@ -2,16 +2,20 @@ import { assert } from '@ember/debug';
 import type { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
 import type { EmberASTPluginEnvironment } from '../types';
-import { isPath } from './utils';
+import { isPath, trackLocals } from './utils';
 
 export default function errorOnInputWithContent(env: EmberASTPluginEnvironment): ASTPlugin {
   let moduleName = env.meta?.moduleName;
+  let { hasLocal, visitor } = trackLocals(env);
 
   return {
     name: 'assert-input-helper-without-block',
 
     visitor: {
+      ...visitor,
       BlockStatement(node: AST.BlockStatement) {
+        if (hasLocal('input')) return;
+
         if (isPath(node.path) && node.path.original === 'input') {
           assert(assertMessage(moduleName, node));
         }

--- a/packages/ember-template-compiler/lib/plugins/transform-each-track-array.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-track-array.ts
@@ -1,7 +1,7 @@
 import type { AST, ASTPlugin } from '@glimmer/syntax';
 import { assert } from '@ember/debug';
 import type { EmberASTPluginEnvironment } from '../types';
-import { isPath } from './utils';
+import { isPath, trackLocals } from './utils';
 
 /**
  @module ember
@@ -25,13 +25,15 @@ import { isPath } from './utils';
 */
 export default function transformEachTrackArray(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
+  let { hasLocal, visitor } = trackLocals(env);
 
   return {
     name: 'transform-each-track-array',
 
     visitor: {
+      ...visitor,
       BlockStatement(node: AST.BlockStatement): AST.Node | void {
-        if (isPath(node.path) && node.path.original === 'each') {
+        if (isPath(node.path) && node.path.original === 'each' && !hasLocal('each')) {
           let firstParam = node.params[0];
           assert('has firstParam', firstParam);
 

--- a/packages/ember-template-compiler/lib/plugins/transform-resolutions.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-resolutions.ts
@@ -67,7 +67,7 @@ const TARGETS = Object.freeze(['helper', 'modifier']);
 export default function transformResolutions(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
   let moduleName = env.meta?.moduleName;
-  let { hasLocal, node: tracker } = trackLocals();
+  let { hasLocal, node: tracker } = trackLocals(env);
   let seen: Set<AST.Node> | undefined;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-wrap-mount-and-outlet.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-wrap-mount-and-outlet.ts
@@ -37,15 +37,13 @@ import { isPath, trackLocals } from './utils';
 export default function transformWrapMountAndOutlet(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
-  let { hasLocal, node } = trackLocals();
+  let { hasLocal, visitor } = trackLocals(env);
 
   return {
     name: 'transform-wrap-mount-and-outlet',
 
     visitor: {
-      Template: node,
-      ElementNode: node,
-      Block: node,
+      ...visitor,
 
       MustacheStatement(node: AST.MustacheStatement): AST.Node | void {
         if (

--- a/packages/ember-template-compiler/lib/plugins/utils.ts
+++ b/packages/ember-template-compiler/lib/plugins/utils.ts
@@ -1,4 +1,5 @@
 import type { AST } from '@glimmer/syntax';
+import type { EmberASTPluginEnvironment } from '../types';
 
 export function isPath(node: AST.Node): node is AST.PathExpression {
   return node.type === 'PathExpression';
@@ -20,7 +21,11 @@ function getLocalName(node: string | AST.VarHead): string {
   }
 }
 
-export function trackLocals() {
+export function inScope(env: EmberASTPluginEnvironment, name: string): boolean {
+  return Boolean(env.lexicalScope?.(name));
+}
+
+export function trackLocals(env: EmberASTPluginEnvironment) {
   let locals = new Map();
 
   let node = {
@@ -49,7 +54,12 @@ export function trackLocals() {
   };
 
   return {
-    hasLocal: (key: string) => locals.has(key),
+    hasLocal: (key: string) => locals.has(key) || inScope(env, key),
     node,
+    visitor: {
+      Template: node,
+      ElementNode: node,
+      Block: node,
+    },
   };
 }

--- a/packages/ember-template-compiler/lib/types.ts
+++ b/packages/ember-template-compiler/lib/types.ts
@@ -3,6 +3,7 @@ import type {
   ASTPluginEnvironment,
   builders,
   PrecompileOptions,
+  PrecompileOptionsWithLexicalScope,
 } from '@glimmer/syntax';
 
 export type Builders = typeof builders;
@@ -19,10 +20,13 @@ interface Plugins {
   ast: PluginFunc[];
 }
 
+export type LexicalScope = NonNullable<PrecompileOptionsWithLexicalScope['lexicalScope']>;
+
 export interface EmberPrecompileOptions extends PrecompileOptions {
   isProduction?: boolean;
   moduleName?: string;
   plugins?: Plugins;
+  lexicalScope?: LexicalScope;
 }
 
 export type EmberASTPluginEnvironment = ASTPluginEnvironment & EmberPrecompileOptions;

--- a/packages/internal-test-helpers/index.ts
+++ b/packages/internal-test-helpers/index.ts
@@ -25,7 +25,11 @@ export { equalsElement, classes, styles, regex } from './lib/matchers';
 export { runAppend, runDestroy, runTask, runTaskNext, runLoopSettled } from './lib/run';
 export { getContext, setContext, unsetContext } from './lib/test-context';
 
-export { default as AbstractTestCase, AbstractStrictTestCase } from './lib/test-cases/abstract';
+export {
+  default as AbstractTestCase,
+  type TestCase,
+  AbstractStrictTestCase,
+} from './lib/test-cases/abstract';
 export { default as AbstractApplicationTestCase } from './lib/test-cases/abstract-application';
 export { default as ApplicationTestCase } from './lib/test-cases/application';
 export { default as QueryParamTestCase } from './lib/test-cases/query-param';

--- a/packages/internal-test-helpers/index.ts
+++ b/packages/internal-test-helpers/index.ts
@@ -14,6 +14,7 @@ export {
   ignoreDeprecation,
 } from './lib/ember-dev/deprecation';
 export {
+  defComponent,
   defineComponent,
   defineSimpleHelper,
   defineSimpleModifier,
@@ -24,7 +25,7 @@ export { equalsElement, classes, styles, regex } from './lib/matchers';
 export { runAppend, runDestroy, runTask, runTaskNext, runLoopSettled } from './lib/run';
 export { getContext, setContext, unsetContext } from './lib/test-context';
 
-export { default as AbstractTestCase } from './lib/test-cases/abstract';
+export { default as AbstractTestCase, AbstractStrictTestCase } from './lib/test-cases/abstract';
 export { default as AbstractApplicationTestCase } from './lib/test-cases/abstract-application';
 export { default as ApplicationTestCase } from './lib/test-cases/application';
 export { default as QueryParamTestCase } from './lib/test-cases/query-param';
@@ -32,6 +33,15 @@ export { default as RenderingTestCase } from './lib/test-cases/rendering';
 export { default as RouterNonApplicationTestCase } from './lib/test-cases/router-non-application';
 export { default as RouterTestCase } from './lib/test-cases/router';
 export { default as AutobootApplicationTestCase } from './lib/test-cases/autoboot-application';
+export { getAssert } from './lib/assert-helpers';
+export {
+  getElement,
+  assertElement,
+  assertHTML,
+  assertClassicComponentElement,
+  type ClassicComponentShape,
+} from './lib/element-helpers';
+export { clickElement } from './lib/event-helpers';
 
 export {
   default as TestResolver,

--- a/packages/internal-test-helpers/lib/assert-helpers.ts
+++ b/packages/internal-test-helpers/lib/assert-helpers.ts
@@ -1,0 +1,16 @@
+import { getContext } from './test-context';
+
+export function getAssert(): QUnit['assert'] {
+  let context = getContext();
+
+  if (!context) {
+    throw new Error('Test context is not set up.');
+  }
+
+  let assert = context['assert'];
+  if (!assert) {
+    throw new Error('`assert` property on test context is not set up.');
+  }
+
+  return assert;
+}

--- a/packages/internal-test-helpers/lib/component-helper.ts
+++ b/packages/internal-test-helpers/lib/component-helper.ts
@@ -1,0 +1,35 @@
+import { getContext } from './test-context';
+
+export function getComponent(): Record<string, unknown> {
+  let context = getContext();
+  if (!context) {
+    throw new Error('Test context is not set up.');
+  }
+
+  let component = context['component'];
+  if (component && typeof component === 'object') {
+    return component;
+  }
+
+  throw new Error('`component` property on test context is not set up.');
+}
+
+export function getOwner() {
+  let context = getContext();
+
+  if (!context) {
+    throw new Error('Test context is not set up.');
+  }
+
+  return context['owner'];
+}
+
+export function rerenderComponent() {
+  let component = getComponent();
+
+  if (typeof component['rerender'] !== 'function') {
+    throw new Error('Component does not support `rerender`.');
+  }
+
+  component['rerender']();
+}

--- a/packages/internal-test-helpers/lib/define-template-values.ts
+++ b/packages/internal-test-helpers/lib/define-template-values.ts
@@ -87,6 +87,26 @@ class FunctionalModifierManager implements ModifierManager<SimpleModifierState> 
 const FUNCTIONAL_MODIFIER_MANAGER = new FunctionalModifierManager();
 const FUNCTIONAL_MODIFIER_MANAGER_FACTORY = () => FUNCTIONAL_MODIFIER_MANAGER;
 
+/**
+ * The signature of this test helper is closer to the signature of the
+ * `template()` function in `@ember/template-compiler`. It can express the same
+ * functionality as {@linkcode defineComponent}, but most tests still use
+ * `defineComponent`. Migrating tests from {@linkcode defineComponent} is
+ * straightforward, and there's no *semantic* reason not to do so.
+ */
+export function defComponent(
+  templateSource: string,
+  options?: {
+    component?: object | undefined;
+    scope?: Record<string, unknown> | undefined;
+  }
+) {
+  let definition = options?.component ?? templateOnlyComponent();
+  let scopeValues = options?.scope ?? null;
+
+  return defineComponent(scopeValues, templateSource, definition);
+}
+
 export function defineComponent(
   scopeValues: Record<string, unknown> | null,
   templateSource: string,
@@ -103,10 +123,12 @@ export function defineComponent(
   return definition;
 }
 
-export function defineSimpleHelper<T extends Function>(helperFn: T): T {
+export function defineSimpleHelper<T extends (...args: unknown[]) => unknown>(helperFn: T): T {
   return setHelperManager(FUNCTIONAL_HELPER_MANAGER_FACTORY, helperFn);
 }
 
-export function defineSimpleModifier<T extends Function>(modifierFn: T): T {
+export function defineSimpleModifier<T extends (element: Element, ...args: any[]) => any>(
+  modifierFn: T
+): T {
   return setModifierManager(FUNCTIONAL_MODIFIER_MANAGER_FACTORY, modifierFn);
 }

--- a/packages/internal-test-helpers/lib/element-helpers.ts
+++ b/packages/internal-test-helpers/lib/element-helpers.ts
@@ -1,4 +1,11 @@
+import { getAssert } from './assert-helpers';
+import equalTokens from './equal-tokens';
+import { classes, equalsElement, regex } from './matchers';
 import { getContext } from './test-context';
+
+export const TextNode = window.Text;
+export const HTMLElement = window.HTMLElement;
+export const Comment = window.Comment;
 
 export function getElement(): HTMLElement {
   let context = getContext();
@@ -12,4 +19,103 @@ export function getElement(): HTMLElement {
   }
 
   return element;
+}
+
+export function isMarker(node: unknown): node is Comment | typeof TextNode {
+  if (node instanceof Comment && node.textContent === '') {
+    return true;
+  }
+
+  if (node instanceof TextNode && node.textContent === '') {
+    return true;
+  }
+
+  return false;
+}
+
+export function assertHTML(html: string): void {
+  equalTokens(getElement(), html, `#qunit-fixture content should be: \`${html}\``);
+}
+
+export function assertElement(
+  node: ChildNode | null,
+  {
+    ElementType = HTMLElement,
+    tagName,
+    attrs = null,
+    content = null,
+  }: {
+    ElementType?: typeof HTMLElement;
+    tagName: string;
+    attrs?: Record<string, unknown> | null;
+    content?: unknown;
+  }
+) {
+  if (!node || !(node instanceof ElementType)) {
+    throw new Error(`Expecting a ${ElementType.name}, but got ${String(node)}`);
+  }
+
+  equalsElement(getAssert(), node, tagName, attrs, content);
+}
+
+export interface ClassicComponentShape {
+  ElementType?: typeof HTMLElement;
+  tagName: string;
+  attrs?: Record<string, unknown>;
+  content?: unknown;
+}
+
+export function assertClassicComponentElement(
+  node: ChildNode | null,
+  shape: ClassicComponentShape
+): void;
+export function assertClassicComponentElement(shape: ClassicComponentShape): void;
+export function assertClassicComponentElement(
+  ...args: [node: ChildNode | null, shape: ClassicComponentShape] | [shape: ClassicComponentShape]
+): void {
+  let node = args.length === 2 ? args[0] : getElement().firstChild;
+  let shape = args.length === 2 ? args[1] : args[0];
+
+  let attrs = Object.assign({
+    id: regex(/^ember\d*$/),
+    class: classes('ember-view'),
+    ...shape.attrs,
+  });
+
+  assertElement(node, {
+    ElementType: shape.ElementType ?? HTMLElement,
+    tagName: shape.tagName,
+    attrs,
+    content: shape.content,
+  });
+}
+
+export function assertSameNode(actual: ChildNode | undefined, expected: ChildNode | undefined) {
+  getAssert().strictEqual(actual, expected, 'DOM node stability');
+}
+
+export function assertInvariants(oldSnapshot: ChildNode[], newSnapshot?: ChildNode[]): void {
+  newSnapshot = newSnapshot || takeSnapshot();
+
+  getAssert().strictEqual(newSnapshot.length, oldSnapshot.length, 'Same number of nodes');
+
+  for (let i = 0; i < oldSnapshot.length; i++) {
+    assertSameNode(newSnapshot[i], oldSnapshot[i]);
+  }
+}
+
+export function takeSnapshot() {
+  let snapshot: ChildNode[] = [];
+
+  let node = getElement().firstChild;
+
+  while (node) {
+    if (!isMarker(node)) {
+      snapshot.push(node);
+    }
+
+    node = node.nextSibling;
+  }
+
+  return snapshot;
 }

--- a/packages/internal-test-helpers/lib/ember-dev/namespaces.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/namespaces.ts
@@ -6,7 +6,7 @@ export function setupNamespacesCheck(hooks: NestedHooks): void {
     let { assert } = QUnit.config.current;
 
     if (NAMESPACES.length > 0) {
-      assert.ok(false, 'Should not have any NAMESPACES after tests');
+      assert.ok(false, `Should not have any NAMESPACES after tests (had: ${NAMESPACES.join(',')})`);
       run(() => {
         let namespaces = NAMESPACES.slice();
         for (let namespace of namespaces) {

--- a/packages/internal-test-helpers/lib/event-helpers.ts
+++ b/packages/internal-test-helpers/lib/event-helpers.ts
@@ -1,0 +1,15 @@
+import { getElement } from './element-helpers';
+import { runLoopSettled } from './run';
+
+export function clickElement(selector: HTMLElement | string) {
+  let element;
+  if (typeof selector === 'string') {
+    element = getElement().querySelector(selector) as HTMLElement | null;
+  } else {
+    element = selector;
+  }
+
+  let event = element!.click();
+
+  return runLoopSettled(event);
+}

--- a/packages/internal-test-helpers/lib/module-for.ts
+++ b/packages/internal-test-helpers/lib/module-for.ts
@@ -6,14 +6,14 @@ import { all } from 'rsvp';
 import type { Generator, Mixin } from './apply-mixins';
 import applyMixins from './apply-mixins';
 import getAllPropertyNames from './get-all-property-names';
-import type { AbstractStrictTestCase } from './test-cases/abstract';
+import type { TestCase } from './test-cases/abstract';
 import { setContext, unsetContext } from './test-context';
 
-interface TestClass<T extends AbstractStrictTestCase> {
+interface TestClass<T extends TestCase> {
   new (assert: QUnit['assert']): T;
 }
 
-interface TestContext<T extends AbstractStrictTestCase> {
+interface TestContext<T extends TestCase> {
   instance: T | null | undefined;
 }
 
@@ -28,7 +28,7 @@ const ASSERT_DESTROYABLES = (() => {
   return assertDestroyables !== null;
 })();
 
-export function moduleForDevelopment<T extends AbstractStrictTestCase, M extends Generator>(
+export function moduleForDevelopment<T extends TestCase, M extends Generator>(
   description: string,
   TestClass: TestClass<T>,
   ...mixins: Mixin<M>[]
@@ -39,7 +39,7 @@ export function moduleForDevelopment<T extends AbstractStrictTestCase, M extends
   }
 }
 
-export default function moduleFor<T extends AbstractStrictTestCase, M extends Generator>(
+export default function moduleFor<T extends TestCase, M extends Generator>(
   description: string,
   TestClass: TestClass<T>,
   ...mixins: Mixin<M>[]
@@ -57,7 +57,7 @@ function afterEachFinally() {
   }
 }
 
-export function setupTestClass<T extends AbstractStrictTestCase, G extends Generator>(
+export function setupTestClass<T extends TestCase, G extends Generator>(
   hooks: NestedHooks,
   TestClass: TestClass<T>,
   ...mixins: Mixin<G>[]
@@ -123,7 +123,7 @@ export function setupTestClass<T extends AbstractStrictTestCase, G extends Gener
     });
   }
 
-  function generateTest<T extends AbstractStrictTestCase>(name: keyof T & string) {
+  function generateTest<T extends TestCase>(name: keyof T & string) {
     if (name.indexOf('@test ') === 0) {
       QUnit.test(name.slice(5), function (this: TestContext<T>, assert) {
         return (this.instance![name] as any)(assert);

--- a/packages/internal-test-helpers/lib/module-for.ts
+++ b/packages/internal-test-helpers/lib/module-for.ts
@@ -1,19 +1,19 @@
 /* globals URLSearchParams */
-import { DEBUG } from '@glimmer/env';
 import { isEnabled } from '@ember/canary-features';
-import type { Mixin, Generator } from './apply-mixins';
+import { assertDestroyablesDestroyed, enableDestroyableTracking } from '@glimmer/destroyable';
+import { DEBUG } from '@glimmer/env';
+import { all } from 'rsvp';
+import type { Generator, Mixin } from './apply-mixins';
 import applyMixins from './apply-mixins';
 import getAllPropertyNames from './get-all-property-names';
+import type { AbstractStrictTestCase } from './test-cases/abstract';
 import { setContext, unsetContext } from './test-context';
-import { all } from 'rsvp';
-import { enableDestroyableTracking, assertDestroyablesDestroyed } from '@glimmer/destroyable';
-import type AbstractTestCase from './test-cases/abstract';
 
-interface TestClass<T extends AbstractTestCase> {
+interface TestClass<T extends AbstractStrictTestCase> {
   new (assert: QUnit['assert']): T;
 }
 
-interface TestContext<T extends AbstractTestCase> {
+interface TestContext<T extends AbstractStrictTestCase> {
   instance: T | null | undefined;
 }
 
@@ -28,7 +28,7 @@ const ASSERT_DESTROYABLES = (() => {
   return assertDestroyables !== null;
 })();
 
-export function moduleForDevelopment<T extends AbstractTestCase, M extends Generator>(
+export function moduleForDevelopment<T extends AbstractStrictTestCase, M extends Generator>(
   description: string,
   TestClass: TestClass<T>,
   ...mixins: Mixin<M>[]
@@ -39,7 +39,7 @@ export function moduleForDevelopment<T extends AbstractTestCase, M extends Gener
   }
 }
 
-export default function moduleFor<T extends AbstractTestCase, M extends Generator>(
+export default function moduleFor<T extends AbstractStrictTestCase, M extends Generator>(
   description: string,
   TestClass: TestClass<T>,
   ...mixins: Mixin<M>[]
@@ -57,7 +57,7 @@ function afterEachFinally() {
   }
 }
 
-export function setupTestClass<T extends AbstractTestCase, G extends Generator>(
+export function setupTestClass<T extends AbstractStrictTestCase, G extends Generator>(
   hooks: NestedHooks,
   TestClass: TestClass<T>,
   ...mixins: Mixin<G>[]
@@ -123,7 +123,7 @@ export function setupTestClass<T extends AbstractTestCase, G extends Generator>(
     });
   }
 
-  function generateTest<T extends AbstractTestCase>(name: keyof T & string) {
+  function generateTest<T extends AbstractStrictTestCase>(name: keyof T & string) {
     if (name.indexOf('@test ') === 0) {
       QUnit.test(name.slice(5), function (this: TestContext<T>, assert) {
         return (this.instance![name] as any)(assert);

--- a/packages/internal-test-helpers/lib/test-cases/abstract.ts
+++ b/packages/internal-test-helpers/lib/test-cases/abstract.ts
@@ -26,6 +26,8 @@ function isMarker(node: unknown): node is Comment | typeof TextNode {
   return false;
 }
 
+export type TestCase = AbstractStrictTestCase | AbstractTestCase;
+
 export abstract class AbstractStrictTestCase {
   snapshot: ChildNode[] | null = null;
   component: unknown;


### PR DESCRIPTION
There's more in this commit than there should be, largely because this
commit bundles a change to the plugins that fixes lexical scope bugs.

I intend to separate those changes out into their own PR before
attempting to merge this one. This PR also needs a flag for the new API.

Finally this commit adds some new testing infrastructure to generalize
the base render tests so it can be used with templates that are not
registered into a container. This is useful more generally, and could
be used in other places in the test suite in the future.