### PR TITLE
Fixes Ember keyword shadowing

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -1,4 +1,10 @@
-import { RenderingTestCase, moduleFor, strip, runTask } from 'internal-test-helpers';
+import {
+  RenderingTestCase,
+  defineComponent,
+  moduleFor,
+  runTask,
+  strip,
+} from 'internal-test-helpers';
 
 import { set } from '@ember/object';
 
@@ -18,6 +24,21 @@ moduleFor(
       this.assertText('Sergio');
 
       this.assertStableRerender();
+    }
+
+    ['@test the array helper can be shadowed']() {
+      function array(...list) {
+        return list.map((n) => n * 2);
+      }
+
+      let First = defineComponent({ array }, `{{#each (array 1 2 3) as |n|}}[{{n}}]{{/each}}`);
+
+      let Root = defineComponent(
+        { shadowArray: array, First },
+        `{{#let shadowArray as |array|}}{{#each (array 5 10 15) as |n|}}[{{n}}]{{/each}}{{/let}}<First />`
+      );
+
+      this.renderComponent(Root, { expect: '[10][20][30][2][4][6]' });
     }
 
     ['@test can have more than one value']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -1,6 +1,6 @@
 import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
-import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, defineComponent, moduleFor, runTask } from 'internal-test-helpers';
 import { Component } from '../../utils/helpers';
 
 moduleFor(
@@ -20,6 +20,14 @@ moduleFor(
           },
         }),
       });
+    }
+
+    '@test fn can be shadowed'() {
+      let First = defineComponent(
+        { fn: boundFn, boundFn, id, invoke },
+        `[{{invoke (fn id 1)}}]{{#let boundFn as |fn|}}[{{invoke (fn id 2)}}{{/let}}]`
+      );
+      this.renderComponent(First, { expect: `[bound:1][bound:2]` });
     }
 
     '@test updates when arguments change'() {
@@ -209,3 +217,13 @@ moduleFor(
     }
   }
 );
+
+function invoke(fn) {
+  return fn();
+}
+
+function boundFn(fn, ...args) {
+  return () => fn(...args.map((arg) => `bound:${arg}`));
+}
+
+let id = (arg) => arg;

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, defineComponent, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set, get } from '@ember/object';
 
@@ -30,6 +30,17 @@ moduleFor(
       );
 
       this.assertText('[red] [red]');
+    }
+
+    ['@test can be shadowed']() {
+      let get = (obj, key) => `obj.${key}=${obj[key]}`;
+      let obj = { apple: 'red', banana: 'yellow' };
+      let Root = defineComponent(
+        { get, outerGet: get, obj },
+        `[{{get obj 'apple'}}][{{#let outerGet as |get|}}{{get obj 'banana'}}{{/let}}]`
+      );
+
+      this.renderComponent(Root, { expect: '[obj.apple=red][obj.banana=yellow]' });
     }
 
     ['@test should be able to get an object value with nested static key']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -1,4 +1,4 @@
-import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, defineComponent, moduleFor, runTask } from 'internal-test-helpers';
 
 import { Component } from '../../utils/helpers';
 
@@ -15,6 +15,21 @@ moduleFor(
       runTask(() => this.rerender());
 
       this.assertText('Sergio');
+    }
+
+    ['@test can be shadowed']() {
+      let hash = (obj) =>
+        Object.entries(obj)
+          .map(([key, value]) => `hash:${key}=${value}`)
+          .join(',');
+      let Root = defineComponent(
+        { hash, shadowHash: hash },
+        `({{hash apple='red' banana='yellow'}}) ({{#let shadowHash as |hash|}}{{hash apple='green'}}{{/let}})`
+      );
+
+      this.renderComponent(Root, {
+        expect: '(hash:apple=red,hash:banana=yellow) (hash:apple=green)',
+      });
     }
 
     ['@test can have more than one key-value']() {

--- a/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.ts
+++ b/packages/ember-template-compiler/lib/plugins/assert-input-helper-without-block.ts
@@ -2,16 +2,20 @@ import { assert } from '@ember/debug';
 import type { AST, ASTPlugin } from '@glimmer/syntax';
 import calculateLocationDisplay from '../system/calculate-location-display';
 import type { EmberASTPluginEnvironment } from '../types';
-import { isPath } from './utils';
+import { isPath, trackLocals } from './utils';
 
 export default function errorOnInputWithContent(env: EmberASTPluginEnvironment): ASTPlugin {
   let moduleName = env.meta?.moduleName;
+  let { hasLocal, visitor } = trackLocals(env);
 
   return {
     name: 'assert-input-helper-without-block',
 
     visitor: {
+      ...visitor,
       BlockStatement(node: AST.BlockStatement) {
+        if (hasLocal('input')) return;
+
         if (isPath(node.path) && node.path.original === 'input') {
           assert(assertMessage(moduleName, node));
         }

--- a/packages/ember-template-compiler/lib/plugins/transform-each-track-array.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-track-array.ts
@@ -1,7 +1,7 @@
 import type { AST, ASTPlugin } from '@glimmer/syntax';
 import { assert } from '@ember/debug';
 import type { EmberASTPluginEnvironment } from '../types';
-import { isPath } from './utils';
+import { isPath, trackLocals } from './utils';
 
 /**
  @module ember
@@ -25,13 +25,15 @@ import { isPath } from './utils';
 */
 export default function transformEachTrackArray(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
+  let { hasLocal, visitor } = trackLocals(env);
 
   return {
     name: 'transform-each-track-array',
 
     visitor: {
+      ...visitor,
       BlockStatement(node: AST.BlockStatement): AST.Node | void {
-        if (isPath(node.path) && node.path.original === 'each') {
+        if (isPath(node.path) && node.path.original === 'each' && !hasLocal('each')) {
           let firstParam = node.params[0];
           assert('has firstParam', firstParam);
 

--- a/packages/ember-template-compiler/lib/plugins/transform-resolutions.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-resolutions.ts
@@ -67,7 +67,7 @@ const TARGETS = Object.freeze(['helper', 'modifier']);
 export default function transformResolutions(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
   let moduleName = env.meta?.moduleName;
-  let { hasLocal, node: tracker } = trackLocals();
+  let { hasLocal, node: tracker } = trackLocals(env);
   let seen: Set<AST.Node> | undefined;
 
   return {

--- a/packages/ember-template-compiler/lib/plugins/transform-wrap-mount-and-outlet.ts
+++ b/packages/ember-template-compiler/lib/plugins/transform-wrap-mount-and-outlet.ts
@@ -37,15 +37,13 @@ import { isPath, trackLocals } from './utils';
 export default function transformWrapMountAndOutlet(env: EmberASTPluginEnvironment): ASTPlugin {
   let { builders: b } = env.syntax;
 
-  let { hasLocal, node } = trackLocals();
+  let { hasLocal, visitor } = trackLocals(env);
 
   return {
     name: 'transform-wrap-mount-and-outlet',
 
     visitor: {
-      Template: node,
-      ElementNode: node,
-      Block: node,
+      ...visitor,
 
       MustacheStatement(node: AST.MustacheStatement): AST.Node | void {
         if (

--- a/packages/ember-template-compiler/lib/plugins/utils.ts
+++ b/packages/ember-template-compiler/lib/plugins/utils.ts
@@ -1,4 +1,5 @@
 import type { AST } from '@glimmer/syntax';
+import type { EmberASTPluginEnvironment } from '../types';
 
 export function isPath(node: AST.Node): node is AST.PathExpression {
   return node.type === 'PathExpression';
@@ -20,7 +21,11 @@ function getLocalName(node: string | AST.VarHead): string {
   }
 }
 
-export function trackLocals() {
+export function inScope(env: EmberASTPluginEnvironment, name: string): boolean {
+  return Boolean(env.lexicalScope?.(name));
+}
+
+export function trackLocals(env: EmberASTPluginEnvironment) {
   let locals = new Map();
 
   let node = {
@@ -49,7 +54,12 @@ export function trackLocals() {
   };
 
   return {
-    hasLocal: (key: string) => locals.has(key),
+    hasLocal: (key: string) => locals.has(key) || inScope(env, key),
     node,
+    visitor: {
+      Template: node,
+      ElementNode: node,
+      Block: node,
+    },
   };
 }

--- a/packages/ember-template-compiler/lib/types.ts
+++ b/packages/ember-template-compiler/lib/types.ts
@@ -23,6 +23,7 @@ export interface EmberPrecompileOptions extends PrecompileOptions {
   isProduction?: boolean;
   moduleName?: string;
   plugins?: Plugins;
+  lexicalScope?: (name: string) => boolean;
 }
 
 export type EmberASTPluginEnvironment = ASTPluginEnvironment & EmberPrecompileOptions;

--- a/packages/ember-template-compiler/tests/plugins/assert-against-attrs-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-against-attrs-test.js
@@ -1,5 +1,5 @@
 import TransformTestCase from '../utils/transform-test-case';
-import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
+import { defineComponent, moduleFor, RenderingTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'ember-template-compiler: assert against attrs',
@@ -62,6 +62,14 @@ moduleFor(
       });
       this.render('<Foo />');
       this.assertComponentElement(this.firstChild, { content: 'foo' });
+    }
+
+    ["@test it doesn't assert lexical scope values"]() {
+      let component = defineComponent({ attrs: 'just a string' }, `It's {{attrs}}`);
+      this.registerComponent('root', { ComponentClass: component });
+      this.render('<Root />');
+      this.assertHTML("It's just a string");
+      this.assertStableRerender();
     }
 
     ["@test it doesn't assert component block params"]() {

--- a/packages/ember-template-compiler/tests/plugins/assert-array-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-array-test.js
@@ -1,0 +1,42 @@
+import { defineComponent, moduleFor, RenderingTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'ember-template-compiler: assert-array-test',
+  class extends RenderingTestCase {
+    ['@test block param `array` is not transformed']() {
+      // Intentionally double all of the values to verify that this
+      // version of the `array` function is used.
+      function customArray(...values) {
+        return values.map((value) => value * 2);
+      }
+
+      let Root = defineComponent(
+        { customArray },
+        `{{#let customArray as |array|}}<ul>{{#each (array 1 2 3) as |item|}}<li>{{item}}</li>{{/each}}</ul>{{/let}}`
+      );
+      this.registerComponent('root', { ComponentClass: Root });
+
+      this.render('<Root />');
+      this.assertHTML('<ul><li>2</li><li>4</li><li>6</li></ul>');
+      this.assertStableRerender();
+    }
+
+    ['@test lexical scope `array` is not transformed']() {
+      // Intentionally double all of the values to verify that this
+      // version of the `array` function is used.
+      function array(...values) {
+        return values.map((value) => value * 2);
+      }
+
+      let Root = defineComponent(
+        { array },
+        `<ul>{{#each (array 1 2 3) as |item|}}<li>{{item}}</li>{{/each}}</ul>`
+      );
+      this.registerComponent('root', { ComponentClass: Root });
+
+      this.render('<Root />');
+      this.assertHTML('<ul><li>2</li><li>4</li><li>6</li></ul>');
+      this.assertStableRerender();
+    }
+  }
+);

--- a/packages/ember-template-compiler/tests/plugins/assert-input-helper-without-block-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-input-helper-without-block-test.js
@@ -1,9 +1,9 @@
+import { defineComponent, moduleFor, RenderingTestCase } from 'internal-test-helpers';
 import { compile } from '../../index';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'ember-template-compiler: assert-input-helper-without-block',
-  class extends AbstractTestCase {
+  class extends RenderingTestCase {
     ['@test Using {{#input}}{{/input}} is not valid']() {
       let expectedMessage = `The {{input}} helper cannot be used in block form. ('baz/foo-bar' @ L1:C0) `;
 
@@ -12,6 +12,31 @@ moduleFor(
           moduleName: 'baz/foo-bar',
         });
       }, expectedMessage);
+    }
+
+    ['@test Block params are not asserted']() {
+      let shadowInput = defineComponent({}, `It's just {{yield}}`);
+
+      let Root = defineComponent(
+        { shadowInput },
+        `{{#let shadowInput as |input|}}{{#input}}an input{{/input}}{{/let}}`
+      );
+      this.registerComponent('root', { ComponentClass: Root });
+
+      this.render('<Root />');
+      this.assertHTML("It's just an input");
+      this.assertStableRerender();
+    }
+
+    ['@test Lexical scope values are not asserted']() {
+      let input = defineComponent({}, `It's just {{yield}}`);
+
+      let Root = defineComponent({ input }, `{{#input}}an input{{/input}}`);
+      this.registerComponent('root', { ComponentClass: Root });
+
+      this.render('<Root />');
+      this.assertHTML("It's just an input");
+      this.assertStableRerender();
     }
   }
 );

--- a/packages/internal-test-helpers/lib/test-cases/rendering.ts
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.ts
@@ -1,19 +1,19 @@
+import type { Renderer } from '@ember/-internals/glimmer';
+import { _resetRenderers, helper, Helper } from '@ember/-internals/glimmer';
+import { EventDispatcher } from '@ember/-internals/views';
+import Component, { setComponentTemplate } from '@ember/component';
 import type { EmberPrecompileOptions } from 'ember-template-compiler';
 import { compile } from 'ember-template-compiler';
-import { EventDispatcher } from '@ember/-internals/views';
-import type { Renderer } from '@ember/-internals/glimmer';
-import Component, { setComponentTemplate } from '@ember/component';
-import { helper, Helper, _resetRenderers } from '@ember/-internals/glimmer';
 import type Resolver from '../test-resolver';
 import { ModuleBasedResolver } from '../test-resolver';
 
-import AbstractTestCase from './abstract';
+import type { InternalFactory } from '@ember/-internals/owner';
+import templateOnly from '@ember/component/template-only';
+import type EngineInstance from '@ember/engine/instance';
+import type { BootOptions, EngineInstanceOptions } from '@ember/engine/instance';
 import buildOwner from '../build-owner';
 import { runAppend, runDestroy, runTask } from '../run';
-import type { InternalFactory } from '@ember/-internals/owner';
-import type { BootOptions, EngineInstanceOptions } from '@ember/engine/instance';
-import type EngineInstance from '@ember/engine/instance';
-import templateOnly from '@ember/component/template-only';
+import AbstractTestCase from './abstract';
 
 const TextNode = window.Text;
 
@@ -172,6 +172,13 @@ export default abstract class RenderingTestCase extends AbstractTestCase {
     runAppend(this.component);
   }
 
+  renderComponent(component: object, options: { expect: string }) {
+    this.registerComponent('root', { ComponentClass: component });
+    this.render('<Root />');
+    this.assertHTML(options.expect);
+    this.assertStableRerender();
+  }
+
   rerender() {
     this.component!.rerender();
   }
@@ -195,14 +202,21 @@ export default abstract class RenderingTestCase extends AbstractTestCase {
 
   registerComponent(
     name: string,
-    { ComponentClass = Component, template = null, resolveableTemplate = null }
+    {
+      ComponentClass = Component,
+      template = null,
+      resolveableTemplate = null,
+    }: {
+      ComponentClass?: object | null;
+      template?: string | null;
+      resolveableTemplate?: string | null;
+    }
   ) {
     let { owner } = this;
 
     if (ComponentClass) {
       // We cannot set templates multiple times on a class
       if (ComponentClass === Component) {
-        // @ts-expect-error - class/instance types in TS are hard
         ComponentClass = class extends Component {};
       }
 


### PR DESCRIPTION
This commit consistently fixes the interaction between keywords and lexical variables (JS or Handlebars) to match the specified behavior: keywords are **always** superseded by in-scope lexical variables.

Ember keywords are implemented as AST transformations, and there were two sources of bugs that made implementation of these keywords inconsistent with the specified behavior:

1. In some cases, AST transforms applied to situations where the keyword in question was shadowed by a Handlebars block param. This means that the variable would be silently overridden by the AST transform.
2. In all cases, AST transforms applied when the keyword was shadowed by a lexical variable (i.e. in-scope JS variable) of the same name. This isn't supposed to happen, as lexical JS variables are supposed to have the same rules as variables bound via JS block params.

This commit has tests for many of these cases. Some additional tests are forthcoming, mostly in cases where the transform in question wasn't tested at all before this change.