### PR TITLE
releasing @glimmer/component@2.0.0-beta.22

### DIFF
--- a/packages/@glimmer/component/CHANGELOG.md
+++ b/packages/@glimmer/component/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @glimmer/component
+
+## 2.0.0-beta.22 2024-10-29
+
+ - BREAKING: converted to V2 addon
+ - BREAKING: dropped support for ember < 3.13
+
+
+## Older Releases
+
+Versions up to 1.1.12 and 2.0.0-beta.21 were maintained in https://github.com/glimmerjs/glimmer.js

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glimmer/component",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.22",
   "description": "Glimmer component library",
   "exports": {
     ".": "./dist/index.js"


### PR DESCRIPTION
Publishing a beta of our newly-ported @glimmer/component. There was already a long series of 2.0 betas, so this is beta.22.