### PR TITLE
[BUGFIX release] importing ember-source/types no longer works (it should)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   ],
   "exports": {
     "./*": "./dist/packages/*",
+    "./types": {
+      "types": "./types/stable/index.d.ts"
+    },
     "./dist/ember-template-compiler.js": "./dist/ember-template-compiler.js",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Resolves: https://github.com/emberjs/ember.js/issues/20789

Which allows folks to use:
```ts
import 'ember-source/types';
```
in some ts file.

or

```ts
types: ['ember-source/types']
```
in tsconfig.json


Tested locally:
![image](https://github.com/user-attachments/assets/1cd30644-fb1e-4635-ac48-5e9dc4651424)
![image](https://github.com/user-attachments/assets/c9a2b34a-8714-48fc-a0f6-4ff860dbea83)

And one additional error state (which is reality before this PR)
![image](https://github.com/user-attachments/assets/2dfbaa2a-8e5c-406d-84c6-5eb457b60bbb)
