### PR TITLE
Fix changelog for `@glimmer/component` v2 (supported version)

### DIFF
--- a/packages/@glimmer/component/CHANGELOG.md
+++ b/packages/@glimmer/component/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## 2.0.0 2024-10-29
 
  - BREAKING: converted to V2 addon
- - BREAKING: dropped support for ember < 3.13
+ - BREAKING: dropped support for ember < 4.10
 
 
 ## 2.0.0-beta.22 2024-10-29
 
  - BREAKING: converted to V2 addon
- - BREAKING: dropped support for ember < 3.13
+ - BREAKING: dropped support for ember < 4.10
 
 
 ## Older Releases

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -23,9 +23,6 @@
   "devDependencies": {
     "typescript": "5.1"
   },
-  "peerDependencies": {
-    "ember-source": ">= 4.10.0"
-  },
   "engines": {
     "node": ">= 18"
   },

--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -23,6 +23,9 @@
   "devDependencies": {
     "typescript": "5.1"
   },
+  "peerDependencies": {
+    "ember-source": ">= 4.10.0"
+  },
   "engines": {
     "node": ">= 18"
   },


### PR DESCRIPTION
Like discussed in #20790 we should fix the changelog for `@glimmer/component` v2.

The package supports only `ember-source` >= 4.10, because it use `@ember/owner` which was introduced in [v4.10](https://github.com/emberjs/ember.js/blob/main/CHANGELOG.md#v4100-january-11-2023) of ember

~In additional there was added the `peerDependency`, so that consumer apps are getting dependency warning for incorrect version use~

close #20790 