### PR TITLE
Fix typescript@next support

### DIFF
--- a/packages/@ember/-internals/environment/lib/global.ts
+++ b/packages/@ember/-internals/environment/lib/global.ts
@@ -2,7 +2,7 @@
 declare const mainContext: object | undefined;
 
 // from lodash to catch fake globals
-function checkGlobal(value: any | null | undefined): value is object {
+function checkGlobal(value: any | null | undefined): object | undefined {
   return value && value.Object === Object ? value : undefined;
 }
 


### PR DESCRIPTION
The newest typescript catches a real proble. This type wasn't correct. You can only use a type predicate if your implementation returns a boolean, but this implementation very deliberately returns its argument if that argument passes a check.