### PR TITLE
Enable `deprecate-import-from-ember` deprecation

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -95,7 +95,7 @@ export const DEPRECATIONS = {
     return deprecation({
       id: `deprecate-import-${dasherize(importName).toLowerCase()}-from-ember`,
       for: 'ember-source',
-      since: { available: '5.10.0' },
+      since: { available: '5.10.0', enabled: '6.3.0' },
       until: '7.0.0',
       url: `https://deprecations.emberjs.com/id/import-${dasherize(
         importName

--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -95,7 +95,7 @@ export const DEPRECATIONS = {
     return deprecation({
       id: `deprecate-import-${dasherize(importName).toLowerCase()}-from-ember`,
       for: 'ember-source',
-      since: { available: '5.10.0', enabled: '6.3.0' },
+      since: { available: '5.10.0', enabled: '6.5.0' },
       until: '7.0.0',
       url: `https://deprecations.emberjs.com/id/import-${dasherize(
         importName


### PR DESCRIPTION
What are folks thoughts on enabling this? and then the deprecation messages would force us to work on improving the inspector experience?

I have some ideas for how to bring back compatibility.


Our setup would be something like this:

```js
const EMBER_INSPECTOR_SUPPORT = Symbol.for('__EMBER_INSPECTOR__');
globalThis[EMBER_INSPECTOR_SUPPORT] ||= {};
globalThis[EMBER_INSPECTOR_SUPPORT].init = async function loadEmberInspectorUtilities() {
  // store things on the secret object 2 lines above
  globalThis[EMBER_INSPECTOR_SUPPORT].tracking = await import(...);
  /* ... etc ... */.container = await import(...);

  // ensuring to set up an event listener pair for communicating via postMessage with the inspector
}
```

This should probably _wrap_ all of this code: https://github.com/emberjs/ember.js/pull/20775/files#diff-b2c569a1648b65b7314971b3bd201a82fda450a5cccc8c3d415b864166c98e27

And then on the app side, we only need to load the module, since everything the inspector needs is await-imported
```js
import '@ember/inspector-support';
```

And then on the inspector side, we access the globalThis
```js
// loading the inspector
await globalThis[EMBER_INSPECTOR_SUPPORT].init();

// we can now start building the UI / Panels in the ember-inspector project.
```


@PatrickJS , @ef4 thoughts?