### PR TITLE
Enable importing-inject-from-ember-service deprecation

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -144,6 +144,7 @@ export const DEPRECATIONS = {
     id: 'importing-inject-from-ember-service',
     since: {
       available: '6.2.0',
+      enabled: '6.3.0',
     },
     until: '7.0.0',
     url: 'https://deprecations.emberjs.com/id/importing-inject-from-ember-service',


### PR DESCRIPTION
This is ready for release (https://github.com/emberjs/rfcs/pull/1061).