### PR TITLE
Remove the `helper` wrapper from the helper generator

### DIFF
--- a/blueprints/helper/files/__root__/helpers/__name__.ts
+++ b/blueprints/helper/files/__root__/helpers/__name__.ts
@@ -1,5 +1,3 @@
-import { helper } from '@ember/component/helper';
-
-export default helper(function <%= camelizedModuleName %>(positional /*, named*/) {
-  return positional;
-});
+export default function <%= camelizedModuleName %>(positionalA /*, positionalB, named*/) {
+  return positionalA;
+}

--- a/node-tests/fixtures/helper/helper.js
+++ b/node-tests/fixtures/helper/helper.js
@@ -1,5 +1,3 @@
-import { helper } from '@ember/component/helper';
-
-export default helper(function fooBarBaz(positional /*, named*/) {
-  return positional;
-});
+export default function fooBarBaz(positionalA /*, positionalB, named*/) {
+  return positionalA;
+}


### PR DESCRIPTION
Plain function helpers have been supported since ember-source 4.5 so we no longer need the wrapping `helper` call.