### PR TITLE
Disable Ubuntu app-armor in CI to avoid Chromium/Puppeteer bug "No Usable Sandbox!"

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,5 +30,13 @@ runs:
         restore-keys: |
           ${{ runner.os }}-puppeteer-
 
+    - name: Disable AppArmor
+      # Ubuntu >= 23 has AppArmor enabled by default, which breaks Puppeteer.
+      # See https://github.com/puppeteer/puppeteer/issues/12818 "No usable sandbox!"
+      # this is taken from the solution used in Puppeteer's own CI: https://github.com/puppeteer/puppeteer/pull/13196
+      # The alternative is to pin Ubuntu 22 or to use aa-exec to disable AppArmor for commands that need Puppeteer.
+      run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+      shell: bash
+
     - run: pnpm install ${{ fromJSON('{"false":"--no-lockfile", "true":"--frozen-lockfile"}')[inputs.use_lockfile] }}
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -35,6 +35,7 @@ runs:
       # See https://github.com/puppeteer/puppeteer/issues/12818 "No usable sandbox!"
       # this is taken from the solution used in Puppeteer's own CI: https://github.com/puppeteer/puppeteer/pull/13196
       # The alternative is to pin Ubuntu 22 or to use aa-exec to disable AppArmor for commands that need Puppeteer.
+      # This is also suggested by Chromium https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
       run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
 
   browser-test:
     name: Browser Tests (Firefox)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Firefox is not installing on Ubuntu 24 on GitHub Actions https://github.com/browser-actions/setup-firefox/issues/622
     needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


See https://github.com/puppeteer/puppeteer/issues/12818