### PR TITLE
Fix source maps in published packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,14 +130,19 @@ module.exports = {
 
     let templateCompiler = new Funnel(tree, {
       destDir: 'ember',
-      include: ['ember-template-compiler.js', 'ember-template-compiler.map'],
+      include: ['ember-template-compiler.js', 'ember-template-compiler.js.map'],
     });
 
     let which = isProduction ? 'prod' : 'debug';
 
     let ember = new Funnel(tree, {
       destDir: 'ember',
-      include: [`ember.${which}.js`, `ember.${which}.map`, 'ember-testing.js', 'ember-testing.map'],
+      include: [
+        `ember.${which}.js`,
+        `ember.${which}.js.map`,
+        'ember-testing.js',
+        'ember-testing.js.map',
+      ],
       getDestinationPath(path) {
         return path.replace(`ember.${which}.`, 'ember.');
       },

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "dist/packages",
     "dist/dependencies",
     "dist/ember-template-compiler.js",
-    "dist/ember-template-compiler.map",
+    "dist/ember-template-compiler.js.map",
     "dist/ember.debug.js",
-    "dist/ember.debug.map",
+    "dist/ember.debug.js.map",
     "dist/ember.prod.js",
-    "dist/ember.prod.map",
+    "dist/ember.prod.js.map",
     "dist/ember-testing.js",
-    "dist/ember-testing.map",
+    "dist/ember-testing.js.map",
     "docs/data.json",
     "lib",
-    "types"
+    "types/stable"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed this problem from this warning in my build:

```
Warning: ignoring input sourcemap for ../rewritten-packages/@embroider/synthesized-vendor/vendor/ember/ember-testing.js because
ENOENT: no such file or directory, open '.../node_modules/.embroider/rewritten-packages/@embroider/synthesized-vendor/vendor/ember/ember-template-compiler.js.map'
```

Indeed, it seems like as of 5.10.0-beta.1, we stopped publishing source maps:

https://unpkg.com/browse/ember-source@5.10.0-beta.1/dist/

...despite having every intention to do so still.

Last good version:

https://unpkg.com/browse/ember-source@5.10.0-alpha.4/dist/

It took me way to long to spot this, but the problem is in the extension; in the broccoli build, they had a `$name.map` filename, whereas in the new build (#20675) it's `$name.js.map`.

Adjusted the entries in package.json to match; also removed the types publish script that was accidentally included in the tarball.

* * *

As for my original quest to fix the warning, it turns out this is not sufficient. The file is placed there by @embroider/compat these days:

https://github.com/embroider-build/embroider/pull/2164

It'll have to be updated to also emit the source map file (if it is present, since this has been broken for a while).

But this is a prerequisite to fixing that.