### PR TITLE
Fix nightly TS

### DIFF
--- a/.github/workflows/night-ts.yml
+++ b/.github/workflows/night-ts.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - run: pnpm build
       - run: pnpm add --save-dev typescript@next --workspace-root
       - run: pnpm type-check
   notify:


### PR DESCRIPTION
Looks like it wasn't building `@glimmer/component`, so this should do it

Tested locally via:
```bash
pnpm install
pnpm build
pnpm add --save-dev typescript@next --workspace-root
pnpm type-check
```