### PR TITLE
Enable missing debug tests and fix a test setup problem

### DIFF
--- a/packages/@ember/debug/index.ts
+++ b/packages/@ember/debug/index.ts
@@ -98,7 +98,12 @@ if (DEBUG) {
       case 'debug':
         return (debug = callback as DebugFunc);
       case 'deprecate':
-        return (currentDeprecate = callback as DeprecateFunc);
+        if (callback === deprecate) {
+          currentDeprecate = undefined;
+          return deprecate;
+        } else {
+          return (currentDeprecate = callback as DeprecateFunc);
+        }
       case 'debugSeal':
         return (debugSeal = callback as DebugSealFunc);
       case 'debugFreeze':

--- a/packages/internal-test-helpers/lib/module-for.ts
+++ b/packages/internal-test-helpers/lib/module-for.ts
@@ -34,7 +34,7 @@ export function moduleForDevelopment<T extends AbstractTestCase, M extends Gener
   ...mixins: Mixin<M>[]
 ) {
   // @ts-expect-error Our tests run in vite, vite supports this
-  if (import.meta.mode === 'development') {
+  if (import.meta.env.MODE === 'development') {
     moduleFor(description, TestClass, ...mixins);
   }
 }


### PR DESCRIPTION
I discovered that `moduleForDevelopment` is not actually running any tests, because I got the Vite-specific `import.meta.env` wrong. This PR fixes that so the tests run.

Once they were running, they detected a problem in the debug handlers, which I think is limited to our own test suite. But if you do:

```js
setDebugFunction('deprecate', getDebugFunction('deprecate'))
```

future deprecate calls hit a stack overflow. The fix is included here.