### PR TITLE
Fix LOG_VERSIONS and restore test suite coverage of real class field semantics

### DIFF
--- a/packages/@ember/-internals/metal/lib/libraries.ts
+++ b/packages/@ember/-internals/metal/lib/libraries.ts
@@ -69,8 +69,8 @@ export class Libraries {
     }
   }
 
-  isRegistered?: (name: string) => boolean;
-  logVersions?: () => void;
+  declare isRegistered?: (name: string) => boolean;
+  declare logVersions?: () => void;
 }
 
 if (DEBUG) {

--- a/packages/@ember/routing/tests/location/hash_location_test.js
+++ b/packages/@ember/routing/tests/location/hash_location_test.js
@@ -6,8 +6,8 @@ import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 let location;
 
 function createLocation(options, assert) {
-  let HashTestLocation = HashLocation.extend({
-    _location: {
+  class HashTestLocation extends HashLocation {
+    _location = {
       href: 'http://test.com/',
       pathname: '/',
       hash: '',
@@ -15,8 +15,8 @@ function createLocation(options, assert) {
       replace() {
         assert.ok(false, 'location.replace should not be called during testing');
       },
-    },
-  });
+    };
+  }
 
   if (!options) {
     options = {};

--- a/packages/@ember/routing/tests/location/history_location_test.js
+++ b/packages/@ember/routing/tests/location/history_location_test.js
@@ -52,9 +52,9 @@ moduleFor(
         },
       };
 
-      HistoryTestLocation = HistoryLocation.extend({
-        history: FakeHistory,
-      });
+      HistoryTestLocation = class extends HistoryLocation {
+        history = FakeHistory;
+      };
     }
 
     teardown() {

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -987,15 +987,15 @@ moduleFor(
       let rootURL = '/blahzorz';
       this.add(
         'location:history-test',
-        HistoryLocation.extend({
-          rootURL: 'this is not the URL you are looking for',
-          history: {
+        class extends HistoryLocation {
+          rootURL = 'this is not the URL you are looking for';
+          history = {
             pushState() {},
-          },
+          };
           initState() {
             assert.equal(this.get('rootURL'), rootURL);
-          },
-        })
+          }
+        }
       );
 
       this.router.reopen({

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -43,6 +43,7 @@ export default defineConfig(({ mode }) => {
     optimizeDeps: { noDiscovery: true },
     publicDir: 'tests/public',
     build,
+    esbuild: false,
   };
 });
 


### PR DESCRIPTION
Ember's debug logging of its own version was accidentally broken since 5.10 when we reformed the build.

The problem was:
 - we switched to typescript's more spec-compliant class field semantics, where fields without `declare` are in fact present as real class fields with an undefined initializer.
 - our test suite was accidentally getting processed by vite's default (and pretty broken!) esbuild TS loader, which uses the loose & wrong field semantics.
 - `logVersions` in `class Libraries` is written in a picky way that breaks if you get the spec-compliant field semantics.

This PR disables vite's built-in esbuild, which revealed the bug.

The change to logVersions is the only real user-facing bugfix. There were also some similar bugs in the test suite itself which are fixed here.

(All of this was precipated by me working on stable decorators, which *also* requires disabling vite's hidden-and-terrible TS support.)