### PR TITLE
Inline @glimmer/env

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@embroider/addon-shim": "^1.9.0",
     "@glimmer/compiler": "0.94.9",
     "@glimmer/destroyable": "0.94.7",
-    "@glimmer/env": "^0.1.7",
     "@glimmer/global-context": "0.93.3",
     "@glimmer/interfaces": "0.94.6",
     "@glimmer/manager": "0.94.8",

--- a/packages/@glimmer/env/index.ts
+++ b/packages/@glimmer/env/index.ts
@@ -1,0 +1,2 @@
+export const DEBUG = false;
+export const CI = false;

--- a/packages/@glimmer/env/package.json
+++ b/packages/@glimmer/env/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@glimmer/env",
+  "version": "0.1.7",
+  "description": "Glimmer application environment variables stub",
+  "repository": "https://github.com/emberjs/ember.js",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@glimmer/destroyable':
         specifier: 0.94.7
         version: 0.94.7
-      '@glimmer/env':
-        specifier: ^0.1.7
-        version: 0.1.7
       '@glimmer/global-context':
         specifier: 0.93.3
         version: 0.93.3
@@ -1301,6 +1298,8 @@ importers:
       typescript:
         specifier: '5.1'
         version: 5.1.6
+
+  packages/@glimmer/env: {}
 
   packages/@glimmer/tracking:
     dependencies:

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -221,7 +221,6 @@ export function exposedDependencies() {
     router_js: require.resolve('router_js/dist/modules/index.js'),
     'route-recognizer': require.resolve('route-recognizer/dist/route-recognizer.es.js'),
     ...walkGlimmerDeps([
-      '@glimmer/env',
       '@glimmer/node',
       '@simple-dom/document',
       '@glimmer/manager',


### PR DESCRIPTION
@glimmer/env lived in the (retired) glimmer.js monorepo. It's only a stub. But we're still pointing at the published package, and should instead inline it here like the other things we took out of that repo.