### PR TITLE
[CLEANUP] Remove DEPRECATE_COMPONENT_TEMPLATE_RESOLVING deprecation

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -102,16 +102,6 @@ export const DEPRECATIONS = {
       ).toLowerCase()}-from-ember`,
     });
   },
-  DEPRECATE_COMPONENT_TEMPLATE_RESOLVING: deprecation({
-    id: 'component-template-resolving',
-    url: 'https://deprecations.emberjs.com/id/component-template-resolving',
-    until: '6.0.0',
-    for: 'ember-source',
-    since: {
-      available: '5.10.0',
-      enabled: '5.10.0',
-    },
-  }),
   DEPRECATE_ARRAY_PROTOTYPE_EXTENSIONS: deprecation({
     id: 'deprecate-array-prototype-extensions',
     url: 'https://deprecations.emberjs.com/id/deprecate-array-prototype-extensions',

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -1,4 +1,4 @@
-import type { InternalFactory, InternalOwner, RegisterOptions } from '@ember/-internals/owner';
+import type { InternalFactory, InternalOwner } from '@ember/-internals/owner';
 import { isFactory } from '@ember/-internals/owner';
 import { assert } from '@ember/debug';
 import { _instrumentStart } from '@ember/instrumentation';
@@ -42,7 +42,6 @@ import { default as uniqueId } from './helpers/unique-id';
 
 import { mountHelper } from './syntax/mount';
 import { outletHelper } from './syntax/outlet';
-import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 
 function instrumentationPayload(name: string) {
   return { object: `component:${name}` };
@@ -54,29 +53,6 @@ function componentFor(
 ): Nullable<InternalFactory<object> | object> {
   let fullName = `component:${name}` as const;
   return owner.factoryFor(fullName) || null;
-}
-
-function layoutFor(
-  name: string,
-  owner: InternalOwner,
-  options?: RegisterOptions
-): Nullable<Template> {
-  if (DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved) {
-    return null;
-  }
-
-  let templateFullName = `template:components/${name}` as const;
-
-  let result = (owner.lookup(templateFullName, options) as Template) || null;
-
-  if (result) {
-    deprecateUntil(
-      `Components with separately resolved templates are deprecated. Migrate to either co-located js/ts + hbs files or to gjs/gts. Tried to lookup '${templateFullName}'.`,
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING
-    );
-  }
-
-  return result;
 }
 
 type LookupResult =
@@ -93,11 +69,7 @@ type LookupResult =
       layout: TemplateFactory;
     };
 
-function lookupComponentPair(
-  owner: InternalOwner,
-  name: string,
-  options?: RegisterOptions
-): Nullable<LookupResult> {
+function lookupComponentPair(owner: InternalOwner, name: string): Nullable<LookupResult> {
   let component = componentFor(name, owner);
 
   if (isFactory(component) && component.class) {
@@ -108,12 +80,10 @@ function lookupComponentPair(
     }
   }
 
-  let layout = layoutFor(name, owner, options);
-
-  if (component === null && layout === null) {
+  if (component === null) {
     return null;
   } else {
-    return { component, layout } as LookupResult;
+    return { component, layout: null } as LookupResult;
   }
 }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -1,16 +1,8 @@
-import {
-  moduleFor,
-  RenderingTestCase,
-  strip,
-  runTask,
-  testUnless,
-  expectDeprecation,
-} from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/object';
 
 import { Component, compile } from '../../utils/helpers';
-import { DEPRECATIONS } from '../../../../deprecations';
 import { setComponentTemplate } from '@glimmer/manager';
 
 class AbstractAppendTest extends RenderingTestCase {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/append-test.js
@@ -286,15 +286,8 @@ class AbstractAppendTest extends RenderingTestCase {
     );
   }
 
-  [`${testUnless(
-    DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-  )} lifecycle hooks during component append`](assert) {
+  [`@test lifecycle hooks during component append`](assert) {
     let hooks = [];
-
-    expectDeprecation(
-      /resolved templates/,
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
-    );
 
     let oldRegisterComponent = this.registerComponent;
     let componentsByName = {};
@@ -539,15 +532,8 @@ class AbstractAppendTest extends RenderingTestCase {
     );
   }
 
-  [`${testUnless(
-    DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-  )} appending, updating and destroying a single component`](assert) {
+  [`@test appending, updating and destroying a single component`](assert) {
     let willDestroyCalled = 0;
-
-    expectDeprecation(
-      /separately resolved templates/,
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
-    );
 
     this.registerComponent('x-parent', {
       ComponentClass: Component.extend({
@@ -566,7 +552,7 @@ class AbstractAppendTest extends RenderingTestCase {
         tagName: '',
       }),
 
-      resolveableTemplate: '[child: {{this.bar}}]{{yield}}',
+      template: '[child: {{this.bar}}]{{yield}}',
     });
 
     let XParent;
@@ -652,9 +638,7 @@ class AbstractAppendTest extends RenderingTestCase {
     assert.equal(renderer._roots.length, 0, 'released the root component');
   }
 
-  [`${testUnless(
-    DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-  )} appending, updating and destroying multiple components`](assert) {
+  [`@test appending, updating and destroying multiple components`](assert) {
     let willDestroyCalled = 0;
 
     this.registerComponent('x-first', {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
@@ -1,9 +1,8 @@
 import { DEBUG } from '@glimmer/env';
-import { moduleFor, RenderingTestCase, runTask, testUnless } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { setComponentTemplate, getComponentTemplate } from '@glimmer/manager';
 import { Component, compile } from '../../utils/helpers';
-import { DEPRECATIONS } from '../../../../deprecations';
 
 moduleFor(
   'Components test: setComponentTemplate',
@@ -11,23 +10,6 @@ moduleFor(
     '@test it basically works'() {
       this.registerComponent('foo-bar', {
         ComponentClass: setComponentTemplate(compile('hello'), Component.extend()),
-      });
-
-      this.render('<FooBar />');
-
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
-
-      runTask(() => this.rerender());
-
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
-    }
-
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-    )} it takes precedence over resolver`]() {
-      this.registerComponent('foo-bar', {
-        ComponentClass: setComponentTemplate(compile('hello'), Component.extend()),
-        resolveableTemplate: 'noooooo!',
       });
 
       this.render('<FooBar />');

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -1,18 +1,9 @@
 import { ENV } from '@ember/-internals/environment';
-import {
-  RenderingTestCase,
-  moduleFor,
-  runDestroy,
-  runAppend,
-  runTask,
-  testUnless,
-  expectDeprecation,
-} from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 
 import { set } from '@ember/object';
 import { templateCacheCounters } from '@ember/-internals/glimmer';
 import { Component } from '../utils/helpers';
-import { DEPRECATIONS } from '../../../deprecations';
 
 moduleFor(
   'ember-glimmer runtime resolver cache',
@@ -123,116 +114,6 @@ moduleFor(
 
       this.assertText('Two');
       this.expectCacheChanges({}, 'toggle back to component-two no change');
-    }
-
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-    )} each template is only compiled once`]() {
-      expectDeprecation(
-        /resolved templates/,
-        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
-      );
-      // static layout
-      this.registerComponent('component-one', { resolveableTemplate: 'One' });
-
-      // test directly import template factory onto late bound layout
-      let Two = Component.extend({
-        layout: this.compile('Two'),
-      });
-      this.registerComponent('component-two', { ComponentClass: Two });
-
-      // inject layout onto component, share layout with component-one
-      let Root = Component.extend({
-        layout: this.owner.lookup('template:components/component-one'),
-      });
-
-      this.registerComponent('root-component', { ComponentClass: Root });
-
-      // template instance shared between to template managers
-      let rootFactory = this.owner.factoryFor('component:root-component');
-
-      // snapshot counters
-      this.getCacheCounters();
-
-      // show component-one for the first time
-      this.render(
-        `
-    {{~#if this.cond~}}
-      {{component-one}}
-    {{~else~}}
-      {{component-two}}
-    {{~/if}}`,
-        {
-          cond: true,
-        }
-      );
-
-      this.assertText('One');
-      this.expectCacheChanges(
-        {
-          componentDefinitionCount: 1,
-          templateCacheMisses: 2,
-          templateCacheHits: ENV._DEBUG_RENDER_TREE ? 1 : 0,
-        },
-        'test case component and component-one no change'
-      );
-
-      // show component-two for the first time
-      runTask(() => set(this.context, 'cond', false));
-
-      this.assertText('Two');
-      this.expectCacheChanges(
-        {
-          templateCacheMisses: 1,
-          componentDefinitionCount: 1,
-          templateCacheHits: ENV._DEBUG_RENDER_TREE ? 1 : 0,
-        },
-        'component-two first render misses template cache'
-      );
-
-      // show component-one again
-      runTask(() => set(this.context, 'cond', true));
-
-      this.assertText('One');
-      this.expectCacheChanges({}, 'toggle back to component-one no change');
-
-      // show component-two again
-      runTask(() => set(this.context, 'cond', false));
-
-      this.assertText('Two');
-      this.expectCacheChanges(
-        {
-          templateCacheHits: ENV._DEBUG_RENDER_TREE ? 2 : 1,
-        },
-        'toggle back to component-two hits template cache'
-      );
-
-      // render new root append
-      let root = rootFactory.create();
-      try {
-        runAppend(root);
-        this.assertText('TwoOne');
-        // roots have different capabilities so this will hit
-        this.expectCacheChanges(
-          { templateCacheHits: ENV._DEBUG_RENDER_TREE ? 2 : 1 },
-          'append root with component-one no change'
-        );
-
-        // render new root append
-        let root2 = rootFactory.create();
-        try {
-          runAppend(root2);
-          this.assertText('TwoOneOne');
-          this.expectCacheChanges(
-            { templateCacheHits: ENV._DEBUG_RENDER_TREE ? 2 : 1 },
-            'append another root no change'
-          );
-        } finally {
-          runDestroy(root2);
-        }
-      } finally {
-        runDestroy(root);
-      }
     }
 
     getCacheCounters() {

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -2,15 +2,8 @@ import Application from '@ember/application';
 import Controller from '@ember/controller';
 import { Component } from '@ember/-internals/glimmer';
 import { compile } from 'ember-template-compiler';
-import {
-  moduleFor,
-  testUnless,
-  ApplicationTestCase,
-  defineComponent,
-  expectDeprecation,
-} from 'internal-test-helpers';
+import { moduleFor, ApplicationTestCase, defineComponent } from 'internal-test-helpers';
 import { DEBUG } from '@glimmer/env';
-import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import templateOnly from '@ember/component/template-only';
 
 moduleFor(
@@ -79,81 +72,6 @@ moduleFor(
         assert.equal(
           text,
           'there goes watch him as he GOES',
-          'The component is composed correctly'
-        );
-      });
-    }
-
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-    )} Late-registered components can be rendered with template registered on the container`](
-      assert
-    ) {
-      expectDeprecation(
-        /resolved templates/,
-        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
-      );
-      this.addTemplate(
-        'application',
-        `<div id='wrapper'>hello world {{sally-rutherford}}-{{#sally-rutherford}}!!!{{/sally-rutherford}}</div>`
-      );
-
-      this.application.instanceInitializer({
-        name: 'sally-rutherford-component-template',
-        initialize(applicationInstance) {
-          applicationInstance.register(
-            'template:components/sally-rutherford',
-            compile('funkytowny{{yield}}')
-          );
-        },
-      });
-      this.application.instanceInitializer({
-        name: 'sally-rutherford-component',
-        initialize(applicationInstance) {
-          applicationInstance.register('component:sally-rutherford', Component);
-        },
-      });
-
-      return this.visit('/').then(() => {
-        let text = this.$('#wrapper').text().trim();
-        assert.equal(
-          text,
-          'hello world funkytowny-funkytowny!!!',
-          'The component is composed correctly'
-        );
-      });
-    }
-
-    [`${testUnless(
-      DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isRemoved
-    )} Late-registered components can be rendered with ONLY the template registered on the container`](
-      assert
-    ) {
-      expectDeprecation(
-        /resolved templates/,
-        DEPRECATIONS.DEPRECATE_COMPONENT_TEMPLATE_RESOLVING.isEnabled
-      );
-
-      this.addTemplate(
-        'application',
-        `<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>`
-      );
-
-      this.application.instanceInitializer({
-        name: 'borf-snorlax-component-template',
-        initialize(applicationInstance) {
-          applicationInstance.register(
-            'template:components/borf-snorlax',
-            compile('goodfreakingTIMES{{yield}}')
-          );
-        },
-      });
-
-      return this.visit('/').then(() => {
-        let text = this.$('#wrapper').text().trim();
-        assert.equal(
-          text,
-          'hello world goodfreakingTIMES-goodfreakingTIMES!!!',
           'The component is composed correctly'
         );
       });


### PR DESCRIPTION
Related to #20816.

The removal of this deprecation means that the resolver's internal function `layoutFor` would always return `null`.   It's only called in one place, so I removed the function and updated `lookupComponentPair` to use `null` in place of the return from `layoutFor`.

While doing the cleanup, we determined that some of the tests were erroneously marked with the deprecation, so for those tests -- in the `tests/integration/components/append-test.js` file -- the `testUnless` wrapper was removed.  One test was modified to build the test component using `template` instead of `resolvableTemplate`.