### PR TITLE
fix Prototype-polluting assignment ('Code Injection')

### DIFF
--- a/packages/@ember/engine/index.ts
+++ b/packages/@ember/engine/index.ts
@@ -472,6 +472,9 @@ export function buildInitializerMethod<
   B extends 'initializers' | 'instanceInitializers',
   T extends B extends 'initializers' ? Engine : EngineInstance,
 >(bucketName: B, humanName: string) {
+  if (bucketName === '__proto__' || bucketName === 'constructor' || bucketName === 'prototype') {
+    throw new Error(`Invalid bucketName: ${bucketName}`);
+  }
   return function (this: typeof Engine, initializer: Initializer<T>) {
     // If this is the first initializer being added to a subclass, we are going to reopen the class
     // to make sure we have a new `initializers` object, which extends from the parent class' using

--- a/packages/@ember/engine/index.ts
+++ b/packages/@ember/engine/index.ts
@@ -472,7 +472,7 @@ export function buildInitializerMethod<
   B extends 'initializers' | 'instanceInitializers',
   T extends B extends 'initializers' ? Engine : EngineInstance,
 >(bucketName: B, humanName: string) {
-  if (bucketName === '__proto__' || bucketName === 'constructor' || bucketName === 'prototype') {
+  if (bucketName !== 'initializers' && bucketName !== 'instanceInitializers') {
     throw new Error(`Invalid bucketName: ${bucketName}`);
   }
   return function (this: typeof Engine, initializer: Initializer<T>) {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/blob/6c601053dab9c40d900f19d16b08620c5e13f6ba/packages/%40ember/engine/index.ts#L503-L503

fix the issue validate the `bucketName` parameter to ensure it cannot be set to a prototype-polluting value like `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a runtime check that explicitly rejects such values. This approach ensures that even if the type system is bypassed, the code remains secure.

The fix involves:
1. Adding a validation step for `bucketName` at the beginning of the `buildInitializerMethod` function.
2. Throwing an error if `bucketName` is set to a disallowed value.

Most JavaScript objects inherit the properties of the built-in `Object.prototype` object. Prototype pollution is a type of vulnerability in which an attacker is able to modify Object.prototype. Since most objects inherit from the compromised `Object.prototype` object, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting. One way to cause prototype pollution is by modifying an object obtained via a user-controlled property name. Most objects have a special `__proto__` property that refers to `Object.prototype`. An attacker can abuse this special property to trick the application into performing unintended modifications of `Object.prototype`.


## POC
the untrusted value `req.params.id` is used as the property name `req.session.todos[id]`. If a malicious user passes in the ID value `__proto__`, the variable `items` will then refer to `Object.prototype`. Finally, the modification of `items` then allows the attacker to inject arbitrary properties onto `Object.prototype`.
```ts
let express = require('express');
let app = express()

app.put('/todos/:id', (req, res) => {
    let id = req.params.id;
    let items = req.session.todos[id];
    if (!items) {
        items = req.session.todos[id] = {};
    }
    items[req.query.name] = req.query.text;
    res.end(200);
});
```
One way to fix this is to use [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) objects to associate key/value pairs instead of regular objects, as shown below:
```ts
let express = require('express');
let app = express()

app.put('/todos/:id', (req, res) => {
    let id = req.params.id;
    let items = req.session.todos.get(id);
    if (!items) {
        items = new Map();
        req.sessions.todos.set(id, items);
    }
    items.set(req.query.name, req.query.text);
    res.end(200);
});
```
Another way to fix it is to prevent the `__proto__` property from being used as a key, as shown below:
```ts
let express = require('express');
let app = express()

app.put('/todos/:id', (req, res) => {
    let id = req.params.id;
    if (id === '__proto__' || id === 'constructor' || id === 'prototype') {
        res.end(403);
        return;
    }
    let items = req.session.todos[id];
    if (!items) {
        items = req.session.todos[id] = {};
    }
    items[req.query.name] = req.query.text;
    res.end(200);
});
```
## References
[Object.prototype.proto](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)