### PR TITLE
[BUGFIX beta] Fix the Embroider smoke tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1712,7 +1712,7 @@ importers:
         version: 3.1.0
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.8.3(@embroider/core@3.5.2))(@embroider/core@3.5.2)(@embroider/webpack@4.1.0(@embroider/core@3.5.2)(webpack@5.98.0))
+        version: 4.0.0(@embroider/compat@3.9.0(@embroider/core@3.5.6))(@embroider/core@3.5.6)(@embroider/webpack@4.1.0(@embroider/core@3.5.6)(webpack@5.98.0))
       '@glimmer/component':
         specifier: workspace:^
         version: link:../../packages/@glimmer/component
@@ -1816,14 +1816,14 @@ importers:
   smoke-tests/scenarios:
     devDependencies:
       '@embroider/compat':
-        specifier: npm:@embroider/compat@latest
-        version: 3.8.3(@embroider/core@3.5.2)
+        specifier: ^3.9.0
+        version: 3.9.0(@embroider/core@3.5.6)
       '@embroider/core':
-        specifier: npm:@embroider/core@latest
-        version: 3.5.2
+        specifier: ^3.5.6
+        version: 3.5.6
       '@embroider/webpack':
-        specifier: npm:@embroider/webpack@latest
-        version: 4.1.0(@embroider/core@3.5.2)(webpack@5.98.0(@swc/core@1.11.1))
+        specifier: ^4.1.0
+        version: 4.1.0(@embroider/core@3.5.6)(webpack@5.98.0(@swc/core@1.11.1))
       '@swc-node/register':
         specifier: ^1.6.8
         version: 1.10.9(@swc/core@1.11.1)(@swc/types@0.1.17)(typescript@5.1.6)
@@ -2790,15 +2790,15 @@ packages:
     peerDependencies:
       '@embroider/core': ^3.4.0
 
-  '@embroider/compat@3.8.3':
-    resolution: {integrity: sha512-FZy8/highQ/4tbbOLpZtmLME+9HYSkcr532Zl2CtsRt1b9gQuOcjCN3tGflpiFFadbaUFaulh8PhWAv6632DuA==}
+  '@embroider/compat@3.9.0':
+    resolution: {integrity: sha512-9jHoKc5tsSFibIGRYoEXGBW1hwm4aaeU5sV4HA+9OBgi2B0YnlcWqMZ5Ef8u5F5DlIJPUtCF0YdyxXaTaAVMyw==}
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
     peerDependencies:
-      '@embroider/core': ^3.5.2
+      '@embroider/core': ^3.5.6
 
-  '@embroider/core@3.5.2':
-    resolution: {integrity: sha512-VRHhVgswkTul7a05+QeMgrYjC7ybzPQkNGkad2abdy8a+rJg8/j/QEdmnPf4gG7a12gr88gMT0nAL60O3JbLCQ==}
+  '@embroider/core@3.5.6':
+    resolution: {integrity: sha512-yCTed4fjX4ZK3baFN4qay8zvER6MB75peCHN0WxfxX4esK/Lgjh8aANLYPsZ/7kmSlKcq4qYnBmBD7peIMh6dA==}
     engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/hbs-loader@3.0.3':
@@ -2810,6 +2810,15 @@ packages:
 
   '@embroider/macros@1.16.11':
     resolution: {integrity: sha512-TUm/74oBr+tWto0IPAht1g6zjpP7UK0aQdnFHHqGvDPc+tAROQb9jKI/ePEuKAdBCV3L7XvvC4Rlf0DNvT4qmw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+
+  '@embroider/macros@1.16.13':
+    resolution: {integrity: sha512-2oGZh0m1byBYQFWEa8b2cvHJB2LzaF3DdMCLCqcRAccABMROt1G3sultnNCT30NhfdGWMEsJOT3Jm4nFxXmTRw==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
       '@glint/template': ^1.0.0
@@ -11677,26 +11686,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/babel-loader-9@3.1.1(@embroider/core@3.5.2)(supports-color@8.1.1)(webpack@5.98.0(@swc/core@1.11.1))':
+  '@embroider/babel-loader-9@3.1.1(@embroider/core@3.5.6)(supports-color@8.1.1)(webpack@5.98.0(@swc/core@1.11.1))':
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
-      '@embroider/core': 3.5.2
+      '@embroider/core': 3.5.6
       babel-loader: 9.2.1(@babel/core@7.26.9)(webpack@5.98.0(@swc/core@1.11.1))
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  '@embroider/babel-loader-9@3.1.1(@embroider/core@3.5.2)(supports-color@8.1.1)(webpack@5.98.0)':
+  '@embroider/babel-loader-9@3.1.1(@embroider/core@3.5.6)(supports-color@8.1.1)(webpack@5.98.0)':
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
-      '@embroider/core': 3.5.2
+      '@embroider/core': 3.5.6
       babel-loader: 9.2.1(@babel/core@7.26.9)(webpack@5.98.0)
     transitivePeerDependencies:
       - supports-color
       - webpack
     optional: true
 
-  '@embroider/compat@3.8.3(@embroider/core@3.5.2)':
+  '@embroider/compat@3.9.0(@embroider/core@3.5.6)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.26.9(supports-color@8.1.1)
@@ -11707,8 +11716,8 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)(supports-color@8.1.1)
       '@babel/runtime': 7.26.9
       '@babel/traverse': 7.26.9(supports-color@8.1.1)
-      '@embroider/core': 3.5.2
-      '@embroider/macros': 1.16.11
+      '@embroider/core': 3.5.6
+      '@embroider/macros': 1.16.13
       '@types/babel__code-frame': 7.0.6
       '@types/yargs': 17.0.33
       assert-never: 1.4.0
@@ -11749,12 +11758,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/core@3.5.2':
+  '@embroider/core@3.5.6':
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
       '@babel/parser': 7.26.9
       '@babel/traverse': 7.26.9(supports-color@8.1.1)
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       assert-never: 1.4.0
       babel-plugin-ember-template-compilation: 2.3.0
@@ -11783,18 +11792,31 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/hbs-loader@3.0.3(@embroider/core@3.5.2)(webpack@5.98.0(@swc/core@1.11.1))':
+  '@embroider/hbs-loader@3.0.3(@embroider/core@3.5.6)(webpack@5.98.0(@swc/core@1.11.1))':
     dependencies:
-      '@embroider/core': 3.5.2
+      '@embroider/core': 3.5.6
       webpack: 5.98.0(@swc/core@1.11.1)
 
-  '@embroider/hbs-loader@3.0.3(@embroider/core@3.5.2)(webpack@5.98.0)':
+  '@embroider/hbs-loader@3.0.3(@embroider/core@3.5.6)(webpack@5.98.0)':
     dependencies:
-      '@embroider/core': 3.5.2
+      '@embroider/core': 3.5.6
       webpack: 5.98.0
     optional: true
 
   '@embroider/macros@1.16.11':
+    dependencies:
+      '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
+      assert-never: 1.4.0
+      babel-import-util: 2.1.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/macros@1.16.13':
     dependencies:
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       assert-never: 1.4.0
@@ -11824,22 +11846,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/test-setup@4.0.0(@embroider/compat@3.8.3(@embroider/core@3.5.2))(@embroider/core@3.5.2)(@embroider/webpack@4.1.0(@embroider/core@3.5.2)(webpack@5.98.0))':
+  '@embroider/test-setup@4.0.0(@embroider/compat@3.9.0(@embroider/core@3.5.6))(@embroider/core@3.5.6)(@embroider/webpack@4.1.0(@embroider/core@3.5.6)(webpack@5.98.0))':
     dependencies:
       lodash: 4.17.21
       resolve: 1.22.10
     optionalDependencies:
-      '@embroider/compat': 3.8.3(@embroider/core@3.5.2)
-      '@embroider/core': 3.5.2
-      '@embroider/webpack': 4.1.0(@embroider/core@3.5.2)(webpack@5.98.0)
+      '@embroider/compat': 3.9.0(@embroider/core@3.5.6)
+      '@embroider/core': 3.5.6
+      '@embroider/webpack': 4.1.0(@embroider/core@3.5.6)(webpack@5.98.0)
 
-  '@embroider/webpack@4.1.0(@embroider/core@3.5.2)(webpack@5.98.0(@swc/core@1.11.1))':
+  '@embroider/webpack@4.1.0(@embroider/core@3.5.6)(webpack@5.98.0(@swc/core@1.11.1))':
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)(supports-color@8.1.1)
-      '@embroider/babel-loader-9': 3.1.1(@embroider/core@3.5.2)(supports-color@8.1.1)(webpack@5.98.0(@swc/core@1.11.1))
-      '@embroider/core': 3.5.2
-      '@embroider/hbs-loader': 3.0.3(@embroider/core@3.5.2)(webpack@5.98.0(@swc/core@1.11.1))
+      '@embroider/babel-loader-9': 3.1.1(@embroider/core@3.5.6)(supports-color@8.1.1)(webpack@5.98.0(@swc/core@1.11.1))
+      '@embroider/core': 3.5.6
+      '@embroider/hbs-loader': 3.0.3(@embroider/core@3.5.6)(webpack@5.98.0(@swc/core@1.11.1))
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       '@types/supports-color': 8.1.3
       assert-never: 1.4.0
@@ -11864,13 +11886,13 @@ snapshots:
       - canvas
       - utf-8-validate
 
-  '@embroider/webpack@4.1.0(@embroider/core@3.5.2)(webpack@5.98.0)':
+  '@embroider/webpack@4.1.0(@embroider/core@3.5.6)(webpack@5.98.0)':
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)(supports-color@8.1.1)
-      '@embroider/babel-loader-9': 3.1.1(@embroider/core@3.5.2)(supports-color@8.1.1)(webpack@5.98.0)
-      '@embroider/core': 3.5.2
-      '@embroider/hbs-loader': 3.0.3(@embroider/core@3.5.2)(webpack@5.98.0)
+      '@embroider/babel-loader-9': 3.1.1(@embroider/core@3.5.6)(supports-color@8.1.1)(webpack@5.98.0)
+      '@embroider/core': 3.5.6
+      '@embroider/hbs-loader': 3.0.3(@embroider/core@3.5.6)(webpack@5.98.0)
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       '@types/supports-color': 8.1.3
       assert-never: 1.4.0

--- a/smoke-tests/scenarios/package.json
+++ b/smoke-tests/scenarios/package.json
@@ -2,9 +2,9 @@
   "name": "ember-source-scenarios",
   "private": true,
   "devDependencies": {
-    "@embroider/compat": "npm:@embroider/compat@latest",
-    "@embroider/core": "npm:@embroider/core@latest",
-    "@embroider/webpack": "npm:@embroider/webpack@latest",
+    "@embroider/compat": "^3.9.0",
+    "@embroider/core": "^3.5.6",
+    "@embroider/webpack": "^4.1.0",
     "@swc-node/register": "^1.6.8",
     "@swc/core": "^1.4.17",
     "@swc/types": "^0.1.6",


### PR DESCRIPTION
This pins the Embroider packages to the latest version the smoke test app supports without code changes. The new releases only support Vite.