### PR TITLE
runtime compiler incorrectly entangles with tracked scope in explicit form

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
@@ -1,6 +1,6 @@
 import { tracked } from '@ember/-internals/metal';
 import { template } from '@ember/template-compiler/runtime';
-import { RenderingTestCase, defineSimpleModifier, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, defineSimpleModifier, moduleFor, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 import { on } from '@ember/modifier/on';
 import { fn } from '@ember/helper';
@@ -36,7 +36,7 @@ moduleFor(
       this.assertHTML('hello there');
       this.assertStableRerender();
 
-      state.str += '!';
+      runTask(() => (state.str += '!'));
 
       this.assertHTML('hello there!');
       this.assertStableRerender();
@@ -57,7 +57,7 @@ moduleFor(
       this.assertHTML('hello there');
       this.assertStableRerender();
 
-      state.str += '!';
+      runTask(() => (state.str += '!'));
 
       this.assertHTML('hello there!');
       this.assertStableRerender();

--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
@@ -1,3 +1,4 @@
+import { tracked } from '@ember/-internals/metal';
 import { template } from '@ember/template-compiler/runtime';
 import { RenderingTestCase, defineSimpleModifier, moduleFor } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
@@ -17,6 +18,48 @@ moduleFor(
       });
 
       this.assertHTML('Hello, world!');
+      this.assertStableRerender();
+    }
+
+    async '@test can derive the template string from tracked'() {
+      class State {
+        @tracked str = `hello there`;
+
+        get component() {
+          return template(this.str);
+        }
+      }
+      let state = new State();
+
+      this.render('<this.state.component />', { state });
+
+      this.assertHTML('hello there');
+      this.assertStableRerender();
+
+      state.str += '!';
+
+      this.assertHTML('hello there!');
+      this.assertStableRerender();
+    }
+
+    async '@test can have tracked data in the scope bag - and changes to that scope bag dont re-compile'() {
+      class State {
+        @tracked str = `hello there`;
+
+        get component() {
+          return template(`{{greeting}}`, { scope: () => ({ greeting: this.str }) });
+        }
+      }
+      let state = new State();
+
+      this.render('<this.state.component />', { state });
+
+      this.assertHTML('hello there');
+      this.assertStableRerender();
+
+      state.str += '!';
+
+      this.assertHTML('hello there!');
       this.assertStableRerender();
     }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
@@ -57,7 +57,6 @@ moduleFor(
           assert.step('get component');
           return template(`{{greeting}}`, {
             scope: () => {
-              assert.step('scope()');
               return { greeting: this.str };
             },
           });
@@ -69,15 +68,14 @@ moduleFor(
         return template('<state.component />', { scope: () => ({ state }) });
       });
 
+      assert.verifySteps(['get component']);
       this.assertHTML('hello there');
       this.assertStableRerender();
-      assert.verifySteps(['get component', 'scope()']);
 
       runTask(() => (state.str += '!'));
-
+      assert.verifySteps([]);
       this.assertHTML('hello there!');
       this.assertStableRerender();
-      assert.verifySteps(['scope()']);
     }
 
     async '@test Can use a custom helper in scope (in append position)'() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-implicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-implicit-test.ts
@@ -1,6 +1,6 @@
 import { tracked } from '@ember/-internals/metal';
 import { template } from '@ember/template-compiler/runtime';
-import { RenderingTestCase, defineSimpleModifier, moduleFor } from 'internal-test-helpers';
+import { RenderingTestCase, defineSimpleModifier, moduleFor, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 import { on } from '@ember/modifier/on';
 import { fn } from '@ember/helper';
@@ -38,7 +38,7 @@ moduleFor(
       this.assertHTML('hello there');
       this.assertStableRerender();
 
-      state.str += '!';
+      runTask(() => (state.str += '!'));
 
       this.assertHTML('hello there!');
       this.assertStableRerender();

--- a/packages/@ember/template-compiler/lib/template.ts
+++ b/packages/@ember/template-compiler/lib/template.ts
@@ -242,12 +242,10 @@ export function template(
   const normalizedOptions = compileOptions(options);
   const component = normalizedOptions.component ?? templateOnly();
 
-  queueMicrotask(() => {
-    const source = glimmerPrecompile(templateString, normalizedOptions);
-    const template = templateFactory(evaluate(`(${source})`) as SerializedTemplateWithLazyBlock);
+  const source = glimmerPrecompile(templateString, normalizedOptions);
+  const template = templateFactory(evaluate(`(${source})`) as SerializedTemplateWithLazyBlock);
 
-    setComponentTemplate(template, component);
-  });
+  setComponentTemplate(template, component);
 
   return component;
 }

--- a/packages/@ember/template-compiler/lib/template.ts
+++ b/packages/@ember/template-compiler/lib/template.ts
@@ -1,3 +1,4 @@
+import { untrack } from '@glimmer/validator';
 import templateOnly, { type TemplateOnlyComponent } from '@ember/component/template-only';
 import { precompile as glimmerPrecompile } from '@glimmer/compiler';
 import type { SerializedTemplateWithLazyBlock } from '@glimmer/interfaces';
@@ -236,10 +237,15 @@ export function template(
   templateString: string,
   providedOptions?: BaseTemplateOptions | BaseClassTemplateOptions<any>
 ): object {
+  // When figuring out how to compile the template, we don't want to engage
+  // with auto-tracking in a way that would cause the template
+  // to be re-rendered when the intended-to-be-lazily-accessesd scope bag's contents changes.
+  //
+  // This is why we use our reactivity-evading utility untrack() here
   const options: EmberPrecompileOptions = { strictMode: true, ...providedOptions };
-  const evaluate = buildEvaluator(options);
+  const evaluate = untrack(() => buildEvaluator(options));
 
-  const normalizedOptions = compileOptions(options);
+  const normalizedOptions = untrack(() => compileOptions(options));
   const component = normalizedOptions.component ?? templateOnly();
 
   const source = glimmerPrecompile(templateString, normalizedOptions);
@@ -262,15 +268,15 @@ function buildEvaluator(options: Partial<EmberPrecompileOptions> | undefined) {
   if (options.eval) {
     return options.eval;
   } else {
-    const scope = options.scope?.();
+    let scope = options.scope?.();
 
     if (!scope) {
       return evaluator;
     }
 
     return (source: string) => {
-      const argNames = Object.keys(scope);
-      const argValues = Object.values(scope);
+      const argNames = Object.keys(scope ?? {});
+      const argValues = Object.values(scope ?? {});
 
       return new Function(...argNames, `return (${source})`)(...argValues);
     };


### PR DESCRIPTION
Observed issue:

- scope bag can include tracked state
- scope bag is evaluated eagerly when running `template()` (twice), which means:
  - all tracked state accessed within the scope bag causes the `template()` compilation to re-compile after each tracked change
  - we probably need to update the underlying compiler and runtime to accept the `() => ({})` form of the scope, rather than `() => []`

Adding queueMicrotask back doesn't solve any of the above.

Why was queueMicrotask removed?
- we want the added tests to work -- with queueMicrotask, we get either _nothing rendered_, or an error.
  ```gjs
  class Demo extends Component {
    // should work, currently doesn't, nothing rendered
    component = template('hello world');

    <template>
      <this.component />
    </template>
  }
  ```
  separate PR to remove this here: https://github.com/emberjs/ember.js/pull/20909