### PR TITLE
Remove unneeded restriction around creating sub-applications

### DIFF
--- a/packages/@ember/-internals/views/lib/system/event_dispatcher.ts
+++ b/packages/@ember/-internals/views/lib/system/event_dispatcher.ts
@@ -13,7 +13,6 @@ import type { ActionState } from '@ember/-internals/glimmer/lib/modifiers/action
 */
 
 const ROOT_ELEMENT_CLASS = 'ember-application';
-const ROOT_ELEMENT_SELECTOR = `.${ROOT_ELEMENT_CLASS}`;
 
 /**
   `Ember.EventDispatcher` handles delegating browser events to their
@@ -162,11 +161,6 @@ export default class EventDispatcher extends EmberObject {
       `You cannot use the same root element (${specifiedRootElement}) multiple times in an Ember.Application`,
       !rootElement.classList.contains(ROOT_ELEMENT_CLASS)
     );
-    assert(
-      'You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application',
-      !rootElement.querySelector(ROOT_ELEMENT_SELECTOR)
-    );
-
     rootElement.classList.add(ROOT_ELEMENT_CLASS);
 
     assert(

--- a/packages/@ember/-internals/views/lib/system/event_dispatcher.ts
+++ b/packages/@ember/-internals/views/lib/system/event_dispatcher.ts
@@ -163,21 +163,6 @@ export default class EventDispatcher extends EmberObject {
       !rootElement.classList.contains(ROOT_ELEMENT_CLASS)
     );
     assert(
-      'You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application',
-      (() => {
-        let target = rootElement.parentNode;
-        while (target instanceof Element) {
-          if (target.classList.contains(ROOT_ELEMENT_CLASS)) {
-            return false;
-          }
-
-          target = target.parentNode;
-        }
-
-        return true;
-      })()
-    );
-    assert(
       'You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application',
       !rootElement.querySelector(ROOT_ELEMENT_SELECTOR)
     );

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -74,16 +74,6 @@ moduleFor(
       });
     }
 
-    [`@test you cannot make a new application that is a descendant of an existing application`]() {
-      expectAssertion(() => {
-        runTask(() =>
-          this.createSecondApplication({
-            rootElement: '#one-child',
-          })
-        );
-      });
-    }
-
     [`@test you cannot make a new application that is a duplicate of an existing application`]() {
       expectAssertion(() => {
         runTask(() =>


### PR DESCRIPTION
A path to unblocking:
- https://github.com/NullVoxPopuli/limber/pull/1925
  - This Limber PR has a patch of the change in this EmberJS PR  

While working new repl infra for https://limber.glimdown.com, I want to take a more "islands" approach, like https://astro.build -- it enables a ton of power -- however, there is an assertion that prevents using nested applications -- which kinda feels silly since we allow it via "engines".

Like with how we use modifiers and 3rd party libraries that manage DOM, whenever we use an element that has some external control of its descendents, we must make the same assumptions and allowances --- generally this is safe, as once we let 3rd party scripts manage their subtree, ember doesn't mess around in there (because when someone would instruct ember to mess around in _someone else's_ subtree, that's when you run in to problems -- but this is easy enough to avoid).

In my use case, I have:
- host ember app (could be any other app though, even react)
  - run through repl stuff
    - be given an element to put somewhere
      - render that element
        - in my case for https://limber.glimdown.com, the element is rendered via a component.
          so this component is mounting a whole new app, and nothing is is going to mess with the subtree.   
          This works via using the new `template()` API for the runtime compiler:
          ```js
          const element = await compiler.compile('gjs', code);
      
          component = template(`{{element}}`, { scope: () => ({ element }) });
          ```