### PR TITLE
Better estimation of asset sizes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,11 @@ inputs:
     description: 'Whether to use the lockfile vs latest floating dependencies'
     required: false
     default: true
+
+  node-version:
+    description: 'The node version to use'
+    required: false
+    default: 18
 runs:
   using: 'composite'
   steps:
@@ -15,7 +20,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: '${{ inputs.node-version }}'
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
     - uses: actions/cache@v4

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -27,9 +27,6 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      # better `du`
-      - run: sudo snap install dust
-
       - uses: dawidd6/action-download-artifact@v9
         with:
           run_id: ${{ inputs.RUN_ID || github.event.workflow_run.id }}
@@ -67,7 +64,7 @@ jobs:
           echo $contents
           echo "prNumber=$contents" >> $GITHUB_OUTPUT
 
-      - name: "[PR] Get sizes for development outputs"
+      - name: "[PR] Get sizes"
         id: dev
         run: |
           cat ${{ steps.find-pr-txt.outputs.txtPath }}
@@ -77,7 +74,7 @@ jobs:
           done <<< $(cat ${{ steps.find-pr-txt.outputs.txtPath }})
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      - name: "[Main] Get sizes for development outputs"
+      - name: "[Main] Get sizes"
         id: main-dev
         run: |
           cd main/
@@ -89,13 +86,13 @@ jobs:
           done <<< $(cat out.txt)
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      - name: "[Dev] calculate diff"
+      - name: "calculate diff"
         run: |
           # diff exits with status 1 if there is a diff
           diff -u main/out.txt ${{ steps.find-pr-txt.outputs.txtPath }} > dev-diff.txt || echo "Differences exist"
           cat dev-diff.txt
 
-      - name: "[Dev] store diff in GITHUB_OUTPUT"
+      - name: "store diff in GITHUB_OUTPUT"
         id: dev-diff
         run: |
           echo 'diffText<<EOF' >> $GITHUB_OUTPUT
@@ -106,7 +103,7 @@ jobs:
 
 
 
-      - name: "[Debug] collected data from artifacts"
+      - name: "collected data from artifacts"
         run: |
           echo "PR number"
           echo -e "${{ steps.find-pr-number.outputs.prNumber }}"
@@ -124,20 +121,16 @@ jobs:
       #########################
       # Intended Layout:
       #
-      #  |      | This PR | Main |
-      #  | Dev  |   x1    |  y1  |
-      #  | Prod |   x2    |  y2  |
-      #
-      #  NOTE: we we don't have a prod build for this library
-      #        because we currently expect non-compiler usage
-      #        (so consumers should have terser or similar properly configured for DCE)
+      #  | This PR | Main |
+      #  |   x1    |  y1  |
+      #  |   x2    |  y2  |
       #
       #########################
       - uses: mshick/add-pr-comment@v2
         with:
           issue: ${{ steps.find-pr-number.outputs.prNumber }}
           message: |
-            <details><summary>Development Assets</summary>
+            <details><summary>Estimated Asset Sizes</summary>
 
             Diff
 
@@ -147,9 +140,9 @@ jobs:
 
             Details
 
-            <table><thead><tr><th></th><th>This PR</th><th>main</th></tr></thead>
+            <table><thead><tr><th>This PR</th><th>main</th></tr></thead>
             <tbody>
-            <tr><td>Dev</td><td>
+            <tr><td>
 
             ```
             ${{ steps.dev.outputs.sizes }}

--- a/.github/workflows/size-main.yml
+++ b/.github/workflows/size-main.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+        with:
+          node-version: 22
       - run: pnpm build
 
       - name: "Get estimated sizes for production outputs"

--- a/.github/workflows/size-main.yml
+++ b/.github/workflows/size-main.yml
@@ -19,7 +19,7 @@ jobs:
         id: main-dev
         run: |
           mkdir -p main
-          node ./bin/minify-assets.sh > ./main/out.txt
+          node ./bin/minify-assets.mjs > ./main/out.txt
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/size-main.yml
+++ b/.github/workflows/size-main.yml
@@ -13,26 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - run: sudo snap install dust
       - run: pnpm build
 
-      - name: "Get sizes for development outputs"
+      - name: "Get estimated sizes for production outputs"
         id: main-dev
         run: |
-          ./bin/minify-folder.sh ./dist/packages/
           mkdir -p main
-          cd dist/packages
-
-          dust --ignore_hidden \
-              --reverse \
-              --apparent-size \
-              --no-percent-bars \
-              --only-dir \
-              --depth 0 \
-              --filter '@(ember|glimmer).+\.min\.js$' \
-            > out.min.txt
-          cp out.txt ../../main/
-
+          node ./bin/minify-assets.sh > ./main/out.txt
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/size-main.yml
+++ b/.github/workflows/size-main.yml
@@ -19,14 +19,18 @@ jobs:
       - name: "Get sizes for development outputs"
         id: main-dev
         run: |
+          ./bin/minify-folder.sh ./dist/packages/
           mkdir -p main
           cd dist/packages
+
           dust --ignore_hidden \
-              --reverse --apparent-size \
+              --reverse \
+              --apparent-size \
               --no-percent-bars \
               --only-dir \
-              --depth 20 \
-            > out.txt
+              --depth 0 \
+              --filter '@(ember|glimmer).+\.min\.js$' \
+            > out.min.txt
           cp out.txt ../../main/
 
 

--- a/.github/workflows/size-pr.yml
+++ b/.github/workflows/size-pr.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: "Get estimated sizes for production outputs"
         id: dev
-        run: node ./bin/minify-assets.sh > ./pr/out.txt
+        run: node ./bin/minify-assets.mjs > ./pr/out.txt
 
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/size-pr.yml
+++ b/.github/workflows/size-pr.yml
@@ -19,24 +19,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm build
-      - run: sudo snap install dust
 
       - name: Save PR number
         run: |
           mkdir -p ./pr
           echo "${{ github.event.number }}" > ./pr/NR
 
-      - name: "Get sizes for development outputs"
+      - name: "Get estimated sizes for production outputs"
         id: dev
-        run: |
-          cd dist/packages
-          dust --ignore_hidden \
-              --reverse --apparent-size \
-              --no-percent-bars \
-              --only-dir \
-              --depth 20 \
-            > out.txt
-          cp out.txt ../../pr/
+        run: node ./bin/minify-assets.sh > ./pr/out.txt
 
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/size-pr.yml
+++ b/.github/workflows/size-pr.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+        with:
+          node-version: 22
       - run: pnpm build
 
       - name: Save PR number

--- a/bin/minify-assets.mjs
+++ b/bin/minify-assets.mjs
@@ -119,9 +119,9 @@ for (const pkg of packages) {
     writeFileSync(minFileName, result.code);
 
     let compressed = brotli.compress(result.code, {
-      mode: 1, // 0 = generic, 1 = text, 2 = font (WOFF2)
+      // mode: 1, // 0 = generic, 1 = text, 2 = font (WOFF2)
       quality: 11, // 0 - 11
-      lgwin: 22, // window size
+      // lgwin: 22, // window size
     });
 
     // console.log(brotli.decompress(brotli.compress(result.code)).length, result.code.length);
@@ -162,12 +162,12 @@ function printTable(data) {
 }
 
 printTable([
-  ['', 'Min', 'Gzip', 'Brotli'],
+  ['', 'Min', 'Gzip' /* 'Brotli' */],
   [
     'Total',
     size(Object.values(min).reduce((a, b) => a + b, 0)),
     size(Object.values(gzip).reduce((a, b) => a + b, 0)),
-    size(Object.values(br).reduce((a, b) => a + b, 0)),
+    // size(Object.values(br).reduce((a, b) => a + b, 0)),
   ],
 ]);
 
@@ -187,33 +187,33 @@ for (const pkg of packages.filter((p) => p.startsWith('@glimmer'))) {
 }
 
 printTable([
-  ['@ember/*', 'Min', 'Gzip', 'Brotli'],
+  ['@ember/*', 'Min', 'Gzip' /*  'Brotli' */],
   [
     'Total',
     size(totalMin(packageData.ember)),
     size(totalGz(packageData.ember)),
-    size(totalBr(packageData.ember)),
+    // size(totalBr(packageData.ember)),
   ],
   ...packageData.ember.map((x) => [
     x[0].replace('@ember/', ''),
     size(x[1]),
     size(x[2]),
-    size(x[3]),
+    // size(x[3]),
   ]),
 ]);
 
 printTable([
-  ['@glimmer/*', 'Min', 'Gzip', 'Brotli'],
+  ['@glimmer/*', 'Min', 'Gzip' /* 'Brotli' */],
   [
     'Total',
     size(totalMin(packageData.glimmer)),
     size(totalGz(packageData.glimmer)),
-    size(totalBr(packageData.glimmer)),
+    // size(totalBr(packageData.glimmer)),
   ],
   ...packageData.glimmer.map((x) => [
     x[0].replace('@glimmer/', ''),
     size(x[1]),
     size(x[2]),
-    size(x[3]),
+    // size(x[3]),
   ]),
 ]);

--- a/bin/minify-assets.mjs
+++ b/bin/minify-assets.mjs
@@ -74,9 +74,9 @@ function totalGz(dataset) {
   return dataset.reduce((a, b) => a + b[2], 0);
 }
 
-function totalBr(dataset) {
-  return dataset.reduce((a, b) => a + b[3], 0);
-}
+// function totalBr(dataset) {
+//   return dataset.reduce((a, b) => a + b[3], 0);
+// }
 
 import { buildMacros } from '@embroider/macros/babel';
 

--- a/bin/minify-assets.mjs
+++ b/bin/minify-assets.mjs
@@ -1,0 +1,153 @@
+const packages = [
+  '@ember/-internals',
+  '@ember/application',
+  '@ember/array',
+  '@ember/canary-features',
+  '@ember/component',
+  '@ember/controller',
+  '@ember/debug',
+  '@ember/deprecated-features',
+  '@ember/destroyable',
+  '@ember/enumerable',
+  '@ember/helper',
+  '@ember/instrumentation',
+  '@ember/modifier',
+  '@ember/object',
+  '@ember/owner',
+  '@ember/renderer',
+  '@ember/routing',
+  '@ember/runloop',
+  '@ember/service',
+  '@ember/template',
+  '@ember/template-compilation',
+  '@ember/template-compiler',
+  '@ember/template-factory',
+  '@ember/test',
+  '@ember/utils',
+  '@ember/version',
+  '@glimmer/destroyable',
+  '@glimmer/encoder',
+  '@glimmer/env',
+  '@glimmer/global-context',
+  '@glimmer/manager',
+  '@glimmer/node',
+  '@glimmer/opcode-compiler',
+  '@glimmer/owner',
+  '@glimmer/program',
+  '@glimmer/reference',
+  '@glimmer/runtime',
+  '@glimmer/tracking',
+  '@glimmer/util',
+  '@glimmer/validator',
+  '@glimmer/vm',
+  '@glimmer/wire-format',
+];
+import glob from 'glob';
+import nodeGzip from 'node-gzip';
+
+import { join } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { minify } from 'terser';
+import { transformSync } from '@babel/core';
+import * as brotli from 'brotli';
+import { partial } from 'filesize';
+const size = partial({ standard: 'jedec' });
+
+const root = join(process.cwd(), 'dist/packages');
+
+let min = {};
+let br = {};
+let gzip = {};
+
+import { buildMacros } from '@embroider/macros/babel';
+
+const macros = buildMacros();
+let babelOptions = {
+  cwd: process.cwd(),
+  plugins: [...macros.babelMacros],
+};
+
+for (const pkg of packages) {
+  let jsFiles = glob.sync(`${root}/${pkg}/**/*.js`);
+
+  for (let file of jsFiles) {
+    let source = readFileSync(file, 'utf8');
+    let transformed = transformSync(source, {
+      ...babelOptions,
+      filename: file,
+    }).code;
+    let result = await minify(transformed, {
+      module: true,
+      mangle: false,
+      ecma: 2021,
+      compress: {
+        ecma: 2021,
+        passes: 3,
+        defaults: true,
+        keep_fargs: false,
+        keep_fnames: false,
+        /**
+         * Required for {{debugger}} to work
+         */
+        drop_debugger: false,
+      },
+    });
+
+    let minFileName = file + '.min';
+    writeFileSync(minFileName, result.code);
+
+    let compressed = brotli.compress(result.code, {
+      mode: 1, // 0 = generic, 1 = text, 2 = font (WOFF2)
+      quality: 11, // 0 - 11
+      lgwin: 22, // window size
+    });
+
+    // console.log(brotli.decompress(brotli.compress(result.code)).length, result.code.length);
+
+    let compressedFileName = minFileName + '.br';
+    writeFileSync(compressedFileName, compressed);
+
+    let gzipFileName = minFileName + '.gz';
+    let gzipCompressed = (await nodeGzip.gzip(result.code)).toString();
+    writeFileSync(gzipFileName, gzipCompressed);
+
+    let minSize = new Blob([result.code]).size;
+    let brSize = new Blob([compressed.toString()]).size;
+    let gzSize = new Blob([gzipCompressed]).size;
+
+    min[pkg] = min[pkg] || 0;
+    min[pkg] += minSize;
+
+    br[pkg] = br[pkg] || 0;
+    br[pkg] += brSize;
+
+    gzip[pkg] = gzip[pkg] || 0;
+    gzip[pkg] += gzSize;
+  }
+}
+
+let totalMin = Object.values(min).reduce((a, b) => a + b, 0);
+let totalGz = Object.values(gzip).reduce((a, b) => a + b, 0);
+let totalBr = Object.values(br).reduce((a, b) => a + b, 0);
+
+let data = [
+  ['Package', 'Min', 'Gzip', 'Brotli'],
+  ['Total', size(totalMin), size(totalGz), size(totalBr)],
+];
+for (const pkg of packages) {
+  let minSize = size(min[pkg]);
+  let brSize = size(br[pkg]);
+  let gzSize = size(gzip[pkg]);
+
+  data.push([pkg, minSize, gzSize, brSize]);
+}
+
+import { table } from 'table';
+
+console.info(
+  table(data, {
+    drawHorizontalLine: (lineIndex, rowCount) => {
+      return lineIndex === 0 || lineIndex === 1 || lineIndex === 2 || lineIndex === rowCount;
+    },
+  })
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "6.7.0-alpha.1",
+  "version": "6.7.0-alpha.1.nvp-asset-sizes+ad603139",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"
@@ -111,6 +111,7 @@
     "@babel/plugin-transform-typescript": "^7.22.9",
     "@babel/preset-env": "^7.16.11",
     "@babel/types": "^7.22.5",
+    "@embroider/macros": "^1.18.0",
     "@embroider/shared-internals": "^2.5.0",
     "@eslint/js": "^9.21.0",
     "@glimmer/component": "workspace:^",
@@ -125,6 +126,7 @@
     "auto-dist-tag": "^2.1.1",
     "babel-plugin-debug-macros": "1.0.0",
     "babel-plugin-ember-template-compilation": "^2.1.1",
+    "brotli": "^1.3.3",
     "dag-map": "^2.0.2",
     "decorator-transforms": "2.0.0",
     "ember-cli": "^6.3.0",
@@ -141,6 +143,7 @@
     "eslint-plugin-qunit": "^8.1.2",
     "execa": "^5.1.1",
     "expect-type": "^0.15.0",
+    "filesize": "^10.1.6",
     "finalhandler": "^1.1.2",
     "fs-extra": "^11.1.1",
     "git-repo-info": "^2.1.1",
@@ -149,6 +152,7 @@
     "globals": "^16.0.0",
     "html-differ": "^1.4.0",
     "mocha": "^10.2.0",
+    "node-gzip": "^1.1.2",
     "npm-run-all2": "^6.0.6",
     "prettier": "^3.5.3",
     "puppeteer": "^24.2.0",
@@ -159,6 +163,8 @@
     "rsvp": "^4.8.5",
     "serve-static": "^1.14.2",
     "simple-dom": "^1.4.0",
+    "table": "^6.9.0",
+    "terser": "^5.42.0",
     "testem": "^3.10.1",
     "testem-failure-only-reporter": "^1.0.0",
     "typescript": "5.1",
@@ -395,5 +401,10 @@
       ]
     }
   },
-  "packageManager": "pnpm@10.5.0"
+  "packageManager": "pnpm@10.5.0",
+  "_originalVersion": "6.7.0-alpha.1",
+  "_versionPreviouslyCalculated": true,
+  "publishConfig": {
+    "tag": "alpha"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "6.7.0-alpha.1.nvp-asset-sizes+ad603139",
+  "version": "6.7.0-alpha.1",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"
@@ -401,10 +401,5 @@
       ]
     }
   },
-  "packageManager": "pnpm@10.5.0",
-  "_originalVersion": "6.7.0-alpha.1",
-  "_versionPreviouslyCalculated": true,
-  "publishConfig": {
-    "tag": "alpha"
-  }
+  "packageManager": "pnpm@10.5.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@babel/types':
         specifier: ^7.22.5
         version: 7.26.9
+      '@embroider/macros':
+        specifier: ^1.18.0
+        version: 1.18.0
       '@embroider/shared-internals':
         specifier: ^2.5.0
         version: 2.9.0(supports-color@8.1.1)
@@ -187,6 +190,9 @@ importers:
       babel-plugin-ember-template-compilation:
         specifier: ^2.1.1
         version: 2.3.0
+      brotli:
+        specifier: ^1.3.3
+        version: 1.3.3
       dag-map:
         specifier: ^2.0.2
         version: 2.0.2
@@ -235,6 +241,9 @@ importers:
       expect-type:
         specifier: ^0.15.0
         version: 0.15.0
+      filesize:
+        specifier: ^10.1.6
+        version: 10.1.6
       finalhandler:
         specifier: ^1.1.2
         version: 1.3.1
@@ -259,6 +268,9 @@ importers:
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
+      node-gzip:
+        specifier: ^1.1.2
+        version: 1.1.2
       npm-run-all2:
         specifier: ^6.0.6
         version: 6.2.6
@@ -289,6 +301,12 @@ importers:
       simple-dom:
         specifier: ^1.4.0
         version: 1.4.0
+      table:
+        specifier: ^6.9.0
+        version: 6.9.0
+      terser:
+        specifier: ^5.42.0
+        version: 5.42.0
       testem:
         specifier: ^3.10.1
         version: 3.15.2(handlebars@4.7.8)(underscore@1.13.7)
@@ -303,7 +321,7 @@ importers:
         version: 8.26.0(eslint@9.21.0)(typescript@5.1.6)
       vite:
         specifier: ^5.4.12
-        version: 5.4.14(@types/node@20.17.19)(terser@5.39.0)
+        version: 5.4.14(@types/node@20.17.19)(terser@5.42.0)
 
   packages/@ember/-internals:
     dependencies:
@@ -2808,15 +2826,6 @@ packages:
       '@embroider/core': ^3.4.0
       webpack: ^5
 
-  '@embroider/macros@1.16.11':
-    resolution: {integrity: sha512-TUm/74oBr+tWto0IPAht1g6zjpP7UK0aQdnFHHqGvDPc+tAROQb9jKI/ePEuKAdBCV3L7XvvC4Rlf0DNvT4qmw==}
-    engines: {node: 12.* || 14.* || >= 16}
-    peerDependencies:
-      '@glint/template': ^1.0.0
-    peerDependenciesMeta:
-      '@glint/template':
-        optional: true
-
   '@embroider/macros@1.16.13':
     resolution: {integrity: sha512-2oGZh0m1byBYQFWEa8b2cvHJB2LzaF3DdMCLCqcRAccABMROt1G3sultnNCT30NhfdGWMEsJOT3Jm4nFxXmTRw==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2826,8 +2835,21 @@ packages:
       '@glint/template':
         optional: true
 
+  '@embroider/macros@1.18.0':
+    resolution: {integrity: sha512-KanP80XxNK4bmQ1HKTcUjy/cdCt9n7knPMLK1vzHdOFymACHo+GbhgUjXjYdOCuBTv+ZwcjL2P2XDmBcYS9r8g==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+
   '@embroider/shared-internals@2.9.0':
     resolution: {integrity: sha512-8untWEvGy6av/oYibqZWMz/yB+LHsKxEOoUZiLvcpFwWj2Sipc0DcXeTJQZQZ++otNkLCWyDrDhOLrOkgjOPSg==}
+    engines: {node: 12.* || 14.* || >= 16}
+
+  '@embroider/shared-internals@3.0.0':
+    resolution: {integrity: sha512-5J5ipUMCAinQS38WW7wedruq5Z4VnHvNo+ZgOduw0PtI9w0CQWx7/HE+98PBDW8jclikeF+aHwF317vc1hwuzg==}
     engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/test-setup@4.0.0':
@@ -4509,6 +4531,10 @@ packages:
     resolution: {integrity: sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==}
     engines: {node: '>= 12.*'}
 
+  babel-import-util@3.0.1:
+    resolution: {integrity: sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==}
+    engines: {node: '>= 12.*'}
+
   babel-loader@8.4.1:
     resolution: {integrity: sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==}
     engines: {node: '>= 8.9'}
@@ -4854,6 +4880,9 @@ packages:
   broccoli@3.5.2:
     resolution: {integrity: sha512-sWi3b3fTUSVPDsz5KsQ5eCQNVAtLgkIE/HYFkEZXR/07clqmd4E/gFiuwSaqa9b+QTXc1Uemfb7TVWbEIURWDg==}
     engines: {node: 8.* || >= 10.*}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
@@ -7622,6 +7651,9 @@ packages:
   lodash.templatesettings@4.2.0:
     resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
@@ -7973,6 +8005,9 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-gzip@1.1.2:
+    resolution: {integrity: sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -9125,6 +9160,10 @@ packages:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
 
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -9435,6 +9474,10 @@ packages:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
+
   tap-parser@7.0.0:
     resolution: {integrity: sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==}
     hasBin: true
@@ -9475,6 +9518,11 @@ packages:
 
   terser@5.39.0:
     resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.42.0:
+    resolution: {integrity: sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -11446,7 +11494,7 @@ snapshots:
       '@ember-data/request-utils': 5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-cli-path-utils: 1.0.0
@@ -11463,7 +11511,7 @@ snapshots:
       '@ember-data/request-utils': 5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -11474,7 +11522,7 @@ snapshots:
   '@ember-data/graph@5.3.11(@ember-data/store@5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)':
     dependencies:
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -11487,7 +11535,7 @@ snapshots:
       '@ember-data/graph': 5.3.11(@ember-data/store@5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/request-utils': 5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
     transitivePeerDependencies:
@@ -11500,7 +11548,7 @@ snapshots:
       '@ember-data/request-utils': 5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -11518,7 +11566,7 @@ snapshots:
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/tracking': 5.3.11(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-cli-string-utils: 1.1.0
@@ -11534,7 +11582,7 @@ snapshots:
 
   '@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)':
     dependencies:
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -11547,7 +11595,7 @@ snapshots:
   '@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1)':
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
     transitivePeerDependencies:
@@ -11562,7 +11610,7 @@ snapshots:
       '@ember-data/request-utils': 5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-cli-path-utils: 1.0.0
@@ -11578,7 +11626,7 @@ snapshots:
       '@ember-data/request': 5.3.11(@warp-drive/core-types@0.0.1)
       '@ember-data/request-utils': 5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/tracking': 5.3.11(@warp-drive/core-types@0.0.1)(ember-source@)
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -11588,7 +11636,7 @@ snapshots:
 
   '@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@)':
     dependencies:
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -11618,7 +11666,7 @@ snapshots:
   '@ember/test-helpers@3.3.1(@babel/core@7.26.9)(ember-source@)(webpack@5.98.0)':
     dependencies:
       '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@simple-dom/interface': 1.4.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -11768,7 +11816,7 @@ snapshots:
       webpack: 5.98.0
     optional: true
 
-  '@embroider/macros@1.16.11':
+  '@embroider/macros@1.16.13':
     dependencies:
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       assert-never: 1.4.0
@@ -11781,11 +11829,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/macros@1.16.13':
+  '@embroider/macros@1.18.0':
     dependencies:
-      '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
+      '@embroider/shared-internals': 3.0.0
       assert-never: 1.4.0
-      babel-import-util: 2.1.1
+      babel-import-util: 3.0.1
       ember-cli-babel: 7.26.11
       find-up: 5.0.0
       lodash: 4.17.21
@@ -11806,6 +11854,24 @@ snapshots:
       minimatch: 3.1.2
       pkg-entry-points: 1.1.1
       resolve-package-path: 4.0.3
+      semver: 7.7.1
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/shared-internals@3.0.0':
+    dependencies:
+      babel-import-util: 3.0.1
+      debug: 4.4.0(supports-color@8.1.1)
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.1
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
       semver: 7.7.1
       typescript-memoize: 1.1.1
     transitivePeerDependencies:
@@ -13437,7 +13503,7 @@ snapshots:
   '@warp-drive/build-config@0.0.1':
     dependencies:
       '@embroider/addon-shim': 1.9.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       babel-import-util: 2.1.1
       broccoli-funnel: 3.0.8
       semver: 7.7.1
@@ -13447,7 +13513,7 @@ snapshots:
 
   '@warp-drive/core-types@0.0.1':
     dependencies:
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
     transitivePeerDependencies:
       - '@glint/template'
@@ -13854,6 +13920,8 @@ snapshots:
   babel-import-util@2.1.1: {}
 
   babel-import-util@3.0.0: {}
+
+  babel-import-util@3.0.1: {}
 
   babel-loader@8.4.1(@babel/core@7.26.9)(webpack@5.98.0(@swc/core@1.11.1)):
     dependencies:
@@ -14556,6 +14624,10 @@ snapshots:
       watch-detector: 1.0.2
     transitivePeerDependencies:
       - supports-color
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
 
   browser-stdout@1.3.1: {}
 
@@ -15289,7 +15361,7 @@ snapshots:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.9)
       '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.9)(supports-color@8.1.1)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)(supports-color@8.1.1)
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       babel-loader: 8.4.1(@babel/core@7.26.9)(webpack@5.98.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -15883,7 +15955,7 @@ snapshots:
       '@ember-data/store': 5.3.11(@ember-data/request-utils@5.3.11(@ember/string@3.1.1)(@warp-drive/core-types@0.0.1)(ember-source@))(@ember-data/request@5.3.11(@warp-drive/core-types@0.0.1))(@ember-data/tracking@5.3.11(@warp-drive/core-types@0.0.1)(ember-source@))(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember-data/tracking': 5.3.11(@warp-drive/core-types@0.0.1)(ember-source@)
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       '@warp-drive/build-config': 0.0.1
       '@warp-drive/core-types': 0.0.1
       ember-source: 'link:'
@@ -15932,7 +16004,7 @@ snapshots:
     dependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.26.9)(ember-source@)(webpack@5.98.0)
       '@embroider/addon-shim': 1.9.0
-      '@embroider/macros': 1.16.11
+      '@embroider/macros': 1.16.13
       ember-cli-test-loader: 3.1.0
       ember-source: 'link:'
       qunit: 2.24.1
@@ -18129,6 +18201,8 @@ snapshots:
     dependencies:
       lodash._reinterpolate: 3.0.0
 
+  lodash.truncate@4.4.2: {}
+
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.21: {}
@@ -18514,6 +18588,8 @@ snapshots:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
+
+  node-gzip@1.1.2: {}
 
   node-int64@0.4.0: {}
 
@@ -19770,6 +19846,12 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   smart-buffer@4.2.0: {}
 
   snake-case@3.0.4:
@@ -20149,6 +20231,14 @@ snapshots:
       '@pkgr/core': 0.1.1
       tslib: 2.8.1
 
+  table@6.9.0:
+    dependencies:
+      ajv: 8.17.1
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   tap-parser@7.0.0:
     dependencies:
       events-to-array: 1.1.2
@@ -20203,6 +20293,13 @@ snapshots:
       webpack: 5.98.0
 
   terser@5.39.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.6
+      acorn: 8.14.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  terser@5.42.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
       acorn: 8.14.0
@@ -20728,7 +20825,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@5.4.14(@types/node@20.17.19)(terser@5.39.0):
+  vite@5.4.14(@types/node@20.17.19)(terser@5.42.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
@@ -20736,7 +20833,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.19
       fsevents: 2.3.3
-      terser: 5.39.0
+      terser: 5.42.0
 
   vow-fs@0.3.6:
     dependencies:


### PR DESCRIPTION
See example here (on my fork): https://github.com/NullVoxPopuli/ember.js/pull/7#issuecomment-2965043758


i dunno if it needs said, but these numbers are if you use _every_ module in your app -- which .. most folks will not be using (runtime compiler?)

Also, this excludes our third-party deps, such as router_js, @simple-dom, etc (these are very tiny)

Copied here:

<!-- add-pr-comment:add-pr-comment -->

<details><summary>Estimated Asset Sizes</summary>

Diff

```diff
--- main/out.txt	2025-06-12 04:23:22.000000000 +0000
+++ pr/./pr-15601557105/out.txt	2025-06-12 04:23:40.000000000 +0000
@@ -1,13 +1,13 @@
 ╔═══════╤══════════╤═══════════╗
 ║       │ Min      │ Gzip      ║
 ╟───────┼──────────┼───────────╢
-║ Total │ 409.3 KB │ 228.73 KB ║
+║ Total │ 408.7 KB │ 228.33 KB ║
 ╚═══════╧══════════╧═══════════╝
 
 ╔══════════════════════╤═══════════╤═══════════╗
 ║ @ember/*             │ Min       │ Gzip      ║
 ╟──────────────────────┼───────────┼───────────╢
-║ Total                │ 239.69 KB │ 147.05 KB ║
+║ Total                │ 239.09 KB │ 146.64 KB ║
 ╟──────────────────────┼───────────┼───────────╢
 ║ -internals           │ 35.92 KB  │ 25.65 KB  ║
 ║ application          │ 12.83 KB  │ 7.58 KB   ║
@@ -22,7 +22,7 @@
 ║ helper               │ 823 B     │ 615 B     ║
 ║ instrumentation      │ 2.43 KB   │ 1.78 KB   ║
 ║ modifier             │ 669 B     │ 605 B     ║
-║ object               │ 33.78 KB  │ 20.82 KB  ║
+║ object               │ 33.18 KB  │ 20.42 KB  ║
 ║ owner                │ 159 B     │ 178 B     ║
 ║ renderer             │ 385 B     │ 344 B     ║
 ║ routing              │ 58.05 KB  │ 33.12 KB  ║
```

Details

<table><thead><tr><th>This PR</th><th>main</th></tr></thead>
<tbody>
<tr><td>

```
╔═══════╤══════════╤═══════════╗
║       │ Min      │ Gzip      ║
╟───────┼──────────┼───────────╢
║ Total │ 408.7 KB │ 228.33 KB ║
╚═══════╧══════════╧═══════════╝

╔══════════════════════╤═══════════╤═══════════╗
║ @ember/*             │ Min       │ Gzip      ║
╟──────────────────────┼───────────┼───────────╢
║ Total                │ 239.09 KB │ 146.64 KB ║
╟──────────────────────┼───────────┼───────────╢
║ -internals           │ 35.92 KB  │ 25.65 KB  ║
║ application          │ 12.83 KB  │ 7.58 KB   ║
║ array                │ 12.66 KB  │ 7.32 KB   ║
║ canary-features      │ 304 B     │ 405 B     ║
║ component            │ 1.07 KB   │ 995 B     ║
║ controller           │ 1.8 KB    │ 1.36 KB   ║
║ debug                │ 11.4 KB   │ 7.87 KB   ║
║ deprecated-features  │ 31 B      │ 77 B      ║
║ destroyable          │ 561 B     │ 383 B     ║
║ enumerable           │ 259 B     │ 387 B     ║
║ helper               │ 823 B     │ 615 B     ║
║ instrumentation      │ 2.43 KB   │ 1.78 KB   ║
║ modifier             │ 669 B     │ 605 B     ║
║ object               │ 33.18 KB  │ 20.42 KB  ║
║ owner                │ 159 B     │ 178 B     ║
║ renderer             │ 385 B     │ 344 B     ║
║ routing              │ 58.05 KB  │ 33.12 KB  ║
║ runloop              │ 2.2 KB    │ 1.41 KB   ║
║ service              │ 859 B     │ 741 B     ║
║ template             │ 396 B     │ 342 B     ║
║ template-compilation │ 429 B     │ 366 B     ║
║ template-compiler    │ 57.81 KB  │ 30.44 KB  ║
║ template-factory     │ 94 B      │ 160 B     ║
║ test                 │ 923 B     │ 627 B     ║
║ utils                │ 3.93 KB   │ 3.51 KB   ║
║ version              │ 55 B      │ 131 B     ║
╚══════════════════════╧═══════════╧═══════════╝

╔═════════════════╤═══════════╤══════════╗
║ @glimmer/*      │ Min       │ Gzip     ║
╟─────────────────┼───────────┼──────────╢
║ Total           │ 169.61 KB │ 81.69 KB ║
╟─────────────────┼───────────┼──────────╢
║ destroyable     │ 2.7 KB    │ 1.35 KB  ║
║ encoder         │ 596 B     │ 653 B    ║
║ env             │ 38 B      │ 87 B     ║
║ global-context  │ 886 B     │ 545 B    ║
║ manager         │ 12.19 KB  │ 5.44 KB  ║
║ node            │ 2.71 KB   │ 1.81 KB  ║
║ opcode-compiler │ 29.89 KB  │ 13.23 KB ║
║ owner           │ 159 B     │ 202 B    ║
║ program         │ 7.1 KB    │ 3.63 KB  ║
║ reference       │ 5.51 KB   │ 3.18 KB  ║
║ runtime         │ 95.26 KB  │ 42.51 KB ║
║ tracking        │ 989 B     │ 972 B    ║
║ util            │ 3.03 KB   │ 2.29 KB  ║
║ validator       │ 6 KB      │ 3.72 KB  ║
║ vm              │ 784 B     │ 798 B    ║
║ wire-format     │ 1.84 KB   │ 1.35 KB  ║
╚═════════════════╧═══════════╧══════════╝
```

</td><td>

```
╔═══════╤══════════╤═══════════╗
║       │ Min      │ Gzip      ║
╟───────┼──────────┼───────────╢
║ Total │ 409.3 KB │ 228.73 KB ║
╚═══════╧══════════╧═══════════╝

╔══════════════════════╤═══════════╤═══════════╗
║ @ember/*             │ Min       │ Gzip      ║
╟──────────────────────┼───────────┼───────────╢
║ Total                │ 239.69 KB │ 147.05 KB ║
╟──────────────────────┼───────────┼───────────╢
║ -internals           │ 35.92 KB  │ 25.65 KB  ║
║ application          │ 12.83 KB  │ 7.58 KB   ║
║ array                │ 12.66 KB  │ 7.32 KB   ║
║ canary-features      │ 304 B     │ 405 B     ║
║ component            │ 1.07 KB   │ 995 B     ║
║ controller           │ 1.8 KB    │ 1.36 KB   ║
║ debug                │ 11.4 KB   │ 7.87 KB   ║
║ deprecated-features  │ 31 B      │ 77 B      ║
║ destroyable          │ 561 B     │ 383 B     ║
║ enumerable           │ 259 B     │ 387 B     ║
║ helper               │ 823 B     │ 615 B     ║
║ instrumentation      │ 2.43 KB   │ 1.78 KB   ║
║ modifier             │ 669 B     │ 605 B     ║
║ object               │ 33.78 KB  │ 20.82 KB  ║
║ owner                │ 159 B     │ 178 B     ║
║ renderer             │ 385 B     │ 344 B     ║
║ routing              │ 58.05 KB  │ 33.12 KB  ║
║ runloop              │ 2.2 KB    │ 1.41 KB   ║
║ service              │ 859 B     │ 741 B     ║
║ template             │ 396 B     │ 342 B     ║
║ template-compilation │ 429 B     │ 366 B     ║
║ template-compiler    │ 57.81 KB  │ 30.44 KB  ║
║ template-factory     │ 94 B      │ 160 B     ║
║ test                 │ 923 B     │ 627 B     ║
║ utils                │ 3.93 KB   │ 3.51 KB   ║
║ version              │ 55 B      │ 131 B     ║
╚══════════════════════╧═══════════╧═══════════╝

╔═════════════════╤═══════════╤══════════╗
║ @glimmer/*      │ Min       │ Gzip     ║
╟─────────────────┼───────────┼──────────╢
║ Total           │ 169.61 KB │ 81.69 KB ║
╟─────────────────┼───────────┼──────────╢
║ destroyable     │ 2.7 KB    │ 1.35 KB  ║
║ encoder         │ 596 B     │ 653 B    ║
║ env             │ 38 B      │ 87 B     ║
║ global-context  │ 886 B     │ 545 B    ║
║ manager         │ 12.19 KB  │ 5.44 KB  ║
║ node            │ 2.71 KB   │ 1.81 KB  ║
║ opcode-compiler │ 29.89 KB  │ 13.23 KB ║
║ owner           │ 159 B     │ 202 B    ║
║ program         │ 7.1 KB    │ 3.63 KB  ║
║ reference       │ 5.51 KB   │ 3.18 KB  ║
║ runtime         │ 95.26 KB  │ 42.51 KB ║
║ tracking        │ 989 B     │ 972 B    ║
║ util            │ 3.03 KB   │ 2.29 KB  ║
║ validator       │ 6 KB      │ 3.72 KB  ║
║ vm              │ 784 B     │ 798 B    ║
║ wire-format     │ 1.84 KB   │ 1.35 KB  ║
╚═════════════════╧═══════════╧══════════╝
```

</td></tr>
</tbody></table>
</details>