### PR TITLE
Switch most uses of EmberObject in tests to CoreObject

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/angle-bracket-invocation-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, RenderingTestCase, strip, classes, runTask } from 'internal-test-helpers';
 import { setModifierManager, modifierCapabilities } from '@glimmer/manager';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 
 import { set, setProperties } from '@ember/object';
 
@@ -35,7 +35,7 @@ let BaseModifier = setModifierManager(
   (owner) => {
     return new CustomModifierManager(owner);
   },
-  class extends EmberObject {
+  class extends CoreObject {
     didInsertElement() {}
     didUpdate() {}
     willDestroyElement() {}

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -16,7 +16,8 @@ import { tracked } from '@ember/-internals/metal';
 import { alias } from '@ember/object/computed';
 import { on } from '@ember/object/evented';
 import Service, { service } from '@ember/service';
-import EmberObject, { set, get, computed, observer } from '@ember/object';
+import { set, get, computed, observer } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A as emberA } from '@ember/array';
 
 import { Component, compile, htmlSafe } from '../../utils/helpers';
@@ -2494,7 +2495,7 @@ moduleFor(
       this.registerComponent('x-outer', {
         ComponentClass: class extends Component {
           value = 1;
-          wrapper = EmberObject.create({ content: null });
+          wrapper = CoreObject.create({ content: null });
         },
         template:
           '<div id="outer-value">{{this.wrapper.content}}</div> {{x-inner value=this.value wrapper=this.wrapper}}',
@@ -2503,7 +2504,7 @@ moduleFor(
       this.registerComponent('x-inner', {
         ComponentClass: class extends Component {
           didReceiveAttrs() {
-            this.get('wrapper').set('content', this.get('value'));
+            set(this.wrapper, 'content', this.value);
           }
           value = null;
         },

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -3,7 +3,7 @@ import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 import { action, set } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import Controller from '@ember/controller';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 
 import { Component } from '../../utils/helpers';
 
@@ -157,7 +157,7 @@ moduleFor(
         });
       }, /`actions` must be provided at extend time, not at create time/);
       // but should be OK on an object that doesn't mix in Ember.ActionHandler
-      EmberObject.create({
+      CoreObject.create({
         actions: ['foo'],
       });
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/template-only-components-test.js
@@ -2,7 +2,8 @@ import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 import { setComponentTemplate } from '@glimmer/manager';
 import { templateOnlyComponent } from '@glimmer/runtime';
 import { compile } from 'ember-template-compiler';
-import EmberObject from '@ember/object';
+import { set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { Component } from '../../utils/helpers';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
 
@@ -127,7 +128,7 @@ moduleFor(
       this.registerComponent('x-outer', {
         ComponentClass: class extends Component {
           value = 1;
-          wrapper = EmberObject.create({ content: null });
+          wrapper = CoreObject.create({ content: null });
         },
         template:
           '<div id="outer-value">{{x-inner-template-only value=this.wrapper.content wrapper=this.wrapper}}</div>{{x-inner value=this.value wrapper=this.wrapper}}',
@@ -136,7 +137,7 @@ moduleFor(
       this.registerComponent('x-inner', {
         ComponentClass: class extends Component {
           didReceiveAttrs() {
-            this.get('wrapper').set('content', this.get('value'));
+            set(this.wrapper, 'content', this.value);
           }
           value = null;
         },

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -4,6 +4,7 @@ import ArrayProxy from '@ember/array/proxy';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import { tracked } from '@ember/-internals/metal';
 import { computed, get, set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { Promise } from 'rsvp';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
@@ -656,7 +657,7 @@ moduleFor(
     }
 
     '@test computed properties can depend on nested args'() {
-      let foo = EmberObject.create({
+      let foo = CoreObject.create({
         text: 'hello!',
       });
 
@@ -678,10 +679,10 @@ moduleFor(
 
       this.assertText('hello!');
 
-      runTask(() => foo.set('text', 'hello world!'));
+      runTask(() => set(foo, 'text', 'hello world!'));
       this.assertText('hello world!');
 
-      runTask(() => foo.set('text', 'hello!'));
+      runTask(() => set(foo, 'text', 'hello!'));
       this.assertText('hello!');
     }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -4,8 +4,8 @@ import { RenderingTestCase, moduleFor, applyMixins, classes, runTask } from 'int
 
 import { set, computed } from '@ember/object';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
-import EmberObject from '@ember/object';
 import { readOnly } from '@ember/object/computed';
+import CoreObject from '@ember/object/core';
 import ObjectProxy from '@ember/object/proxy';
 import { constructStyleDeprecationMessage } from '@ember/-internals/views';
 import { Component, SafeString, htmlSafe } from '../utils/helpers';
@@ -291,10 +291,10 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can render a computed property']() {
-    let Formatter = class extends EmberObject {
+    let Formatter = class extends CoreObject {
       @computed('message')
       get formattedMessage() {
-        return this.get('message').toUpperCase();
+        return this.message.toUpperCase();
       }
     };
 
@@ -318,10 +318,10 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can render a computed property with nested dependency']() {
-    let Formatter = class extends EmberObject {
+    let Formatter = class extends CoreObject {
       @computed('messenger.message')
       get formattedMessage() {
-        return this.get('messenger.message').toUpperCase();
+        return this.messenger.message.toUpperCase();
       }
     };
 
@@ -612,7 +612,7 @@ class DynamicContentTest extends RenderingTestCase {
   }
 
   ['@test it can render a readOnly property of a path']() {
-    let Messenger = class extends EmberObject {
+    let Messenger = class extends CoreObject {
       @readOnly('a.b.c')
       message;
     };

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-component-manager-test.js
@@ -2,11 +2,11 @@ import { DEBUG } from '@glimmer/env';
 import { moduleFor, RenderingTestCase, runTask, strip } from 'internal-test-helpers';
 
 import { componentCapabilities } from '@glimmer/manager';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { set, setProperties, computed } from '@ember/object';
 import { setComponentManager } from '@ember/-internals/glimmer';
 
-class BasicComponentManager extends EmberObject {
+class BasicComponentManager extends CoreObject {
   capabilities = componentCapabilities('3.13');
 
   createComponent(factory, args) {
@@ -38,7 +38,7 @@ class ComponentManagerTest extends RenderingTestCase {
   constructor(assert) {
     super(...arguments);
 
-    InstrumentedComponentManager = class extends EmberObject {
+    InstrumentedComponentManager = class extends CoreObject {
       capabilities = componentCapabilities('3.13', {
         destructor: true,
         asyncLifecycleCallbacks: true,
@@ -83,7 +83,7 @@ moduleFor(
     ['@test it can render a basic component with custom component manager']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
         }
       );
@@ -101,7 +101,7 @@ moduleFor(
     ['@test it can render a basic component with custom component manager with a factory']() {
       let ComponentClass = setComponentManager(
         () => BasicComponentManager.create(),
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
         }
       );
@@ -119,7 +119,7 @@ moduleFor(
     ['@test it can have no template context']() {
       class ComponentWithNoTemplate {}
       setComponentManager(() => {
-        let Manager = class extends EmberObject {
+        let Manager = class extends CoreObject {
           capabilities = componentCapabilities('3.13');
 
           createComponent() {
@@ -148,7 +148,7 @@ moduleFor(
     ['@test it can discover component manager through inheritance - ES Classes']() {
       class Base {}
       setComponentManager(() => {
-        let Manager = class extends EmberObject {
+        let Manager = class extends CoreObject {
           capabilities = componentCapabilities('3.13');
 
           createComponent(Factory, args) {
@@ -182,7 +182,7 @@ moduleFor(
     }
 
     ['@test it can discover component manager through inheritance - Ember Object']() {
-      let Parent = setComponentManager(createBasicManager, class extends EmberObject {});
+      let Parent = setComponentManager(createBasicManager, class extends CoreObject {});
       let Child = class extends Parent {};
       let Grandchild = class extends Child {
         init() {
@@ -208,7 +208,7 @@ moduleFor(
 
       let ComponentClass = setComponentManager(
         () => {
-          let Manager = class extends EmberObject {
+          let Manager = class extends CoreObject {
             capabilities = componentCapabilities('3.13');
 
             createComponent(factory) {
@@ -223,7 +223,7 @@ moduleFor(
           };
           return new Manager();
         },
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
           count = 1234;
         }
@@ -246,7 +246,7 @@ moduleFor(
     ['@test it can set arguments on the component instance']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.named.firstName', 'args.named.lastName')
           get salutation() {
             return this.args.named.firstName + ' ' + this.args.named.lastName;
@@ -267,7 +267,7 @@ moduleFor(
     ['@test arguments are updated if they change']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.named.firstName', 'args.named.lastName')
           get salutation() {
             return this.args.named.firstName + ' ' + this.args.named.lastName;
@@ -300,7 +300,7 @@ moduleFor(
     ['@test it can set positional params on the component instance']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.positional.[]')
           get salutation() {
             return this.args.positional[0] + ' ' + this.args.positional[1];
@@ -321,7 +321,7 @@ moduleFor(
     ['@test positional params are updated if they change (computed, arr tag)']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.positional.[]')
           get salutation() {
             return this.args.positional[0] + ' ' + this.args.positional[1];
@@ -354,7 +354,7 @@ moduleFor(
     ['@test positional params are updated if they change (computed, individual tags)']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.positional.0', 'args.positional.1')
           get salutation() {
             return this.args.positional[0] + ' ' + this.args.positional[1];
@@ -387,7 +387,7 @@ moduleFor(
     ['@test positional params are updated if they change (native)']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           get salutation() {
             return this.args.positional[0] + ' ' + this.args.positional[1];
           }
@@ -419,7 +419,7 @@ moduleFor(
     ['@test it can opt-in to running destructor'](assert) {
       let ComponentClass = setComponentManager(
         () => {
-          return EmberObject.create({
+          return CoreObject.create({
             capabilities: componentCapabilities('3.13', {
               destructor: true,
             }),
@@ -441,7 +441,7 @@ moduleFor(
             },
           });
         },
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
           destroy() {
             assert.step('component.destroy()');
@@ -469,7 +469,7 @@ moduleFor(
     ['@test it can opt-in to running async lifecycle hooks'](assert) {
       let ComponentClass = setComponentManager(
         () => {
-          return EmberObject.create({
+          return CoreObject.create({
             capabilities: componentCapabilities('3.13', {
               asyncLifecycleCallbacks: true,
               updateHook: true,
@@ -504,7 +504,7 @@ moduleFor(
             },
           });
         },
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
         }
       );
@@ -532,7 +532,7 @@ moduleFor(
 
       let ComponentClass = setComponentManager(
         () => {
-          return EmberObject.create({
+          return CoreObject.create({
             capabilities: {
               asyncLifecycleCallbacks: true,
               destructor: true,
@@ -568,7 +568,7 @@ moduleFor(
             },
           });
         },
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
         }
       );
@@ -593,7 +593,7 @@ moduleFor(
     ['@test it can render a basic component with custom component manager']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
         }
       );
@@ -611,7 +611,7 @@ moduleFor(
     ['@test it can set arguments on the component instance']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.named.firstName', 'args.named.lastName')
           get salutation() {
             return this.args.named.firstName + ' ' + this.args.named.lastName;
@@ -630,7 +630,7 @@ moduleFor(
     }
 
     ['@test it can pass attributes']() {
-      let ComponentClass = setComponentManager(createBasicManager, class extends EmberObject {});
+      let ComponentClass = setComponentManager(createBasicManager, class extends CoreObject {});
 
       this.registerComponent('foo-bar', {
         template: `<p ...attributes>Hello world!</p>`,
@@ -645,7 +645,7 @@ moduleFor(
     ['@test arguments are updated if they change']() {
       let ComponentClass = setComponentManager(
         createBasicManager,
-        class extends EmberObject {
+        class extends CoreObject {
           @computed('args.named.firstName', 'args.named.lastName')
           get salutation() {
             return this.args.named.firstName + ' ' + this.args.named.lastName;
@@ -676,7 +676,7 @@ moduleFor(
     }
 
     ['@test updating attributes triggers updateComponent and didUpdateComponent'](assert) {
-      let TestManager = class extends EmberObject {
+      let TestManager = class extends CoreObject {
         capabilities = componentCapabilities('3.13', {
           destructor: true,
           asyncLifecycleCallbacks: true,
@@ -717,7 +717,7 @@ moduleFor(
         () => {
           return TestManager.create();
         },
-        class extends EmberObject {
+        class extends CoreObject {
           didRender() {}
           didUpdate() {}
         }
@@ -848,7 +848,7 @@ moduleFor(
 
       let ComponentClass = setComponentManager(
         () => {
-          return EmberObject.create({
+          return CoreObject.create({
             capabilities: {
               asyncLifecycleCallbacks: true,
               destructor: true,
@@ -884,7 +884,7 @@ moduleFor(
             },
           });
         },
-        class extends EmberObject {
+        class extends CoreObject {
           greeting = 'hello';
         }
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -9,7 +9,8 @@ import {
 
 import { Component } from '@ember/-internals/glimmer';
 import { setModifierManager, modifierCapabilities } from '@glimmer/manager';
-import EmberObject, { set } from '@ember/object';
+import { set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { tracked } from '@ember/-internals/metal';
 import { backtrackingMessageFor } from '../utils/debug-stack';
 
@@ -42,7 +43,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new this.CustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         didInsertElement() {}
         didUpdate() {}
         willDestroyElement() {}
@@ -68,7 +69,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new this.CustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         didInsertElement() {}
         didUpdate() {}
         willDestroyElement() {}
@@ -110,7 +111,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new this.CustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         didInsertElement() {}
         didUpdate() {}
         willDestroyElement() {}
@@ -148,7 +149,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new this.CustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         didInsertElement() {}
         didUpdate() {}
         willDestroyElement() {}
@@ -164,7 +165,7 @@ class ModifierManagerTest extends RenderingTestCase {
           positional[0];
 
           assert.equal(this.element.tagName, 'H1');
-          this.set('savedElement', this.element);
+          set(this, 'savedElement', this.element);
         }
         didUpdate() {
           assert.equal(this.element, this.savedElement);
@@ -184,7 +185,7 @@ class ModifierManagerTest extends RenderingTestCase {
   }
 
   '@test lifecycle hooks are autotracked by default'(assert) {
-    let TrackedClass = class extends EmberObject {
+    let TrackedClass = class extends CoreObject {
       @tracked
       count = 0;
     };
@@ -199,7 +200,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new this.CustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         didInsertElement() {}
         didUpdate() {}
         willDestroyElement() {}
@@ -251,7 +252,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new this.CustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         static create() {
           return new this();
         }
@@ -300,7 +301,7 @@ class ModifierManagerTest extends RenderingTestCase {
       (owner) => {
         return new OverrideCustomModifierManager(owner);
       },
-      class extends EmberObject {
+      class extends CoreObject {
         didInsertElement() {
           assert.step('didInsertElement');
         }
@@ -361,7 +362,7 @@ moduleFor(
         (owner) => {
           return new this.CustomModifierManager(owner);
         },
-        class extends EmberObject {
+        class extends CoreObject {
           didInsertElement() {}
           didUpdate() {}
           willDestroyElement() {}
@@ -417,7 +418,7 @@ moduleFor(
         (owner) => {
           return new this.CustomModifierManager(owner);
         },
-        class extends EmberObject {
+        class extends CoreObject {
           didInsertElement() {}
           didUpdate() {}
           willDestroyElement() {}
@@ -578,7 +579,7 @@ moduleFor(
         (owner) => {
           return new CustomModifierManager(owner);
         },
-        class extends EmberObject {
+        class extends CoreObject {
           didInsertElement() {
             assert.ok(false);
           }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -1,4 +1,5 @@
-import EmberObject from '@ember/object';
+import { set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A } from '@ember/array';
 import MutableArray from '@ember/array/mutable';
 import {
@@ -60,7 +61,7 @@ moduleFor(
     '@test nested tracked properties rerender when updated'(assert) {
       let computeCount = 0;
 
-      let Person = class extends EmberObject {
+      let Person = class extends CoreObject {
         @tracked
         name = 'bob';
       };
@@ -172,7 +173,7 @@ moduleFor(
     }
 
     '@test custom ember array properties rerender when updated'() {
-      let CustomArray = class extends EmberObject.extend(MutableArray) {
+      let CustomArray = class extends CoreObject.extend(MutableArray) {
         init() {
           super.init(...arguments);
           this._vals = [1, 2, 3];
@@ -229,7 +230,7 @@ moduleFor(
     '@test nested getters update when dependent properties are invalidated'(assert) {
       let computeCount = 0;
 
-      let Person = class extends EmberObject {
+      let Person = class extends CoreObject {
         @tracked
         first = 'Rob';
         @tracked
@@ -327,7 +328,7 @@ moduleFor(
     '@test class based helpers are autotracked'(assert) {
       let computeCount = 0;
 
-      let TrackedClass = class extends EmberObject {
+      let TrackedClass = class extends CoreObject {
         @tracked
         value = 'bob';
       };
@@ -366,7 +367,7 @@ moduleFor(
     }
 
     '@test each-in autotracks non-tracked values correctly'() {
-      let obj = EmberObject.create({ value: 'bob' });
+      let obj = CoreObject.create({ value: 'bob' });
 
       this.registerComponent('person', {
         ComponentClass: class extends Component {
@@ -383,13 +384,13 @@ moduleFor(
 
       this.assertText('bob-value');
 
-      runTask(() => obj.set('value', 'sal'));
+      runTask(() => set(obj, 'value', 'sal'));
 
       this.assertText('sal-value');
     }
 
     '@test each-in autotracks arrays acorrectly'() {
-      let obj = EmberObject.create({ arr: A([1]) });
+      let obj = CoreObject.create({ arr: A([1]) });
 
       this.registerComponent('person', {
         ComponentClass: class extends Component {

--- a/packages/@ember/-internals/metal/tests/accessors/get_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/get_test.js
@@ -1,5 +1,6 @@
 import { ENV } from '@ember/-internals/environment';
-import EmberObject, { observer } from '@ember/object';
+import { observer } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { get } from '../..';
 import Mixin from '@ember/object/mixin';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -102,7 +103,7 @@ moduleFor(
       let func = function () {};
       func.bar = 'awesome';
 
-      let destroyedObj = EmberObject.create({ bar: 'great' });
+      let destroyedObj = CoreObject.create({ bar: 'great' });
       run(() => destroyedObj.destroy());
 
       assert.equal(get({ foo: null }, 'foo.bar'), undefined);

--- a/packages/@ember/-internals/metal/tests/accessors/set_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { get, set, trySet, computed } from '../..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -145,7 +145,7 @@ moduleFor(
     }
 
     ['@test should respect prototypical inheritance when subclasses override CPs'](assert) {
-      let ParentClass = class extends EmberObject {
+      let ParentClass = class extends CoreObject {
         @computed
         get prop() {
           return this._val;
@@ -171,7 +171,7 @@ moduleFor(
     ['@test should respect prototypical inheritance when subclasses override CPs with native classes'](
       assert
     ) {
-      class ParentClass extends EmberObject {
+      class ParentClass extends CoreObject {
         @computed
         set prop(val) {
           assert.ok(false, 'incorrect setter called');

--- a/packages/@ember/-internals/metal/tests/alias_test.js
+++ b/packages/@ember/-internals/metal/tests/alias_test.js
@@ -8,7 +8,7 @@ import {
   removeObserver,
   tagForProperty,
 } from '..';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A } from '@ember/array';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
 import { destroy } from '@glimmer/destroyable';
@@ -70,13 +70,13 @@ moduleFor(
     }
 
     ['@test nested aliases should trigger computed property invalidation [GH#19279]'](assert) {
-      let AttributeModel = class extends EmberObject {
+      let AttributeModel = class extends CoreObject {
         @alias('additives.length')
         countAdditives;
         additives = A();
       };
 
-      let RootModel = class extends EmberObject {
+      let RootModel = class extends CoreObject {
         @computed('metaAttributes.@each.countAdditives')
         get allAdditives() {
           return this.metaAttributes.reduce((acc, el) => {
@@ -95,7 +95,7 @@ moduleFor(
     async [`@test inheriting an observer of the alias from the prototype then
     redefining the alias on the instance to another property dependent on same key
     does not call the observer twice`](assert) {
-      let obj1 = class extends EmberObject {
+      let obj1 = class extends CoreObject {
         foo = null;
         @alias('foo') bar;
         @alias('foo') baz;

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core'
 import { meta as metaFor } from '@ember/-internals/meta';
 import {
   computed,
@@ -28,7 +28,7 @@ moduleFor(
   'computed',
   class extends ComputedTestCase {
     ['@test isComputed is true for computed property on a factory'](assert) {
-      let Obj = class extends EmberObject {
+      let Obj = class extends CoreObject {
         @computed
         get foo() {
           return undefined;
@@ -41,7 +41,7 @@ moduleFor(
     }
 
     ['@test isComputed is true for computed property on an instance'](assert) {
-      let Obj = class extends EmberObject {
+      let Obj = class extends CoreObject {
         @computed
         get foo() {
           return undefined;
@@ -105,7 +105,7 @@ moduleFor(
     ['@test computed property can be defined and accessed on a class constructor'](assert) {
       let count = 0;
 
-      let Obj = class extends EmberObject {
+      let Obj = class extends CoreObject {
         static bar = 123;
 
         @computed
@@ -693,7 +693,7 @@ moduleFor(
   'computed - improved cp syntax',
   class extends AbstractTestCase {
     ['@test setter and getters are passed using an object'](assert) {
-      let testObj = class extends EmberObject {
+      let testObj = class extends CoreObject {
         a = '1';
         b = '2';
         @computed('a')
@@ -702,36 +702,36 @@ moduleFor(
         }
         set aInt(value) {
           assert.equal(value, 123, 'setter receives the new value');
-          this.set('a', String(value)); // side effect
+          set(this, 'a', String(value)); // side effect
         }
       }.create();
 
-      assert.ok(testObj.get('aInt') === 1, 'getter works');
-      testObj.set('aInt', 123);
-      assert.ok(testObj.get('a') === '123', 'setter works');
-      assert.ok(testObj.get('aInt') === 123, 'cp has been updated too');
+      assert.ok(testObj.aInt === 1, 'getter works');
+      set(testObj, 'aInt', 123);
+      assert.ok(testObj.a === '123', 'setter works');
+      assert.ok(testObj.aInt === 123, 'cp has been updated too');
     }
 
     ['@test an omitted setter cannot be set later'](assert) {
-      let testObj = class extends EmberObject {
+      let testObj = class extends CoreObject {
         a = '1';
         b = '2';
         @computed('a')
         get aInt() {
-          return parseInt(this.get('a'));
+          return parseInt(this.a);
         }
       }.create();
 
-      assert.ok(testObj.get('aInt') === 1, 'getter works');
-      assert.ok(testObj.get('a') === '1');
+      assert.ok(testObj.aInt === 1, 'getter works');
+      assert.ok(testObj.a === '1');
 
       expectAssertion(() => {
-        testObj.set('aInt', '123');
+        set(testObj, 'aInt', '123');
       }, /Cannot override the computed property `aInt` on <\(unknown\):ember\d*>./);
     }
 
     ['@test the return value of the setter gets cached'](assert) {
-      let testObj = EmberObject.extend({
+      let testObj = CoreObject.extend({
         a: '1',
         sampleCP: computed('a', {
           get() {
@@ -744,8 +744,8 @@ moduleFor(
         }),
       }).create();
 
-      testObj.set('sampleCP', 'abcd');
-      assert.ok(testObj.get('sampleCP') === 'set-value', 'The return value of the CP was cached');
+      set(testObj, 'sampleCP', 'abcd');
+      assert.ok(get(testObj, 'sampleCP') === 'set-value', 'The return value of the CP was cached');
     }
   }
 );

--- a/packages/@ember/-internals/runtime/tests/array/every-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/every-test.js
@@ -1,6 +1,6 @@
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 
 class EveryTest extends AbstractTestCase {
   '@test every should should invoke callback on each item as long as you return true'() {
@@ -39,7 +39,7 @@ class IsEveryTest extends AbstractTestCase {
   '@test should return true of every property matches'() {
     let obj = this.newObject([
       { foo: 'foo', bar: 'BAZ' },
-      EmberObject.create({ foo: 'foo', bar: 'bar' }),
+      CoreObject.create({ foo: 'foo', bar: 'bar' }),
     ]);
 
     this.assert.equal(obj.isEvery('foo', 'foo'), true, 'isEvery(foo)');
@@ -49,7 +49,7 @@ class IsEveryTest extends AbstractTestCase {
   '@test should return true of every property is true'() {
     let obj = this.newObject([
       { foo: 'foo', bar: true },
-      EmberObject.create({ foo: 'bar', bar: false }),
+      CoreObject.create({ foo: 'bar', bar: false }),
     ]);
 
     // different values - all eval to true
@@ -60,7 +60,7 @@ class IsEveryTest extends AbstractTestCase {
   '@test should return true if every property matches null'() {
     let obj = this.newObject([
       { foo: null, bar: 'BAZ' },
-      EmberObject.create({ foo: null, bar: null }),
+      CoreObject.create({ foo: null, bar: null }),
     ]);
 
     this.assert.equal(obj.isEvery('foo', null), true, "isEvery('foo', null)");
@@ -70,7 +70,7 @@ class IsEveryTest extends AbstractTestCase {
   '@test should return true if every property is undefined'() {
     let obj = this.newObject([
       { foo: undefined, bar: 'BAZ' },
-      EmberObject.create({ bar: undefined }),
+      CoreObject.create({ bar: undefined }),
     ]);
 
     this.assert.equal(obj.isEvery('foo', undefined), true, "isEvery('foo', undefined)");

--- a/packages/@ember/-internals/runtime/tests/array/filter-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/filter-test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
 
@@ -24,7 +24,7 @@ class FilterByTest extends AbstractTestCase {
   '@test should include in result if property is true'() {
     let obj, ary;
 
-    ary = [{ foo: 'foo', bar: true }, EmberObject.create({ foo: 'bar', bar: false })];
+    ary = [{ foo: 'foo', bar: true }, CoreObject.create({ foo: 'bar', bar: false })];
 
     obj = this.newObject(ary);
 
@@ -38,9 +38,9 @@ class FilterByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: 2 }),
+      CoreObject.create({ name: 'obj2', foo: 2 }),
       { name: 'obj3', foo: 2 },
-      EmberObject.create({ name: 'obj4', foo: 3 }),
+      CoreObject.create({ name: 'obj4', foo: 3 }),
     ];
 
     obj = this.newObject(ary);
@@ -53,9 +53,9 @@ class FilterByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: null }),
+      CoreObject.create({ name: 'obj2', foo: null }),
       { name: 'obj3', foo: null },
-      EmberObject.create({ name: 'obj4', foo: 3 }),
+      CoreObject.create({ name: 'obj4', foo: 3 }),
     ];
 
     obj = this.newObject(ary);
@@ -68,11 +68,11 @@ class FilterByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: 3 }),
+      CoreObject.create({ name: 'obj2', foo: 3 }),
       { name: 'obj3', foo: undefined },
-      EmberObject.create({ name: 'obj4', foo: undefined }),
+      CoreObject.create({ name: 'obj4', foo: undefined }),
       { name: 'obj5' },
-      EmberObject.create({ name: 'obj6' }),
+      CoreObject.create({ name: 'obj6' }),
     ];
 
     obj = this.newObject(ary);
@@ -85,11 +85,11 @@ class FilterByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: 3 }),
+      CoreObject.create({ name: 'obj2', foo: 3 }),
       { name: 'obj3', foo: undefined },
-      EmberObject.create({ name: 'obj4', foo: undefined }),
+      CoreObject.create({ name: 'obj4', foo: undefined }),
       { name: 'obj5' },
-      EmberObject.create({ name: 'obj6' }),
+      CoreObject.create({ name: 'obj6' }),
     ];
 
     obj = this.newObject(ary);

--- a/packages/@ember/-internals/runtime/tests/array/find-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/find-test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
 
@@ -39,7 +39,7 @@ class FindByTests extends AbstractTestCase {
   '@test should return first object of property matches'() {
     let ary, obj;
 
-    ary = [{ foo: 'foo', bar: 'BAZ' }, EmberObject.create({ foo: 'foo', bar: 'bar' })];
+    ary = [{ foo: 'foo', bar: 'BAZ' }, CoreObject.create({ foo: 'foo', bar: 'bar' })];
 
     obj = this.newObject(ary);
 
@@ -50,7 +50,7 @@ class FindByTests extends AbstractTestCase {
   '@test should return first object with truthy prop'() {
     let ary, obj;
 
-    ary = [{ foo: 'foo', bar: false }, EmberObject.create({ foo: 'bar', bar: true })];
+    ary = [{ foo: 'foo', bar: false }, CoreObject.create({ foo: 'bar', bar: true })];
 
     obj = this.newObject(ary);
 
@@ -62,7 +62,7 @@ class FindByTests extends AbstractTestCase {
   '@test should return first null property match'() {
     let ary, obj;
 
-    ary = [{ foo: null, bar: 'BAZ' }, EmberObject.create({ foo: null, bar: null })];
+    ary = [{ foo: null, bar: 'BAZ' }, CoreObject.create({ foo: null, bar: null })];
 
     obj = this.newObject(ary);
 
@@ -73,7 +73,7 @@ class FindByTests extends AbstractTestCase {
   '@test should return first undefined property match'() {
     let ary, obj;
 
-    ary = [{ foo: undefined, bar: 'BAZ' }, EmberObject.create({})];
+    ary = [{ foo: undefined, bar: 'BAZ' }, CoreObject.create({})];
 
     obj = this.newObject(ary);
 

--- a/packages/@ember/-internals/runtime/tests/array/invoke-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/invoke-test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { NativeArray } from '@ember/array';
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
@@ -13,10 +13,10 @@ class InvokeTests extends AbstractTestCase {
     cnt = 0;
     ary = [
       { foo: F },
-      EmberObject.create({ foo: F }),
+      CoreObject.create({ foo: F }),
 
       // NOTE: does not impl foo - invoke should just skip
-      EmberObject.create({ bar: F }),
+      CoreObject.create({ bar: F }),
 
       { foo: F },
     ];

--- a/packages/@ember/-internals/runtime/tests/array/isAny-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/isAny-test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
 
@@ -6,7 +6,7 @@ class IsAnyTests extends AbstractTestCase {
   '@test should return true of any property matches'() {
     let obj = this.newObject([
       { foo: 'foo', bar: 'BAZ' },
-      EmberObject.create({ foo: 'foo', bar: 'bar' }),
+      CoreObject.create({ foo: 'foo', bar: 'bar' }),
     ]);
 
     this.assert.equal(obj.isAny('foo', 'foo'), true, 'isAny(foo)');
@@ -17,7 +17,7 @@ class IsAnyTests extends AbstractTestCase {
   '@test should return true of any property is true'() {
     let obj = this.newObject([
       { foo: 'foo', bar: true },
-      EmberObject.create({ foo: 'bar', bar: false }),
+      CoreObject.create({ foo: 'bar', bar: false }),
     ]);
 
     // different values - all eval to true
@@ -29,7 +29,7 @@ class IsAnyTests extends AbstractTestCase {
   '@test should return true if any property matches null'() {
     let obj = this.newObject([
       { foo: null, bar: 'bar' },
-      EmberObject.create({ foo: 'foo', bar: null }),
+      CoreObject.create({ foo: 'foo', bar: null }),
     ]);
 
     this.assert.equal(obj.isAny('foo', null), true, "isAny('foo', null)");
@@ -37,14 +37,14 @@ class IsAnyTests extends AbstractTestCase {
   }
 
   '@test should return true if any property is undefined'() {
-    let obj = this.newObject([{ foo: undefined, bar: 'bar' }, EmberObject.create({ foo: 'foo' })]);
+    let obj = this.newObject([{ foo: undefined, bar: 'bar' }, CoreObject.create({ foo: 'foo' })]);
 
     this.assert.equal(obj.isAny('foo', undefined), true, "isAny('foo', undefined)");
     this.assert.equal(obj.isAny('bar', undefined), true, "isAny('bar', undefined)");
   }
 
   '@test should not match undefined properties without second argument'() {
-    let obj = this.newObject([{ foo: undefined }, EmberObject.create({})]);
+    let obj = this.newObject([{ foo: undefined }, CoreObject.create({})]);
 
     this.assert.equal(obj.isAny('foo'), false, "isAny('foo', undefined)");
   }

--- a/packages/@ember/-internals/runtime/tests/array/reject-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/reject-test.js
@@ -1,6 +1,6 @@
 import { AbstractTestCase } from 'internal-test-helpers';
 import { runArrayTests } from '../helpers/array';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 
 class RejectTest extends AbstractTestCase {
   '@test should reject any item that does not meet the condition'() {
@@ -28,7 +28,7 @@ class RejectByTest extends AbstractTestCase {
   '@test should reject based on object'() {
     let obj, ary;
 
-    ary = [{ foo: 'foo', bar: 'BAZ' }, EmberObject.create({ foo: 'foo', bar: 'bar' })];
+    ary = [{ foo: 'foo', bar: 'BAZ' }, CoreObject.create({ foo: 'foo', bar: 'bar' })];
 
     obj = this.newObject(ary);
 
@@ -39,7 +39,7 @@ class RejectByTest extends AbstractTestCase {
   '@test should include in result if property is false'() {
     let obj, ary;
 
-    ary = [{ foo: false, bar: true }, EmberObject.create({ foo: false, bar: false })];
+    ary = [{ foo: false, bar: true }, CoreObject.create({ foo: false, bar: false })];
 
     obj = this.newObject(ary);
 
@@ -52,9 +52,9 @@ class RejectByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: 2 }),
+      CoreObject.create({ name: 'obj2', foo: 2 }),
       { name: 'obj3', foo: 2 },
-      EmberObject.create({ name: 'obj4', foo: 3 }),
+      CoreObject.create({ name: 'obj4', foo: 3 }),
     ];
 
     obj = this.newObject(ary);
@@ -67,9 +67,9 @@ class RejectByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: null }),
+      CoreObject.create({ name: 'obj2', foo: null }),
       { name: 'obj3', foo: null },
-      EmberObject.create({ name: 'obj4', foo: 3 }),
+      CoreObject.create({ name: 'obj4', foo: 3 }),
     ];
 
     obj = this.newObject(ary);
@@ -80,7 +80,7 @@ class RejectByTest extends AbstractTestCase {
   '@test should correctly reject undefined second argument'() {
     let obj, ary;
 
-    ary = [{ name: 'obj1', foo: 3 }, EmberObject.create({ name: 'obj2', foo: 2 })];
+    ary = [{ name: 'obj1', foo: 3 }, CoreObject.create({ name: 'obj2', foo: 2 })];
 
     obj = this.newObject(ary);
 
@@ -92,11 +92,11 @@ class RejectByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: 3 }),
+      CoreObject.create({ name: 'obj2', foo: 3 }),
       { name: 'obj3', foo: undefined },
-      EmberObject.create({ name: 'obj4', foo: undefined }),
+      CoreObject.create({ name: 'obj4', foo: undefined }),
       { name: 'obj5' },
-      EmberObject.create({ name: 'obj6' }),
+      CoreObject.create({ name: 'obj6' }),
     ];
 
     obj = this.newObject(ary);
@@ -113,15 +113,15 @@ class RejectByTest extends AbstractTestCase {
 
     ary = [
       { name: 'obj1', foo: 3 },
-      EmberObject.create({ name: 'obj2', foo: 3 }),
+      CoreObject.create({ name: 'obj2', foo: 3 }),
       { name: 'obj3', foo: undefined },
-      EmberObject.create({ name: 'obj4', foo: undefined }),
+      CoreObject.create({ name: 'obj4', foo: undefined }),
       { name: 'obj5' },
-      EmberObject.create({ name: 'obj6' }),
+      CoreObject.create({ name: 'obj6' }),
       { name: 'obj7', foo: null },
-      EmberObject.create({ name: 'obj8', foo: null }),
+      CoreObject.create({ name: 'obj8', foo: null }),
       { name: 'obj9', foo: false },
-      EmberObject.create({ name: 'obj10', foo: false }),
+      CoreObject.create({ name: 'obj10', foo: false }),
     ];
 
     obj = this.newObject(ary);

--- a/packages/@ember/-internals/runtime/tests/core/is_array_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_array_test.js
@@ -1,6 +1,6 @@
 import { A as emberA, isArray } from '@ember/array';
 import ArrayProxy from '@ember/array/proxy';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { window } from '@ember/-internals/browser-environment';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -37,7 +37,7 @@ moduleFor(
     '@test Ember.isArray does not trigger proxy assertion when probing for length GH#16495'(
       assert
     ) {
-      let instance = class extends EmberObject {
+      let instance = class extends CoreObject {
         // intentionally returning non-null / non-undefined
         unknownProperty() {
           return false;

--- a/packages/@ember/-internals/runtime/tests/helpers/array.js
+++ b/packages/@ember/-internals/runtime/tests/helpers/array.js
@@ -8,7 +8,8 @@ import {
   arrayContentWillChange,
   arrayContentDidChange,
 } from '@ember/-internals/metal';
-import EmberObject, { get, computed } from '@ember/object';
+import { get, computed } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor } from 'internal-test-helpers';
 
 export function newFixture(cnt) {
@@ -31,7 +32,7 @@ export function newObjectsFixture(cnt) {
   return ret;
 }
 
-const ArrayTestsObserverClass = class extends EmberObject {
+const ArrayTestsObserverClass = class extends CoreObject {
   init() {
     super.init(...arguments);
     this.isEnabled = true;
@@ -168,7 +169,7 @@ class ArrayProxyHelpers extends AbstractArrayHelper {
   Implement a basic fake mutable array.  This validates that any non-native
   enumerable can impl this API.
 */
-const TestArray = EmberObject.extend(EmberArray, {
+const TestArray = CoreObject.extend(EmberArray, {
   _content: null,
 
   init() {
@@ -204,7 +205,7 @@ const TestArray = EmberObject.extend(EmberArray, {
   Implement a basic fake mutable array.  This validates that any non-native
   enumerable can impl this API.
 */
-const TestMutableArray = EmberObject.extend(MutableArray, {
+const TestMutableArray = CoreObject.extend(MutableArray, {
   _content: null,
 
   init(ary = []) {

--- a/packages/@ember/-internals/runtime/tests/inject_test.js
+++ b/packages/@ember/-internals/runtime/tests/inject_test.js
@@ -1,6 +1,6 @@
 import { inject } from '@ember/-internals/metal';
 import { DEBUG } from '@glimmer/env';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { buildOwner } from 'internal-test-helpers';
 import { runDestroy, moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -9,7 +9,7 @@ moduleFor(
   class extends AbstractTestCase {
     ['@test attempting to inject a nonexistent container key should error']() {
       let owner = buildOwner();
-      let AnObject = class extends EmberObject {
+      let AnObject = class extends CoreObject {
         @inject('bar', 'baz')
         foo;
       };
@@ -25,7 +25,7 @@ moduleFor(
 
     ['@test factories should return a list of lazy injection full names'](assert) {
       if (DEBUG) {
-        let AnObject = class extends EmberObject {
+        let AnObject = class extends CoreObject {
           @inject('foo', 'bar')
           foo;
 

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -1,5 +1,6 @@
 import { addObserver } from '@ember/-internals/metal';
-import EmberObject, { get, set } from '@ember/object';
+import { get, set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A as emberA } from '@ember/array';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
 
@@ -20,13 +21,13 @@ moduleFor(
     async ['@test chained observers on enumerable properties are triggered when the observed property of any item changes'](
       assert
     ) {
-      let family = EmberObject.create({ momma: null });
-      let momma = EmberObject.create({ children: [] });
+      let family = CoreObject.create({ momma: null });
+      let momma = CoreObject.create({ children: [] });
 
-      let child1 = EmberObject.create({ name: 'Bartholomew' });
-      let child2 = EmberObject.create({ name: 'Agnes' });
-      let child3 = EmberObject.create({ name: 'Dan' });
-      let child4 = EmberObject.create({ name: 'Nancy' });
+      let child1 = CoreObject.create({ name: 'Bartholomew' });
+      let child2 = CoreObject.create({ name: 'Agnes' });
+      let child3 = CoreObject.create({ name: 'Dan' });
+      let child4 = CoreObject.create({ name: 'Nancy' });
 
       set(family, 'momma', momma);
       set(momma, 'children', emberA([child1, child2, child3]));
@@ -39,7 +40,7 @@ moduleFor(
       observerFiredCount = 0;
 
       for (let i = 0; i < momma.children.length; i++) {
-        momma.children[i].set('name', 'Juan');
+        set(momma.children[i], 'name', 'Juan');
         await runLoopSettled();
       }
       assert.equal(observerFiredCount, 3, 'observer fired after changing child names');

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/system/object/base_test.js
@@ -1,4 +1,5 @@
-import EmberObject, { get, set } from '@ember/object';
+import { get, set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 /*
@@ -29,7 +30,7 @@ moduleFor(
   'A new EmberObject instance',
   class extends AbstractTestCase {
     beforeEach() {
-      obj = EmberObject.create({
+      obj = CoreObject.create({
         foo: 'bar',
         total: 12345,
         aMethodThatExists() {},
@@ -49,12 +50,12 @@ moduleFor(
       obj = undefined;
     }
 
-    ['@test Should return its properties when requested using EmberObject#get'](assert) {
+    ['@test Should return its properties when requested using get'](assert) {
       assert.equal(get(obj, 'foo'), 'bar');
       assert.equal(get(obj, 'total'), 12345);
     }
 
-    ['@test Should allow changing of those properties by calling EmberObject#set'](assert) {
+    ['@test Should allow changing of those properties by calling set'](assert) {
       assert.equal(get(obj, 'foo'), 'bar');
       assert.equal(get(obj, 'total'), 12345);
 
@@ -68,10 +69,10 @@ moduleFor(
 );
 
 moduleFor(
-  'EmberObject superclass and subclasses',
+  'CoreObject superclass and subclasses',
   class extends AbstractTestCase {
     beforeEach() {
-      obj = class extends EmberObject {
+      obj = class extends CoreObject {
         method1() {
           return 'hello';
         }
@@ -90,7 +91,7 @@ moduleFor(
     }
 
     ['@test Checking the detectInstance() function on an object and its subclass'](assert) {
-      assert.ok(EmberObject.detectInstance(obj.create()));
+      assert.ok(CoreObject.detectInstance(obj.create()));
       assert.ok(obj.detectInstance(obj.create()));
     }
   }

--- a/packages/@ember/-internals/runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/@ember/-internals/runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -1,4 +1,5 @@
-import EmberObject, { get } from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 /*
@@ -23,7 +24,7 @@ moduleFor(
   'EmberObject Concatenated Properties',
   class extends AbstractTestCase {
     beforeEach() {
-      klass = EmberObject.extend({
+      klass = CoreObject.extend({
         concatenatedProperties: ['values', 'functions'],
         values: ['a', 'b', 'c'],
         functions: [K],

--- a/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/accessor_test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -7,7 +7,7 @@ moduleFor(
     ['@test works with getters'](assert) {
       let value = 'building';
 
-      let Base = class extends EmberObject {
+      let Base = class extends CoreObject {
         get foo() {
           if (value === 'building') {
             throw Error('base should not be called yet');

--- a/packages/@ember/-internals/runtime/tests/mixins/array_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/array_test.js
@@ -6,7 +6,8 @@ import {
   arrayContentDidChange,
   arrayContentWillChange,
 } from '@ember/-internals/metal';
-import EmberObject, { get, set, computed, observer as emberObserver } from '@ember/object';
+import { get, set, computed, observer as emberObserver } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import EmberArray, { A as emberA } from '@ember/array';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
 
@@ -14,7 +15,7 @@ import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpe
   Implement a basic fake mutable array.  This validates that any non-native
   enumerable can impl this API.
 */
-const TestArray = class extends EmberObject.extend(EmberArray) {
+const TestArray = class extends CoreObject.extend(EmberArray) {
   _content = null;
 
   init() {
@@ -50,7 +51,7 @@ moduleFor(
   'Ember.Array',
   class extends AbstractTestCase {
     ['@test the return value of slice has Ember.Array applied'](assert) {
-      let x = EmberObject.extend(EmberArray).create({
+      let x = CoreObject.extend(EmberArray).create({
         length: 0,
       });
       let y = x.slice(1);
@@ -80,7 +81,7 @@ moduleFor(
 // CONTENT DID CHANGE
 //
 
-class DummyArray extends EmberObject.extend(EmberArray) {
+class DummyArray extends CoreObject.extend(EmberArray) {
   length = 0;
   objectAt(idx) {
     return 'ITEM-' + idx;
@@ -194,7 +195,7 @@ moduleFor(
     beforeEach(assert) {
       obj = DummyArray.create();
 
-      observer = class extends EmberObject {
+      observer = class extends CoreObject {
         arrayWillChange() {
           assert.equal(this._before, null); // should only call once
           this._before = Array.prototype.slice.call(arguments);
@@ -286,7 +287,7 @@ moduleFor(
     async ['@test adding an object should notify (@each.isDone)'](assert) {
       let called = 0;
 
-      let observerObject = EmberObject.create({
+      let observerObject = CoreObject.create({
         wasCalled() {
           called++;
         },
@@ -295,7 +296,7 @@ moduleFor(
       addObserver(ary, '@each.isDone', observerObject, 'wasCalled');
 
       ary.addObject(
-        EmberObject.create({
+        CoreObject.create({
           desc: 'foo',
           isDone: false,
         })
@@ -308,7 +309,7 @@ moduleFor(
     async ['@test using @each to observe arrays that does not return objects raise error'](assert) {
       let called = 0;
 
-      let observerObject = EmberObject.create({
+      let observerObject = CoreObject.create({
         wasCalled() {
           called++;
         },
@@ -342,7 +343,7 @@ moduleFor(
     ['@test should be clear caches for computed properties that have dependent keys on arrays that are changed after object initialization'](
       assert
     ) {
-      let obj = class extends EmberObject {
+      let obj = class extends CoreObject {
         init() {
           super.init(...arguments);
           set(this, 'resources', emberA());
@@ -354,7 +355,7 @@ moduleFor(
         }
       }.create();
 
-      get(obj, 'resources').pushObject(EmberObject.create({ common: 'HI!' }));
+      get(obj, 'resources').pushObject(CoreObject.create({ common: 'HI!' }));
       assert.equal('HI!', get(obj, 'common'));
 
       set(objectAt(get(obj, 'resources'), 0), 'common', 'BYE!');
@@ -366,7 +367,7 @@ moduleFor(
     ) {
       let count = 0;
 
-      let obj = EmberObject.extend({
+      let obj = CoreObject.extend({
         init() {
           this._super(...arguments);
           // Observer does not fire on init
@@ -377,7 +378,7 @@ moduleFor(
       }).create();
 
       // Observer fires first time when new object is added
-      get(obj, 'resources').pushObject(EmberObject.create({ common: 'HI!' }));
+      get(obj, 'resources').pushObject(CoreObject.create({ common: 'HI!' }));
       await runLoopSettled();
 
       // Observer fires second time when property on an object is changed

--- a/packages/@ember/-internals/runtime/tests/mixins/comparable_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/comparable_test.js
@@ -1,9 +1,10 @@
-import EmberObject, { get } from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { compare } from '@ember/utils';
 import Comparable from '../../lib/mixins/comparable';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
-class Rectangle extends EmberObject.extend(Comparable) {
+class Rectangle extends CoreObject.extend(Comparable) {
   length = 0;
   width = 0;
 

--- a/packages/@ember/-internals/runtime/tests/mixins/container_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/container_proxy_test.js
@@ -1,7 +1,7 @@
 import { getOwner } from '@ember/-internals/owner';
 import { Container, Registry } from '@ember/-internals/container';
 import ContainerProxy from '../../lib/mixins/container_proxy';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { run, schedule } from '@ember/runloop';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { destroy } from '@glimmer/destroyable';
@@ -10,7 +10,7 @@ moduleFor(
   '@ember/-internals/runtime/mixins/container_proxy',
   class extends AbstractTestCase {
     beforeEach() {
-      this.Owner = EmberObject.extend(ContainerProxy);
+      this.Owner = CoreObject.extend(ContainerProxy);
       this.instance = this.Owner.create();
 
       this.registry = new Registry();
@@ -31,7 +31,7 @@ moduleFor(
 
       this.registry.register(
         'service:auth',
-        class extends EmberObject {
+        class extends CoreObject {
           willDestroy() {
             assert.ok(getOwner(this).lookup('service:auth'), 'can still lookup');
           }
@@ -53,7 +53,7 @@ moduleFor(
 
       this.registry.register(
         'service:foo',
-        class FooService extends EmberObject {
+        class FooService extends CoreObject {
           willDestroy() {
             assert.ok(true, 'is properly destroyed');
           }

--- a/packages/@ember/-internals/runtime/tests/mixins/target_action_support_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/target_action_support_test.js
@@ -1,5 +1,5 @@
 import { context } from '@ember/-internals/environment';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import TargetActionSupport from '../../lib/mixins/target_action_support';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -20,7 +20,7 @@ moduleFor(
     ['@test it should return false if no target or action are specified'](assert) {
       assert.expect(1);
 
-      let obj = EmberObject.extend(TargetActionSupport).create();
+      let obj = CoreObject.extend(TargetActionSupport).create();
 
       assert.ok(false === obj.triggerAction(), 'no target or action was specified');
     }
@@ -28,8 +28,8 @@ moduleFor(
     ['@test it should support actions specified as strings'](assert) {
       assert.expect(2);
 
-      let obj = EmberObject.extend(TargetActionSupport).create({
-        target: EmberObject.create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
+        target: CoreObject.create({
           anEvent() {
             assert.ok(true, 'anEvent method was called');
           },
@@ -44,8 +44,8 @@ moduleFor(
     ['@test it should invoke the send() method on objects that implement it'](assert) {
       assert.expect(3);
 
-      let obj = EmberObject.extend(TargetActionSupport).create({
-        target: EmberObject.create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
+        target: CoreObject.create({
           send(evt, context) {
             assert.equal(evt, 'anEvent', 'send() method was invoked with correct event name');
             assert.equal(context, obj, 'send() method was invoked with correct context');
@@ -64,13 +64,13 @@ moduleFor(
       let Test = {};
       lookup.Test = Test;
 
-      Test.targetObj = EmberObject.create({
+      Test.targetObj = CoreObject.create({
         anEvent() {
           assert.ok(true, 'anEvent method was called on global object');
         },
       });
 
-      let myObj = EmberObject.extend(TargetActionSupport).create({
+      let myObj = CoreObject.extend(TargetActionSupport).create({
         target: 'Test.targetObj',
         action: 'anEvent',
       });
@@ -80,10 +80,10 @@ moduleFor(
 
     ['@test it should use an actionContext object specified as a property on the object'](assert) {
       assert.expect(2);
-      let obj = EmberObject.extend(TargetActionSupport).create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
         action: 'anEvent',
         actionContext: {},
-        target: EmberObject.create({
+        target: CoreObject.create({
           anEvent(ctx) {
             assert.ok(
               obj.actionContext === ctx,
@@ -102,10 +102,10 @@ moduleFor(
       lookup.Test = Test;
       Test.aContext = {};
 
-      let obj = EmberObject.extend(TargetActionSupport).create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
         action: 'anEvent',
         actionContext: 'Test.aContext',
-        target: EmberObject.create({
+        target: CoreObject.create({
           anEvent(ctx) {
             assert.ok(Test.aContext === ctx, 'anEvent method was called with the expected context');
           },
@@ -117,12 +117,12 @@ moduleFor(
 
     ['@test it should use the target specified in the argument'](assert) {
       assert.expect(2);
-      let targetObj = EmberObject.create({
+      let targetObj = CoreObject.create({
         anEvent() {
           assert.ok(true, 'anEvent method was called');
         },
       });
-      let obj = EmberObject.extend(TargetActionSupport).create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
         action: 'anEvent',
       });
 
@@ -135,8 +135,8 @@ moduleFor(
     ['@test it should use the action specified in the argument'](assert) {
       assert.expect(2);
 
-      let obj = EmberObject.extend(TargetActionSupport).create({
-        target: EmberObject.create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
+        target: CoreObject.create({
           anEvent() {
             assert.ok(true, 'anEvent method was called');
           },
@@ -151,8 +151,8 @@ moduleFor(
     ['@test it should use the actionContext specified in the argument'](assert) {
       assert.expect(2);
       let context = {};
-      let obj = EmberObject.extend(TargetActionSupport).create({
-        target: EmberObject.create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
+        target: CoreObject.create({
           anEvent(ctx) {
             assert.ok(context === ctx, 'anEvent method was called with the expected context');
           },
@@ -170,8 +170,8 @@ moduleFor(
       assert.expect(3);
       let param1 = 'someParam';
       let param2 = 'someOtherParam';
-      let obj = EmberObject.extend(TargetActionSupport).create({
-        target: EmberObject.create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
+        target: CoreObject.create({
           anEvent(first, second) {
             assert.ok(
               first === param1,
@@ -194,8 +194,8 @@ moduleFor(
 
     ['@test it should use a null value specified in the actionContext argument'](assert) {
       assert.expect(2);
-      let obj = EmberObject.extend(TargetActionSupport).create({
-        target: EmberObject.create({
+      let obj = CoreObject.extend(TargetActionSupport).create({
+        target: CoreObject.create({
           anEvent(ctx) {
             assert.ok(null === ctx, 'anEvent method was called with the expected context (null)');
           },

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
@@ -1,6 +1,7 @@
 import ArrayProxy from '@ember/array/proxy';
-import EmberObject, { observer } from '@ember/object';
+import { observer } from '@ember/object';
 import { oneWay as reads, not } from '@ember/object/computed';
+import CoreObject from '@ember/object/core';
 import { A as a } from '@ember/array';
 import { moduleFor, AbstractTestCase, runTask, runLoopSettled } from 'internal-test-helpers';
 import { set, get } from '@ember/object';
@@ -158,7 +159,7 @@ moduleFor(
 
       aCalled = bCalled = cCalled = dCalled = eCalled = 0;
 
-      let obj = EmberObject.extend({
+      let obj = CoreObject.extend({
         colors: reads('model'),
         length: reads('colors.length'),
 
@@ -172,7 +173,7 @@ moduleFor(
       // bootstrap aliases
       obj.length;
 
-      obj.set(
+      set(obj,
         'model',
         ArrayProxy.create({
           content: a(['red', 'yellow', 'blue']),
@@ -181,9 +182,9 @@ moduleFor(
 
       await runLoopSettled();
 
-      assert.equal(obj.get('colors.content.length'), 3);
-      assert.equal(obj.get('colors.length'), 3);
-      assert.equal(obj.get('length'), 3);
+      assert.equal(get(obj, 'colors.content.length'), 3);
+      assert.equal(get(obj, 'colors.length'), 3);
+      assert.equal(get(obj, 'length'), 3);
 
       assert.equal(aCalled, 1, 'expected observer `length` to be called ONCE');
       assert.equal(bCalled, 1, 'expected observer `colors.length` to be called ONCE');
@@ -191,12 +192,12 @@ moduleFor(
       assert.equal(dCalled, 1, 'expected observer `colors.[]` to be called ONCE');
       assert.equal(eCalled, 1, 'expected observer `colors.content.[]` to be called ONCE');
 
-      obj.get('colors').pushObjects(['green', 'red']);
+      get(obj, 'colors').pushObjects(['green', 'red']);
       await runLoopSettled();
 
-      assert.equal(obj.get('colors.content.length'), 5);
-      assert.equal(obj.get('colors.length'), 5);
-      assert.equal(obj.get('length'), 5);
+      assert.equal(get(obj, 'colors.content.length'), 5);
+      assert.equal(get(obj, 'colors.length'), 5);
+      assert.equal(get(obj, 'length'), 5);
 
       assert.equal(aCalled, 2, 'expected observer `length` to be called TWICE');
       assert.equal(bCalled, 2, 'expected observer `colors.length` to be called TWICE');

--- a/packages/@ember/-internals/runtime/tests/system/namespace/base_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/namespace/base_test.js
@@ -3,6 +3,7 @@ import { run } from '@ember/runloop';
 import { get, setNamespaceSearchDisabled } from '@ember/-internals/metal';
 import { guidFor, getName } from '@ember/-internals/utils';
 import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import Namespace from '@ember/application/namespace';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -61,16 +62,16 @@ moduleFor(
 
     ['@test Classes under an Namespace are properly named'](assert) {
       let nsA = (lookup.NamespaceA = Namespace.create());
-      nsA.Foo = EmberObject.extend();
+      nsA.Foo = CoreObject.extend();
       Namespace.processAll();
       assert.equal(getName(nsA.Foo), 'NamespaceA.Foo', 'Classes pick up their parent namespace');
 
-      nsA.Bar = EmberObject.extend();
+      nsA.Bar = CoreObject.extend();
       Namespace.processAll();
       assert.equal(getName(nsA.Bar), 'NamespaceA.Bar', 'New Classes get the naming treatment too');
 
       let nsB = (lookup.NamespaceB = Namespace.create());
-      nsB.Foo = EmberObject.extend();
+      nsB.Foo = CoreObject.extend();
       Namespace.processAll();
       assert.equal(
         getName(nsB.Foo),
@@ -101,8 +102,8 @@ moduleFor(
           name: 'CustomNamespaceB',
         }));
 
-        nsA.Foo = class extends EmberObject {};
-        nsB.Foo = class extends EmberObject {};
+        nsA.Foo = class extends CoreObject {};
+        nsB.Foo = class extends CoreObject {};
 
         Namespace.processAll();
 
@@ -126,8 +127,8 @@ moduleFor(
 
       let namespace = (lookup.NS = Namespace.create());
 
-      namespace.ClassA = class extends EmberObject {};
-      namespace.ClassB = class extends EmberObject {};
+      namespace.ClassA = class extends CoreObject {};
+      namespace.ClassB = class extends CoreObject {};
 
       Namespace.processAll();
 

--- a/packages/@ember/application/tests/application_instance_test.js
+++ b/packages/@ember/application/tests/application_instance_test.js
@@ -4,7 +4,7 @@ import ApplicationInstance from '@ember/application/instance';
 import { run } from '@ember/runloop';
 import { privatize as P } from '@ember/-internals/container';
 import { factory } from 'internal-test-helpers';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import {
   moduleFor,
   ModuleBasedTestResolver,
@@ -209,7 +209,7 @@ moduleFor(
     ['@test can build a registry via ApplicationInstance.setupRegistry() -- simulates ember-test-helpers'](
       assert
     ) {
-      let namespace = EmberObject.create({
+      let namespace = CoreObject.create({
         Resolver: { create: function () {} },
       });
 

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -8,7 +8,7 @@ import Router from '@ember/routing/router';
 import NoneLocation from '@ember/routing/none-location';
 import { _loaded } from '@ember/application';
 import Controller from '@ember/controller';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import {
   moduleFor,
   ApplicationTestCase,
@@ -309,7 +309,7 @@ moduleFor(
     [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](
       assert
     ) {
-      let namespace = EmberObject.create({
+      let namespace = CoreObject.create({
         Resolver: { create: function () {} },
       });
 
@@ -326,7 +326,7 @@ moduleFor(
     [`@test can build a registry via Application.buildRegistry() --- simulates ember-test-helpers`](
       assert
     ) {
-      let namespace = EmberObject.create({
+      let namespace = CoreObject.create({
         Resolver: { create() {} },
       });
 

--- a/packages/@ember/application/tests/dependency_injection_test.js
+++ b/packages/@ember/application/tests/dependency_injection_test.js
@@ -1,6 +1,6 @@
 import { context } from '@ember/-internals/environment';
 import { run } from '@ember/runloop';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import EmberApplication from '@ember/application';
 import {
   moduleFor,
@@ -21,11 +21,11 @@ moduleFor(
         Resolver: ModuleBasedTestResolver,
       });
 
-      application.Person = class extends EmberObject {};
-      application.Orange = class extends EmberObject {};
-      application.Email = class extends EmberObject {};
-      application.User = class extends EmberObject {};
-      application.PostIndexController = class extends EmberObject {};
+      application.Person = class extends CoreObject {};
+      application.Orange = class extends CoreObject {};
+      application.Email = class extends CoreObject {};
+      application.User = class extends CoreObject {};
+      application.PostIndexController = class extends CoreObject {};
 
       application.register('model:person', application.Person, {
         singleton: false,

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -6,7 +6,8 @@ import {
   defineComponent,
 } from 'internal-test-helpers';
 import { service } from '@ember/service';
-import EmberObject from '@ember/object';
+import { set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { RSVP, onerrorDefault } from '@ember/-internals/runtime';
 import { later } from '@ember/runloop';
 import { action } from '@ember/object';
@@ -646,11 +647,11 @@ moduleFor(
         }
       );
 
-      let Counter = class extends EmberObject {
+      let Counter = class extends CoreObject {
         value = 0;
 
         increment() {
-          this.incrementProperty('value');
+          set(this, 'value', this.value + 1);
         }
       };
 

--- a/packages/@ember/controller/tests/controller_test.js
+++ b/packages/@ember/controller/tests/controller_test.js
@@ -1,6 +1,7 @@
 import Controller, { inject as injectController } from '@ember/controller';
 import Service, { service } from '@ember/service';
-import EmberObject, { get } from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import Mixin from '@ember/object/mixin';
 import { setOwner } from '@ember/-internals/owner';
 import { runDestroy, buildOwner } from 'internal-test-helpers';
@@ -228,12 +229,12 @@ moduleFor(
       let owner = buildOwner();
 
       expectAssertion(function () {
-        let AnObject = class extends EmberObject {
+        let AnObject = class extends CoreObject {
           @injectController('bar')
           foo;
         };
 
-        owner.register('controller:bar', class extends EmberObject {});
+        owner.register('controller:bar', class extends CoreObject {});
         owner.register('foo:main', AnObject);
 
         owner.lookup('foo:main');

--- a/packages/@ember/debug/tests/main_test.js
+++ b/packages/@ember/debug/tests/main_test.js
@@ -1,5 +1,5 @@
 import { ENV } from '@ember/-internals/environment';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { HANDLERS } from '../lib/handlers';
 import {
   registerHandler,
@@ -238,7 +238,7 @@ moduleForDevelopment(
 
     ['@test assert does not throw if second argument is an object'](assert) {
       assert.expect(1);
-      let Igor = class extends EmberObject {};
+      let Igor = class extends CoreObject {};
 
       emberAssert('is truthy', Igor);
       emberAssert('is truthy', Igor.create());

--- a/packages/@ember/engine/tests/engine_test.js
+++ b/packages/@ember/engine/tests/engine_test.js
@@ -1,7 +1,7 @@
 import { context } from '@ember/-internals/environment';
 import { run } from '@ember/runloop';
 import Engine from '@ember/engine';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { processAllNamespaces } from '@ember/-internals/metal';
 import { getName } from '@ember/-internals/utils';
 import {
@@ -37,7 +37,7 @@ moduleFor(
     }
 
     ['@test acts like a namespace'](assert) {
-      engine.Foo = class extends EmberObject {};
+      engine.Foo = class extends CoreObject {};
       processAllNamespaces();
       assert.equal(getName(engine.Foo), 'TestEngine.Foo', 'Classes pick up their parent namespace');
     }

--- a/packages/@ember/object/tests/action_test.js
+++ b/packages/@ember/object/tests/action_test.js
@@ -1,5 +1,6 @@
 import { Component } from '@ember/-internals/glimmer';
-import EmberObject, { action } from '@ember/object';
+import { action } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
 
 moduleFor(
@@ -24,7 +25,7 @@ moduleFor(
     }
 
     '@test action decorator does not add actions to superclass'(assert) {
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @action
         foo() {
           // Do nothing
@@ -172,7 +173,7 @@ moduleFor(
 
     '@test action decorator throws an error if applied to non-methods'() {
       expectAssertion(() => {
-        class TestObject extends EmberObject {
+        class TestObject extends CoreObject {
           @action foo = 'bar';
         }
 
@@ -182,7 +183,7 @@ moduleFor(
 
     '@test action decorator throws an error if passed a function in native classes'() {
       expectAssertion(() => {
-        class TestObject extends EmberObject {
+        class TestObject extends CoreObject {
           @action(function () {}) foo = 'bar';
         }
 

--- a/packages/@ember/object/tests/computed/computed_macros_test.js
+++ b/packages/@ember/object/tests/computed/computed_macros_test.js
@@ -16,7 +16,8 @@ import {
   and,
   or,
 } from '@ember/object/computed';
-import EmberObject, { get, set, computed, defineProperty } from '@ember/object';
+import { get, set, computed, defineProperty } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A as emberA } from '@ember/array';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -24,7 +25,7 @@ moduleFor(
   'CP macros',
   class extends AbstractTestCase {
     ['@test empty part 1/2'](assert) {
-      let obj = class extends EmberObject {
+      let obj = class extends CoreObject {
         bestLannister = null;
         lannisters = null;
 
@@ -45,7 +46,7 @@ moduleFor(
     }
 
     ['@test notEmpty part 1/2'](assert) {
-      let obj = class extends EmberObject {
+      let obj = class extends CoreObject {
         bestLannister = null;
         lannisters = null;
 

--- a/packages/@ember/object/tests/computed/dependent-key-compat-test.js
+++ b/packages/@ember/object/tests/computed/dependent-key-compat-test.js
@@ -1,4 +1,5 @@
-import EmberObject, { computed, observer } from '@ember/object';
+import { computed, observer } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { tracked } from '@ember/-internals/metal';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
@@ -32,7 +33,7 @@ moduleFor(
     }
 
     '@test it works with classic classes'(assert) {
-      let Person = class extends EmberObject {
+      let Person = class extends CoreObject {
         @tracked
         firstName = 'Tom';
         @tracked
@@ -61,7 +62,7 @@ moduleFor(
     async '@test it works with async observers'(assert) {
       let count = 0;
 
-      let Person = EmberObject.extend({
+      let Person = CoreObject.extend({
         firstName: tracked({ value: 'Tom' }),
         lastName: tracked({ value: 'Dale' }),
 
@@ -98,7 +99,7 @@ moduleFor(
     '@test it does not work with sync observers'(assert) {
       let count = 0;
 
-      let Person = EmberObject.extend({
+      let Person = CoreObject.extend({
         firstName: tracked({ value: 'Tom' }),
         lastName: tracked({ value: 'Dale' }),
 

--- a/packages/@ember/object/tests/create_test.js
+++ b/packages/@ember/object/tests/create_test.js
@@ -4,19 +4,20 @@ import { addObserver } from '@ember/object/observers';
 import Mixin from '@ember/object/mixin';
 import Service, { service } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
-import EmberObject, { computed, observer } from '@ember/object';
+import { computed, get, observer } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { alias } from '@ember/object/computed';
 import { buildOwner, moduleFor, runDestroy, AbstractTestCase } from 'internal-test-helpers';
 import { destroy } from '@glimmer/destroyable';
 
 moduleFor(
-  'EmberObject.create',
+  'CoreObject.create',
   class extends AbstractTestCase {
     ['@test simple properties are set'](assert) {
       expectNoDeprecation();
 
-      let o = EmberObject.create({ ohai: 'there' });
-      assert.equal(o.get('ohai'), 'there');
+      let o = CoreObject.create({ ohai: 'there' });
+      assert.equal(get(o, 'ohai'), 'there');
     }
 
     ['@test explicit injection does not raise deprecation'](assert) {
@@ -27,7 +28,7 @@ moduleFor(
       class FooService extends Service {
         bar = 'foo';
       }
-      class FooObject extends EmberObject {
+      class FooObject extends CoreObject {
         @service foo;
       }
       owner.register('service:foo', FooService);
@@ -40,7 +41,7 @@ moduleFor(
     }
 
     ['@test calls computed property setters'](assert) {
-      let MyClass = EmberObject.extend({
+      let MyClass = CoreObject.extend({
         foo: computed({
           get() {
             return "this is not the value you're looking for";
@@ -52,19 +53,19 @@ moduleFor(
       });
 
       let o = MyClass.create({ foo: 'bar' });
-      assert.equal(o.get('foo'), 'bar');
+      assert.equal(get(o, 'foo'), 'bar');
     }
 
     ['@test sets up mandatory setters for simple properties watched with observers'](assert) {
       if (DEBUG) {
-        let MyClass = EmberObject.extend({
+        let MyClass = CoreObject.extend({
           foo: null,
           bar: null,
           fooDidChange: observer('foo', function () {}),
         });
 
         let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-        assert.equal(o.get('foo'), 'bar');
+        assert.equal(get(o, 'foo'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(descriptor.set, 'Mandatory setter was setup');
@@ -80,7 +81,7 @@ moduleFor(
 
     ['@test sets up mandatory setters for simple properties watched with computeds'](assert) {
       if (DEBUG) {
-        let MyClass = class extends EmberObject {
+        let MyClass = class extends CoreObject {
           foo = null;
           bar = null;
           @computed('foo')
@@ -90,7 +91,7 @@ moduleFor(
         };
 
         let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-        assert.equal(o.get('fooAlias'), 'bar');
+        assert.equal(get(o, 'fooAlias'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(descriptor.set, 'Mandatory setter was setup');
@@ -106,7 +107,7 @@ moduleFor(
 
     ['@test sets up mandatory setters for simple properties watched with aliases'](assert) {
       if (DEBUG) {
-        let MyClass = class extends EmberObject {
+        let MyClass = class extends CoreObject {
           foo = null;
           bar = null;
           @alias('foo')
@@ -114,7 +115,7 @@ moduleFor(
         };
 
         let o = MyClass.create({ foo: 'bar', bar: 'baz' });
-        assert.equal(o.get('fooAlias'), 'bar');
+        assert.equal(get(o, 'fooAlias'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(descriptor.set, 'Mandatory setter was setup');
@@ -130,7 +131,7 @@ moduleFor(
 
     ['@test does not sets up separate mandatory setters on getters'](assert) {
       if (DEBUG) {
-        let MyClass = EmberObject.extend({
+        let MyClass = CoreObject.extend({
           get foo() {
             return 'bar';
           },
@@ -138,7 +139,7 @@ moduleFor(
         });
 
         let o = MyClass.create({});
-        assert.equal(o.get('foo'), 'bar');
+        assert.equal(get(o, 'foo'), 'bar');
 
         let descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
         assert.ok(!descriptor, 'Mandatory setter was not setup');
@@ -168,7 +169,7 @@ moduleFor(
     ['@test calls setUnknownProperty if undefined'](assert) {
       let setUnknownPropertyCalled = false;
 
-      let MyClass = class extends EmberObject {
+      let MyClass = class extends CoreObject {
         setUnknownProperty(/* key, value */) {
           setUnknownPropertyCalled = true;
         }
@@ -180,7 +181,7 @@ moduleFor(
 
     ['@test throws if you try to define a computed property']() {
       expectAssertion(function () {
-        EmberObject.create({
+        CoreObject.create({
           foo: computed(function () {}),
         });
       }, 'EmberObject.create no longer supports defining computed properties. Define computed properties using extend() or reopen() before calling create().');
@@ -188,7 +189,7 @@ moduleFor(
 
     ['@test throws if you try to call _super in a method']() {
       expectAssertion(function () {
-        EmberObject.create({
+        CoreObject.create({
           foo() {
             this._super(...arguments);
           },
@@ -204,30 +205,30 @@ moduleFor(
       });
 
       expectAssertion(function () {
-        EmberObject.create(myMixin);
+        CoreObject.create(myMixin);
       }, 'EmberObject.create no longer supports mixing in other definitions, use .extend & .create separately instead.');
     }
 
-    ['@test inherits properties from passed in EmberObject'](assert) {
-      let baseObj = EmberObject.create({ foo: 'bar' });
-      let secondaryObj = EmberObject.create(baseObj);
+    ['@test inherits properties from passed in CoreObject'](assert) {
+      let baseObj = CoreObject.create({ foo: 'bar' });
+      let secondaryObj = CoreObject.create(baseObj);
 
       assert.equal(
         secondaryObj.foo,
         baseObj.foo,
-        'Em.O.create inherits properties from EmberObject parameter'
+        'Em.O.create inherits properties from CoreObject parameter'
       );
     }
 
     ['@test throws if you try to pass anything a string as a parameter']() {
       let expected = 'EmberObject.create only accepts objects.';
 
-      expectAssertion(() => EmberObject.create('some-string'), expected);
+      expectAssertion(() => CoreObject.create('some-string'), expected);
     }
 
-    ['@test EmberObject.create can take undefined as a parameter'](assert) {
-      let o = EmberObject.create(undefined);
-      assert.deepEqual(EmberObject.create(), o);
+    ['@test CoreObject.create can take undefined as a parameter'](assert) {
+      let o = CoreObject.create(undefined);
+      assert.deepEqual(CoreObject.create(), o);
     }
 
     ['@test can use getOwner in a proxy init GH#16484'](assert) {
@@ -235,7 +236,7 @@ moduleFor(
       let options = {};
       setOwner(options, owner);
 
-      let ProxyClass = class extends EmberObject {
+      let ProxyClass = class extends CoreObject {
         init() {
           super.init(...arguments);
           let localOwner = getOwner(this);
@@ -257,7 +258,7 @@ moduleFor(
       let container = registry.container();
       container.owner = {};
 
-      registry.register('component:foo-bar', EmberObject);
+      registry.register('component:foo-bar', CoreObject);
 
       let componentFactory = container.factoryFor('component:foo-bar');
       let instance = componentFactory.create();
@@ -274,7 +275,7 @@ moduleFor(
       let container = registry.container();
       container.owner = {};
 
-      registry.register('component:foo-bar', EmberObject);
+      registry.register('component:foo-bar', CoreObject);
 
       let instance = container.lookup('component:foo-bar');
 

--- a/packages/@ember/object/tests/destroy_test.js
+++ b/packages/@ember/object/tests/destroy_test.js
@@ -1,7 +1,8 @@
 import { run } from '@ember/runloop';
 import { beginPropertyChanges, endPropertyChanges } from '@ember/-internals/metal';
 import { peekMeta } from '@ember/-internals/meta';
-import EmberObject, { get, set, observer } from '@ember/object';
+import { get, set, observer } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { DEBUG } from '@glimmer/env';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
 
@@ -9,7 +10,7 @@ moduleFor(
   '@ember/-internals/runtime/system/object/destroy_test',
   class extends AbstractTestCase {
     ['@test should schedule objects to be destroyed at the end of the run loop'](assert) {
-      let obj = EmberObject.create();
+      let obj = CoreObject.create();
       let meta;
 
       run(() => {
@@ -31,7 +32,7 @@ moduleFor(
       assert
     ) {
       if (DEBUG) {
-        let obj = EmberObject.extend({
+        let obj = CoreObject.extend({
           fooDidChange: observer('foo', function () {}),
         }).create({
           foo: 'bar',
@@ -47,19 +48,19 @@ moduleFor(
 
     async ['@test observers should not fire after an object has been destroyed'](assert) {
       let count = 0;
-      let obj = EmberObject.extend({
+      let obj = CoreObject.extend({
         fooDidChange: observer('foo', function () {
           count++;
         }),
       }).create();
 
-      obj.set('foo', 'bar');
+      set(obj, 'foo', 'bar');
       await runLoopSettled();
 
       assert.equal(count, 1, 'observer was fired once');
 
       beginPropertyChanges();
-      obj.set('foo', 'quux');
+      set(obj, 'foo', 'quux');
       obj.destroy();
       endPropertyChanges();
       await runLoopSettled();
@@ -75,11 +76,11 @@ moduleFor(
 
       let objs = {};
 
-      let A = EmberObject.extend({
+      let A = CoreObject.extend({
         objs: objs,
         isAlive: true,
         willDestroy() {
-          this.set('isAlive', false);
+          set(this, 'isAlive', false);
         },
         bDidChange: observer('objs.b.isAlive', function () {
           shouldNotChange++;
@@ -89,11 +90,11 @@ moduleFor(
         }),
       });
 
-      let B = EmberObject.extend({
+      let B = CoreObject.extend({
         objs: objs,
         isAlive: true,
         willDestroy() {
-          this.set('isAlive', false);
+          set(this, 'isAlive', false);
         },
         aDidChange: observer('objs.a.isAlive', function () {
           shouldNotChange++;
@@ -103,11 +104,11 @@ moduleFor(
         }),
       });
 
-      let C = EmberObject.extend({
+      let C = CoreObject.extend({
         objs: objs,
         isAlive: true,
         willDestroy() {
-          this.set('isAlive', false);
+          set(this, 'isAlive', false);
         },
         aDidChange: observer('objs.a.isAlive', function () {
           shouldNotChange++;
@@ -117,7 +118,7 @@ moduleFor(
         }),
       });
 
-      let LongLivedObject = EmberObject.extend({
+      let LongLivedObject = CoreObject.extend({
         objs: objs,
         isAliveDidChange: observer('objs.a.isAlive', function () {
           shouldChange++;

--- a/packages/@ember/object/tests/es-compatibility-test.js
+++ b/packages/@ember/object/tests/es-compatibility-test.js
@@ -1,4 +1,5 @@
-import EmberObject, { computed, observer } from '@ember/object';
+import EmberObject, { computed, observer, set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import {
   defineProperty,
   on,
@@ -17,7 +18,7 @@ moduleFor(
     ['@test extending an Ember.Object'](assert) {
       let calls = [];
 
-      class MyObject extends EmberObject {
+      class MyObject extends CoreObject {
         constructor() {
           calls.push('constructor');
           super(...arguments);
@@ -54,7 +55,7 @@ moduleFor(
     ['@test normal method super'](assert) {
       let calls = [];
 
-      let Foo = class extends EmberObject {
+      let Foo = class extends CoreObject {
         method() {
           calls.push('foo');
         }
@@ -112,7 +113,7 @@ moduleFor(
     ['@test static method super'](assert) {
       let calls;
 
-      let Foo = class extends EmberObject {
+      let Foo = class extends CoreObject {
         static method() {
           calls.push('foo');
         }
@@ -176,7 +177,7 @@ moduleFor(
         property2: 'data-2',
       });
 
-      class MyObject extends EmberObject.extend(Mixin1, Mixin2) {}
+      class MyObject extends CoreObject.extend(Mixin1, Mixin2) {}
 
       let myObject = MyObject.create();
       assert.equal(myObject.property1, 'data-1', 'includes the first mixin');
@@ -184,16 +185,16 @@ moduleFor(
     }
 
     ['@test using instanceof'](assert) {
-      class MyObject extends EmberObject {}
+      class MyObject extends CoreObject {}
 
       let myObject = MyObject.create();
 
       assert.ok(myObject instanceof MyObject);
-      assert.ok(myObject instanceof EmberObject);
+      assert.ok(myObject instanceof CoreObject);
     }
 
-    ['@test using Ember.Object#detect'](assert) {
-      let Parent = class extends EmberObject {};
+    ['@test using CoreObject#detect'](assert) {
+      let Parent = class extends CoreObject {};
       class Child extends Parent {}
       let Grandchild = class extends Child {};
 
@@ -201,10 +202,10 @@ moduleFor(
       assert.ok(Child.detect(Grandchild), 'Child.detect(Grandchild)');
     }
 
-    ['@test extending an ES subclass of EmberObject'](assert) {
+    ['@test extending an ES subclass of CoreObject'](assert) {
       let calls = [];
 
-      class SubEmberObject extends EmberObject {
+      class SubCoreObject extends CoreObject {
         constructor() {
           calls.push('constructor');
           super(...arguments);
@@ -216,16 +217,16 @@ moduleFor(
         }
       }
 
-      class MyObject extends SubEmberObject {}
+      class MyObject extends SubCoreObject {}
 
       MyObject.create();
       assert.deepEqual(calls, ['constructor', 'init'], 'constructor then init called (create)');
     }
 
-    ['@test calling extend on an ES subclass of EmberObject'](assert) {
+    ['@test calling extend on an ES subclass of CoreObject'](assert) {
       let calls = [];
 
-      class SubEmberObject extends EmberObject {
+      class SubCoreObject extends CoreObject {
         constructor() {
           calls.push('before constructor');
           super(...arguments);
@@ -239,7 +240,7 @@ moduleFor(
         }
       }
 
-      let MyObject = class extends SubEmberObject {};
+      let MyObject = class extends SubCoreObject {};
 
       MyObject.create();
       assert.deepEqual(
@@ -260,10 +261,10 @@ moduleFor(
     ['@test calling metaForProperty on a native class works'](assert) {
       assert.expect(0);
 
-      class SubEmberObject extends EmberObject {}
+      class SubCoreObject extends CoreObject {}
 
       defineProperty(
-        SubEmberObject.prototype,
+        SubCoreObject.prototype,
         'foo',
         computed('foo', {
           get() {
@@ -273,7 +274,7 @@ moduleFor(
       );
 
       // able to get meta without throwing an error
-      SubEmberObject.metaForProperty('foo');
+      SubCoreObject.metaForProperty('foo');
     }
 
     '@test observes / removeObserver on / removeListener interop'(assert) {
@@ -283,7 +284,7 @@ moduleFor(
       let someEventBase = 0;
       let someEventA = 0;
       let someEventB = 0;
-      class A extends EmberObject.extend({
+      class A extends CoreObject.extend({
         fooDidChange: observer('foo', function () {
           fooDidChangeBase++;
         }),
@@ -332,7 +333,7 @@ moduleFor(
       assert.equal(someEventB, 0);
 
       let a = A.create();
-      a.set('foo', 'something');
+      set(a, 'foo', 'something');
 
       // TODO: Generator transpilation code doesn't play nice with class definitions/hoisting
       return runLoopSettled().then(async () => {
@@ -346,7 +347,7 @@ moduleFor(
         assert.equal(someEventB, 0);
 
         let b = B.create();
-        b.set('foo', 'something');
+        set(B, 'foo', 'something');
         await runLoopSettled();
 
         assert.equal(fooDidChangeBase, 1);

--- a/packages/@ember/object/tests/events_test.js
+++ b/packages/@ember/object/tests/events_test.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import Evented from '@ember/object/evented';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -11,7 +11,7 @@ moduleFor(
         count++;
       };
 
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
 
       obj.on('event!', F);
       obj.trigger('event!');
@@ -31,7 +31,7 @@ moduleFor(
         count++;
       };
 
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
 
       obj.one('event!', F);
       obj.trigger('event!');
@@ -46,7 +46,7 @@ moduleFor(
     ['@test triggering an event can have arguments'](assert) {
       let self, args;
 
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
 
       obj.on('event!', function () {
         args = [].slice.call(arguments);
@@ -63,7 +63,7 @@ moduleFor(
       let self, args;
       let count = 0;
 
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
 
       obj.one('event!', function () {
         args = [].slice.call(arguments);
@@ -87,7 +87,7 @@ moduleFor(
     ['@test binding an event can specify a different target'](assert) {
       let self, args;
 
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
       let target = {};
 
       obj.on('event!', target, function () {
@@ -110,7 +110,7 @@ moduleFor(
         count++;
       };
 
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
 
       obj.one('event!', target, 'fn');
       obj.trigger('event!');
@@ -123,7 +123,7 @@ moduleFor(
     }
 
     ['@test a listener registered with one can be removed with off'](assert) {
-      let obj = class extends EmberObject.extend(Evented) {
+      let obj = class extends CoreObject.extend(Evented) {
         F() {}
       }.create();
       let F = function () {};
@@ -140,7 +140,7 @@ moduleFor(
     }
 
     ['@test adding and removing listeners should be chainable'](assert) {
-      let obj = EmberObject.extend(Evented).create();
+      let obj = CoreObject.extend(Evented).create();
       let F = function () {};
 
       let ret = obj.on('event!', F);

--- a/packages/@ember/object/tests/mixin/merged_properties_test.js
+++ b/packages/@ember/object/tests/mixin/merged_properties_test.js
@@ -1,4 +1,5 @@
-import EmberObject, { get } from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import Mixin, { mixin } from '@ember/object/mixin';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -102,7 +103,7 @@ moduleFor(
     }
 
     ['@test mergedProperties should exist even if not explicitly set on create'](assert) {
-      let AnObj = class extends EmberObject {
+      let AnObj = class extends CoreObject {
         mergedProperties = ['options'];
         options = {
           a: 'a',
@@ -123,7 +124,7 @@ moduleFor(
     }
 
     ['@test defining mergedProperties at create time should not modify the prototype'](assert) {
-      let AnObj = class extends EmberObject {
+      let AnObj = class extends CoreObject {
         mergedProperties = ['options'];
         options = {
           a: 1,

--- a/packages/@ember/object/tests/mixin/reopen_test.js
+++ b/packages/@ember/object/tests/mixin/reopen_test.js
@@ -1,4 +1,5 @@
-import EmberObject, { get } from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import Mixin from '@ember/object/mixin';
 import { run } from '@ember/runloop';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
@@ -20,7 +21,7 @@ moduleFor(
     ['@test using reopen() and calling _super where there is not a super function does not cause infinite recursion'](
       assert
     ) {
-      let Taco = class extends EmberObject {
+      let Taco = class extends CoreObject {
         createBreakfast() {
           // There is no original createBreakfast function.
           // Calling the wrapped _super function here

--- a/packages/@ember/object/tests/reopenClass_test.js
+++ b/packages/@ember/object/tests/reopenClass_test.js
@@ -1,12 +1,12 @@
 import { get } from '@ember/object';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'system/object/reopenClass',
   class extends AbstractTestCase {
     ['@test adds new properties to subclass'](assert) {
-      let Subclass = class extends EmberObject {};
+      let Subclass = class extends CoreObject {};
       Subclass.reopenClass({
         foo() {
           return 'FOO';
@@ -19,7 +19,7 @@ moduleFor(
     }
 
     ['@test class properties inherited by subclasses'](assert) {
-      let Subclass = class extends EmberObject {};
+      let Subclass = class extends CoreObject {};
       Subclass.reopenClass({
         foo() {
           return 'FOO';

--- a/packages/@ember/object/tests/reopen_test.js
+++ b/packages/@ember/object/tests/reopen_test.js
@@ -1,4 +1,5 @@
-import EmberObject, { get } from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 // TODO: Update these tests (or the title) to match each other.
@@ -6,7 +7,7 @@ moduleFor(
   'system/core_object/reopen',
   class extends AbstractTestCase {
     ['@test adds new properties to subclass instance'](assert) {
-      let Subclass = class extends EmberObject {};
+      let Subclass = class extends CoreObject {};
       Subclass.reopen({
         foo() {
           return 'FOO';
@@ -19,7 +20,7 @@ moduleFor(
     }
 
     ['@test reopened properties inherited by subclasses'](assert) {
-      let Subclass = class extends EmberObject {};
+      let Subclass = class extends CoreObject {};
       let SubSub = class extends Subclass {};
 
       Subclass.reopen({
@@ -34,7 +35,7 @@ moduleFor(
     }
 
     ['@test allows reopening already instantiated classes'](assert) {
-      let Subclass = class extends EmberObject {};
+      let Subclass = class extends CoreObject {};
 
       Subclass.create();
 
@@ -42,7 +43,9 @@ moduleFor(
         trololol: true,
       });
 
-      assert.equal(Subclass.create().get('trololol'), true, 'reopen works');
+      let instance = Subclass.create();
+
+      assert.equal(get(instance, 'trololol'), true, 'reopen works');
     }
   }
 );

--- a/packages/@ember/object/tests/strict-mode-test.js
+++ b/packages/@ember/object/tests/strict-mode-test.js
@@ -1,11 +1,11 @@
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'strict mode tests',
   class extends AbstractTestCase {
     ['@test __superWrapper does not throw errors in strict mode'](assert) {
-      let Foo = class extends EmberObject {
+      let Foo = class extends CoreObject {
         blah() {
           return 'foo';
         }

--- a/packages/@ember/object/tests/toString_test.js
+++ b/packages/@ember/object/tests/toString_test.js
@@ -1,18 +1,18 @@
 import { guidFor, setName } from '@ember/-internals/utils';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 moduleFor(
   'system/object/toString',
   class extends AbstractTestCase {
     ['@test toString includes toStringExtension if defined'](assert) {
-      let Foo = class extends EmberObject {
+      let Foo = class extends CoreObject {
         toStringExtension() {
           return 'fooey';
         }
       };
       let foo = Foo.create();
-      let Bar = class extends EmberObject {};
+      let Bar = class extends CoreObject {};
       let bar = Bar.create();
 
       // simulate these classes being defined on a Namespace

--- a/packages/@ember/service/tests/service_test.js
+++ b/packages/@ember/service/tests/service_test.js
@@ -1,5 +1,5 @@
 import Service, { inject, service } from '@ember/service';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import {
   AbstractTestCase,
   buildOwner,
@@ -25,7 +25,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @inject('main') main;
       }
 
@@ -51,7 +51,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @inject main;
       }
 
@@ -75,7 +75,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @service('main') main;
       }
 
@@ -94,7 +94,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @service main;
       }
 

--- a/packages/@ember/service/tests/service_ts_test.ts
+++ b/packages/@ember/service/tests/service_ts_test.ts
@@ -1,5 +1,5 @@
 import Service, { inject, service } from '@ember/service';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import {
   AbstractTestCase,
   buildOwner,
@@ -25,7 +25,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @inject('main') declare main: MainService;
       }
 
@@ -51,7 +51,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @inject declare main: MainService;
       }
 
@@ -75,7 +75,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @service('main') declare main: MainService;
       }
 
@@ -94,7 +94,7 @@ moduleFor(
 
       class MainService extends Service {}
 
-      class Foo extends EmberObject {
+      class Foo extends CoreObject {
         @service declare main: MainService;
       }
 

--- a/packages/@ember/utils/tests/compare_test.js
+++ b/packages/@ember/utils/tests/compare_test.js
@@ -1,14 +1,15 @@
 import { compare, typeOf } from '@ember/utils';
-import EmberObject from '@ember/object';
+import { get } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { Comparable } from '@ember/-internals/runtime';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 let data = [];
-let Comp = EmberObject.extend(Comparable);
+let Comp = CoreObject.extend(Comparable);
 
 Comp.reopenClass({
   compare(obj) {
-    return obj.get('val');
+    return get(obj, 'val');
   },
 });
 
@@ -28,7 +29,7 @@ moduleFor(
       data[9] = [1, 2, 3];
       data[10] = [1, 3];
       data[11] = { a: 'hash' };
-      data[12] = EmberObject.create();
+      data[12] = CoreObject.create();
       data[13] = function (a) {
         return a;
       };

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -1,8 +1,9 @@
 import Route from '@ember/routing/route';
-import EmberObject, { computed } from '@ember/object';
+import { computed } from '@ember/object';
 import { A as emberA } from '@ember/array';
 
 import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+import CoreObject from '@ember/object/core';
 
 moduleFor(
   'The example renders correctly',
@@ -14,12 +15,12 @@ moduleFor(
         '<h1>People</h1><ul>{{#each @model as |person|}}<li>Hello, <b>{{person.fullName}}</b>!</li>{{/each}}</ul>'
       );
 
-      let Person = class extends EmberObject {
+      let Person = class extends CoreObject {
         firstName = null;
         lastName = null;
         @computed('firstName', 'lastName')
         get fullName() {
-          return `${this.get('firstName')} ${this.get('lastName')}`;
+          return `${this.firstName} ${this.lastName}`;
         }
       };
 

--- a/packages/ember/tests/routing/decoupled_basic_test.js
+++ b/packages/ember/tests/routing/decoupled_basic_test.js
@@ -5,7 +5,8 @@ import { compile } from 'ember-template-compiler';
 import Route from '@ember/routing/route';
 import NoneLocation from '@ember/routing/none-location';
 import HistoryLocation from '@ember/routing/history-location';
-import EmberObject, { set } from '@ember/object';
+import { set } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import {
   moduleFor,
   ApplicationTestCase,
@@ -116,7 +117,7 @@ moduleFor(
 
       let menuItem, resolve;
 
-      let MenuItem = class extends EmberObject {
+      let MenuItem = class extends CoreObject {
         static find(id) {
           menuItem = MenuItem.create({ id: id });
 
@@ -161,7 +162,7 @@ moduleFor(
         this.route('special', { path: '/specials/:menu_item_id' });
       });
 
-      let MenuItem = class extends EmberObject {
+      let MenuItem = class extends CoreObject {
         static find(id) {
           return { id: id };
         }
@@ -243,7 +244,7 @@ moduleFor(
 
       let menuItem, resolve;
 
-      let MenuItem = class extends EmberObject {
+      let MenuItem = class extends CoreObject {
         static find(id) {
           menuItem = MenuItem.create({ id: id });
           return new RSVP.Promise((res) => (resolve = res));

--- a/packages/ember/tests/routing/model_loading_test.js
+++ b/packages/ember/tests/routing/model_loading_test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A as emberA } from '@ember/array';
 import { moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
@@ -338,7 +338,7 @@ moduleFor(
         'route:special',
         class extends Route {
           model(params) {
-            return EmberObject.create({
+            return CoreObject.create({
               menuItemId: params.menu_item_id,
             });
           }
@@ -355,7 +355,7 @@ moduleFor(
     }
 
     ['@test The Specials Page defaults to looking models up via `find`']() {
-      let MenuItem = class extends EmberObject {
+      let MenuItem = class extends CoreObject {
         static find(id) {
           return MenuItem.create({ id });
         }
@@ -390,7 +390,7 @@ moduleFor(
         this.route('special', { path: '/specials/:menu_item_id' });
       });
 
-      let MenuItem = class extends EmberObject {
+      let MenuItem = class extends CoreObject {
         static find(id) {
           return MenuItem.create({ id: id });
         }
@@ -428,7 +428,7 @@ moduleFor(
       let menuItem;
       let rootElement;
 
-      let MenuItem = class extends EmberObject {
+      let MenuItem = class extends CoreObject {
         static find(id) {
           menuItem = MenuItem.create({ id: id });
           return menuItem;
@@ -828,7 +828,7 @@ moduleFor(
 
     ['@test Route model hook finds the same model as a manual find'](assert) {
       let post;
-      let Post = class extends EmberObject {
+      let Post = class extends CoreObject {
         static find() {
           post = this;
           return {};

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { dasherize } from '@ember/-internals/string';
-import EmberObject, { action, get, computed } from '@ember/object';
+import { action, get, computed } from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { RSVP } from '@ember/-internals/runtime';
 import { A as emberA } from '@ember/array';
 import { run } from '@ember/runloop';
@@ -801,7 +802,7 @@ moduleFor(
       this.add(
         'route:index',
         class extends Route {
-          queryParams = EmberObject.create({
+          queryParams = CoreObject.create({
             unknownProperty() {
               return { refreshModel: true };
             },
@@ -1012,7 +1013,7 @@ moduleFor(
       this.add(
         'route:application',
         class extends Route {
-          queryParams = EmberObject.create({
+          queryParams = CoreObject.create({
             unknownProperty(/* keyName */) {
               // We are simulating all qps requiring refresh
               return { replace: true };

--- a/packages/ember/tests/routing/template_rendering_test.js
+++ b/packages/ember/tests/routing/template_rendering_test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
-import EmberObject from '@ember/object';
+import CoreObject from '@ember/object/core';
 import { A as emberA } from '@ember/array';
 import { moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
@@ -209,7 +209,7 @@ moduleFor(
         'route:page',
         class extends Route {
           model(params) {
-            return EmberObject.create({ name: params.name });
+            return CoreObject.create({ name: params.name });
           }
         }
       );
@@ -241,7 +241,7 @@ moduleFor(
       assert.equal(insertionCount, 1, 'view should have inserted only once');
       let router = this.applicationInstance.lookup('router:main');
 
-      await run(() => router.transitionTo('page', EmberObject.create({ name: 'third' })));
+      await run(() => router.transitionTo('page', CoreObject.create({ name: 'third' })));
 
       assert.equal(getTextOf(rootElement.querySelector('p')), 'third');
       assert.equal(insertionCount, 1, 'view should still have inserted only once');


### PR DESCRIPTION
This helps move us towards a future where we don't have EmberObject.