### PR TITLE
Fix minify-assets CI comment to handle the case where a package has been removed

### DIFF
--- a/bin/minify-assets.mjs
+++ b/bin/minify-assets.mjs
@@ -67,15 +67,15 @@ let packageData = {
 };
 
 function totalMin(dataset) {
-  return dataset.reduce((a, b) => a + b[1], 0);
+  return dataset.reduce((a, b) => a + (b[1] || 0), 0);
 }
 
 function totalGz(dataset) {
-  return dataset.reduce((a, b) => a + b[2], 0);
+  return dataset.reduce((a, b) => a + (b[2] || 0), 0);
 }
 
 // function totalBr(dataset) {
-//   return dataset.reduce((a, b) => a + b[3], 0);
+//   return dataset.reduce((a, b) => a + (b[3] || 0), 0);
 // }
 
 import { buildMacros } from '@embroider/macros/babel';
@@ -196,9 +196,9 @@ printTable([
   ],
   ...packageData.ember.map((x) => [
     x[0].replace('@ember/', ''),
-    size(x[1]),
-    size(x[2]),
-    // size(x[3]),
+    size(x[1] || 0),
+    size(x[2] || 0),
+    // size(x[3] || 0),
   ]),
 ]);
 
@@ -212,8 +212,8 @@ printTable([
   ],
   ...packageData.glimmer.map((x) => [
     x[0].replace('@glimmer/', ''),
-    size(x[1]),
-    size(x[2]),
-    // size(x[3]),
+    size(x[1] || 0),
+    size(x[2] || 0),
+    // size(x[3] || 0),
   ]),
 ]);


### PR DESCRIPTION
Demo of this working on the `next` branch here:

https://github.com/NullVoxPopuli/ember.js/pull/8#issuecomment-2968723690

<!-- add-pr-comment:add-pr-comment -->

<details><summary>Estimated Asset Sizes</summary>

Diff

```diff
--- main/out.txt	2025-06-13 01:37:58.000000000 +0000
+++ pr/./pr-15624453604/out.txt	2025-06-13 01:39:10.000000000 +0000
@@ -1,39 +1,39 @@
-╔═══════╤══════════╤═══════════╗
-║       │ Min      │ Gzip      ║
-╟───────┼──────────┼───────────╢
-║ Total │ 409.3 KB │ 228.73 KB ║
-╚═══════╧══════════╧═══════════╝
+╔═══════╤═══════════╤═══════════╗
+║       │ Min       │ Gzip      ║
+╟───────┼───────────┼───────────╢
+║ Total │ 381.18 KB │ 212.27 KB ║
+╚═══════╧═══════════╧═══════════╝
 
 ╔══════════════════════╤═══════════╤═══════════╗
 ║ @ember/*             │ Min       │ Gzip      ║
 ╟──────────────────────┼───────────┼───────────╢
-║ Total                │ 239.69 KB │ 147.05 KB ║
+║ Total                │ 211.57 KB │ 130.58 KB ║
 ╟──────────────────────┼───────────┼───────────╢
-║ -internals           │ 35.92 KB  │ 25.65 KB  ║
-║ application          │ 12.83 KB  │ 7.58 KB   ║
-║ array                │ 12.66 KB  │ 7.32 KB   ║
+║ -internals           │ 28.02 KB  │ 20 KB     ║
+║ application          │ 12.34 KB  │ 7.56 KB   ║
+║ array                │ 1.38 KB   │ 1.34 KB   ║
 ║ canary-features      │ 304 B     │ 405 B     ║
-║ component            │ 1.07 KB   │ 995 B     ║
-║ controller           │ 1.8 KB    │ 1.36 KB   ║
-║ debug                │ 11.4 KB   │ 7.87 KB   ║
+║ component            │ 1.07 KB   │ 988 B     ║
+║ controller           │ 1.25 KB   │ 1.14 KB   ║
+║ debug                │ 10.98 KB  │ 7.78 KB   ║
 ║ deprecated-features  │ 31 B      │ 77 B      ║
 ║ destroyable          │ 561 B     │ 383 B     ║
-║ enumerable           │ 259 B     │ 387 B     ║
-║ helper               │ 823 B     │ 615 B     ║
+║ enumerable           │ 0 B       │ 0 B       ║
+║ helper               │ 823 B     │ 590 B     ║
 ║ instrumentation      │ 2.43 KB   │ 1.78 KB   ║
-║ modifier             │ 669 B     │ 605 B     ║
-║ object               │ 33.78 KB  │ 20.82 KB  ║
+║ modifier             │ 669 B     │ 614 B     ║
+║ object               │ 28.6 KB   │ 17.21 KB  ║
 ║ owner                │ 159 B     │ 178 B     ║
-║ renderer             │ 385 B     │ 344 B     ║
-║ routing              │ 58.05 KB  │ 33.12 KB  ║
-║ runloop              │ 2.2 KB    │ 1.41 KB   ║
-║ service              │ 859 B     │ 741 B     ║
-║ template             │ 396 B     │ 342 B     ║
+║ renderer             │ 385 B     │ 331 B     ║
+║ routing              │ 56.75 KB  │ 32.97 KB  ║
+║ runloop              │ 2.2 KB    │ 1.34 KB   ║
+║ service              │ 859 B     │ 760 B     ║
+║ template             │ 396 B     │ 343 B     ║
 ║ template-compilation │ 429 B     │ 366 B     ║
 ║ template-compiler    │ 57.81 KB  │ 30.44 KB  ║
 ║ template-factory     │ 94 B      │ 160 B     ║
 ║ test                 │ 923 B     │ 627 B     ║
-║ utils                │ 3.93 KB   │ 3.51 KB   ║
+║ utils                │ 3.17 KB   │ 3.22 KB   ║
 ║ version              │ 55 B      │ 131 B     ║
 ╚══════════════════════╧═══════════╧═══════════╝
 
@@ -46,14 +46,14 @@
 ║ encoder         │ 596 B     │ 653 B    ║
 ║ env             │ 38 B      │ 87 B     ║
 ║ global-context  │ 886 B     │ 545 B    ║
-║ manager         │ 12.19 KB  │ 5.44 KB  ║
+║ manager         │ 12.19 KB  │ 5.41 KB  ║
 ║ node            │ 2.71 KB   │ 1.81 KB  ║
 ║ opcode-compiler │ 29.89 KB  │ 13.23 KB ║
 ║ owner           │ 159 B     │ 202 B    ║
 ║ program         │ 7.1 KB    │ 3.63 KB  ║
 ║ reference       │ 5.51 KB   │ 3.18 KB  ║
 ║ runtime         │ 95.26 KB  │ 42.51 KB ║
-║ tracking        │ 989 B     │ 972 B    ║
+║ tracking        │ 989 B     │ 1003 B   ║
 ║ util            │ 3.03 KB   │ 2.29 KB  ║
 ║ validator       │ 6 KB      │ 3.72 KB  ║
 ║ vm              │ 784 B     │ 798 B    ║
```

Details

<table><thead><tr><th>This PR</th><th>main</th></tr></thead>
<tbody>
<tr><td>

```
╔═══════╤═══════════╤═══════════╗
║       │ Min       │ Gzip      ║
╟───────┼───────────┼───────────╢
║ Total │ 381.18 KB │ 212.27 KB ║
╚═══════╧═══════════╧═══════════╝

╔══════════════════════╤═══════════╤═══════════╗
║ @ember/*             │ Min       │ Gzip      ║
╟──────────────────────┼───────────┼───────────╢
║ Total                │ 211.57 KB │ 130.58 KB ║
╟──────────────────────┼───────────┼───────────╢
║ -internals           │ 28.02 KB  │ 20 KB     ║
║ application          │ 12.34 KB  │ 7.56 KB   ║
║ array                │ 1.38 KB   │ 1.34 KB   ║
║ canary-features      │ 304 B     │ 405 B     ║
║ component            │ 1.07 KB   │ 988 B     ║
║ controller           │ 1.25 KB   │ 1.14 KB   ║
║ debug                │ 10.98 KB  │ 7.78 KB   ║
║ deprecated-features  │ 31 B      │ 77 B      ║
║ destroyable          │ 561 B     │ 383 B     ║
║ enumerable           │ 0 B       │ 0 B       ║
║ helper               │ 823 B     │ 590 B     ║
║ instrumentation      │ 2.43 KB   │ 1.78 KB   ║
║ modifier             │ 669 B     │ 614 B     ║
║ object               │ 28.6 KB   │ 17.21 KB  ║
║ owner                │ 159 B     │ 178 B     ║
║ renderer             │ 385 B     │ 331 B     ║
║ routing              │ 56.75 KB  │ 32.97 KB  ║
║ runloop              │ 2.2 KB    │ 1.34 KB   ║
║ service              │ 859 B     │ 760 B     ║
║ template             │ 396 B     │ 343 B     ║
║ template-compilation │ 429 B     │ 366 B     ║
║ template-compiler    │ 57.81 KB  │ 30.44 KB  ║
║ template-factory     │ 94 B      │ 160 B     ║
║ test                 │ 923 B     │ 627 B     ║
║ utils                │ 3.17 KB   │ 3.22 KB   ║
║ version              │ 55 B      │ 131 B     ║
╚══════════════════════╧═══════════╧═══════════╝

╔═════════════════╤═══════════╤══════════╗
║ @glimmer/*      │ Min       │ Gzip     ║
╟─────────────────┼───────────┼──────────╢
║ Total           │ 169.61 KB │ 81.69 KB ║
╟─────────────────┼───────────┼──────────╢
║ destroyable     │ 2.7 KB    │ 1.35 KB  ║
║ encoder         │ 596 B     │ 653 B    ║
║ env             │ 38 B      │ 87 B     ║
║ global-context  │ 886 B     │ 545 B    ║
║ manager         │ 12.19 KB  │ 5.41 KB  ║
║ node            │ 2.71 KB   │ 1.81 KB  ║
║ opcode-compiler │ 29.89 KB  │ 13.23 KB ║
║ owner           │ 159 B     │ 202 B    ║
║ program         │ 7.1 KB    │ 3.63 KB  ║
║ reference       │ 5.51 KB   │ 3.18 KB  ║
║ runtime         │ 95.26 KB  │ 42.51 KB ║
║ tracking        │ 989 B     │ 1003 B   ║
║ util            │ 3.03 KB   │ 2.29 KB  ║
║ validator       │ 6 KB      │ 3.72 KB  ║
║ vm              │ 784 B     │ 798 B    ║
║ wire-format     │ 1.84 KB   │ 1.35 KB  ║
╚═════════════════╧═══════════╧══════════╝
```

</td><td>

```
╔═══════╤══════════╤═══════════╗
║       │ Min      │ Gzip      ║
╟───────┼──────────┼───────────╢
║ Total │ 409.3 KB │ 228.73 KB ║
╚═══════╧══════════╧═══════════╝

╔══════════════════════╤═══════════╤═══════════╗
║ @ember/*             │ Min       │ Gzip      ║
╟──────────────────────┼───────────┼───────────╢
║ Total                │ 239.69 KB │ 147.05 KB ║
╟──────────────────────┼───────────┼───────────╢
║ -internals           │ 35.92 KB  │ 25.65 KB  ║
║ application          │ 12.83 KB  │ 7.58 KB   ║
║ array                │ 12.66 KB  │ 7.32 KB   ║
║ canary-features      │ 304 B     │ 405 B     ║
║ component            │ 1.07 KB   │ 995 B     ║
║ controller           │ 1.8 KB    │ 1.36 KB   ║
║ debug                │ 11.4 KB   │ 7.87 KB   ║
║ deprecated-features  │ 31 B      │ 77 B      ║
║ destroyable          │ 561 B     │ 383 B     ║
║ enumerable           │ 259 B     │ 387 B     ║
║ helper               │ 823 B     │ 615 B     ║
║ instrumentation      │ 2.43 KB   │ 1.78 KB   ║
║ modifier             │ 669 B     │ 605 B     ║
║ object               │ 33.78 KB  │ 20.82 KB  ║
║ owner                │ 159 B     │ 178 B     ║
║ renderer             │ 385 B     │ 344 B     ║
║ routing              │ 58.05 KB  │ 33.12 KB  ║
║ runloop              │ 2.2 KB    │ 1.41 KB   ║
║ service              │ 859 B     │ 741 B     ║
║ template             │ 396 B     │ 342 B     ║
║ template-compilation │ 429 B     │ 366 B     ║
║ template-compiler    │ 57.81 KB  │ 30.44 KB  ║
║ template-factory     │ 94 B      │ 160 B     ║
║ test                 │ 923 B     │ 627 B     ║
║ utils                │ 3.93 KB   │ 3.51 KB   ║
║ version              │ 55 B      │ 131 B     ║
╚══════════════════════╧═══════════╧═══════════╝

╔═════════════════╤═══════════╤══════════╗
║ @glimmer/*      │ Min       │ Gzip     ║
╟─────────────────┼───────────┼──────────╢
║ Total           │ 169.61 KB │ 81.69 KB ║
╟─────────────────┼───────────┼──────────╢
║ destroyable     │ 2.7 KB    │ 1.35 KB  ║
║ encoder         │ 596 B     │ 653 B    ║
║ env             │ 38 B      │ 87 B     ║
║ global-context  │ 886 B     │ 545 B    ║
║ manager         │ 12.19 KB  │ 5.44 KB  ║
║ node            │ 2.71 KB   │ 1.81 KB  ║
║ opcode-compiler │ 29.89 KB  │ 13.23 KB ║
║ owner           │ 159 B     │ 202 B    ║
║ program         │ 7.1 KB    │ 3.63 KB  ║
║ reference       │ 5.51 KB   │ 3.18 KB  ║
║ runtime         │ 95.26 KB  │ 42.51 KB ║
║ tracking        │ 989 B     │ 972 B    ║
║ util            │ 3.03 KB   │ 2.29 KB  ║
║ validator       │ 6 KB      │ 3.72 KB  ║
║ vm              │ 784 B     │ 798 B    ║
║ wire-format     │ 1.84 KB   │ 1.35 KB  ║
╚═════════════════╧═══════════╧══════════╝
```

</td></tr>
</tbody></table>
</details>


And while we aren't taking the `next` branch that seriously right now, it'd be good for this script to be a bit more robust, as there are packages we want to remove eventually.