### PR TITLE
Add trustedHTML via alias/re-export of htmlSafe

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -456,7 +456,7 @@ export {
   type FunctionBasedHelper,
   type FunctionBasedHelperInstance,
 } from './lib/helper';
-export { SafeString, trustedHTML, isTrustedHTML, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export { SafeString, trustHTML, isTrustedHTML, htmlSafe, isHTMLSafe } from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -456,7 +456,14 @@ export {
   type FunctionBasedHelper,
   type FunctionBasedHelperInstance,
 } from './lib/helper';
-export { SafeString, trustHTML, isTrustedHTML, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export {
+  TrustedHTML,
+  SafeString,
+  trustHTML,
+  isTrustedHTML,
+  htmlSafe,
+  isHTMLSafe,
+} from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -456,7 +456,7 @@ export {
   type FunctionBasedHelper,
   type FunctionBasedHelperInstance,
 } from './lib/helper';
-export { SafeString, htmlSafe, isHTMLSafe } from './lib/utils/string';
+export { SafeString, trustedHTML, isTrustedHTML, htmlSafe, isHTMLSafe } from './lib/utils/string';
 export { Renderer, _resetRenderers, renderSettled } from './lib/renderer';
 export {
   getTemplate,

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -106,6 +106,39 @@ export function htmlSafe(str: string): SafeString {
 }
 
 /**
+  Use this method to indicate that a string should be rendered as HTML
+  without escaping when the string is used in a template. To say this another way,
+  strings marked with `trustedHTML` will not be HTML escaped.
+
+  A word of warning -   The `trustedHTML` method does not make the string safe;
+  it only tells the framework to treat the string as if it is safe to render
+  as HTML - that we trust its contents to be safe. If a string contains user inputs or other untrusted
+  data, you must sanitize the string before using the `trustedHTML` method.
+  Otherwise your code is vulnerable to
+  [Cross-Site Scripting](https://owasp.org/www-community/attacks/DOM_Based_XSS).
+  There are many open source sanitization libraries to choose from,
+  both for front end and server-side sanitization.
+
+  ```glimmer-js
+  import { trustedHTML } from '@ember/template';
+
+  const someTrustedOrSanitizedString = "<div>Hello!</div>"
+
+  <template>
+    {{trustedHTML someTrustedOrSanitizedString}}
+  </template>
+  ```
+
+  @method trustedHTML
+  @for @ember/template
+  @param str {String} The string to treat as trusted.
+  @static
+  @return {SafeString} A string that will not be HTML escaped by Handlebars.
+  @public
+ */
+export const trustedHTML = htmlSafe;
+
+/**
   Detects if a string was decorated using `htmlSafe`.
 
   ```javascript

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -34,7 +34,7 @@ import type { SafeString as GlimmerSafeString } from '@glimmer/runtime';
 
   @for @ember/template
   @class TrustedHTML
-  @since 4.12.0
+  @since 6.7.0
   @public
  */
 export class TrustedHTML implements GlimmerSafeString {
@@ -100,7 +100,7 @@ export class TrustedHTML implements GlimmerSafeString {
   @since 4.12.0
   @public
  */
-export class SafeString extends TrustedHTML {}
+export const SafeString = TrustedHTML;
 
 /**
   Use this method to indicate that a string should be rendered as HTML

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -101,6 +101,7 @@ export class TrustedHTML implements GlimmerSafeString {
   @public
  */
 export const SafeString = TrustedHTML;
+export type SafeString = TrustedHTML;
 
 /**
   Use this method to indicate that a string should be rendered as HTML

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -166,3 +166,24 @@ export function isHTMLSafe(str: unknown): str is SafeString {
     str !== null && typeof str === 'object' && typeof (str as SafeString).toHTML === 'function'
   );
 }
+
+/**
+  Detects if a string was decorated using `trustedHTML`.
+
+  ```javascript
+  import { trustedHTML, isHTMLSafe } from '@ember/template';
+
+  let plainString = 'plain string';
+  let safeString = trustedHTML('<div>someValue</div>');
+
+  isTrustedHTML(plainString); // false
+  isTrustedHTML(safeString);  // true
+  ```
+
+  @method isHTMLSafe
+  @for @ember/template
+  @static
+  @return {Boolean} `true` if the string was decorated with `htmlSafe`, `false` otherwise.
+  @public
+*/
+export const isTrustedHTML = isHTMLSafe;

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -108,35 +108,35 @@ export function htmlSafe(str: string): SafeString {
 /**
   Use this method to indicate that a string should be rendered as HTML
   without escaping when the string is used in a template. To say this another way,
-  strings marked with `trustedHTML` will not be HTML escaped.
+  strings marked with `trustHTML` will not be HTML escaped.
 
-  A word of warning -   The `trustedHTML` method does not make the string safe;
+  A word of warning -   The `trustHTML` method does not make the string safe;
   it only tells the framework to treat the string as if it is safe to render
   as HTML - that we trust its contents to be safe. If a string contains user inputs or other untrusted
-  data, you must sanitize the string before using the `trustedHTML` method.
+  data, you must sanitize the string before using the `trustHTML` method.
   Otherwise your code is vulnerable to
   [Cross-Site Scripting](https://owasp.org/www-community/attacks/DOM_Based_XSS).
   There are many open source sanitization libraries to choose from,
   both for front end and server-side sanitization.
 
   ```glimmer-js
-  import { trustedHTML } from '@ember/template';
+  import { trustHTML } from '@ember/template';
 
   const someTrustedOrSanitizedString = "<div>Hello!</div>"
 
   <template>
-    {{trustedHTML someTrustedOrSanitizedString}}
+    {{trustHTML someTrustedOrSanitizedString}}
   </template>
   ```
 
-  @method trustedHTML
+  @method trustHTML
   @for @ember/template
   @param str {String} The string to treat as trusted.
   @static
   @return {SafeString} A string that will not be HTML escaped by Handlebars.
   @public
  */
-export const trustedHTML = htmlSafe;
+export const trustHTML = htmlSafe;
 
 /**
   Detects if a string was decorated using `htmlSafe`.
@@ -168,13 +168,13 @@ export function isHTMLSafe(str: unknown): str is SafeString {
 }
 
 /**
-  Detects if a string was decorated using `trustedHTML`.
+  Detects if a string was decorated using `trustHTML`.
 
   ```javascript
-  import { trustedHTML, isHTMLSafe } from '@ember/template';
+  import { trustHTML, isHTMLSafe } from '@ember/template';
 
   let plainString = 'plain string';
-  let safeString = trustedHTML('<div>someValue</div>');
+  let safeString = trustHTML('<div>someValue</div>');
 
   isTrustedHTML(plainString); // false
   isTrustedHTML(safeString);  // true

--- a/packages/@ember/-internals/glimmer/lib/utils/string.ts
+++ b/packages/@ember/-internals/glimmer/lib/utils/string.ts
@@ -5,6 +5,69 @@
 import type { SafeString as GlimmerSafeString } from '@glimmer/runtime';
 
 /**
+  A wrapper around a string that has been marked as "trusted". **When
+  rendered in HTML, Ember will not perform any escaping.**
+
+  Note:
+
+  1. This does not *make* the string safe; it means that some code in your
+     application has *marked* it as trusted using the `trustHTML()` function.
+
+  2. The only public API for getting a `TrutsedHTML` is calling `trustHTML()`. It
+     is *not* user-constructible.
+
+  If a string contains user inputs or other untrusted data, you must sanitize
+  the string before using the `trustHTML` method. Otherwise your code is
+  vulnerable to [Cross-Site Scripting][xss]. There are many open source
+  sanitization libraries to choose from, both for front end and server-side
+  sanitization.
+
+  [xss]: https://owasp.org/www-community/attacks/DOM_Based_XSS
+
+  ```javascript
+  import { trustHTML } from '@ember/template';
+
+  let someTrustedOrSanitizedString = "<div>Hello!</div>"
+
+  trustHTML(someTrustedorSanitizedString);
+  ```
+
+  @for @ember/template
+  @class TrustedHTML
+  @since 4.12.0
+  @public
+ */
+export class TrustedHTML implements GlimmerSafeString {
+  private readonly __string: string;
+
+  constructor(string: string) {
+    this.__string = string;
+  }
+
+  /**
+    Get the string back to use as a string.
+
+    @public
+    @method toString
+    @returns {String} The string marked as trusted
+   */
+  toString(): string {
+    return `${this.__string}`;
+  }
+
+  /**
+    Get the wrapped string as HTML to use without escaping.
+
+    @public
+    @method toHTML
+    @returns {String} the trusted string, without any escaping applied
+   */
+  toHTML(): string {
+    return this.toString();
+  }
+}
+
+/**
   A wrapper around a string that has been marked as safe ("trusted"). **When
   rendered in HTML, Ember will not perform any escaping.**
 
@@ -37,35 +100,7 @@ import type { SafeString as GlimmerSafeString } from '@glimmer/runtime';
   @since 4.12.0
   @public
  */
-export class SafeString implements GlimmerSafeString {
-  private readonly __string: string;
-
-  constructor(string: string) {
-    this.__string = string;
-  }
-
-  /**
-    Get the string back to use as a string.
-
-    @public
-    @method toString
-    @returns {String} The string marked as trusted
-   */
-  toString(): string {
-    return `${this.__string}`;
-  }
-
-  /**
-    Get the wrapped string as HTML to use without escaping.
-
-    @public
-    @method toHTML
-    @returns {String} the trusted string, without any escaping applied
-   */
-  toHTML(): string {
-    return this.toString();
-  }
-}
+export class SafeString extends TrustedHTML {}
 
 /**
   Use this method to indicate that a string should be rendered as HTML
@@ -96,14 +131,7 @@ export class SafeString implements GlimmerSafeString {
   @return {SafeString} A string that will not be HTML escaped by Handlebars.
   @public
 */
-export function htmlSafe(str: string): SafeString {
-  if (str === null || str === undefined) {
-    str = '';
-  } else if (typeof str !== 'string') {
-    str = String(str);
-  }
-  return new SafeString(str);
-}
+export const htmlSafe = trustHTML;
 
 /**
   Use this method to indicate that a string should be rendered as HTML
@@ -133,10 +161,17 @@ export function htmlSafe(str: string): SafeString {
   @for @ember/template
   @param str {String} The string to treat as trusted.
   @static
-  @return {SafeString} A string that will not be HTML escaped by Handlebars.
+  @return {TrustedHTML} A string that will not be HTML escaped by Handlebars.
   @public
  */
-export const trustHTML = htmlSafe;
+export function trustHTML(str: string): TrustedHTML {
+  if (str === null || str === undefined) {
+    str = '';
+  } else if (typeof str !== 'string') {
+    str = String(str);
+  }
+  return new TrustedHTML(str);
+}
 
 /**
   Detects if a string was decorated using `htmlSafe`.
@@ -157,21 +192,13 @@ export const trustHTML = htmlSafe;
   @return {Boolean} `true` if the string was decorated with `htmlSafe`, `false` otherwise.
   @public
 */
-export function isHTMLSafe(str: unknown): str is SafeString {
-  return (
-    // SAFETY: cast `as SafeString` only present to make this check "legal"; we
-    // can further improve this by changing the behavior to do an `in` check
-    // instead, but that's worth landing as a separate change for bisecting if
-    // it happens to have an impact on e.g. perf.
-    str !== null && typeof str === 'object' && typeof (str as SafeString).toHTML === 'function'
-  );
-}
+export const isHTMLSafe = isTrustedHTML;
 
 /**
   Detects if a string was decorated using `trustHTML`.
 
   ```javascript
-  import { trustHTML, isHTMLSafe } from '@ember/template';
+  import { trustHTML, isTrustedHTML } from '@ember/template';
 
   let plainString = 'plain string';
   let safeString = trustHTML('<div>someValue</div>');
@@ -180,10 +207,18 @@ export function isHTMLSafe(str: unknown): str is SafeString {
   isTrustedHTML(safeString);  // true
   ```
 
-  @method isHTMLSafe
+  @method isTrustedHTML
   @for @ember/template
   @static
   @return {Boolean} `true` if the string was decorated with `htmlSafe`, `false` otherwise.
   @public
 */
-export const isTrustedHTML = isHTMLSafe;
+export function isTrustedHTML(str: unknown): str is TrustedHTML {
+  return (
+    // SAFETY: cast `as SafeString` only present to make this check "legal"; we
+    // can further improve this by changing the behavior to do an `in` check
+    // instead, but that's worth landing as a separate change for bisecting if
+    // it happens to have an impact on e.g. perf.
+    str !== null && typeof str === 'object' && typeof (str as TrustedHTML).toHTML === 'function'
+  );
+}

--- a/packages/@ember/template/index.ts
+++ b/packages/@ember/template/index.ts
@@ -6,4 +6,5 @@ export {
   htmlSafe,
   isHTMLSafe,
   type SafeString,
+  type TrustedHTML,
 } from '@ember/-internals/glimmer';

--- a/packages/@ember/template/index.ts
+++ b/packages/@ember/template/index.ts
@@ -2,7 +2,7 @@
 // value, since it should not be constructed by users.
 export {
   isTrustedHTML,
-  trustedHTML,
+  trustHTML,
   htmlSafe,
   isHTMLSafe,
   type SafeString,

--- a/packages/@ember/template/index.ts
+++ b/packages/@ember/template/index.ts
@@ -1,3 +1,9 @@
 // NOTE: this intentionally *only* exports the *type* `SafeString`, not its
 // value, since it should not be constructed by users.
-export { htmlSafe, isHTMLSafe, type SafeString } from '@ember/-internals/glimmer';
+export {
+  isTrustedHTML,
+  trustedHTML,
+  htmlSafe,
+  isHTMLSafe,
+  type SafeString,
+} from '@ember/-internals/glimmer';

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -253,6 +253,7 @@ module.exports = {
     'helper',
     'helperContainer',
     'htmlSafe',
+    'trustHTML',
     'if',
     'in-element',
     'includes',
@@ -292,6 +293,7 @@ module.exports = {
     'isFactory',
     'isFulfilled',
     'isHTMLSafe',
+    'isTrustedHTML',
     'isInteractive',
     'isNone',
     'isObject',
@@ -599,6 +601,7 @@ module.exports = {
     'Service',
     'TestAdapter',
     'Transition',
+    'TrustedHTML',
     'rsvp',
   ],
   modules: [


### PR DESCRIPTION
htmlsafe is a misleading phrase, so here we are aliasing to what we really mean: that we trust the HTML 


we should do an RFC to deprecate htmlSafe