### PR TITLE
fix: Make the inject deprecation message more understandable

### DIFF
--- a/packages/@ember/service/index.ts
+++ b/packages/@ember/service/index.ts
@@ -27,7 +27,7 @@ export function inject(
   ...args: [] | [name: string] | ElementDescriptor
 ): PropertyDecorator | DecoratorPropertyDescriptor | void {
   deprecateUntil(
-    'Importing `inject` from `@ember/service` is deprecated. Please import `service` instead.',
+    "Importing `inject` from `@ember/service` is deprecated. Please import `service` instead. This likely means that you want to find lines: `import { inject as service } from '@ember/service'` and replace them with: `import { service } from '@ember/service';`",
     DEPRECATIONS.DEPRECATE_IMPORT_INJECT
   );
 


### PR DESCRIPTION
Maybe it's just me, but looking at: `Importing `inject` from `@ember/service` is deprecated. Please import `service` instead` has few issues:

- Which file / line triggered this issue? (This would be an ideal information to have, but I guess it's not really possible?)
- What does `importing X from Y` even mean? Are we talking about ES2015 keyword? Is that some Ember internal nomenclature? Something tied to the build system itself (like import in babel config?), etc...
- What does `please import service instead` mean? Can I get an example?

I personally **love** unambiguous, easy to follow instructions that has examples of the most likely cases and are copy&pasteable.

Hence this PR.