### PR TITLE
Add a test that verifies `@model` is stable between route transitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - name: rollup
+        run: pnpm build
       - name: build
         run: pnpm vite build --mode=development
       - name: test
@@ -104,6 +106,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - name: rollup
+        run: pnpm build
       - name: build
         run: pnpm vite build --mode=${{ matrix.BUILD || 'development' }}
       - name: test

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import { Component } from '@ember/-internals/glimmer';
 import { tracked } from '@ember/-internals/metal';
 import { set } from '@ember/object';
+import GlimmerComponent from '@glimmer/component';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
 import { runTask } from '../../../../../../internal-test-helpers/lib/run';
 import { template } from '@ember/template-compiler';
@@ -413,10 +414,9 @@ moduleFor(
       });
 
       this.addComponent('foo', {
-        // TODO: use a Glimmer Component instead, since that's the requirement to make it fail
-        ComponentClass: class extends Component {
+        ComponentClass: class extends GlimmerComponent {
           willDestroy() {
-            assert.step(this.model);
+            assert.step(this.args.model);
           }
         },
       });

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -40,6 +40,14 @@ export default defineConfig(({ mode }) => {
       viteResolverBug(),
       version(),
     ],
+    resolve: {
+      alias: {
+        '@glimmer/component': resolve(
+          dirname(fileURLToPath(import.meta.url)),
+          './packages/@glimmer/component/dist/index.js'
+        ),
+      },
+    },
     optimizeDeps: { noDiscovery: true },
     publicDir: 'tests/public',
     build,


### PR DESCRIPTION


This adds a failing test for the issue mentioned in https://github.com/emberjs/ember.js/issues/18987 based on the [StackBlitz reproduction](https://stackblitz.com/edit/ember-cli-editor-output-exrpkxkg?file=app%2Ftemplates%2Fapplication.hbs) and supersedes https://github.com/emberjs/ember.js/pull/19257.

I needed to do some changes to the Vite and CI setup to make the `@glimmer/component` imports working in the test files. Not sure if what I did is the best solution but it works for the reproduction at least.