### PR TITLE
[Bugfix Beta] Fix issue with renderer's cleanup since the introduction of renderComponent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ test/tmp
 test/version_tmp
 test_*.html
 /tests/ember-tests.js
+/smoke-tests/scenarios/output/
 tmp
 tmp*.gem
 tmp.bpm

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -227,6 +227,8 @@ class ClassicRootState {
 
       let result = (this.result = iterator.sync());
 
+      associateDestroyableChild(owner, result);
+
       // override .render function after initial render
       this.render = errorLoopTransaction(() => result.rerender({ alwaysRevalidate: false }));
     });

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -648,6 +648,10 @@ export function renderComponent(
 
   let innerResult = renderer.render(component, { into, args }).result;
 
+  if (innerResult) {
+    associateDestroyableChild(owner, innerResult);
+  }
+
   let result = {
     destroy() {
       if (innerResult) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -99,6 +99,17 @@ moduleFor(
 
       assertHTML('');
     }
+
+    '@test destroy of the owner cleans up dom via destrying the test context'() {
+      let Foo = defComponent('Hello, world!');
+      let Root = defComponent('<Foo/>', { scope: { Foo } });
+
+      this.renderComponent(Root, { expect: 'Hello, world!' });
+
+      run(() => destroy(this.owner));
+
+      assertHTML('');
+    }
   }
 );
 
@@ -189,17 +200,6 @@ moduleFor(
       assertHTML('');
     }
 
-    '@test [RenderComponentTestCase] destroy cleans up dom via destrying the test context'() {
-      let Foo = defComponent('Hello, world!');
-      let Root = defComponent('<Foo/>', { scope: { Foo } });
-
-      this.renderComponent(Root, { expect: 'Hello, world!' });
-
-      run(() => destroy(this));
-
-      assertHTML('');
-    }
-
     '@test Can use a component in scope'() {
       let Foo = defComponent('Hello, world!');
       let Root = defComponent('<Foo/>', { scope: { Foo } });
@@ -240,6 +240,24 @@ moduleFor(
       let Root = defComponent('{{if true "foo" "bar"}}{{unless true "foo" "bar"}}');
 
       this.renderComponent(Root, { expect: 'foobar' });
+    }
+
+    '@test multiple components have independent lifetimes'() {
+      class State {
+        @tracked showSecond = true;
+      }
+      let state = new State();
+      let Foo = defComponent('Hello, world!');
+      let Root = defComponent('<Foo />{{#if state.showSecond}}<Foo />{{/if}}', {
+        scope: { state, Foo },
+      });
+
+      this.renderComponent(Root, { expect: 'Hello, world!Hello, world!' });
+
+      this.assertChange({
+        change: () => (state.showSecond = false),
+        expect: 'Hello, world!<!---->',
+      });
     }
 
     '@test Can use a dynamic component definition'() {

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -110,7 +110,7 @@ function basicTest(scenarios: Scenarios, appName: string) {
               import { module, test } from 'qunit';
               import { clearRender, render } from '@ember/test-helpers';
               import { setupRenderingTest } from 'ember-qunit';
-              import { registerDestructor } from '@ember/destroyable';
+              import { destroy, registerDestructor } from '@ember/destroyable';
 
               import Component from '@glimmer/component';
 
@@ -158,6 +158,8 @@ function basicTest(scenarios: Scenarios, appName: string) {
                     await render(
                       <template><WillDestroy @onDestroy={{onDestroy}} /></template>
                     );
+
+                    destroy(this.owner);
                   });
                 });
 

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -172,7 +172,7 @@ function basicTest(scenarios: Scenarios, appName: string) {
                 });
 
                 test('it calls "registerDestructor"', async function (assert) {
-                  const onDestroy = () => assert.step('WillDestroy destroyed');
+                  const onDestroy = () => assert.step('destroyed');
 
                   await render(<template><Destructor @onDestroy={{onDestroy}} /></template>);
 

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -106,6 +106,37 @@ function basicTest(scenarios: Scenarios, appName: string) {
             `,
           },
           integration: {
+            'destruction-test.gjs': `
+              import { module, test } from 'qunit';
+              import { render } from '@ember/test-helpers';
+              import { setupRenderingTest } from 'ember-qunit';
+
+              import Component from '@glimmer/component';
+
+              class Dropdown extends Component {
+                willDestroy() {
+                  super.willDestroy();
+                  this.args.onDestroy();
+                }
+              }
+
+
+              module('Integration | Component | dropdown', function (hooks) {
+                setupRenderingTest(hooks);
+
+                hooks.after(function (assert) {
+                  assert.verifySteps(['Dropdown destroyed']);
+                });
+
+                test('it calls "@onDestroy"', async function (assert) {
+                  const onDropdownDestroy = () => assert.step('Dropdown destroyed');
+
+                  await render(
+                    <template><Dropdown @onDestroy={{onDropdownDestroy}} /></template>,
+                  );
+                });
+              });
+            `,
             'interactive-example-test.js': `
               import { module, test } from 'qunit';
               import { setupRenderingTest } from 'ember-qunit';


### PR DESCRIPTION
From: https://github.com/bertdeblock/failing-ember-beta-test

Very surprised our existing tests didn't catch this


It turns out we haven't been doing much owner-linked destruction testing.

If folks use clearRender, things work great.
The issue is that if the owner is destroyed, we want everything used with the owner to also be destroyed -- and somehow this linkage got missed during the renderComponent work.


Implementation PR, for reference: https://github.com/emberjs/ember.js/pull/20962