### PR TITLE
Drop installation of `ember-cli-htmlbars-inline-precompile` from blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Ember Changelog
 
-## v6.7.0-beta.1 (July 21, 2025)
+## v6.7.0 (September  1, 2025)
 
 - [#20939](https://github.com/emberjs/ember.js/pull/20939) [ENHANCEMENT] Add `import { trustHTML } from '@ember/template';` as an alias of `import { htmlSafe } from '@ember/template', for naming that better matches the behavior.
 - [#20941](https://github.com/emberjs/ember.js/pull/20941) [CLEANUP] Remove code from `deprecate-array-prototype-extensions` deprecation that was until 6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Ember Changelog
 
+## v6.7.0-beta.1 (July 21, 2025)
+
+- [#20939](https://github.com/emberjs/ember.js/pull/20939) [ENHANCEMENT] Add `import { trustHTML } from '@ember/template';` as an alias of `import { htmlSafe } from '@ember/template', for naming that better matches the behavior.
+- [#20941](https://github.com/emberjs/ember.js/pull/20941) [CLEANUP] Remove code from `deprecate-array-prototype-extensions` deprecation that was until 6.0
+- [#20920](https://github.com/emberjs/ember.js/pull/20920) / [#20922](https://github.com/emberjs/ember.js/pull/20922) [INTERNAL] Remove many uses of `.extend`
+- [#20926](https://github.com/emberjs/ember.js/pull/20926) [INTERNAL] Remove all view mixins
+
 ## v6.6.0 (July 21, 2025)
 
 - [#20627](https://github.com/emberjs/ember.js/pull/20627) [CLEANUP] Remove `escapeExpression` from `@ember/template`

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
-const isPackageMissing = require('ember-cli-is-package-missing');
 const getPathOption = require('ember-cli-get-component-path-option');
 const semver = require('semver');
 
@@ -141,18 +140,5 @@ module.exports = {
     }
 
     return false;
-  },
-
-  afterInstall: function (options) {
-    if (
-      !options.dryRun &&
-      options.testType === 'integration' &&
-      !this._useNamedHbsImport() &&
-      isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')
-    ) {
-      return this.addPackagesToProject([
-        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' },
-      ]);
-    }
   },
 };

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const isPackageMissing = require('ember-cli-is-package-missing');
 const semver = require('semver');
 
 const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
@@ -49,17 +48,5 @@ module.exports = {
     }
 
     return false;
-  },
-
-  afterInstall: function (options) {
-    if (
-      !options.dryRun &&
-      !this._useNamedHbsImport() &&
-      isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')
-    ) {
-      return this.addPackagesToProject([
-        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' },
-      ]);
-    }
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "6.7.0-alpha.1",
+  "version": "6.7.0-beta.1",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "6.7.0-beta.1",
+  "version": "6.7.0",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
`ember-cli-htmlbars-inline-precompile` shouldn't be required any more.

Part of the work required for https://github.com/ember-cli/ember-cli/issues/10814

---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/).