### PR TITLE
[BUGFIX beta] Drop ember-cli-htmlbars-inline-precompile from component-test blueprint

### DIFF
--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
-const isPackageMissing = require('ember-cli-is-package-missing');
 const getPathOption = require('ember-cli-get-component-path-option');
 const semver = require('semver');
 
@@ -141,18 +140,5 @@ module.exports = {
     }
 
     return false;
-  },
-
-  afterInstall: function (options) {
-    if (
-      !options.dryRun &&
-      options.testType === 'integration' &&
-      !this._useNamedHbsImport() &&
-      isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')
-    ) {
-      return this.addPackagesToProject([
-        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' },
-      ]);
-    }
   },
 };

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const isPackageMissing = require('ember-cli-is-package-missing');
 const semver = require('semver');
 
 const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
@@ -49,17 +48,5 @@ module.exports = {
     }
 
     return false;
-  },
-
-  afterInstall: function (options) {
-    if (
-      !options.dryRun &&
-      !this._useNamedHbsImport() &&
-      isPackageMissing(this, 'ember-cli-htmlbars-inline-precompile')
-    ) {
-      return this.addPackagesToProject([
-        { name: 'ember-cli-htmlbars-inline-precompile', target: '^0.3.1' },
-      ]);
-    }
   },
 };


### PR DESCRIPTION
Closes https://github.com/emberjs/ember.js/pull/20983

I asked Florian to target the oldest branch that it applies to but we don't do it that way in ember-source 🙈 sorry for the confusion

@kategengler this needs to be backported to all active versions, at least to beta so I can fix the tutorial 👍 