### PR TITLE
[BUGFIX] renderComponent error: 'attempted to close a tracking frame, but one was not open'

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -632,7 +632,7 @@ export function renderComponent(
     env && 'document' in env
       ? (env?.['document'] as SimpleDocument | Document)
       : globalThis.document;
-  
+
   // Reuse renderer per owner to avoid creating multiple EvaluationContexts
   // which can cause tracking frame conflicts
   let renderer = RENDERER_CACHE.get(owner);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -656,7 +656,9 @@ moduleFor(
       );
 
       this.renderComponent(Root, {
-        expect: [`<div id="a">hi:a</div><br>`, `<div id="b">hi:b</div>`, ``, ``].join('\n'),
+        expect: [`<div id="a">a:Hi: THERE</div><br>`, `<div id="b">b:Hi: THERE</div>`, ``, ``].join(
+          '\n'
+        ),
       });
 
       run(() => destroy(this));

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -632,6 +632,37 @@ moduleFor(
         this.renderComponent(Root, { expect: '' });
       }, /but that value was not in scope: a-helper/);
     }
+
+    '@test rendering multiple times to adjacent elements'(assert: Assert) {
+      this.owner.register('helper:a-helper', (str: string) => str.toUpperCase());
+      let Loose = defineComponent(null, `Hi: {{a-helper "there"}}`);
+      let get = (id) => this.element.querySelector(id);
+      function render(Comp: GlimmerishComponent, id: string, owner: Owner) {
+        renderComponent(Comp, {
+          into: get(`#${id}`),
+          owner,
+        });
+      }
+      let A = defComponent('a:<Loose />', { scope: { Loose } });
+      let B = defComponent('b:<Loose />', { scope: { Loose } });
+      let Root = defComponent(
+        [
+          `<div id="a"></div><br>`,
+          `<div id="b"></div>`,
+          `{{render A 'a' owner}}`,
+          `{{render B 'b' owner}}`,
+        ].join('\n'),
+        { scope: { render, A, B, owner: this.owner } }
+      );
+
+      this.renderComponent(Root, {
+        expect: [`<div id="a">hi:a</div><br>`, `<div id="b">hi:b</div>`, ``, ``].join('\n'),
+      });
+
+      run(() => destroy(this));
+
+      assertHTML('');
+    }
   }
 );
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -604,6 +604,39 @@ moduleFor(
         expect: '<div data-one="">3</div><div data-two="">3</div>',
       });
     }
+
+    '@test rendering multiple times to adjacent elements'() {
+      let aHelper = (str: string) => str.toUpperCase();
+      let Child = defComponent(`Hi: {{aHelper "there"}}`, { scope: { aHelper } });
+      let get = (id: string) => this.element.querySelector(id);
+      function render(Comp: GlimmerishComponent, id: string, owner: Owner) {
+        renderComponent(Comp, {
+          into: get(`#${id}`)!,
+          owner,
+        });
+      }
+      let A = defComponent('a:<Child />', { scope: { Child } });
+      let B = defComponent('b:<Child />', { scope: { Child } });
+      let Root = defComponent(
+        [
+          `<div id="a"></div><br>`,
+          `<div id="b"></div>`,
+          `{{render A 'a' owner}}`,
+          `{{render B 'b' owner}}`,
+        ].join('\n'),
+        { scope: { render, A, B, owner: this.owner } }
+      );
+
+      this.renderComponent(Root, {
+        expect: [`<div id="a">a:Hi: THERE</div><br>`, `<div id="b">b:Hi: THERE</div>`, ``, ``].join(
+          '\n'
+        ),
+      });
+
+      run(() => destroy(this));
+
+      assertHTML('');
+    }
   }
 );
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -666,13 +666,13 @@ moduleFor(
       }, /but that value was not in scope: a-helper/);
     }
 
-    '@test rendering multiple times to adjacent elements'(assert: Assert) {
+    '@test rendering multiple times to adjacent elements'() {
       this.owner.register('helper:a-helper', (str: string) => str.toUpperCase());
       let Loose = defineComponent(null, `Hi: {{a-helper "there"}}`);
-      let get = (id) => this.element.querySelector(id);
+      let get = (id: string) => this.element.querySelector(id);
       function render(Comp: GlimmerishComponent, id: string, owner: Owner) {
         renderComponent(Comp, {
-          into: get(`#${id}`),
+          into: get(`#${id}`)!,
           owner,
         });
       }


### PR DESCRIPTION
This happens when:
- renderComponent is called twice, sequentially
- the renderedComponent calls another component
- and the rendered component calls a helper
- the owner is passed to renderComponent

these 4 things are required to reproduce the error
- not passing the owner results in a passing test
- not invoking a child component results in a passing test
- not invoking a helper results in a passing test