### PR TITLE
[BUGFIX] renderComponent error: 'Cannot read property of undefined: reading syscall'

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -637,6 +637,51 @@ moduleFor(
 
       assertHTML('');
     }
+
+    async '@test async rendering multiple times to adjacent elements'() {
+      let Child = defComponent(`Hi`, { scope: {} });
+      let get = (id: string) => this.element.querySelector(id);
+      let promises: Promise<unknown>[] = [];
+
+      function render(Comp: GlimmerishComponent, id: string, owner: Owner) {
+        let promise = (async () => {
+          await Promise.resolve();
+          let element = get(`#${id}`);
+
+          renderComponent(Comp, {
+            into: element!,
+            owner,
+          });
+        })();
+
+        promises.push(promise);
+
+        return;
+      }
+      let A = defComponent('a:<Child />', { scope: { Child } });
+      let B = defComponent('b:<Child />', { scope: { Child } });
+      let Root = defComponent(
+        [
+          `<div id="a"></div><br>`,
+          `<div id="b"></div>`,
+          `{{render A 'a' owner}}`,
+          `{{render B 'b' owner}}`,
+        ].join('\n'),
+        { scope: { render, A, B, owner: this.owner } }
+      );
+
+      this.renderComponent(Root, {
+        expect: [`<div id="a"></div><br>`, `<div id="b"></div>`, ``, ``].join('\n'),
+      });
+
+      await Promise.all(promises);
+
+      assertHTML([`<div id="a">a:Hi</div><br>`, `<div id="b">b:Hi</div>`, ``, ``].join('\n'));
+
+      run(() => destroy(this));
+
+      assertHTML('');
+    }
   }
 );
 

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -9,7 +9,6 @@ import type {
   HandleResult,
   HighLevelOp,
   LayoutWithContext,
-  Nullable,
   SerializedBlock,
   SerializedInlineBlock,
   Statement,
@@ -37,7 +36,7 @@ class CompilableTemplateImpl<S extends SymbolTable> implements CompilableTemplat
     }
   }
 
-  compiled: Nullable<HandleResult> = null;
+  compiled: WeakMap<EvaluationContext, HandleResult> = new WeakMap();
 
   constructor(
     readonly statements: WireFormat.Statement[],
@@ -70,14 +69,16 @@ function maybeCompile(
   compilable: CompilableTemplateImpl<SymbolTable>,
   context: EvaluationContext
 ): HandleResult {
-  if (compilable.compiled !== null) return compilable.compiled;
+  if (compilable.compiled.has(context)) {
+    return compilable.compiled.get(context) as HandleResult;
+  }
 
-  compilable.compiled = PLACEHOLDER_HANDLE;
+  compilable.compiled.set(context, PLACEHOLDER_HANDLE);
 
   let { statements, meta } = compilable;
 
   let result = compileStatements(statements, meta, context);
-  compilable.compiled = result;
+  compilable.compiled.set(context, result);
 
   return result;
 }


### PR DESCRIPTION
Similar to: https://github.com/emberjs/ember.js/pull/20995

but maybe more representative of real-world usage (renderComponent called from a modifier, or external library, etc).

When the owner is passed to renderComponent, and renderComponent is called multiple times, we get this error:
```
Error occurred:

- While rendering:
  {ROOT}
    (unknown template-only component)

index.js:122 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'syscall')
    at Object.evaluate (index.js:122:17)
    at LowLevelVM.evaluateSyscall (index.js:2900:20)
    at LowLevelVM.evaluateInner (index.js:2879:64)
    at LowLevelVM.evaluateOuter (index.js:2876:10)
    at VM.next (index.js:4194:45)
    at VM._execute (index.js:4184:21)
    at VM.execute (index.js:4164:26)
    at index.js:4221:76
    at debug.runInTrackingTransaction (index.js:42:19)
    at TemplateIteratorImpl.sync (index.js:4221:37)
```


