### PR TITLE
[BUGFIX release]: don't render if we're mid-destroy

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -10,6 +10,7 @@ import {
   associateDestroyableChild,
   destroy,
   isDestroyed,
+  isDestroying,
   registerDestructor,
 } from '@glimmer/destroyable';
 import { DEBUG } from '@glimmer/env';
@@ -158,8 +159,13 @@ class ComponentRootState {
 
       associateDestroyableChild(this, this.#result);
 
-      // override .render function after initial render
-      this.#render = errorLoopTransaction(() => result.rerender({ alwaysRevalidate: false }));
+      this.#render = errorLoopTransaction(() => {
+        if (isDestroying(result) || isDestroying(result)) return;
+
+        return result.rerender({
+          alwaysRevalidate: false,
+        });
+      });
     });
   }
 
@@ -228,8 +234,13 @@ class ClassicRootState {
 
       associateDestroyableChild(owner, result);
 
-      // override .render function after initial render
-      this.render = errorLoopTransaction(() => result.rerender({ alwaysRevalidate: false }));
+      this.render = errorLoopTransaction(() => {
+        if (isDestroying(result) || isDestroying(result)) return;
+
+        return result.rerender({
+          alwaysRevalidate: false,
+        });
+      });
     });
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -501,7 +501,7 @@ moduleFor(
        *
        *
        * NOTE: for this verify-steps, we only expect foo:3 once, because the first
-       *       incartaion of renderComponent (back when foo was 2) will not run again, due
+       *       incarnation of renderComponent (back when foo was 2) will not run again, due
        *       to being destroyed.
        */
       assert.verifySteps([`render:root`, `foo:3`]);

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -498,11 +498,21 @@ moduleFor(
        * https://github.com/emberjs/rfcs/pull/1099/files#diff-2b962105b9083ca84579cdc957f27f49407440f3c5078083fa369ec18cc46da8R365
        *
        * We could later add an option to not do this behavior
+       *
+       *
+       * NOTE: for this verify-steps, we only expect foo:3 once, because the first
+       *       incartaion of renderComponent (back when foo was 2) will not run again, due
+       *       to being destroyed.
        */
-      assert.verifySteps(
-        [`render:root`, `foo:3`, `foo:3`],
-        `Destruction is async, so we get an extra 'foo:3' here, and then because our getter consumes foo (since renderComponent is eager), we dirty the cached getter, and re-run the getter, creating a new renderComponent call, overwriting the existing contents`
-      );
+      assert.verifySteps([`render:root`, `foo:3`]);
+
+      assert.strictEqual(this.element.innerHTML, '<div>3 <button>++</button></div>');
+
+      run(() => {
+        destroy(this.owner);
+      });
+
+      assert.strictEqual(this.element.innerHTML, '');
     }
 
     '@test multiple renderComponents share reactivity'() {


### PR DESCRIPTION
This change fixes an issue discovered by @btecu:
- https://github.com/btecu/ember-select/pull/100


```
not ok 17 Chrome 142.0 - [73 ms] - Integration | Component | x-select: it works with multiple components on the same page
    ---
        stack: >
            Error: Attempted to associate a destroyable child with an object that is already destroying or destroyed
                at associateDestroyableChild (http://localhost:7357/assets/app-CDeM15aH.js:1776:35)
                at TryOpcode.handleException (http://localhost:7357/assets/app-CDeM15aH.js:28359:5)
                at UpdatingVMFrame.handleException (http://localhost:7357/assets/app-CDeM15aH.js:28498:52)
                at UpdatingVM.throw (http://localhost:7357/assets/app-CDeM15aH.js:28320:16)
                at Assert.evaluate (http://localhost:7357/assets/app-CDeM15aH.js:25538:42)
                at UpdatingVM._execute (http://localhost:7357/assets/app-CDeM15aH.js:28307:34)
                at http://localhost:7357/assets/app-CDeM15aH.js:28290:51
                at debug.runInTrackingTransaction (http://localhost:7357/assets/app-CDeM15aH.js:2413:19)
                at UpdatingVM.execute (http://localhost:7357/assets/app-CDeM15aH.js:28290:15)
                at RenderResultImpl.rerender (http://localhost:7357/assets/app-CDeM15aH.js:28516:8)
```

This would only happen in Chome and would not occur in FireFox -- but given the nature of the error message, I figure it _is_ a problem that could show up anywhere -- we don't want our renderer to double-associate destroyable children.


--------------------

I tested this change out locally on that PR and the tests pass.


An existing test started failing with this change, but I think the behavior may have been wrong.

It was a new test with the renderComponent stuff, and I've adjusted it (and the comment) to be more clear as to what I now expect.


--------------

This fix is _unrelated_ to:
- https://github.com/emberjs/ember.js/issues/20984