### PR TITLE
[BUGFIX beta] Align EmberArray.reduce with native semantics, related with issue #21005.

### DIFF
--- a/packages/@ember/-internals/runtime/tests/array/reduce-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/reduce-test.js
@@ -8,6 +8,12 @@ class ReduceTests extends AbstractTestCase {
     this.assert.equal(res, 6);
   }
 
+  '@test uses the first item as the initial accumulator when not provided'() {
+    let obj = this.newObject([1, 2, 3]);
+    let res = obj.reduce((previousValue, item) => previousValue + item);
+    this.assert.equal(res, 6);
+  }
+
   '@test passes index of item to callback'() {
     let obj = this.newObject([1, 2, 3]);
     let res = obj.reduce((previousValue, item, index) => previousValue + index, 0);
@@ -18,6 +24,15 @@ class ReduceTests extends AbstractTestCase {
     let obj = this.newObject([1, 2, 3]);
     let res = obj.reduce((previousValue, item, index, enumerable) => enumerable, 0);
     this.assert.equal(res, obj);
+  }
+
+  '@test throws when called on an empty array without an initial value'() {
+    let obj = this.newObject([]);
+
+    this.assert.throws(
+      () => obj.reduce(() => 0),
+      /Reduce of empty array with no initial value/
+    );
   }
 }
 

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1380,19 +1380,32 @@ const EmberArray = Mixin.create(Enumerable, {
     return any(this, callback);
   },
 
-  // FIXME: When called without initialValue, behavior does not match native behavior
   reduce<T, V>(
     this: EmberArray<T>,
     callback: (summation: V, current: T, index: number, arr: EmberArray<T>) => V,
-    initialValue: V
+    initialValue?: V
   ) {
     assert('`reduce` expects a function as first argument.', typeof callback === 'function');
 
-    let ret = initialValue;
+    let length = this.length;
+    let startIndex = 0;
+    let ret: V;
 
-    this.forEach(function (item, i) {
-      ret = callback(ret, item, i, this);
-    }, this);
+    if (arguments.length > 1) {
+      ret = initialValue as V;
+    } else {
+      if (length === 0) {
+        throw new TypeError('Reduce of empty array with no initial value');
+      }
+
+      ret = objectAt(this, 0) as unknown as V;
+      startIndex = 1;
+    }
+
+    for (let index = startIndex; index < length; index++) {
+      let item = objectAt(this, index) as T;
+      ret = callback(ret, item, index, this);
+    }
 
     return ret;
   },


### PR DESCRIPTION
 ## Summary

  - Fixes EmberArray.prototype.reduce so it behaves like native Array.prototype.reduce when initialValue is omitted.
  - Adds regression coverage for both the implicit‐initial scenario and the empty-array TypeError.

  ## Customer Impact / Use Case

  Apps relying on EmberArray.reduce without an explicit initialValue currently get undefined as the first accumulator and never see
  the expected TypeError on empty collections, yielding incorrect results and masking bugs.

  ## Implementation Details

  - Detect whether initialValue was provided (arguments.length > 1), seed the accumulator accordingly, and reuse objectAt to keep proxy support intact.
  - Throw TypeError('Reduce of empty array with no initial value') when the array is empty and no seed is passed.
  - Extend packages/@ember/-internals/runtime/tests/array/reduce-test.js with two new tests covering these code paths across every helper used in runArrayTests.
  
  ## Tests

All unit tests passed after modification.
<img width="1125" height="169" alt="Captura de tela 2025-11-16 073436" src="https://github.com/user-attachments/assets/dab2415e-6c9f-4494-819a-0c04c5c5b3e8" />
