### PR TITLE
Fix NaN handling in compare() function

### DIFF
--- a/packages/@ember/utils/lib/compare.ts
+++ b/packages/@ember/utils/lib/compare.ts
@@ -40,6 +40,20 @@ type Compare = -1 | 0 | 1;
 //                                `._________`-.   `.   `.___
 //                                              SSt  `------'`
 function spaceship(a: number, b: number): Compare {
+  // Handle NaN cases explicitly to ensure we always return -1, 0, or 1
+  const aIsNaN = Number.isNaN(a);
+  const bIsNaN = Number.isNaN(b);
+
+  if (aIsNaN && bIsNaN) {
+    return 0; // NaN === NaN for ordering purposes
+  }
+  if (aIsNaN) {
+    return -1; // NaN < any number
+  }
+  if (bIsNaN) {
+    return 1; // any number > NaN
+  }
+
   // SAFETY: `Math.sign` always returns `-1` for negative, `0` for zero, and `1`
   // for positive numbers. (The extra precision is useful for the way we use
   // this in the context of `compare`.)

--- a/packages/@ember/utils/tests/compare_test.js
+++ b/packages/@ember/utils/tests/compare_test.js
@@ -84,5 +84,20 @@ moduleFor(
       assert.equal(compare('b', zero), 0, 'Second item comparable - returns  0 (negated)');
       assert.equal(compare('c', one), -1, 'Second item comparable - returns  1 (negated)');
     }
+
+    ['@test NaN handling'](assert) {
+      assert.equal(compare(NaN, NaN), 0, 'NaN should equal NaN for ordering');
+      assert.equal(compare(NaN, 0), -1, 'NaN should be less than 0');
+      assert.equal(compare(NaN, 5), -1, 'NaN should be less than positive numbers');
+      assert.equal(compare(NaN, -5), -1, 'NaN should be less than negative numbers');
+      assert.equal(compare(NaN, Infinity), -1, 'NaN should be less than Infinity');
+      assert.equal(compare(NaN, -Infinity), -1, 'NaN should be less than -Infinity');
+
+      assert.equal(compare(0, NaN), 1, '0 should be greater than NaN');
+      assert.equal(compare(5, NaN), 1, 'positive numbers should be greater than NaN');
+      assert.equal(compare(-5, NaN), 1, 'negative numbers should be greater than NaN');
+      assert.equal(compare(Infinity, NaN), 1, 'Infinity should be greater than NaN');
+      assert.equal(compare(-Infinity, NaN), 1, '-Infinity should be greater than NaN');
+    }
   }
 );

--- a/packages/@ember/utils/tests/compare_test.js
+++ b/packages/@ember/utils/tests/compare_test.js
@@ -99,5 +99,17 @@ moduleFor(
       assert.equal(compare(Infinity, NaN), 1, 'Infinity should be greater than NaN');
       assert.equal(compare(-Infinity, NaN), 1, '-Infinity should be greater than NaN');
     }
+
+    ['@test sort with compare'](assert) {
+      let arr = [NaN, 10, -5, 0, NaN, 5];
+      arr.sort(compare);
+
+      assert.ok(Number.isNaN(arr[0]), 'index 0 is NaN');
+      assert.ok(Number.isNaN(arr[1]), 'index 1 is NaN');
+      assert.equal(arr[2], -5, 'index 2 is -5');
+      assert.equal(arr[3], 0, 'index 3 is 0');
+      assert.equal(arr[4], 5, 'index 4 is 5');
+      assert.equal(arr[5], 10, 'index 5 is 10');
+    }
   }
 );


### PR DESCRIPTION
- Add explicit NaN checks in spaceship helper to ensure it always returns -1, 0, or 1
- Treat NaN as less than all other numbers and equal to itself for ordering
- Add comprehensive test coverage for NaN edge cases
- Fixes potential runtime errors from unexpected NaN return values
#21016 
