### PR TITLE
Re-activate linting

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      # Temporarily disabled to see the later parts of CI
-      # - name: linting
-      # run: pnpm lint
+      - name: linting
+        run: pnpm lint
       - id: set-matrix
         working-directory: smoke-tests/scenarios
         run: |
@@ -40,10 +39,10 @@ jobs:
   types-range:
     name: Type Checking (other supported versions)
     runs-on: ubuntu-latest
-    needs: [ 'types' ]
+    needs: ["types"]
     strategy:
       matrix:
-        ts-version: [ '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9' ]
+        ts-version: ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -70,7 +69,7 @@ jobs:
   variant-tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [ basic-test, lint, types ]
+    needs: [basic-test, lint, types]
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +109,7 @@ jobs:
   browserstack-test:
     name: Browserstack Tests (Safari, Edge)
     runs-on: ubuntu-latest
-    needs: [ basic-test, lint, types ]
+    needs: [basic-test, lint, types]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,11 @@ export default [
       'glimmer-vm/repo-metadata/',
       'glimmer-vm/**/rollup.config.mjs',
       'glimmer-vm/packages/@glimmer/vm-babel-plugins/',
+      'glimmer-vm/bin/**',
+      'glimmer-vm/guides/**',
+      'glimmer-vm/benchmark/**',
+      'glimmer-vm/*.{js,ts}',
+      'packages/@glimmer-workspace/**',
     ],
   },
   pluginJs.configs.recommended,
@@ -284,6 +289,210 @@ export default [
       globals: {
         ...globals.qunit,
       },
+    },
+  },
+
+  ...tseslint.configs.recommendedTypeChecked.map((config) => {
+    return {
+      ...config,
+      files: ['packages/@glimmer/**/*.ts'],
+    };
+  }),
+  {
+    files: ['packages/@glimmer/**/*.{ts,js}'],
+    rules: {
+      'ember-internal/require-yuidoc-access': 'off',
+      'ember-internal/no-const-outside-module-scope': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/**/*.ts'],
+    rules: {
+      'prefer-const': 'off',
+      'qunit/no-conditional-assertions': 'off',
+      'disable-features/disable-generator-functions': 'off',
+      '@typescript-eslint/no-deprecated': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/restrict-plus-operands': 'error',
+      '@typescript-eslint/no-unnecessary-type-arguments': 'error',
+      '@typescript-eslint/naming-convention': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/no-confusing-void-expression': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
+    },
+  },
+  {
+    files: ['packages/@glimmer/constants/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/global-context/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/component/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-declaration-merging': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/debug/**/*.ts'],
+    rules: {
+      'no-fallthrough': 'off',
+      'no-implicit-coercion': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/debug-util/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-extraneous-class': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/local-debug-flags/**/*.ts'],
+    rules: {
+      'no-implicit-coercion': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/interfaces/**/*.ts'],
+    rules: {
+      'import/export': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/encoder/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/vm/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/compiler/**/*.ts'],
+    rules: {
+      'no-implicit-coercion': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/opcode-compiler/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/destroyable/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/reference/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/manager/**/*.ts'],
+    rules: {
+      'no-implicit-coercion': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/node/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/runtime/**/*.ts'],
+    rules: {
+      'no-implicit-coercion': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/validator/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-deprecated': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/syntax/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-function-type': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/wire-format/**/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-function-type': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+    },
+  },
+  {
+    files: ['packages/@glimmer/**/test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-function-type': 'off',
+      '@typescript-eslint/no-unnecessary-type-arguments': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/naming-convention': 'off',
     },
   },
 ];

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -984,8 +984,8 @@ moduleFor(
 class LazyObject {
   value = 123;
 
+  // eslint-disable-next-line no-dupe-class-members
   @computed('_value')
-   
   get value() {
     return get(this, '_value');
   }

--- a/packages/@ember/-internals/metal/tests/computed_test.js
+++ b/packages/@ember/-internals/metal/tests/computed_test.js
@@ -985,7 +985,7 @@ class LazyObject {
   value = 123;
 
   @computed('_value')
-  // eslint-disable-next-line no-dupe-class-members
+   
   get value() {
     return get(this, '_value');
   }

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -16,7 +16,6 @@ import { LOCAL_LOGGER } from '@glimmer/util';
 import pass0 from './passes/1-normalization/index';
 import { visit as pass2 } from './passes/2-encoding/index';
 
-// eslint-disable-next-line unused-imports/no-unused-vars
 declare function require(id: 'crypto'): Crypto;
 declare function require(id: string): unknown;
 

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/README.md
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/README.md
@@ -1,4 +1,4 @@
 ---
-noteId: "a5195d00ecb511eaa450939780d4843d"
+noteId: 'a5195d00ecb511eaa450939780d4843d'
 tags: []
 ---

--- a/packages/@glimmer/debug-util/test/debug-to-string-test.ts
+++ b/packages/@glimmer/debug-util/test/debug-to-string-test.ts
@@ -56,7 +56,7 @@ if (DEBUG) {
     );
   });
   QUnit.test('should return debug name for class', (assert) => {
-    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+     
     assert.deepEqual(debugToString(class Foo {}), 'Foo');
   });
   QUnit.test('should return debug name for ember-like object #1', (assert) => {

--- a/packages/@glimmer/debug-util/test/debug-to-string-test.ts
+++ b/packages/@glimmer/debug-util/test/debug-to-string-test.ts
@@ -56,7 +56,6 @@ if (DEBUG) {
     );
   });
   QUnit.test('should return debug name for class', (assert) => {
-     
     assert.deepEqual(debugToString(class Foo {}), 'Foo');
   });
   QUnit.test('should return debug name for ember-like object #1', (assert) => {

--- a/packages/@glimmer/debug/lib/metadata.ts
+++ b/packages/@glimmer/debug/lib/metadata.ts
@@ -166,8 +166,8 @@ export function strip(strings: TemplateStringsArray, ...args: unknown[]) {
     out += `${string}${dynamic}`;
   }
 
-  /* eslint-disable-next-line regexp/no-super-linear-backtracking,
-     @typescript-eslint/no-non-null-assertion -- @fixme */
+  // NOTE: this regex may be non-performant
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   out = /^\s*?\n?([\s\S]*?)\s*$/u.exec(out)![1] as string;
 
   let min = Number.MAX_SAFE_INTEGER;

--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -145,8 +145,7 @@ export function unregisterDestructor<T extends Destroyable>(
   meta[destructorsKey] = remove(
     meta[destructorsKey],
     destructor,
-    DEBUG &&
-      'attempted to remove a destructor that was not registered with the destroyable'
+    DEBUG && 'attempted to remove a destructor that was not registered with the destroyable'
   );
 }
 

--- a/packages/@glimmer/global-context/index.ts
+++ b/packages/@glimmer/global-context/index.ts
@@ -127,7 +127,6 @@ export function debugAssert(
   msg: string | (() => string),
   options?: { id: string }
 ): asserts test {
-   
   if (DEBUG && assert) {
     assert(test, typeof msg === 'string' ? msg : msg(), options);
   }

--- a/packages/@glimmer/global-context/index.ts
+++ b/packages/@glimmer/global-context/index.ts
@@ -127,7 +127,7 @@ export function debugAssert(
   msg: string | (() => string),
   options?: { id: string }
 ): asserts test {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+   
   if (DEBUG && assert) {
     assert(test, typeof msg === 'string' ? msg : msg(), options);
   }

--- a/packages/@glimmer/manager/lib/internal/api.ts
+++ b/packages/@glimmer/manager/lib/internal/api.ts
@@ -41,7 +41,6 @@ function setManager<Def extends object>(
 ): Def {
   if (DEBUG) {
     debugAssert(
-       
       obj !== null && (typeof obj === 'object' || typeof obj === 'function'),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       `Attempted to set a manager on a non-object value. Managers can only be associated with objects or functions. Value was ${debugToString!(
@@ -99,7 +98,6 @@ export function getInternalModifierManager(
 ): InternalModifierManager | null {
   if (DEBUG) {
     debugAssert(
-       
       (typeof definition === 'object' && definition !== null) || typeof definition === 'function',
       () =>
         // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme
@@ -145,7 +143,6 @@ export function getInternalHelperManager(
   isOptional?: true
 ): CustomHelperManager | Helper | null {
   debugAssert(
-     
     (typeof definition === 'object' && definition !== null) || typeof definition === 'function',
     () =>
       // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme
@@ -193,7 +190,6 @@ export function getInternalComponentManager(
   isOptional?: true
 ): InternalComponentManager | null {
   debugAssert(
-     
     (typeof definition === 'object' && definition !== null) || typeof definition === 'function',
     () =>
       // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme

--- a/packages/@glimmer/manager/lib/internal/api.ts
+++ b/packages/@glimmer/manager/lib/internal/api.ts
@@ -41,7 +41,7 @@ function setManager<Def extends object>(
 ): Def {
   if (DEBUG) {
     debugAssert(
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS-only check
+       
       obj !== null && (typeof obj === 'object' || typeof obj === 'function'),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       `Attempted to set a manager on a non-object value. Managers can only be associated with objects or functions. Value was ${debugToString!(
@@ -99,7 +99,7 @@ export function getInternalModifierManager(
 ): InternalModifierManager | null {
   if (DEBUG) {
     debugAssert(
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS-only check
+       
       (typeof definition === 'object' && definition !== null) || typeof definition === 'function',
       () =>
         // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme
@@ -145,7 +145,7 @@ export function getInternalHelperManager(
   isOptional?: true
 ): CustomHelperManager | Helper | null {
   debugAssert(
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS-only check
+     
     (typeof definition === 'object' && definition !== null) || typeof definition === 'function',
     () =>
       // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme
@@ -193,7 +193,7 @@ export function getInternalComponentManager(
   isOptional?: true
 ): InternalComponentManager | null {
   debugAssert(
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS-only check
+     
     (typeof definition === 'object' && definition !== null) || typeof definition === 'function',
     () =>
       // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme

--- a/packages/@glimmer/manager/lib/public/helper.ts
+++ b/packages/@glimmer/manager/lib/public/helper.ts
@@ -24,7 +24,6 @@ export function helperCapabilities<Version extends keyof HelperCapabilitiesVersi
   options: Partial<HelperCapabilities> = {}
 ): HelperCapabilities {
   debugAssert(
-     
     managerAPI === '3.23',
     () =>
       `Invalid helper manager compatibility specified; you specified ${managerAPI}, but only '3.23' is supported.`

--- a/packages/@glimmer/manager/lib/public/helper.ts
+++ b/packages/@glimmer/manager/lib/public/helper.ts
@@ -24,7 +24,7 @@ export function helperCapabilities<Version extends keyof HelperCapabilitiesVersi
   options: Partial<HelperCapabilities> = {}
 ): HelperCapabilities {
   debugAssert(
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS-only check
+     
     managerAPI === '3.23',
     () =>
       `Invalid helper manager compatibility specified; you specified ${managerAPI}, but only '3.23' is supported.`

--- a/packages/@glimmer/manager/lib/public/template.ts
+++ b/packages/@glimmer/manager/lib/public/template.ts
@@ -7,11 +7,7 @@ const TEMPLATES: WeakMap<object, TemplateFactory> = new WeakMap();
 const getPrototypeOf = Reflect.getPrototypeOf;
 
 export function setComponentTemplate(factory: TemplateFactory, obj: object) {
-  if (
-    DEBUG &&
-     
-    !(obj !== null && (typeof obj === 'object' || typeof obj === 'function'))
-  ) {
+  if (DEBUG && !(obj !== null && (typeof obj === 'object' || typeof obj === 'function'))) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
     throw new Error(`Cannot call \`setComponentTemplate\` on \`${debugToString!(obj)}\``);
   }

--- a/packages/@glimmer/manager/lib/public/template.ts
+++ b/packages/@glimmer/manager/lib/public/template.ts
@@ -9,7 +9,7 @@ const getPrototypeOf = Reflect.getPrototypeOf;
 export function setComponentTemplate(factory: TemplateFactory, obj: object) {
   if (
     DEBUG &&
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS-only check
+     
     !(obj !== null && (typeof obj === 'object' || typeof obj === 'function'))
   ) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -376,11 +376,11 @@ export function InvokeNonStaticComponent(
   op: PushStatementOp,
   { capabilities, elementBlock, positional, named, atNames, blocks: namedBlocks, layout }: Component
 ): void {
-  let bindableBlocks = !!namedBlocks;
+  let bindableBlocks = Boolean(namedBlocks);
   let bindableAtNames =
     capabilities === true ||
     hasCapability(capabilities, InternalComponentCapabilities.prepareArgs) ||
-    !!(named && named[0].length !== 0);
+    Boolean(named && named[0].length !== 0);
 
   let blocks = namedBlocks.with('attrs', elementBlock);
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/components.ts
@@ -380,7 +380,7 @@ export function InvokeNonStaticComponent(
   let bindableAtNames =
     capabilities === true ||
     hasCapability(capabilities, InternalComponentCapabilities.prepareArgs) ||
-    Boolean(named && named[0].length !== 0);
+    named?.[0].length !== 0;
 
   let blocks = namedBlocks.with('attrs', elementBlock);
 

--- a/packages/@glimmer/opcode-compiler/lib/syntax/compilers.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/compilers.ts
@@ -33,7 +33,7 @@ export class Compilers<PushOp extends PushExpressionOp, TSexpOpcodes extends Sex
     let name = sexp[0];
     let index = unwrap(this.names[name]);
     let func = this.funcs[index];
-    localAssert(Boolean(func), `expected an implementation for ${sexp[0]}`);
+    localAssert(func, `expected an implementation for ${sexp[0]}`);
 
     func(op, sexp);
   }

--- a/packages/@glimmer/opcode-compiler/lib/syntax/compilers.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/compilers.ts
@@ -33,7 +33,7 @@ export class Compilers<PushOp extends PushExpressionOp, TSexpOpcodes extends Sex
     let name = sexp[0];
     let index = unwrap(this.names[name]);
     let func = this.funcs[index];
-    localAssert(!!func, `expected an implementation for ${sexp[0]}`);
+    localAssert(Boolean(func), `expected an implementation for ${sexp[0]}`);
 
     func(op, sexp);
   }

--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -168,13 +168,10 @@ export function valueForRef<T>(_ref: Reference<T>): T {
   if (tag === null || !validateTag(tag, lastRevision)) {
     const { compute } = ref;
 
-    const newTag = track(
-      () => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-        lastValue = ref.lastValue = compute!();
-      },
-      DEBUG && ref.debugLabel
-    );
+    const newTag = track(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
+      lastValue = ref.lastValue = compute!();
+    }, DEBUG && ref.debugLabel);
 
     tag = ref.tag = newTag;
 

--- a/packages/@glimmer/reference/test/iterable-test.ts
+++ b/packages/@glimmer/reference/test/iterable-test.ts
@@ -120,7 +120,7 @@ module('@glimmer/reference: IterableReference', () => {
     });
 
     test('@identity works with null', (assert) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       let arr: any[] = [null];
       let target = new IterableWrapper(arr);
 
@@ -134,7 +134,7 @@ module('@glimmer/reference: IterableReference', () => {
     });
 
     test('@identity works with multiple null values', (assert) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       let arr: any[] = [null];
       let target = new IterableWrapper(arr);
 

--- a/packages/@glimmer/reference/test/iterable-test.ts
+++ b/packages/@glimmer/reference/test/iterable-test.ts
@@ -120,7 +120,6 @@ module('@glimmer/reference: IterableReference', () => {
     });
 
     test('@identity works with null', (assert) => {
-       
       let arr: any[] = [null];
       let target = new IterableWrapper(arr);
 
@@ -134,7 +133,6 @@ module('@glimmer/reference: IterableReference', () => {
     });
 
     test('@identity works with multiple null values', (assert) => {
-       
       let arr: any[] = [null];
       let target = new IterableWrapper(arr);
 

--- a/packages/@glimmer/reference/test/utils/template.ts
+++ b/packages/@glimmer/reference/test/utils/template.ts
@@ -61,12 +61,12 @@ class ObjectIterator extends BoundedIterator {
 
 export const TestContext = {
   getProp(obj: object, path: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+     
     return Reflect.get(obj, path);
   },
 
   getPath(obj: object, path: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+     
     return Reflect.get(obj, path);
   },
 

--- a/packages/@glimmer/reference/test/utils/template.ts
+++ b/packages/@glimmer/reference/test/utils/template.ts
@@ -61,12 +61,10 @@ class ObjectIterator extends BoundedIterator {
 
 export const TestContext = {
   getProp(obj: object, path: string) {
-     
     return Reflect.get(obj, path);
   },
 
   getPath(obj: object, path: string) {
-     
     return Reflect.get(obj, path);
   },
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -193,10 +193,7 @@ APPEND_OPCODES.add(VM_RESOLVE_CURRIED_COMPONENT_OP, (vm) => {
 
   let definition: CurriedValue | ComponentDefinition | null;
 
-  if (
-    DEBUG &&
-    !(typeof value === 'function' || (typeof value === 'object' && value !== null))
-  ) {
+  if (DEBUG && !(typeof value === 'function' || (typeof value === 'object' && value !== null))) {
     throw new Error(
       `Expected a component definition, but received ${value}. You may have accidentally done <${ref.debugLabel}>, where "${ref.debugLabel}" was a string instead of a curried component definition. You must either use the component definition directly, or use the {{component}} helper to create a curried component definition when invoking dynamically.`
     );

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -58,11 +58,7 @@ function toDynamicContentType(value: unknown) {
   if (isCurriedType(value, CURRIED_COMPONENT) || hasInternalComponentManager(value)) {
     return ContentType.Component;
   } else {
-    if (
-      DEBUG &&
-      !isCurriedType(value, CURRIED_HELPER) &&
-      !hasInternalHelperManager(value)
-    ) {
+    if (DEBUG && !isCurriedType(value, CURRIED_HELPER) && !hasInternalHelperManager(value)) {
       throw new Error(
         // eslint-disable-next-line @typescript-eslint/no-base-to-string -- @fixme
         `Attempted use a dynamic value as a component or helper, but that value did not have an associated component or helper manager. The value was: ${value}`

--- a/packages/@glimmer/runtime/lib/helpers/invoke.ts
+++ b/packages/@glimmer/runtime/lib/helpers/invoke.ts
@@ -51,7 +51,7 @@ export function invokeHelper(
   definition: object,
   computeArgs?: (context: object) => Partial<Arguments>
 ): Cache {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- JS usage
+   
   if (DEBUG && (typeof context !== 'object' || context === null)) {
     throw new Error(
       `Expected a context object to be passed as the first parameter to invokeHelper, got ${context}`

--- a/packages/@glimmer/runtime/lib/helpers/invoke.ts
+++ b/packages/@glimmer/runtime/lib/helpers/invoke.ts
@@ -8,9 +8,7 @@ import { createCache, getValue } from '@glimmer/validator';
 
 import { EMPTY_ARGS, EMPTY_NAMED, EMPTY_POSITIONAL } from '../vm/arguments';
 
-let ARGS_CACHES = DEBUG
-  ? new WeakMap<SimpleArgsProxy, Cache<Partial<Arguments>>>()
-  : undefined;
+let ARGS_CACHES = DEBUG ? new WeakMap<SimpleArgsProxy, Cache<Partial<Arguments>>>() : undefined;
 
 function getArgs(proxy: SimpleArgsProxy): Partial<Arguments> {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
@@ -51,7 +49,6 @@ export function invokeHelper(
   definition: object,
   computeArgs?: (context: object) => Partial<Arguments>
 ): Cache {
-   
   if (DEBUG && (typeof context !== 'object' || context === null)) {
     throw new Error(
       `Expected a context object to be passed as the first parameter to invokeHelper, got ${context}`

--- a/packages/@glimmer/syntax/lib/source/source.ts
+++ b/packages/@glimmer/syntax/lib/source/source.ts
@@ -49,6 +49,7 @@ export class Source {
       return null;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     while (true) {
       let nextLine = this.source.indexOf('\n', seenChars);
 
@@ -78,6 +79,7 @@ export class Source {
       if (seenLines === line - 1) {
         if (seenChars + column > nextLine) return nextLine;
 
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (DEBUG) {
           let roundTrip = this.hbsPosFor(seenChars + column);
           localAssert(roundTrip !== null, `the returned offset failed to round-trip`);

--- a/packages/@glimmer/syntax/lib/traversal/errors.ts
+++ b/packages/@glimmer/syntax/lib/traversal/errors.ts
@@ -21,9 +21,8 @@ export interface TraversalErrorConstructor {
 }
 
 const TraversalError: TraversalErrorConstructor = (function () {
-   
   TraversalError.prototype = Object.create(Error.prototype);
-   
+
   TraversalError.prototype.constructor = TraversalError;
 
   function TraversalError(

--- a/packages/@glimmer/syntax/lib/traversal/errors.ts
+++ b/packages/@glimmer/syntax/lib/traversal/errors.ts
@@ -21,9 +21,9 @@ export interface TraversalErrorConstructor {
 }
 
 const TraversalError: TraversalErrorConstructor = (function () {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+   
   TraversalError.prototype = Object.create(Error.prototype);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+   
   TraversalError.prototype.constructor = TraversalError;
 
   function TraversalError(

--- a/packages/@glimmer/syntax/lib/traversal/traverse.ts
+++ b/packages/@glimmer/syntax/lib/traversal/traverse.ts
@@ -177,7 +177,6 @@ function visitKey<N extends ASTv1.Node>(
   }
 
   if (keyEnter !== undefined) {
-     
     if (keyEnter(node, key) !== undefined) {
       throw cannotReplaceOrRemoveInKeyHandlerYet(node, key);
     }
@@ -198,7 +197,6 @@ function visitKey<N extends ASTv1.Node>(
   }
 
   if (keyExit !== undefined) {
-     
     if (keyExit(node, key) !== undefined) {
       throw cannotReplaceOrRemoveInKeyHandlerYet(node, key);
     }

--- a/packages/@glimmer/syntax/lib/traversal/traverse.ts
+++ b/packages/@glimmer/syntax/lib/traversal/traverse.ts
@@ -177,7 +177,7 @@ function visitKey<N extends ASTv1.Node>(
   }
 
   if (keyEnter !== undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- JS API
+     
     if (keyEnter(node, key) !== undefined) {
       throw cannotReplaceOrRemoveInKeyHandlerYet(node, key);
     }
@@ -192,13 +192,13 @@ function visitKey<N extends ASTv1.Node>(
       // TODO: dynamically check the results by having a table of
       // expected node types in value space, not just type space
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       assignKey(node, key, value, result as any);
     }
   }
 
   if (keyExit !== undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- JS API
+     
     if (keyExit(node, key) !== undefined) {
       throw cannotReplaceOrRemoveInKeyHandlerYet(node, key);
     }

--- a/packages/@glimmer/syntax/lib/v1/handlebars-ast.ts
+++ b/packages/@glimmer/syntax/lib/v1/handlebars-ast.ts
@@ -1,6 +1,4 @@
 /**
- * @module
- *
  * This file contains types for the raw AST returned from the Handlebars parser.
  * These types were originally imported from
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/handlebars/index.d.ts.

--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -74,7 +74,7 @@ test('blocks', () => {
       }}
     `);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   let [, block] = ast.body as [any, AST.BlockStatement];
   let [nestedBlock] = block.program.body as [AST.BlockStatement];
   let [nestedBlockText] = nestedBlock.program.body;

--- a/packages/@glimmer/syntax/test/loc-node-test.ts
+++ b/packages/@glimmer/syntax/test/loc-node-test.ts
@@ -74,7 +74,6 @@ test('blocks', () => {
       }}
     `);
 
-   
   let [, block] = ast.body as [any, AST.BlockStatement];
   let [nestedBlock] = block.program.body as [AST.BlockStatement];
   let [nestedBlockText] = nestedBlock.program.body;

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -70,7 +70,6 @@ test('deprecated program visitor', (assert) => {
 });
 
 test('can support the legacy AST transform API via ASTPlugin', (assert) => {
-   
   function ensurePlugin(FunctionOrPlugin: any): ASTPluginBuilder {
     if (FunctionOrPlugin.prototype && FunctionOrPlugin.prototype.transform) {
       return (env: ASTPluginEnvironment) => {

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -70,7 +70,7 @@ test('deprecated program visitor', (assert) => {
 });
 
 test('can support the legacy AST transform API via ASTPlugin', (assert) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   function ensurePlugin(FunctionOrPlugin: any): ASTPluginBuilder {
     if (FunctionOrPlugin.prototype && FunctionOrPlugin.prototype.transform) {
       return (env: ASTPluginEnvironment) => {

--- a/packages/@glimmer/validator/lib/collections/object.ts
+++ b/packages/@glimmer/validator/lib/collections/object.ts
@@ -89,7 +89,6 @@ class TrackedObject<ObjectType extends NonNullable<object>> {
 
       deleteProperty(target, prop) {
         if (prop in target) {
-           
           delete target[prop as keyof ObjectType];
           self.#dirtyStorageFor(prop);
           self.#storages.delete(prop);

--- a/packages/@glimmer/validator/lib/collections/object.ts
+++ b/packages/@glimmer/validator/lib/collections/object.ts
@@ -89,7 +89,7 @@ class TrackedObject<ObjectType extends NonNullable<object>> {
 
       deleteProperty(target, prop) {
         if (prop in target) {
-          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+           
           delete target[prop as keyof ObjectType];
           self.#dirtyStorageFor(prop);
           self.#storages.delete(prop);

--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -215,7 +215,7 @@ if (DEBUG) {
         if (updateStackBegin !== -1) {
           let start = nthIndex(e.stack, '\n', 1, updateStackBegin);
           let end = nthIndex(e.stack, '\n', 4, updateStackBegin);
-           
+
           e.stack = e.stack.substr(0, start) + e.stack.substr(end);
         }
       }

--- a/packages/@glimmer/validator/lib/debug.ts
+++ b/packages/@glimmer/validator/lib/debug.ts
@@ -215,7 +215,7 @@ if (DEBUG) {
         if (updateStackBegin !== -1) {
           let start = nthIndex(e.stack, '\n', 1, updateStackBegin);
           let end = nthIndex(e.stack, '\n', 4, updateStackBegin);
-          // eslint-disable-next-line @typescript-eslint/no-deprecated -- @fixme
+           
           e.stack = e.stack.substr(0, start) + e.stack.substr(end);
         }
       }

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -167,7 +167,7 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
 
   static updateTag(this: void, _tag: UpdatableTag, _subtag: Tag) {
     // catch bug by non-TS users
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+     
     if (DEBUG && _tag[TYPE] !== UPDATABLE_TAG_ID) {
       throw new Error('Attempted to update a tag that was not updatable');
     }
@@ -210,7 +210,7 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
     if (
       DEBUG &&
       // catch bug by non-TS users
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+       
       !(tag[TYPE] === UPDATABLE_TAG_ID || tag[TYPE] === DIRYTABLE_TAG_ID)
     ) {
       throw new Error('Attempted to dirty a tag that was not dirtyable');

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -167,7 +167,7 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
 
   static updateTag(this: void, _tag: UpdatableTag, _subtag: Tag) {
     // catch bug by non-TS users
-     
+
     if (DEBUG && _tag[TYPE] !== UPDATABLE_TAG_ID) {
       throw new Error('Attempted to update a tag that was not updatable');
     }
@@ -210,7 +210,7 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
     if (
       DEBUG &&
       // catch bug by non-TS users
-       
+
       !(tag[TYPE] === UPDATABLE_TAG_ID || tag[TYPE] === DIRYTABLE_TAG_ID)
     ) {
       throw new Error('Attempted to dirty a tag that was not dirtyable');

--- a/packages/@glimmer/validator/test/collections/array-test.ts
+++ b/packages/@glimmer/validator/test/collections/array-test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import-x/no-extraneous-dependencies */
-
 import { trackedArray } from '@glimmer/validator';
 import { expectTypeOf } from 'expect-type';
 
@@ -219,7 +217,6 @@ module('@glimmer/validator: trackedArray()', () => {
       let arr = trackedArray([1, 2, 3]);
 
       assert.strictEqual(
-         
         arr.reduce((s, v) => s + v, ''),
         '123'
       );
@@ -229,7 +226,6 @@ module('@glimmer/validator: trackedArray()', () => {
       let arr = trackedArray([1, 2, 3]);
 
       assert.strictEqual(
-         
         arr.reduceRight((s, v) => s + v, ''),
         '321'
       );

--- a/packages/@glimmer/validator/test/collections/array-test.ts
+++ b/packages/@glimmer/validator/test/collections/array-test.ts
@@ -219,7 +219,7 @@ module('@glimmer/validator: trackedArray()', () => {
       let arr = trackedArray([1, 2, 3]);
 
       assert.strictEqual(
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+         
         arr.reduce((s, v) => s + v, ''),
         '123'
       );
@@ -229,7 +229,7 @@ module('@glimmer/validator: trackedArray()', () => {
       let arr = trackedArray([1, 2, 3]);
 
       assert.strictEqual(
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+         
         arr.reduceRight((s, v) => s + v, ''),
         '321'
       );

--- a/packages/@glimmer/validator/test/collections/map-test.ts
+++ b/packages/@glimmer/validator/test/collections/map-test.ts
@@ -21,7 +21,7 @@ module('@glimmer/validator: trackedMap', function () {
 
   test('works with all kinds of keys', (assert) => {
     // Spoiler: they are needed, as without them, types are inferred
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+     
     const map = trackedMap<unknown, unknown>([
       ['foo', 123],
       [{}, {}],
@@ -110,9 +110,9 @@ module('@glimmer/validator: trackedMap', function () {
 
     map.forEach((v, k) => {
       count++;
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+       
       values += k;
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+       
       values += v;
     });
 

--- a/packages/@glimmer/validator/test/collections/map-test.ts
+++ b/packages/@glimmer/validator/test/collections/map-test.ts
@@ -21,7 +21,7 @@ module('@glimmer/validator: trackedMap', function () {
 
   test('works with all kinds of keys', (assert) => {
     // Spoiler: they are needed, as without them, types are inferred
-     
+
     const map = trackedMap<unknown, unknown>([
       ['foo', 123],
       [{}, {}],
@@ -110,9 +110,9 @@ module('@glimmer/validator: trackedMap', function () {
 
     map.forEach((v, k) => {
       count++;
-       
+
       values += k;
-       
+
       values += v;
     });
 

--- a/packages/@glimmer/validator/test/collections/set-test.ts
+++ b/packages/@glimmer/validator/test/collections/set-test.ts
@@ -5,7 +5,7 @@ import { module, test } from '../-utils';
 
 expectTypeOf<ReturnType<typeof trackedSet<string>>>().toMatchTypeOf<Set<string>>();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 type AnyFn = (...args: any[]) => any;
 
 module('@glimmer/validator: trackedSet', function () {

--- a/packages/@glimmer/validator/test/collections/set-test.ts
+++ b/packages/@glimmer/validator/test/collections/set-test.ts
@@ -5,7 +5,6 @@ import { module, test } from '../-utils';
 
 expectTypeOf<ReturnType<typeof trackedSet<string>>>().toMatchTypeOf<Set<string>>();
 
- 
 type AnyFn = (...args: any[]) => any;
 
 module('@glimmer/validator: trackedSet', function () {

--- a/packages/@glimmer/validator/test/tracking-test.ts
+++ b/packages/@glimmer/validator/test/tracking-test.ts
@@ -401,7 +401,6 @@ module('@glimmer/validator: tracking', () => {
     if (DEBUG) {
       test('createCache throws an error in import.meta.env.DEV mode if users to use with a non-function', (assert) => {
         assert.throws(
-           
           () => createCache(123 as any),
           /Error: createCache\(\) must be passed a function as its first parameter. Called with: 123/u
         );
@@ -409,7 +408,6 @@ module('@glimmer/validator: tracking', () => {
 
       test('getValue throws an error in import.meta.env.DEV mode if users to use with a non-cache', (assert) => {
         assert.throws(
-           
           () => getValue(123 as any),
           /Error: getValue\(\) can only be used on an instance of a cache created with createCache\(\). Called with: 123/u
         );
@@ -428,7 +426,6 @@ module('@glimmer/validator: tracking', () => {
 
       test('isConst throws an error in import.meta.env.DEV mode if users attempt to use with a non-cache', (assert) => {
         assert.throws(
-           
           () => isConst(123 as any),
           /Error: isConst\(\) can only be used on an instance of a cache created with createCache\(\). Called with: 123/u
         );

--- a/packages/@glimmer/validator/test/tracking-test.ts
+++ b/packages/@glimmer/validator/test/tracking-test.ts
@@ -401,8 +401,7 @@ module('@glimmer/validator: tracking', () => {
     if (DEBUG) {
       test('createCache throws an error in import.meta.env.DEV mode if users to use with a non-function', (assert) => {
         assert.throws(
-          /* eslint-disable-next-line @typescript-eslint/no-explicit-any,
-             @typescript-eslint/no-unsafe-argument -- intentional type error to test JS-only behavior */
+           
           () => createCache(123 as any),
           /Error: createCache\(\) must be passed a function as its first parameter. Called with: 123/u
         );
@@ -410,8 +409,7 @@ module('@glimmer/validator: tracking', () => {
 
       test('getValue throws an error in import.meta.env.DEV mode if users to use with a non-cache', (assert) => {
         assert.throws(
-          /* eslint-disable-next-line @typescript-eslint/no-explicit-any,
-             @typescript-eslint/no-unsafe-argument -- intentional type error to test JS-only behavior */
+           
           () => getValue(123 as any),
           /Error: getValue\(\) can only be used on an instance of a cache created with createCache\(\). Called with: 123/u
         );
@@ -430,8 +428,7 @@ module('@glimmer/validator: tracking', () => {
 
       test('isConst throws an error in import.meta.env.DEV mode if users attempt to use with a non-cache', (assert) => {
         assert.throws(
-          /* eslint-disable-next-line @typescript-eslint/no-explicit-any,
-             @typescript-eslint/no-unsafe-argument -- intentional type error to test JS-only behavior */
+           
           () => isConst(123 as any),
           /Error: isConst\(\) can only be used on an instance of a cache created with createCache\(\). Called with: 123/u
         );

--- a/packages/@glimmer/wire-format/lib/resolution.ts
+++ b/packages/@glimmer/wire-format/lib/resolution.ts
@@ -6,7 +6,6 @@ import type {
   StrictResolution,
 } from '@glimmer/interfaces';
 
- 
 export type resolution =
   | ResolveAsComponentOrHelperHeadResolution
   | ResolveAsHelperHeadResolution

--- a/packages/@glimmer/wire-format/lib/resolution.ts
+++ b/packages/@glimmer/wire-format/lib/resolution.ts
@@ -6,7 +6,7 @@ import type {
   StrictResolution,
 } from '@glimmer/interfaces';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
+ 
 export type resolution =
   | ResolveAsComponentOrHelperHeadResolution
   | ResolveAsHelperHeadResolution


### PR DESCRIPTION
- enables type-aware linting for the glimmer projects
- turns off lints for where there were violations for package-specific patterns (matches old behavior roughly)
- removes mentions of rules we don't currently have enabled (such as regex or import-x plugins)