### PR TITLE
Remove @ember/runloop from initializer test blueprints

### DIFF
--- a/blueprints/initializer-test/files/__root__/__testType__/__path__/__name__-test.ts
+++ b/blueprints/initializer-test/files/__root__/__testType__/__path__/__name__-test.ts
@@ -4,7 +4,7 @@ import config from '<%= modulePrefix %>/config/environment';
 import { initialize } from '<%= modulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
-<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app'; <% } else { %>import { run } from '@ember/runloop'; <% } %>
+<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app'; <% } %>
 
   module('<%= friendlyTestName %>', function (hooks) {
     hooks.beforeEach(function () {
@@ -25,7 +25,7 @@ import Resolver from 'ember-resolver';
     });
 
     hooks.afterEach(function () {
-      <% if (destroyAppExists) { %> destroyApp(this.application); <% } else { %> run(this.application, 'destroy'); <% } %>
+      <% if (destroyAppExists) { %> destroyApp(this.application); <% } else { %> this.application.destroy(); <% } %>
   });
 
     // TODO: Replace this with your real tests.

--- a/blueprints/instance-initializer-test/files/__root__/__testType__/__path__/__name__-test.ts
+++ b/blueprints/instance-initializer-test/files/__root__/__testType__/__path__/__name__-test.ts
@@ -4,7 +4,7 @@ import config from '<%= modulePrefix %>/config/environment';
 import { initialize } from '<%= modulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
-<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } else { %>import { run } from '@ember/runloop';<% } %>
+<% if (destroyAppExists) { %>import destroyApp from '../../helpers/destroy-app';<% } %>
 
 module('<%= friendlyTestName %>', function (hooks) {
   hooks.beforeEach(function () {
@@ -26,8 +26,8 @@ module('<%= friendlyTestName %>', function (hooks) {
     this.instance = this.application.buildInstance();
   });
   hooks.afterEach(function () {
-    <% if (destroyAppExists) { %>destroyApp(this.instance);<% } else { %>run(this.instance, 'destroy');<% } %>
-    <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>run(this.application, 'destroy');<% } %>
+    <% if (destroyAppExists) { %>destroyApp(this.instance);<% } else { %>this.instance.destroy();<% } %>
+    <% if (destroyAppExists) { %>destroyApp(this.application);<% } else { %>this.application.destroy();<% } %>
   });
 
   // TODO: Replace this with your real tests.

--- a/node-tests/fixtures/initializer-test/addon.js
+++ b/node-tests/fixtures/initializer-test/addon.js
@@ -4,7 +4,6 @@ import config from 'dummy/config/environment';
 import { initialize } from 'dummy/initializers/foo';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
-import { run } from '@ember/runloop';
 
 module('Unit | Initializer | foo', function (hooks) {
   hooks.beforeEach(function () {
@@ -25,7 +24,7 @@ module('Unit | Initializer | foo', function (hooks) {
   });
 
   hooks.afterEach(function () {
-    run(this.application, 'destroy');
+    this.application.destroy();
   });
 
   // TODO: Replace this with your real tests.

--- a/node-tests/fixtures/initializer-test/app.js
+++ b/node-tests/fixtures/initializer-test/app.js
@@ -4,7 +4,6 @@ import config from 'my-app/config/environment';
 import { initialize } from 'my-app/initializers/foo';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
-import { run } from '@ember/runloop';
 
 module('Unit | Initializer | foo', function (hooks) {
   hooks.beforeEach(function () {
@@ -25,7 +24,7 @@ module('Unit | Initializer | foo', function (hooks) {
   });
 
   hooks.afterEach(function () {
-    run(this.application, 'destroy');
+    this.application.destroy();
   });
 
   // TODO: Replace this with your real tests.

--- a/node-tests/fixtures/instance-initializer-test/addon.js
+++ b/node-tests/fixtures/instance-initializer-test/addon.js
@@ -4,7 +4,6 @@ import config from 'dummy/config/environment';
 import { initialize } from 'dummy/instance-initializers/foo';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
-import { run } from '@ember/runloop';
 
 module('Unit | Instance Initializer | foo', function (hooks) {
   hooks.beforeEach(function () {
@@ -26,8 +25,8 @@ module('Unit | Instance Initializer | foo', function (hooks) {
     this.instance = this.application.buildInstance();
   });
   hooks.afterEach(function () {
-    run(this.instance, 'destroy');
-    run(this.application, 'destroy');
+    this.instance.destroy();
+    this.application.destroy();
   });
 
   // TODO: Replace this with your real tests.

--- a/node-tests/fixtures/instance-initializer-test/app.js
+++ b/node-tests/fixtures/instance-initializer-test/app.js
@@ -4,7 +4,6 @@ import config from 'my-app/config/environment';
 import { initialize } from 'my-app/instance-initializers/foo';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
-import { run } from '@ember/runloop';
 
 module('Unit | Instance Initializer | foo', function (hooks) {
   hooks.beforeEach(function () {
@@ -26,8 +25,8 @@ module('Unit | Instance Initializer | foo', function (hooks) {
     this.instance = this.application.buildInstance();
   });
   hooks.afterEach(function () {
-    run(this.instance, 'destroy');
-    run(this.application, 'destroy');
+    this.instance.destroy();
+    this.application.destroy();
   });
 
   // TODO: Replace this with your real tests.


### PR DESCRIPTION
## Summary
Remove @ember/runloop usage in initializer/instance-initializer test blueprints and fixtures by calling destroy directly when destroyApp helper is unavailable.

## Testing
- pnpm vite build --mode=development
- CI=1 CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" pnpm test
- pnpm build
- pnpm test:node
- pnpm test:blueprints

Fixes #20690