### PR TITLE
Runtime compiler RFC#1070 support

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-implicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-implicit-test.ts
@@ -1,4 +1,5 @@
 import { template } from '@ember/template-compiler/runtime';
+import { ALLOWED_GLOBALS } from '@ember/template-compiler';
 import { RenderingTestCase, defineSimpleModifier, moduleFor } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 import { on } from '@ember/modifier/on';
@@ -462,6 +463,30 @@ moduleFor(
 
       this.assertText('[before]after');
       this.assertStableRerender();
+    }
+  }
+);
+
+moduleFor(
+  'Strict Mode - Runtime Template Compiler (implicit) - allowed globals from RFC#1070',
+  class AllowedGlobalsTest extends RenderingTestCase {
+    static {
+      for (let globalName of ALLOWED_GLOBALS) {
+        if (!(globalName in globalThis)) continue;
+
+        // @ts-expect-error - this *is* generally unsafe
+        AllowedGlobalsTest.prototype[`@test Can use ${globalName}`] = async function () {
+          await this.renderComponentModule(() => {
+            return template(`{{if ${globalName} "exists"}}`, {
+              eval() {
+                return eval(arguments[0]);
+              },
+            });
+          });
+
+          this.assertStableRerender();
+        };
+      }
     }
   }
 );

--- a/packages/@ember/template-compiler/index.ts
+++ b/packages/@ember/template-compiler/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/public-api';
+
+export { ALLOWED_GLOBALS } from './lib/plugins/allowed-globals';

--- a/packages/@ember/template-compiler/lib/compile-options.ts
+++ b/packages/@ember/template-compiler/lib/compile-options.ts
@@ -4,6 +4,7 @@ import {
   STRICT_MODE_KEYWORDS,
   STRICT_MODE_TRANSFORMS,
 } from './plugins/index';
+import { ALLOWED_GLOBALS } from './plugins/allowed-globals';
 import type { EmberPrecompileOptions, PluginFunc } from './types';
 import COMPONENT_NAME_SIMPLE_DASHERIZE_CACHE from './dasherize-component-name';
 
@@ -39,6 +40,10 @@ function buildCompileOptions(_options: EmberPrecompileOptions): EmberPrecompileO
     const globalScopeEvaluator = (value: string) => new Function(`return ${value};`)();
 
     options.lexicalScope = (variable: string) => {
+      if (ALLOWED_GLOBALS.has(variable)) {
+        return variable in globalThis;
+      }
+
       if (inScope(variable, localScopeEvaluator)) {
         return !inScope(variable, globalScopeEvaluator);
       }
@@ -52,7 +57,9 @@ function buildCompileOptions(_options: EmberPrecompileOptions): EmberPrecompileO
   if ('scope' in options) {
     const scope = (options.scope as () => Record<string, unknown>)();
 
-    options.lexicalScope = (variable: string) => variable in scope;
+    options.lexicalScope = (variable: string) => {
+      return variable in scope;
+    };
 
     delete options.scope;
   }

--- a/packages/@ember/template-compiler/lib/plugins/allowed-globals.ts
+++ b/packages/@ember/template-compiler/lib/plugins/allowed-globals.ts
@@ -1,0 +1,72 @@
+/**
+ * @private
+ *
+ * RFC: https://github.com/emberjs/rfcs/pull/1070
+ *
+ * Criteria for inclusion in this list:
+ *
+ *   Any of:
+ *     - begins with an uppercase letter
+ *     - guaranteed to never be added to glimmer as a keyword (e.g.: globalThis)
+ *
+ *   And:
+ *     - must not need new to invoke
+ *     - must not require lifetime management (e.g.: setTimeout)
+ *     - must not be a single-word lower-case API, because of potential collision with future new HTML elements
+ *     - if the API is a function, the return value should not be a promise
+ *     - must be one one of these lists:
+ *        - https://tc39.es/ecma262/#sec-global-object
+ *        - https://tc39.es/ecma262/#sec-function-properties-of-the-global-object
+ *        - https://html.spec.whatwg.org/multipage/nav-history-apis.html#window
+ *        - https://html.spec.whatwg.org/multipage/indices.html#all-interfaces
+ *        - https://html.spec.whatwg.org/multipage/webappapis.html
+ */
+export const ALLOWED_GLOBALS = new Set([
+  // ////////////////
+  // namespaces
+  // ////////////////
+  //   TC39
+  'globalThis',
+  'Atomics',
+  'JSON',
+  'Math',
+  'Reflect',
+  //   WHATWG
+  'localStorage',
+  'sessionStorage',
+  'URL',
+  // ////////////////
+  // functions / utilities
+  // ////////////////
+  //   TC39
+  'isNaN',
+  'isFinite',
+  'parseInt',
+  'parseFloat',
+  'decodeURI',
+  'decodeURIComponent',
+  'encodeURI',
+  'encodeURIComponent',
+  //   WHATWG
+  'postMessage',
+  'structuredClone',
+  // ////////////////
+  // new-less Constructors (still functions)
+  // ////////////////
+  //   TC39
+  'Array', // different behavior from (array)
+  'BigInt',
+  'Boolean',
+  'Date',
+  'Number',
+  'Object', // different behavior from (hash)
+  'String',
+  // ////////////////
+  // Values
+  // ////////////////
+  //   TC39
+  'Infinity',
+  'NaN',
+  //   WHATWG
+  'isSecureContext',
+]);


### PR DESCRIPTION
all of the allowed globals from RFC 1070 were not working with `template()`.

This PR Fixes