### PR TITLE
No more unknownTemplateOnlyComponent

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -110,6 +110,51 @@ class DebugRenderTreeTest extends RenderTest {
     ]);
   }
 
+  @test 'strict-mode template-only invocation names'() {
+    const Greeter = defComponent('Hello');
+    const Actual = defComponent('Hi');
+
+    const Root = defComponent(`<Greeter /><Alias />`, {
+      scope: { Greeter, Alias: Actual },
+      emit: { moduleName: 'root.hbs' },
+    });
+
+    this.renderComponent(Root);
+
+    const element = this.delegate.getInitialElement();
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: '{ROOT}',
+        args: { positional: [], named: {} },
+        instance: null,
+        template: 'root.hbs',
+        bounds: this.elementBounds(element),
+        children: [
+          {
+            type: 'component',
+            name: 'Greeter',
+            args: { positional: [], named: {} },
+            instance: null,
+            template: '(unknown template module)',
+            bounds: this.nodeBounds(element.firstChild),
+            children: [],
+          },
+          {
+            type: 'component',
+            name: 'Alias',
+            args: { positional: [], named: {} },
+            instance: null,
+            template: '(unknown template module)',
+            bounds: this.nodeBounds(element.lastChild),
+            children: [],
+          },
+        ],
+      },
+    ]);
+  }
+
   @test 'strict-mode modifiers'() {
     const state = trackedObj({ showSecond: false });
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -109,12 +109,15 @@ export function resolveComponent(
       expr[1]
     ];
 
+    // Extract invocation name from wire format if available (expr[2] contains the names array)
+    let invocationName = Array.isArray(expr[2]) ? expr[2][0] : lexical?.at(expr[1]);
+
     then(
       constants.component(
         definition as object,
         expect(owner, 'BUG: expected owner when resolving component definition'),
         false,
-        lexical?.at(expr[1])
+        invocationName
       )
     );
   } else {
@@ -287,11 +290,14 @@ export function resolveComponentOrHelper(
       expr[1]
     ];
 
+    // Extract invocation name from wire format if available (expr[2] contains the names array)
+    let invocationName = Array.isArray(expr[2]) ? expr[2][0] : lexical?.at(expr[1]);
+
     let component = constants.component(
       definition as object,
       expect(owner, 'BUG: expected owner when resolving component definition'),
       true,
-      lexical?.at(expr[1])
+      invocationName
     );
 
     if (component !== null) {
@@ -396,7 +402,7 @@ export function resolveOptionalComponentOrHelper(
       definition,
       expect(owner, 'BUG: expected owner when resolving component definition'),
       true,
-      lexical?.at(expr[1])
+      Array.isArray(expr[2]) ? expr[2][0] : lexical?.at(expr[1])
     );
 
     if (component !== null) {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -109,8 +109,7 @@ export function resolveComponent(
       expr[1]
     ];
 
-    // Extract invocation name from wire format if available (expr[2] contains the names array)
-    let invocationName = Array.isArray(expr[2]) ? expr[2][0] : lexical?.at(expr[1]);
+    let invocationName = lexical?.at(expr[1]);
 
     then(
       constants.component(
@@ -290,8 +289,7 @@ export function resolveComponentOrHelper(
       expr[1]
     ];
 
-    // Extract invocation name from wire format if available (expr[2] contains the names array)
-    let invocationName = Array.isArray(expr[2]) ? expr[2][0] : lexical?.at(expr[1]);
+    let invocationName = lexical?.at(expr[1]);
 
     let component = constants.component(
       definition as object,
@@ -402,7 +400,7 @@ export function resolveOptionalComponentOrHelper(
       definition,
       expect(owner, 'BUG: expected owner when resolving component definition'),
       true,
-      Array.isArray(expr[2]) ? expr[2][0] : lexical?.at(expr[1])
+      lexical?.at(expr[1])
     );
 
     if (component !== null) {

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -207,5 +207,10 @@ export function getDebugName(
   manager = definition.manager,
   invocationName?: string
 ): string {
-  return invocationName ?? definition.resolvedName ?? definition.debugName ?? manager.getDebugName(definition.state);
+  return (
+    invocationName ??
+    definition.resolvedName ??
+    definition.debugName ??
+    manager.getDebugName(definition.state)
+  );
 }

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -204,7 +204,8 @@ export default class DebugRenderTreeImpl<TBucket extends object>
 
 export function getDebugName(
   definition: ComponentDefinition,
-  manager = definition.manager
+  manager = definition.manager,
+  invocationName?: string
 ): string {
-  return definition.resolvedName ?? definition.debugName ?? manager.getDebugName(definition.state);
+  return invocationName ?? definition.resolvedName ?? definition.debugName ?? manager.getDebugName(definition.state);
 }


### PR DESCRIPTION
This was really bothering me when I was trying to debug my typedoc renderer 

I need to build this ember and test it in that project before starting review.

As part of debugging this, I think I need a button on the inspector to just show the debugRenderTree node
- https://github.com/emberjs/ember-inspector/pull/2709

## Before

<img width="1075" height="647" alt="image" src="https://github.com/user-attachments/assets/bd156709-7d04-4e01-b518-eeff4b69cd18" />

note for me http://localhost:4201/Runtime/util/page-nav


## After

This is blocked until we ditch the array-form of the scope bag. So many things get easier if we just make the wire format use the same scope names / object we use when hand-writing gjs (de-gjs'd)

The current compiled format just won't work because there is no way to keep the invocation names in an array -- the names are gone at this point.

Unlike class components, template-only components don't have a name, they are just consts, and only browser devtools can get at variable names