### PR TITLE
Add a toggle/qunit/config for skipping the tests that open new tabs

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -1271,6 +1271,10 @@ moduleFor(
     }
 
     async [`@test it does not call preventDefault if 'target' attribute is provided`](assert) {
+      if (QUnit.urlParams.skip_tests_with_target_blank) {
+        assert.ok('skipped');
+        return;
+      }
       this.addTemplate(
         'index',
         `
@@ -1299,6 +1303,11 @@ moduleFor(
     }
 
     async [`@test it should not transition if target is not equal to _self or empty`](assert) {
+      if (QUnit.urlParams.skip_tests_with_target_blank) {
+        assert.ok('skipped');
+        return;
+      }
+
       this.addTemplate(
         'index',
         `


### PR DESCRIPTION
When programmatically running chrome / tests, popup blocking is not enabled.

Having a way to disable the tests that create popups / new windows helps out here.

This is opt-in, and false by default