### PR TITLE
Swap nightly ts test of ts-nightly with ts-latest for better signal-to-noise 

### DIFF
--- a/.github/workflows/night-ts.yml
+++ b/.github/workflows/night-ts.yml
@@ -5,25 +5,25 @@ permissions:
 
 jobs:
   ts-next:
-    name: typescript@next
+    name: typescript@latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm build
-      - run: pnpm add --save-dev typescript@next --workspace-root
+      - run: pnpm add --save-dev typescript@latest --workspace-root
       - run: pnpm type-check
   notify:
     name: Notify Discord
     runs-on: ubuntu-latest
-    needs: [ ts-next ]
+    needs: [ts-next]
     if: failure()
     steps:
       - uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.TYPESCRIPT_WEBHOOK }}
           status: "Failure"
-          title: "Ember.js Nightly TypeScript Run"
+          title: "Latest TypeScript Run"
           color: 0xcc0000
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           username: GitHub Actions


### PR DESCRIPTION
No one really uses nightly TS.
And after
 - nightly ts error
 - I pr fix
 - nightly ts error 2 days later

I decided that the workflow causes more disruption than it meant to prevent