### PR TITLE
Add v6.8.3 to CHANGELOG for `ember-source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 - All changes were internal, docs, and/or bugfixes that were backported.
 
+## v6.8.3 (February 4, 2026)
+ 
+- [#21024](https://github.com/emberjs/ember.js/pull/21024) [BUGFIX] Add @ember/reactive into the AMD bundles
+
 ## v6.8.2 (November 17, 2025)
 
 - [#21002](https://github.com/emberjs/ember.js/pull/21002) [BUGFIX] Don't render if we're mid-destroy


### PR DESCRIPTION
(cherry picked from commit [9d54d2a](https://github.com/emberjs/ember.js/commit/9d54d2a56dc58c3b21e2398085309ffad5562de5))

I noticed this was missing from the changelog on the main branch. I cherry picked it manually and tried to follow other similar commits.