### PR TITLE
[CLEANUP] Fix missing ApplicationInstance in Router tests

### DIFF
--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -348,7 +348,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
           // SAFETY: this is configured in `commonSetupRegistry` in the
           // `@ember/application/lib` package.
           let DefaultRoute: any = routeOwner.factoryFor('route:basic')!.class;
-          routeOwner.register(fullRouteName, class extends DefaultRoute { });
+          routeOwner.register(fullRouteName, class extends DefaultRoute {});
           route = routeOwner.lookup(fullRouteName) as Route;
 
           if (DEBUG) {

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -348,7 +348,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
           // SAFETY: this is configured in `commonSetupRegistry` in the
           // `@ember/application/lib` package.
           let DefaultRoute: any = routeOwner.factoryFor('route:basic')!.class;
-          routeOwner.register(fullRouteName, class extends DefaultRoute {});
+          routeOwner.register(fullRouteName, class extends DefaultRoute { });
           route = routeOwner.lookup(fullRouteName) as Route;
 
           if (DEBUG) {
@@ -664,19 +664,14 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
       this._toplevelView = OutletView.create({ environment, template, application });
       this._toplevelView.setOutletState(root);
 
-      // TODO(SAFETY): At least one test runs without this set correctly. At a
-      // later time, update the test to configure this correctly. The test ID:
       // `Router Service - non application test:  RouterService#transitionTo with basic route`
       let instance = owner.lookup('-application-instance:main') as ApplicationInstance;
-      // let instance = owner.lookup('-application-instance:main') as ApplicationInstance | undefined;
-      // assert('[BUG] unexpectedly missing `-application-instance:main`', instance !== undefined);
+      assert('[BUG] unexpectedly missing `-application-instance:main`', instance !== undefined);
 
-      if (instance) {
-        // SAFETY: LOL. This is calling a deprecated API with a type that we
-        // cannot actually confirm at a type level *is* a `ViewMixin`. Seems:
-        // not great on multiple fronts!
-        instance.didCreateRootView(this._toplevelView as any);
-      }
+      // SAFETY: LOL. This is calling a deprecated API with a type that we
+      // cannot actually confirm at a type level *is* a `ViewMixin`. Seems:
+      // not great on multiple fronts!
+      instance.didCreateRootView(this._toplevelView as any);
     } else {
       this._toplevelView.setOutletState(root);
     }

--- a/packages/internal-test-helpers/lib/test-cases/router-non-application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/router-non-application.ts
@@ -34,6 +34,16 @@ export default class RouterNonApplicationTestCase extends AbstractTestCase {
     owner.register('-view-registry:main', Object.create(null), { instantiate: false });
     owner.register('event_dispatcher:main', EventDispatcher);
 
+    // This is a bit of a hack, but we need to register an application instance
+    // so that the router can look it up. In the future, we should probably
+    // make this a real application instance, or at least a real engine instance.
+    let appInstance = {
+      didCreateRootView: (view: any) => {
+        view.appendTo(this.element);
+      },
+    };
+    owner.register('-application-instance:main', appInstance, { instantiate: false });
+
     this.renderer = this.owner.lookup('renderer:-dom') as Renderer;
     this.element = document.querySelector('#qunit-fixture')!;
     this.component = null;


### PR DESCRIPTION
This PR removes a workaround in `packages/@ember/routing/router.ts` that allowed `ApplicationInstance` to be missing in tests. This occurred because `RouterNonApplicationTestCase` in `packages/internal-test-helpers` did not register an application instance.

I have updated the test case to register a mock `ApplicationInstance`, allowing the router to enforce strict dependency checks and removing the `TODO(SAFETY)` comment.

This ensures better type safety and correctness in the router's dependencies.