### PR TITLE
Lint against invalid commit tagging

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,27 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    name: PR title and commit tag lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: lint PR title and commit tags
+        run: node ./bin/pr-lint.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/bin/pr-lint.mjs
+++ b/bin/pr-lint.mjs
@@ -1,0 +1,219 @@
+/* eslint-disable n/no-process-exit */
+/* eslint-disable no-console */
+/* eslint-disable n/no-unsupported-features/node-builtins */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const EVENT_PATH = process.env.GITHUB_EVENT_PATH;
+const EVENT_NAME = process.env.GITHUB_EVENT_NAME;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const COMMITS_PATH = process.env.PR_LINT_COMMITS_PATH;
+const COMMITS_JSON = process.env.PR_LINT_COMMITS_JSON;
+
+if (!EVENT_PATH || !fs.existsSync(EVENT_PATH)) {
+  console.error('Missing GITHUB_EVENT_PATH; cannot read GitHub event payload.');
+  process.exit(1);
+}
+
+if (EVENT_NAME !== 'pull_request') {
+  console.log(`Skipping PR lint: unsupported event ${EVENT_NAME ?? 'unknown'}.`);
+  process.exit(0);
+}
+
+const event = JSON.parse(fs.readFileSync(EVENT_PATH, 'utf8'));
+const pullRequest = event.pull_request;
+
+if (!pullRequest) {
+  console.error('Missing pull_request in event payload.');
+  process.exit(1);
+}
+
+const { number, base } = pullRequest;
+const repo = base?.repo;
+const owner = repo?.owner?.login;
+const repoName = repo?.name;
+
+if (!owner || !repoName || !number) {
+  console.error('Missing repository or PR info in event payload.');
+  process.exit(1);
+}
+
+const errors = [];
+
+const allowedDocChannels = new Set(['canary', 'beta', 'release']);
+const bugfixChannelPattern = /^(beta|release(-\d+(?:-\d+)*)?|lts(-\d+(?:-\d+)*)?)$/;
+const featureNamePattern = /^[a-zA-Z0-9._-]+$/;
+
+function parseTagLine(line, sourceLabel) {
+  if (!line.startsWith('[')) {
+    return;
+  }
+
+  const closingIndex = line.indexOf(']');
+  if (closingIndex === -1) {
+    errors.push(`${sourceLabel}: missing closing "]" for tag.`);
+    return;
+  }
+
+  const tagContent = line.slice(1, closingIndex).trim();
+  if (!tagContent) {
+    errors.push(`${sourceLabel}: empty tag "[]" is not allowed.`);
+    return;
+  }
+
+  const parts = tagContent.split(/\s+/);
+  const tag = parts[0];
+
+  switch (tag) {
+    case 'BUGFIX': {
+      if (parts.length !== 2 || !bugfixChannelPattern.test(parts[1])) {
+        errors.push(
+          `${sourceLabel}: invalid BUGFIX tag. Use "[BUGFIX beta]", "[BUGFIX release]", or "[BUGFIX release-<x-y>]".`
+        );
+      }
+      return;
+    }
+    case 'CLEANUP': {
+      if (parts.length !== 1) {
+        errors.push(`${sourceLabel}: invalid CLEANUP tag. Use "[CLEANUP]" only.`);
+      }
+      return;
+    }
+    case 'FEATURE': {
+      if (parts.length !== 2 || !featureNamePattern.test(parts[1])) {
+        errors.push(
+          `${sourceLabel}: invalid FEATURE tag. Use "[FEATURE <flag-name>]" (letters, numbers, dot, underscore, dash).`
+        );
+      }
+      return;
+    }
+    case 'DOC': {
+      if (parts.length !== 2 || !allowedDocChannels.has(parts[1])) {
+        errors.push(
+          `${sourceLabel}: invalid DOC tag. Use "[DOC canary]", "[DOC beta]", or "[DOC release]".`
+        );
+      }
+      return;
+    }
+    case 'SECURITY': {
+      if (parts.length !== 2) {
+        errors.push(`${sourceLabel}: invalid SECURITY tag. Use "[SECURITY <cve>]".`);
+      }
+      return;
+    }
+    default: {
+      errors.push(
+        `${sourceLabel}: unknown tag "${tag}". Allowed tags: BUGFIX, CLEANUP, FEATURE, DOC, SECURITY.`
+      );
+    }
+  }
+}
+
+function loadCommitsFromEnv() {
+  if (COMMITS_JSON) {
+    try {
+      const parsed = JSON.parse(COMMITS_JSON);
+      if (!Array.isArray(parsed)) {
+        errors.push('PR_LINT_COMMITS_JSON must be a JSON array.');
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      errors.push(`Failed to parse PR_LINT_COMMITS_JSON: ${error?.message ?? error}`);
+      return null;
+    }
+  }
+
+  if (COMMITS_PATH) {
+    const resolved = path.resolve(process.cwd(), COMMITS_PATH);
+    if (!fs.existsSync(resolved)) {
+      errors.push(`PR_LINT_COMMITS_PATH does not exist: ${resolved}`);
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+      if (!Array.isArray(parsed)) {
+        errors.push('PR_LINT_COMMITS_PATH must contain a JSON array.');
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      errors.push(`Failed to parse PR_LINT_COMMITS_PATH: ${error?.message ?? error}`);
+      return null;
+    }
+  }
+
+  return null;
+}
+
+async function fetchAllCommits() {
+  if (!GITHUB_TOKEN) {
+    throw new Error('Missing GITHUB_TOKEN environment variable.');
+  }
+
+  const commits = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const url = new URL(
+      `https://api.github.com/repos/${owner}/${repoName}/pulls/${number}/commits`
+    );
+    url.searchParams.set('per_page', String(perPage));
+    url.searchParams.set('page', String(page));
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'ember-pr-lint',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch PR commits: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    if (!Array.isArray(data) || data.length === 0) {
+      break;
+    }
+
+    commits.push(...data);
+    if (data.length < perPage) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return commits;
+}
+
+try {
+  const commitsFromEnv = loadCommitsFromEnv();
+  const commits = commitsFromEnv ?? (COMMITS_PATH || COMMITS_JSON ? [] : await fetchAllCommits());
+  for (const commit of commits) {
+    const sha = commit?.sha?.slice(0, 8) ?? 'unknown';
+    const message = commit?.commit?.message ?? '';
+    const subject = message.split(/\r?\n/)[0].trim();
+    if (!subject) {
+      errors.push(`Commit ${sha}: missing commit subject.`);
+      continue;
+    }
+    parseTagLine(subject, `Commit ${sha}`);
+  }
+} catch (error) {
+  errors.push(`Failed to load PR commits: ${error?.message ?? error}`);
+}
+
+if (errors.length > 0) {
+  console.error('PR lint failed:\n');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('PR lint passed.');

--- a/node-tests/bin/pr-lint-test.js
+++ b/node-tests/bin/pr-lint-test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const SCRIPT_PATH = path.resolve(__dirname, '../../bin/pr-lint.mjs');
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function runLint({ title, commits }) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ember-pr-lint-'));
+  const eventPath = path.join(tempDir, 'event.json');
+  const commitsPath = path.join(tempDir, 'commits.json');
+
+  const eventPayload = {
+    pull_request: {
+      title,
+      number: 123,
+      base: {
+        repo: {
+          owner: { login: 'emberjs' },
+          name: 'ember.js',
+        },
+      },
+      head: {
+        sha: 'deadbeef',
+      },
+    },
+  };
+
+  writeJson(eventPath, eventPayload);
+  writeJson(commitsPath, commits);
+
+  const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+    env: {
+      ...process.env,
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_EVENT_NAME: 'pull_request',
+      PR_LINT_COMMITS_PATH: commitsPath,
+    },
+    encoding: 'utf8',
+  });
+
+  return result;
+}
+
+describe('bin/pr-lint', function () {
+  it('passes with valid tags', function () {
+    const result = runLint({
+      title: 'PR title',
+      commits: [
+        {
+          sha: 'abc1234',
+          commit: { message: '[BUGFIX beta] Fix broken thing' },
+        },
+        {
+          sha: 'def5678',
+          commit: { message: '[DOC canary] Update docs' },
+        },
+      ],
+    });
+
+    expect(result.status).to.equal(0);
+    expect(result.stderr).to.equal('');
+    expect(result.stdout).to.contain('PR lint passed');
+  });
+
+  it('passes with no tag', function () {
+    const result = runLint({
+      title: 'PR title',
+      commits: [
+        {
+          sha: 'abc1234',
+          commit: { message: 'Misc cleanup' },
+        },
+      ],
+    });
+
+    expect(result.status).to.equal(0);
+    expect(result.stderr).to.equal('');
+    expect(result.stdout).to.contain('PR lint passed');
+  });
+
+  it('passes with BUGFIX lts tags', function () {
+    const result = runLint({
+      title: 'PR title',
+      commits: [
+        {
+          sha: 'abc1234',
+          commit: { message: '[BUGFIX lts] Fix LTS regression' },
+        },
+        {
+          sha: 'def5678',
+          commit: { message: '[BUGFIX lts-5-12] Fix older LTS regression' },
+        },
+      ],
+    });
+
+    expect(result.status).to.equal(0);
+    expect(result.stderr).to.equal('');
+    expect(result.stdout).to.contain('PR lint passed');
+  });
+
+  it('fails on invalid commit tag', function () {
+    const result = runLint({
+      title: 'PR title',
+      commits: [
+        {
+          sha: 'abc1234',
+          commit: { message: '[DOC alpha] Documentation update' },
+        },
+      ],
+    });
+
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain('Commit abc1234: invalid DOC tag');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lint:format:fix": "prettier --write .",
     "test": "testem ci -f testem.js --host 127.0.0.1 --port 13141",
     "test:blueprints": "mocha node-tests/blueprints/**/*-test.js",
+    "test:bin": "mocha node-tests/bin/**/*-test.js",
     "test:node": "qunit tests/node/**/*-test.js",
     "test:browserstack": "node bin/run-browserstack-tests.js",
     "test:wip": "vite build --mode development --minify false && testem ci",


### PR DESCRIPTION
I'm bad at this, so hopefully a tool can help me be less bad

Example successes:
- no tag used
- correct tags used with correct channels (if allowed)

Example failures:

```
Run node ./bin/pr-lint.mjs
PR lint failed:

- Commit 6bcaf0b5: invalid BUGFIX tag. Use "[BUGFIX beta]", "[BUGFIX release]", or "[BUGFIX release-<x-y>]".

```

