### PR TITLE
[DOC] Removed arguments from willDestroy for Glimmer components

### DIFF
--- a/packages/@glimmer/component/src/index.ts
+++ b/packages/@glimmer/component/src/index.ts
@@ -331,7 +331,7 @@ import { setOwner, type default as Owner } from '@ember/owner';
     @service myAnimations;
 
     willDestroy() {
-      super.willDestroy(...arguments);
+      super.willDestroy();
 
       this.myAnimations.unregister(this);
     }


### PR DESCRIPTION
## Background

In a production project, I saw that developers had written the following,

```gts
import Component from '@glimmer/component';

export default class MyComponent extends Component {
  willDestroy(...args: Parameters<Component['willDestroy']>): void {
    super.willDestroy(...args);

    // ...
  }
}
```

when this would suffice:

```gts
import Component from '@glimmer/component';

export default class MyComponent extends Component {
  willDestroy(): void {
    super.willDestroy();

    // ...
  }
}
```

The [source code for `GlimmerComponent`](https://github.com/emberjs/ember.js/blob/v6.10.1-ember-source/packages/%40glimmer/component/src/-private/component.ts#L285) shows that `willDestroy` doesn't take any arguments, but the [API Guides](https://api.emberjs.com/ember/6.10/modules/@glimmer%2Fcomponent) still claim that it does (I'm guessing based on what had happened with the classic Ember component?).

```ts
import Component from '@glimmer/component';
import { service } from '@ember/service';

export default class SomeComponent extends Component {
  @service myAnimations;

  willDestroy() {
    super.willDestroy(...arguments);

    this.myAnimations.unregister(this);
  }
}
```
