### PR TITLE
[DOC] Fix `@ember/controller` module name in API docs for LTS 4.8

### DIFF
--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -18,7 +18,7 @@ export type ControllerQueryParam = string | Record<string, { type: ControllerQue
 const MODEL = symbol('MODEL');
 
 /**
-@module ember/controller
+@module @ember/controller
 */
 
 /**


### PR DESCRIPTION
Resolves #20348 for the 4.8 LTS branch.

Add missing `@` prefix to `@module` JSDoc tag so that the API docs correctly list `@ember/controller` under Packages for the 4.8 LTS release. (does not fix 4.9–4.11, but that is ok, i guess?)

Backport of #20346 which fixed this on main (landed in 4.12+). 