### PR TITLE
[BUGFIX] Regression [Ember 5.12+] Non helpful error when the function for on modifier was forgot as param

### DIFF
--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -58,18 +58,17 @@ export class OnModifierState {
     let { element, args, listener } = this;
 
     let arg0 = args.positional[0];
-
-    if (DEBUG && !arg0) {
-      throw new Error(
-        'You must pass a valid DOM event name as the first argument to the `on` modifier'
-      );
-    }
-
     let eventName = check(
       arg0 ? valueForRef(arg0) : undefined,
       CheckString,
       () => 'You must pass a valid DOM event name as the first argument to the `on` modifier'
     );
+
+    if (DEBUG && !eventName) {
+      throw new Error(
+        'You must pass a valid DOM event name as the first argument to the `on` modifier'
+      );
+    }
 
     let arg1 = args.positional[1];
     let userProvidedCallback = check(

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -14,7 +14,7 @@ import {
   CheckString,
   CheckUndefined,
 } from '@glimmer/debug';
-import { buildUntouchableThis, localAssert } from '@glimmer/debug-util';
+import { buildUntouchableThis } from '@glimmer/debug-util';
 import { registerDestructor } from '@glimmer/destroyable';
 import { setInternalModifierManager } from '@glimmer/manager';
 import { valueForRef } from '@glimmer/reference';
@@ -57,13 +57,16 @@ export class OnModifierState {
   updateListener(): void {
     let { element, args, listener } = this;
 
-    localAssert(
-      args.positional[0],
-      'You must pass a valid DOM event name as the first argument to the `on` modifier'
-    );
+    let arg0 = args.positional[0];
+
+    if (DEBUG && !arg0) {
+      throw new Error(
+        'You must pass a valid DOM event name as the first argument to the `on` modifier'
+      );
+    }
 
     let eventName = check(
-      valueForRef(args.positional[0]),
+      arg0 ? valueForRef(arg0) : undefined,
       CheckString,
       () => 'You must pass a valid DOM event name as the first argument to the `on` modifier'
     );

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -79,12 +79,13 @@ export class OnModifierState {
       }
     ) as EventListener;
 
-    localAssert(
-      typeof userProvidedCallback === 'function',
-      `You must pass a function as the second argument to the \`on\` modifier; you passed ${
-        userProvidedCallback === null ? 'null' : typeof userProvidedCallback
-      }. While rendering:\n\n${args.positional[1]?.debugLabel ?? `{unlabeled value}`}`
-    );
+    if (DEBUG && typeof userProvidedCallback !== 'function') {
+      throw new Error(
+        `You must pass a function as the second argument to the \`on\` modifier; you passed ${
+          userProvidedCallback === null ? 'null' : typeof userProvidedCallback
+        }. While rendering:\n\n${args.positional[1]?.debugLabel ?? `{unlabeled value}`}`
+      );
+    }
 
     if (DEBUG && args.positional.length !== 2) {
       throw new Error(

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -85,7 +85,7 @@ export class OnModifierState {
       throw new Error(
         `You must pass a function as the second argument to the \`on\` modifier; you passed ${
           userProvidedCallback === null ? 'null' : typeof userProvidedCallback
-        }. While rendering:\n\n${args.positional[1]?.debugLabel ?? `{unlabeled value}`}`
+        }. While rendering:\n\n${args.positional[1]?.debugLabel ?? '(unknown)'} on <${this.element.tagName.toLowerCase()}>`
       );
     }
 

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -57,6 +57,17 @@ export class OnModifierState {
   updateListener(): void {
     let { element, args, listener } = this;
 
+    let selector: string | undefined;
+    if (DEBUG) {
+      const el = this.element;
+      selector =
+        el.tagName.toLowerCase() +
+        (el.id ? `#${el.id}` : '') +
+        Array.from(el.classList)
+          .map((c) => `.${c}`)
+          .join('');
+    }
+
     let arg0 = args.positional[0];
     let eventName = check(
       arg0 ? valueForRef(arg0) : undefined,
@@ -66,7 +77,7 @@ export class OnModifierState {
 
     if (DEBUG && !eventName) {
       throw new Error(
-        'You must pass a valid DOM event name as the first argument to the `on` modifier'
+        `You must pass a valid DOM event name as the first argument to the \`on\` modifier on ${selector}`
       );
     }
 
@@ -85,13 +96,13 @@ export class OnModifierState {
       throw new Error(
         `You must pass a function as the second argument to the \`on\` modifier; you passed ${
           userProvidedCallback === null ? 'null' : typeof userProvidedCallback
-        }. While rendering:\n\n${args.positional[1]?.debugLabel ?? '(unknown)'} on <${this.element.tagName.toLowerCase()}>`
+        }. While rendering:\n\n${args.positional[1]?.debugLabel ?? '(unknown)'} on ${selector}`
       );
     }
 
     if (DEBUG && args.positional.length !== 2) {
       throw new Error(
-        `You can only pass two positional arguments (event name and callback) to the \`on\` modifier, but you provided ${args.positional.length}. Consider using the \`fn\` helper to provide additional arguments to the \`on\` callback.`
+        `You can only pass two positional arguments (event name and callback) to the \`on\` modifier, but you provided ${args.positional.length}. Consider using the \`fn\` helper to provide additional arguments to the \`on\` callback on ${selector}`
       );
     }
 
@@ -127,7 +138,7 @@ export class OnModifierState {
         throw new Error(
           `You can only \`once\`, \`passive\` or \`capture\` named arguments to the \`on\` modifier, but you provided ${Object.keys(
             extra
-          ).join(', ')}.`
+          ).join(', ')} on ${selector}`
         );
       }
     } else {

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -308,6 +308,18 @@ function basicTest(scenarios: Scenarios, appName: string) {
                   });
                   await render(<template><div {{on}}>Click</div></template>);
                 });
+
+                test('error message includes element selector', async function (assert) {
+                  assert.expect(1);
+                  const noop = undefined;
+                  setupOnerror((error) => {
+                    assert.true(
+                      /button#my-id\\.class1\\.class2/.test(error.message),
+                      'Expected element selector in error, got: ' + error.message
+                    );
+                  });
+                  await render(<template><button id="my-id" class="class1 class2" {{on "click" noop}}>Click</button></template>);
+                });
               });
             `,
           },

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -285,7 +285,7 @@ function basicTest(scenarios: Scenarios, appName: string) {
                   resetOnerror();
                 });
 
-                test('throws helpful error when callback is undefined', async function (assert) {
+                test('throws helpful error when callback is missing', async function (assert) {
                   assert.expect(1);
                   const noop = undefined;
                   setupOnerror((error) => {
@@ -297,16 +297,16 @@ function basicTest(scenarios: Scenarios, appName: string) {
                   await render(<template><div {{on "click" noop}}>Click</div></template>);
                 });
 
-                test('throws helpful error when callback is null', async function (assert) {
+                test('throws helpful error when event name is missing', async function (assert) {
                   assert.expect(1);
-                  const noop = null;
+                  const noop = () => {};
                   setupOnerror((error) => {
                     assert.true(
-                      /You must pass a function as the second argument to the \`on\` modifier/.test(error.message),
+                      /You must pass a valid DOM event name as the first argument to the \`on\` modifier/.test(error.message),
                       'Expected helpful error message, got: ' + error.message
                     );
                   });
-                  await render(<template><div {{on "click" noop}}>Click</div></template>);
+                  await render(<template><div {{on}}>Click</div></template>);
                 });
               });
             `,

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -269,6 +269,44 @@ function basicTest(scenarios: Scenarios, appName: string) {
                   let allNodes = flattenTree(tree);
                   let names = allNodes.filter(n => n.type === 'component').map(n => n.name);
                   assert.true(names.includes('HelloWorld'), 'HelloWorld component name is preserved in the render tree (found: ' + names.join(', ') + ')');
+                  });
+              });
+            `,
+            'on-modifier-error-test.gjs': `
+              import { module, test } from 'qunit';
+              import { render, setupOnerror, resetOnerror } from '@ember/test-helpers';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { on } from '@ember/modifier';
+
+              module('on modifier | error handling', function (hooks) {
+                setupRenderingTest(hooks);
+
+                hooks.afterEach(function () {
+                  resetOnerror();
+                });
+
+                test('throws helpful error when callback is undefined', async function (assert) {
+                  assert.expect(1);
+                  const noop = undefined;
+                  setupOnerror((error) => {
+                    assert.true(
+                      /You must pass a function as the second argument to the \`on\` modifier/.test(error.message),
+                      'Expected helpful error message, got: ' + error.message
+                    );
+                  });
+                  await render(<template><div {{on "click" noop}}>Click</div></template>);
+                });
+
+                test('throws helpful error when callback is null', async function (assert) {
+                  assert.expect(1);
+                  const noop = null;
+                  setupOnerror((error) => {
+                    assert.true(
+                      /You must pass a function as the second argument to the \`on\` modifier/.test(error.message),
+                      'Expected helpful error message, got: ' + error.message
+                    );
+                  });
+                  await render(<template><div {{on "click" noop}}>Click</div></template>);
                 });
               });
             `,


### PR DESCRIPTION
Fixes #20783 / #21045                                                                                                                                                                                     
                                                                                                                                                                                                            
  Since Ember 5.12, passing a non-function to the `{{on}}` modifier produces an unhelpful `TypeError: Cannot read properties of undefined (reading 'bind') instead of the previous helpful message: "You must pass a function as the second argument to the on modifier; you passed undefined."`

### Root cause

The glimmer-vm refactor in https://github.com/glimmerjs/glimmer-vm/commit/2d9fc0174e5c49f0b79736664cd4162eccd4e6a8 replaced expect() (a runtime check that always executes) with localAssert() (guarded by LOCAL_DEBUG, which is stripped in published builds). This meant the callback validation became a no-op in published ember-source, while the .bind() call further down — guarded by DEBUG — still runs, producing the unhelpful TypeError.

The key distinction: LOCAL_DEBUG is only true when developing the ember.js repo itself. DEBUG (from @glimmer/env) is true in user app development mode. The existing test suite always runs with LOCAL_DEBUG=true, so this gap was never caught.

### Fix

  - Replace localAssert() with an explicit if (DEBUG) check, matching the pattern already used in the same function for positional argument validation
  - Add a smoke test that runs against built ember-source (LOCAL_DEBUG=false, DEBUG=true) — the exact environment users have — to prevent this class of regression

Cowritten by Claude.

Not sure whether it should be backported to LTS, considering the repo-merge.