### PR TITLE
Simplify lexicalScope function by removing global check

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
@@ -338,7 +338,7 @@ moduleFor(
   }
 );
 
-// These tests are more to ensure that we don't accidentally break anything from 
+// These tests are more to ensure that we don't accidentally break anything from
 // RFC#1070 -- but explicit scope does not _implicitly_ get access to anything
 // so the globals here are still just passed in to the scope bag, as if they were
 // normal variables.

--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
@@ -353,7 +353,10 @@ moduleFor(
         this.prototype[`@test Can use ${globalName}`] = async function () {
           await this.renderComponentModule(() => {
             return template(`{{if ${globalName} "exists"}}`, {
-              scope: () => ({ [globalName]: globalThis[globalName] }),
+              scope: () => ({
+                // @ts-expect-error - dynamic test gets minimally type safety
+                [globalName]: globalThis[globalName],
+              }),
             });
           });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/runtime-template-compiler-explicit-test.ts
@@ -338,6 +338,10 @@ moduleFor(
   }
 );
 
+// These tests are more to ensure that we don't accidentally break anything from 
+// RFC#1070 -- but explicit scope does not _implicitly_ get access to anything
+// so the globals here are still just passed in to the scope bag, as if they were
+// normal variables.
 moduleFor(
   'Strict Mode - Runtime Template Compiler (explicit) - allowed globals from RFC#1070',
   class AllowedGlobalsTest extends RenderingTestCase {
@@ -349,7 +353,7 @@ moduleFor(
         this.prototype[`@test Can use ${globalName}`] = async function () {
           await this.renderComponentModule(() => {
             return template(`{{if ${globalName} "exists"}}`, {
-              scope: () => ({}),
+              scope: () => ({ [globalName]: globalThis[globalName] }),
             });
           });
 

--- a/packages/@ember/template-compiler/lib/compile-options.ts
+++ b/packages/@ember/template-compiler/lib/compile-options.ts
@@ -58,10 +58,6 @@ function buildCompileOptions(_options: EmberPrecompileOptions): EmberPrecompileO
     const scope = (options.scope as () => Record<string, unknown>)();
 
     options.lexicalScope = (variable: string) => {
-      if (ALLOWED_GLOBALS.has(variable)) {
-        return variable in globalThis;
-      }
-
       return variable in scope;
     };
 


### PR DESCRIPTION
Removed check for ALLOWED_GLOBALS in lexicalScope function.

Testing if PR comment from https://github.com/emberjs/ember.js/pull/21076#discussion_r2834877114 is accurate -- as I've forgotten (been too long!)