### PR TITLE
Prod build + package.json#export condition for production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ assets/bpm_libs.js
 assets/bpm_styles.css
 coverage
 dist
+dist-prod
 /docs
 lib/*/tests/all.js
 lib/*/tests/qunit*

--- a/broccoli/import-meta.js
+++ b/broccoli/import-meta.js
@@ -13,7 +13,7 @@ export function importMetaRemoval(debugMacrosMode) {
         return;
       }
 
-      if (debugMacrosMode === false) {
+      if (debugMacrosMode === false || debugMacrosMode === 'production') {
         if (hasDEV(code)) {
           return code.replace(/import.meta.env\??.DEV/g, 'false');
         }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,7 @@ export default [
       'docs/',
       '**/.*',
       '**/dist/',
+      '**/dist-prod/',
       '**/tmp/',
       '**/smoke-tests/',
       '**/types/',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "ember-addon"
   ],
   "exports": {
-    "./*": "./dist/packages/*",
+    "./*": {
+      "development": "./dist/packages/*",
+      "production": "./dist-prod/packages/*",
+      "default": "./dist/packages/*"
+    },
     "./types": {
       "types": "./types/stable/index.d.ts"
     },
@@ -24,6 +28,7 @@
     "blueprints",
     "dist/packages",
     "dist/dependencies",
+    "dist-prod/packages",
     "dist/ember-template-compiler.js",
     "dist/ember-template-compiler.js.map",
     "dist/ember.debug.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -27,7 +27,7 @@ const testDependencies = [
 
 let configs = [
   esmConfig(),
-  esmTemplateCompiler(),
+  esmProdConfig(),
   legacyBundleConfig('./broccoli/amd-compat-entrypoints/ember.debug.js', 'ember.debug.js', {
     isDeveloping: true,
   }),
@@ -55,61 +55,69 @@ export default configs;
 
 function esmConfig() {
   return sharedESMConfig({
-    input: {
-      ...renameEntrypoints(exposedDependencies(), (name) => join('packages', name, 'index')),
-      ...renameEntrypoints(packages(), (name) => join('packages', name)),
-    },
+    input: esmInputs(),
     debugMacrosMode: '@embroider/macros',
+    includePackageMeta: true,
   });
 }
 
-function esmTemplateCompiler() {
+function esmProdConfig() {
   return sharedESMConfig({
-    input: {
-      // the actual authored "./packages/ember-template-compiler/index.ts" is
-      // part of what powers the historical dist/ember-template-compiler.js AMD
-      // bundle. It has historical cruft that has never been present in our ESM
-      // builds.
-      //
-      // On the ESM build, the main entrypoint of ember-template-compiler is the
-      // "minimal.ts" version, which has a lot less in it.
-
-      'packages/ember-template-compiler/index': 'ember-template-compiler/minimal.ts',
-    },
-    // the template compiler is always in debug mode (and doesn't use
-    // embroider/macros, so it's directly invokable on node)
-    debugMacrosMode: true,
+    input: esmInputs(),
+    debugMacrosMode: 'production',
   });
 }
 
-function sharedESMConfig({ input, debugMacrosMode }) {
+function esmInputs() {
+  return {
+    ...renameEntrypoints(exposedDependencies(), (name) => join('packages', name, 'index')),
+    ...renameEntrypoints(packages(), (name) => join('packages', name)),
+    // the actual authored "./packages/ember-template-compiler/index.ts" is
+    // part of what powers the historical dist/ember-template-compiler.js AMD
+    // bundle. It has historical cruft that has never been present in our ESM
+    // builds.
+    //
+    // On the ESM build, the main entrypoint of ember-template-compiler is the
+    // "minimal.ts" version, which has a lot less in it.
+
+    'packages/ember-template-compiler/index': 'ember-template-compiler/minimal.ts',
+  };
+}
+
+function sharedESMConfig({ input, debugMacrosMode, includePackageMeta = false }) {
+  let outputDir = debugMacrosMode === 'production' ? 'dist-prod' : 'dist';
   let babelConfig = { ...sharedBabelConfig };
   babelConfig.plugins = [...babelConfig.plugins, canaryFeatures()];
+
+  let plugins = [
+    importMetaRemoval(debugMacrosMode),
+    babel({
+      babelHelpers: 'bundled',
+      extensions: ['.js', '.ts'],
+      configFile: false,
+      ...babelConfig,
+    }),
+    resolveTS(),
+    version(),
+    resolvePackages({ ...exposedDependencies(), ...hiddenDependencies() }),
+    pruneEmptyBundles(),
+  ];
+
+  if (includePackageMeta) {
+    plugins.push(packageMeta());
+  }
 
   return {
     onLog: handleRollupWarnings,
     input,
     output: {
       format: 'es',
-      dir: 'dist',
+      dir: outputDir,
       hoistTransitiveImports: false,
       generatedCode: 'es2015',
       chunkFileNames: 'packages/shared-chunks/[name]-[hash].js',
     },
-    plugins: [
-      importMetaRemoval(debugMacrosMode),
-      babel({
-        babelHelpers: 'bundled',
-        extensions: ['.js', '.ts'],
-        configFile: false,
-        ...babelConfig,
-      }),
-      resolveTS(),
-      version(),
-      resolvePackages({ ...exposedDependencies(), ...hiddenDependencies() }),
-      pruneEmptyBundles(),
-      packageMeta(),
-    ],
+    plugins,
   };
 }
 
@@ -642,11 +650,15 @@ function pruneEmptyBundles() {
 function packageMeta() {
   return {
     name: 'package-meta',
-    generateBundle() {
+    generateBundle(_outputOptions, bundle) {
       let renamedModules = Object.fromEntries(
-        glob
-          .sync('packages/**/*.js', { cwd: 'dist', nodir: true })
-          .filter((name) => !name.startsWith('packages/shared-chunks/'))
+        Object.keys(bundle)
+          .filter(
+            (name) =>
+              name.startsWith('packages/') &&
+              !name.startsWith('packages/shared-chunks/') &&
+              name.endsWith('.js')
+          )
           .sort()
           .map((name) => {
             return [


### PR DESCRIPTION
 apparently the perf script is trying to use the production bundle, so that kinda counts as tests


This PR depends on https://github.com/emberjs/ember.js/pull/21115 so that the esm / esm-template-compiler unification isn't weird / different from how it is on main