### PR TITLE
[BUGFIX] Fix {{#each}} runtime crash when array contains null/undefined items with key #20786

### DIFF
--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -52,7 +52,12 @@ function keyForPath(path: string): KeyFor {
   if (DEBUG && path[0] === '@') {
     throw new Error(`invalid keypath: '${path}', valid keys: @index, @identity, or a path`);
   }
-  return uniqueKeyFor((item) => getPath(item as object, path));
+  return uniqueKeyFor((item) => {
+    if (item === null || item === undefined) {
+      return item;
+    }
+    return getPath(item as object, path);
+  });
 }
 
 function makeKeyFor(key: string) {

--- a/packages/ember-template-compiler/tests/plugins/assert-array-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-array-test.js
@@ -38,5 +38,23 @@ moduleFor(
       this.assertHTML('<ul><li>2</li><li>4</li><li>6</li></ul>');
       this.assertStableRerender();
     }
+
+    ['@test survives undefined item with key'](assert) {
+      // Intentionally double all of the values to verify that this
+      // version of the `array` function is used.
+      function array(...values) {
+        return values.map((value) => value * 2);
+      }
+
+      let Root = defineComponent(
+        { array },
+        `<ul>{{#each (array undefined) key="anything" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
+      );
+      this.registerComponent('root', { ComponentClass: Root });
+
+      this.render('<Root />');
+      this.assertHTML('<ul><li></li></ul>');
+      this.assertStableRerender();
+    }
   }
 );

--- a/packages/ember-template-compiler/tests/plugins/assert-array-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-array-test.js
@@ -39,21 +39,31 @@ moduleFor(
       this.assertStableRerender();
     }
 
-    ['@test survives undefined item with key'](assert) {
-      // Intentionally double all of the values to verify that this
-      // version of the `array` function is used.
-      function array(...values) {
-        return values.map((value) => value * 2);
-      }
+    ['@test survives undefined item with key']() {
+      let myArray = [1, undefined];
 
       let Root = defineComponent(
-        { array },
-        `<ul>{{#each (array undefined) key="anything" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
+        { myArray },
+        `<ul>{{#each myArray key="anything" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
       );
       this.registerComponent('root', { ComponentClass: Root });
 
       this.render('<Root />');
-      this.assertHTML('<ul><li></li></ul>');
+      this.assertHTML('<ul><li>1</li><li></li></ul>');
+      this.assertStableRerender();
+    }
+
+    ['@test survives null item with key']() {
+      let myArray = [1, null];
+
+      let Root = defineComponent(
+        { myArray },
+        `<ul>{{#each myArray key="anything" as |item|}}<li>{{item}}</li>{{/each}}</ul>`
+      );
+      this.registerComponent('root', { ComponentClass: Root });
+
+      this.render('<Root />');
+      this.assertHTML('<ul><li>1</li><li></li></ul>');
       this.assertStableRerender();
     }
   }


### PR DESCRIPTION
### Summary

 - Fixes `{{#each}}` throwing `Cannot call get with '...' on an undefined object` when the iterated array contains `null` or `undefined` items and a `key` is specified (e.g. `{{#each items key="id"}}`)
 - Guards against `null`/`undefined` items in `keyForPath` before calling `getPath`, returning the item itself as the key

Fixes #20786

### Reproduction
https://limber.glimdown.com/edit?c=MYewdgzgLgBAtgTwIICcUEMEwLwwNoCMANDAK5gAmApgGYCWYVFAugFCsA8UVcADgDbpuAPlYwYAbwkBiKumAALeMjSYYAayoJsAIjoUdMdBBgAfOtzimAvtbHjJEiz1v2pAejmLXHd5YFCVMJAA&format=gjs

### Test plan
  - Added tests for `{{#each}}` with undefined and null items in the array when key is specified
  - Verified tests fail without the fix with the exact error from the bug report
  
  
### Alternatives to this fix
1) Wire getPath to _getPath instead of get in environment.ts
2) Remove/relax the assertion in get() for null/undefined

I'd lean toward the current fix because:
  - The get() assertion is intentional for the public API — calling get(undefined, 'foo') is almost always a bug in user code, and the assertion helps catch that
  - _getPath/_getProp being lenient is for internal chained path traversal (e.g. get(obj, 'a.b.c') where a.b is undefined)
  - Fixing in keyForPath is more targeted
  
  Cowritten by Claude