### PR TITLE
[BUGFIX] Fix crash when accessing negative index of helper positional args #20912

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -782,6 +782,17 @@ moduleFor(
 
       this.assertText('hello');
     }
+
+    ['@test accessing negative index of positional args returns undefined']() {
+      this.registerHelper('my-helper', (positional) => {
+        return String(positional[-1]);
+      });
+
+      this.render('{{my-helper "hello"}}');
+
+      this.assertText('undefined');
+      this.assertStableRerender();
+    }
   }
 );
 

--- a/packages/@glimmer/manager/lib/util/args-proxy.ts
+++ b/packages/@glimmer/manager/lib/util/args-proxy.ts
@@ -47,7 +47,7 @@ function tagForPositionalArg(positionalArgs: CapturedPositionalArguments, key: s
 
     const parsed = convertToInt(key);
 
-    if (parsed !== null && parsed < positionalArgs.length) {
+    if (parsed !== null && parsed >= 0 && parsed < positionalArgs.length) {
       // consume the tag of the referenced index
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       valueForRef(positionalArgs[parsed]!);
@@ -116,7 +116,7 @@ class PositionalArgsProxy implements ProxyHandler<[]> {
 
     const parsed = convertToInt(prop);
 
-    if (parsed !== null && parsed < positional.length) {
+    if (parsed !== null && parsed >= 0 && parsed < positional.length) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       return valueForRef(positional[parsed]!);
     }
@@ -132,7 +132,7 @@ class PositionalArgsProxy implements ProxyHandler<[]> {
   has(_target: [], prop: string | number | symbol) {
     const parsed = convertToInt(prop);
 
-    return parsed !== null && parsed < this.positional.length;
+    return parsed !== null && parsed >= 0 && parsed < this.positional.length;
   }
 }
 


### PR DESCRIPTION
## Summary
  - Fixes helper crash (`Cannot destructure property 'tag' of 'ref'`) when
    accessing a negative index on positional arguments (e.g. `positional[-1]`)
  - Adds `>= 0` bound check in `PositionalArgsProxy.get`, `has`, and
    `tagForPositionalArg`

Fixes #20912

## Test plan
- Added 1 test which fails before the fix as `accessing negative index of positional args returns undefined — TypeError: Cannot destructure property 'tag' of 'ref' as it is undefined` 

Cowritten by Claude