### PR TITLE
[CLEANUP] Remove outdated _super reference from init assertion (#18790)

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -2931,7 +2931,7 @@ moduleFor(
 
       expectAssertion(() => {
         this.render('{{foo-bar}}');
-      }, /You must call `super.init\(...arguments\);` or `this._super\(...arguments\)` when overriding `init` on a framework object. Please update .*/);
+      }, /You must call `super.init\(...arguments\);` when overriding `init` on a framework object. Please update .*/);
     }
 
     ['@test it can use readDOMAttr to read input value']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -77,7 +77,7 @@ moduleFor(
 
       expectAssertion(() => {
         this.render('{{hello-world}}');
-      }, /You must call `super.init\(...arguments\);` or `this._super\(...arguments\)` when overriding `init` on a framework object. Please update .*/);
+      }, /You must call `super.init\(...arguments\);` when overriding `init` on a framework object. Please update .*/);
     }
 
     ['@test class-based helper can recompute a new value'](assert) {

--- a/packages/@ember/object/-internals.ts
+++ b/packages/@ember/object/-internals.ts
@@ -39,7 +39,7 @@ if (DEBUG) {
 
     [ASSERT_INIT_WAS_CALLED]() {
       assert(
-        `You must call \`super.init(...arguments);\` or \`this._super(...arguments)\` when overriding \`init\` on a framework object. Please update ${this} to call \`super.init(...arguments);\` from \`init\` when using native classes or \`this._super(...arguments)\` when using \`EmberObject.extend()\`.`,
+        `You must call \`super.init(...arguments);\` when overriding \`init\` on a framework object. Please update ${this} to call \`super.init(...arguments);\` from \`init\`.`,
         this[INIT_WAS_CALLED]
       );
     }


### PR DESCRIPTION
## Summary
  - Simplifies the init override assertion to only reference super.init(...arguments)
  - Simplifies the init override assertion to focus on super.init(...arguments), dropping the legacy this._super() / EmberObject.extend() alternative

Closes #18790

## Alternative approach: conditional message (per rwjblue's comment)
                                                                                                                                                                                                                                              
  rwjblue suggested detecting octane flags to conditionalize the message. In Ember 7 there are no octane flags, but we could detect the usage pattern at runtime — e.g. check if the user's init was wrapped by EmberObject.extend() (via IS_WRAPPED_FUNCTION_SET in super.ts) and show this._super(...) guidance only in that case:
```js
  if (IS_WRAPPED_FUNCTION_SET.has(this.init)) {
    // suggest this._super(...arguments)
  } else {
    // suggest super.init(...arguments)
  }
  ```

not sure, see draft for alternative with conditional, [supporting classic patterns](https://github.com/johanrd/ember.js/pull/1/changes)

Cowritten by claude