### PR TITLE
[BUGFIX] Fix trackedMap and trackedWeakMap reactivity for existing keys

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/collections/map-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/collections/map-test.ts
@@ -269,6 +269,82 @@ class TrackedMapTest extends RenderTest {
   }
 
   @test
+  'values: set existing value triggers reactivity'() {
+    this.assertReactivity(
+      class extends Component {
+        map = trackedMap([['foo', 123]]);
+
+        get value() {
+          let sum = 0;
+          for (const v of this.map.values()) sum += v;
+          return sum;
+        }
+
+        update() {
+          this.map.set('foo', 456);
+        }
+      }
+    );
+  }
+
+  @test
+  'entries: set existing value triggers reactivity'() {
+    this.assertReactivity(
+      class extends Component {
+        map = trackedMap([['foo', 123]]);
+
+        get value() {
+          let result = '';
+          for (const [k, v] of this.map.entries()) result += `${k}:${v}`;
+          return result;
+        }
+
+        update() {
+          this.map.set('foo', 456);
+        }
+      }
+    );
+  }
+
+  @test
+  'forEach: set existing value triggers reactivity'() {
+    this.assertReactivity(
+      class extends Component {
+        map = trackedMap([['foo', 123]]);
+
+        get value() {
+          let sum = 0;
+          this.map.forEach((v) => {
+            sum += v;
+          });
+          return sum;
+        }
+
+        update() {
+          this.map.set('foo', 456);
+        }
+      }
+    );
+  }
+
+  @test
+  'set existing falsy value triggers reactivity'() {
+    this.assertReactivity(
+      class extends Component {
+        map = trackedMap<string, number>([['foo', 0]]);
+
+        get value() {
+          return this.map.get('foo');
+        }
+
+        update() {
+          this.map.set('foo', 123);
+        }
+      }
+    );
+  }
+
+  @test
   'each: set'() {
     this.assertEachReactivity(
       class extends Component {

--- a/packages/@glimmer-workspace/integration-tests/test/collections/weak-map-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/collections/weak-map-test.ts
@@ -187,6 +187,24 @@ class TrackedWeakMapTest extends RenderTest {
     );
   }
 
+  @test
+  'set existing falsy value triggers reactivity'() {
+    this.assertReactivity(
+      class extends Component {
+        obj = {};
+        map = trackedWeakMap<object, number>([[this.obj, 0]]);
+
+        get value() {
+          return this.map.get(this.obj);
+        }
+
+        update() {
+          this.map.set(this.obj, 123);
+        }
+      }
+    );
+  }
+
   @test 'delete unrelated value'() {
     this.assertReactivity(
       class extends Component {

--- a/packages/@glimmer/validator/lib/collections/map.ts
+++ b/packages/@glimmer/validator/lib/collections/map.ts
@@ -51,10 +51,8 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
   }
 
   // **** ALL GETTERS ****
-  entries() {
-    consumeTag(this.#collection);
-
-    return this.#vals.entries();
+  entries(): MapIterator<[K, V]> {
+    return this[Symbol.iterator]();
   }
 
   getOrInsert(key: K, defaultValue: V): V {
@@ -82,15 +80,23 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
   }
 
   values() {
-    consumeTag(this.#collection);
+    let iterator = this[Symbol.iterator]();
 
-    return this.#vals.values();
+    return {
+      next() {
+        let { value, done } = iterator.next();
+        return { value: done ? (undefined as V) : value![1], done };
+      },
+      [Symbol.iterator]() {
+        return this;
+      },
+    } as MapIterator<V>;
   }
 
   forEach(fn: (value: V, key: K, map: Map<K, V>) => void): void {
-    consumeTag(this.#collection);
-
-    this.#vals.forEach(fn);
+    for (let [key, value] of this) {
+      fn(value, key, this);
+    }
   }
 
   get size(): number {
@@ -121,6 +127,9 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return { value: [currentKey, self.get(currentKey!)], done: false };
       },
+      [Symbol.iterator]() {
+        return this;
+      },
     } as MapIterator<[K, V]>;
   }
 
@@ -129,10 +138,10 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
   }
 
   set(key: K, value: V): this {
-    let existing = this.#vals.get(key);
+    let existing = this.#vals.has(key);
 
     if (existing) {
-      let isUnchanged = this.#options.equals(existing, value);
+      let isUnchanged = this.#options.equals(this.#vals.get(key) as V, value);
 
       if (isUnchanged) {
         return this;

--- a/packages/@glimmer/validator/lib/collections/map.ts
+++ b/packages/@glimmer/validator/lib/collections/map.ts
@@ -107,8 +107,10 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
 
   /**
    * When iterating:
-   * - we entangle with the collection (as we iterate over the whole thing
+   * - we entangle with the collection (as we iterate over the whole thing)
+   *   via keys() → consumeTag(#collection)
    * - for each individual item, we entangle with the item as well
+   *   via get() → consumeTag(#storageFor(key))
    */
   [Symbol.iterator]() {
     let keys = this.keys();
@@ -138,9 +140,9 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
   }
 
   set(key: K, value: V): this {
-    let existing = this.#vals.has(key);
+    let hasExisting = this.#vals.has(key);
 
-    if (existing) {
+    if (hasExisting) {
       let isUnchanged = this.#options.equals(this.#vals.get(key) as V, value);
 
       if (isUnchanged) {
@@ -150,7 +152,7 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
 
     this.#dirtyStorageFor(key);
 
-    if (!existing) {
+    if (!hasExisting) {
       DIRTY_TAG(this.#collection);
     }
 

--- a/packages/@glimmer/validator/lib/collections/map.ts
+++ b/packages/@glimmer/validator/lib/collections/map.ts
@@ -85,7 +85,7 @@ class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
     return {
       next() {
         let { value, done } = iterator.next();
-        return { value: done ? (undefined as V) : value![1], done };
+        return { value: done ? (undefined as V) : value?.[1], done };
       },
       [Symbol.iterator]() {
         return this;

--- a/packages/@glimmer/validator/lib/collections/weak-map.ts
+++ b/packages/@glimmer/validator/lib/collections/weak-map.ts
@@ -51,10 +51,10 @@ class TrackedWeakMap<K extends WeakKey = object, V = unknown> implements WeakMap
   }
 
   set(key: K, value: V): this {
-    let existing = this.#vals.get(key);
+    let existing = this.#vals.has(key);
 
     if (existing) {
-      let isUnchanged = this.#options.equals(existing, value);
+      let isUnchanged = this.#options.equals(this.#vals.get(key) as V, value);
 
       if (isUnchanged) {
         return this;

--- a/packages/@glimmer/validator/lib/collections/weak-map.ts
+++ b/packages/@glimmer/validator/lib/collections/weak-map.ts
@@ -51,9 +51,9 @@ class TrackedWeakMap<K extends WeakKey = object, V = unknown> implements WeakMap
   }
 
   set(key: K, value: V): this {
-    let existing = this.#vals.has(key);
+    let hasExisting = this.#vals.has(key);
 
-    if (existing) {
+    if (hasExisting) {
       let isUnchanged = this.#options.equals(this.#vals.get(key) as V, value);
 
       if (isUnchanged) {


### PR DESCRIPTION
`TrackedMap.set()` and `TrackedWeakMap.set()` use value truthiness (`if (existing)`) instead of `this.#vals.has(key)` to check for existing keys, causing two bugs:

1. **Existing truthy values**: The equality check runs but the collection tag is never dirtied, so iteration consumers (`.values()`, `.entries()`, `.forEach()`) miss value updates
2. **Existing falsy values** (`0`, `false`, `null`, `""`): The equality check is skipped entirely, and the collection tag is dirtied unnecessarily

Additionally, TrackedMap's `.entries()`, `.values()`, and `.forEach()` only consume the collection tag, so they miss per-key value updates even with a correct `set()`. This is in contrast to `[Symbol.iterator]()` which correctly consumes per-key storage tags via `self.get()`.

### Changes

**TrackedMap:**
- **`set()`**: Replace value truthiness checks with `this.#vals.has(key)`
- **`entries()`, `values()`, `forEach()`**: Delegate to `[Symbol.iterator]()` which already correctly consumes both the collection tag and per-key storage tags
- **`[Symbol.iterator]()`**: Add `[Symbol.iterator]()` to the returned object so it satisfies the iterable protocol (needed by `entries()` and `for...of` consumers)
- **Tests**: Add integration tests for `values`, `entries`, `forEach` with existing key updates, and a test for setting existing falsy values

**TrackedWeakMap:**
- **`set()`**: Same truthiness bug fix — replace `this.#vals.get(key)` with `this.#vals.has(key)`
- **Tests**: Add integration test for setting existing falsy values

Fixes #21123