### PR TITLE
Remove ember cli htmlbars 6 support (classic builds now require use-ember-modules)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2972,9 +2972,6 @@ importers:
       ember-cli-babel:
         specifier: ^8.3.1
         version: 8.3.1(@babel/core@7.29.0)
-      ember-cli-htmlbars-6:
-        specifier: npm:ember-cli-htmlbars@^6.0.0
-        version: ember-cli-htmlbars@6.3.0
       qunit:
         specifier: ^2.20.1
         version: 2.25.0
@@ -7643,10 +7640,6 @@ packages:
 
   ember-cli-get-component-path-option@1.0.0:
     resolution: {integrity: sha512-k47TDwcJ2zPideBCZE8sCiShSxQSpebY2BHcX2DdipMmBox5gsfyVrbKJWIHeSTTKyEUgmBIvQkqTOozEziCZA==}
-
-  ember-cli-htmlbars@6.3.0:
-    resolution: {integrity: sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==}
-    engines: {node: 12.* || 14.* || >= 16}
 
   ember-cli-htmlbars@7.0.0:
     resolution: {integrity: sha512-6BFxD19eZY+K62JLBDIKb8fXV29+QBrcT5QH4iHi8xseERX9SEWnYej9FpqL2QuoGjaTGml6QOvu9QlSTDYdVw==}
@@ -18330,25 +18323,6 @@ snapshots:
       - supports-color
 
   ember-cli-get-component-path-option@1.0.0: {}
-
-  ember-cli-htmlbars@6.3.0:
-    dependencies:
-      '@ember/edition-utils': 1.2.0
-      babel-plugin-ember-template-compilation: 2.4.1
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
-      broccoli-debug: 0.6.5
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      ember-cli-version-checker: 5.1.2
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
-      heimdalljs-logger: 0.1.10
-      js-string-escape: 1.0.1
-      semver: 7.7.4
-      silent-error: 1.1.1
-      walk-sync: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   ember-cli-htmlbars@7.0.0(@babel/core@7.29.0)(ember-source@):
     dependencies:

--- a/smoke-tests/scenarios/package.json
+++ b/smoke-tests/scenarios/package.json
@@ -10,7 +10,6 @@
     "@swc/types": "^0.1.6",
     "@types/node": "^20.12.7",
     "ember-cli-babel": "^8.3.1",
-    "ember-cli-htmlbars-6": "npm:ember-cli-htmlbars@^6.0.0",
     "qunit": "^2.20.1",
     "scenario-tester": "^4.0.0",
     "typescript": "5.1",

--- a/smoke-tests/scenarios/scenarios.ts
+++ b/smoke-tests/scenarios/scenarios.ts
@@ -1,14 +1,6 @@
 import { Project, Scenarios } from 'scenario-tester';
 import { dirname } from 'node:path';
 
-function classic(project: Project) {
-  // our monorepo uses pnpm overrides to force-upgrade ember-cli-htmlbars to 7,
-  // so that we can actually test the case where the use-ember-modules flag is
-  // enabled. This scenario ensures that when the flag is off, we still work
-  // with ember-cli-htmlbars 6.
-  project.linkDevDependency('ember-cli-htmlbars', { resolveName: 'ember-cli-htmlbars-6', baseDir: __dirname });
-}
-
 function classicUseModulesFeature(project: Project) {
   project.mergeFiles({
     config: {
@@ -32,7 +24,6 @@ function embroiderVite(project: Project) {}
 export const v1AppScenarios = Scenarios.fromProject(() =>
   Project.fromDir(dirname(require.resolve('../app-template/package.json')), { linkDevDeps: true })
 ).expand({
-  classic,
   classicUseModulesFeature,
   embroiderWebpack,
 });


### PR DESCRIPTION
this is a breaking change

extracted from https://github.com/emberjs/ember.js/pull/21132