### PR TITLE
[BUGFIX LTS] Fix crash *during* destroy in fastboot

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -232,7 +232,16 @@ class ClassicRootState {
 
       let result = (this.result = iterator.sync());
 
-      associateDestroyableChild(owner, result);
+      // Associate the result with the root state (not the owner) so that
+      // destruction cascades through:
+      //   Owner → Container → Renderer → RendererState → ClassicRootState → result
+      // This ensures the container is still alive when component destructors
+      // run (e.g. willDestroy looking up the renderer via injection).
+      // Previously, associating with the owner made the result a sibling of
+      // the Container, causing the Container to be destroyed first — which
+      // broke FastBoot where the container was already dead by the time
+      // component teardown tried to do lookups. (See: emberjs/ember.js#20984)
+      associateDestroyableChild(this, result);
 
       this.render = errorLoopTransaction(() => {
         if (isDestroying(result) || isDestroyed(result)) return;

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -232,15 +232,6 @@ class ClassicRootState {
 
       let result = (this.result = iterator.sync());
 
-      // Associate the result with the root state (not the owner) so that
-      // destruction cascades through:
-      //   Owner → Container → Renderer → RendererState → ClassicRootState → result
-      // This ensures the container is still alive when component destructors
-      // run (e.g. willDestroy looking up the renderer via injection).
-      // Previously, associating with the owner made the result a sibling of
-      // the Container, causing the Container to be destroyed first — which
-      // broke FastBoot where the container was already dead by the time
-      // component teardown tried to do lookups. (See: emberjs/ember.js#20984)
       associateDestroyableChild(this, result);
 
       this.render = errorLoopTransaction(() => {


### PR DESCRIPTION
Fixes: https://github.com/emberjs/ember.js/issues/20984

## Testing

- Terminal 1
  - clone / checkout this branch
  - `pnpm install` 
  - `pnpm build`
  - `echo $PWD` (copy this)
- Terminal 2
  - clone https://github.com/NullVoxPopuli/ember-6-8-fastboot-cleanup-reproduction
  - `cd ember-6-8-fastboot-cleanup-reproduction
  - `pnpm install`
  - `pnpm add $PATH_FROM_TERMINAL_1`
  - `pnpm start`
  - visiting the page should not error

