### PR TITLE
[BUGFIX] Fix EmberArray.reduce to match native behavior

### DIFF
--- a/packages/@ember/-internals/runtime/tests/array/reduce-test.js
+++ b/packages/@ember/-internals/runtime/tests/array/reduce-test.js
@@ -19,6 +19,31 @@ class ReduceTests extends AbstractTestCase {
     let res = obj.reduce((previousValue, item, index, enumerable) => enumerable, 0);
     this.assert.equal(res, obj);
   }
+
+  '@test works without an initialValue'() {
+    let obj = this.newObject([1, 2, 3]);
+    let res = obj.reduce((previousValue, item) => previousValue + item);
+    this.assert.equal(res, 6);
+  }
+
+  '@test passes correct index when without an initialValue'() {
+    let obj = this.newObject([1, 2, 3]);
+    let res = obj.reduce((previousValue, item, index) => previousValue + index);
+    // starts at item 2 (index 1): 1 + 1 = 2
+    // then item 3 (index 2): 2 + 2 = 4
+    this.assert.equal(res, 4);
+  }
+
+  '@test throws a TypeError when reducing an empty array without an initialValue'() {
+    let obj = this.newObject([]);
+    this.assert.throws(
+      () => {
+        obj.reduce((previousValue, item) => previousValue + item);
+      },
+      TypeError,
+      'Reduce of empty array with no initial value'
+    );
+  }
 }
 
 runArrayTests('reduce', ReduceTests);

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1387,15 +1387,26 @@ const EmberArray = Mixin.create(Enumerable, {
   reduce<T, V>(
     this: EmberArray<T>,
     callback: (summation: V, current: T, index: number, arr: EmberArray<T>) => V,
-    initialValue: V
+    initialValue?: V
   ) {
     assert('`reduce` expects a function as first argument.', typeof callback === 'function');
 
-    let ret = initialValue;
+    let hasInitialValue = arguments.length > 1;
+    let ret: any = initialValue;
+    let startIndex = 0;
 
-    this.forEach(function (item, i) {
+    if (!hasInitialValue) {
+      if (this.length === 0) {
+        throw new TypeError('Reduce of empty array with no initial value');
+      }
+      ret = this.objectAt(0);
+      startIndex = 1;
+    }
+
+    for (let i = startIndex; i < this.length; i++) {
+      let item = this.objectAt(i) as T;
       ret = callback(ret, item, i, this);
-    }, this);
+    }
 
     return ret;
   },


### PR DESCRIPTION
## Description
Fixes a FIXME where `EmberArray#reduce` did not match the native `Array.prototype.reduce` behavior when no `initialValue` was provided. See `packages/@ember/array/index.ts`.

- If no `initialValue` is provided and the array is empty, it now throws a `TypeError` (consistent with native).
- If no `initialValue` is provided, it uses the first item as the initial value and begins iterating from index 1.

Tested with new test cases in `reduce-test.js`.

## Verification
`pnpm lint:format:fix` and `pnpm test` were run to ensure formatting is correct and no regressions were introduced.