### PR TITLE
Fix: prevent unnecessary property change notifications for NaN

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -72,7 +72,7 @@ export type ComputedPropertyCallback = ComputedPropertyGetterFunction | Computed
 
 const DEEP_EACH_REGEX = /\.@each\.[^.]+\./;
 
-function noop(): void {}
+function noop(): void { }
 /**
   `@computed` is a decorator that turns a JavaScript getter and setter into a
   computed property, which is a _cached, trackable value_. By default the getter
@@ -345,7 +345,7 @@ export class ComputedProperty extends ComputedDescriptor {
       assert(
         `Attempted to use @computed on ${keyName}, but it did not have a getter or a setter. You must either pass a get a function or getter/setter to @computed directly (e.g. \`@computed({ get() { ... } })\`) or apply @computed directly to a getter/setter`,
         propertyDesc &&
-          (typeof propertyDesc.get === 'function' || typeof propertyDesc.set === 'function')
+        (typeof propertyDesc.get === 'function' || typeof propertyDesc.set === 'function')
       );
 
       let { get, set } = propertyDesc;
@@ -374,9 +374,9 @@ export class ComputedProperty extends ComputedDescriptor {
     function addArg(property: string): void {
       assert(
         `Dependent keys containing @each only work one level deep. ` +
-          `You used the key "${property}" which is invalid. ` +
-          `Please create an intermediary computed property or ` +
-          `switch to using tracked properties.`,
+        `You used the key "${property}" which is invalid. ` +
+        `Please create an intermediary computed property or ` +
+        `switch to using tracked properties.`,
         DEEP_EACH_REGEX.test(property) === false
       );
 
@@ -531,7 +531,7 @@ export class ComputedProperty extends ComputedDescriptor {
     }
 
     // allows setter to return the same value that is cached already
-    if (hadCachedValue && cachedValue === ret) {
+    if (hadCachedValue && Object.is(cachedValue, ret)) {
       return ret;
     }
 

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -95,7 +95,7 @@ export function _setProp(obj: object, keyName: string, value: any) {
       (obj as any)[keyName] = value;
     }
 
-    if (currentValue !== value) {
+    if (!Object.is(currentValue, value)) {
       notifyPropertyChange(obj, keyName);
     }
   }


### PR DESCRIPTION
## Fix: Correct equality check for NaN in property change detection

### Problem
Currently, both `_setProp` (`property_set.ts`) and the computed property caching logic (`computed.ts`) use strict equality (`===` / `!==`) to determine whether a property value has changed.

However, in JavaScript `NaN !== NaN` always evaluates to `true`. Because of this, updating a property from `NaN` to `NaN` is incorrectly treated as a change. This bypasses Ember’s early-return optimizations and triggers `notifyPropertyChange`, even though the value has not actually changed.

In larger applications, this can lead to unnecessary observer executions, reactive updates, and avoidable DOM re-renders.

### Solution
Replace strict equality checks with `Object.is()` when comparing the new value with the cached value. `Object.is()` correctly handles edge cases such as `NaN` and distinguishes between `+0` and `-0`.

With this change, setting a property from `NaN` to `NaN` will be correctly recognized as an unchanged value, preventing unnecessary reactive updates.

### Impact
This improves the correctness of Ember’s change detection and avoids false-positive property change notifications in the core reactivity loop. Although small, this fix helps eliminate potential performance overhead caused by redundant updates.