### PR TITLE
Update pkg-size action

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - uses: wyvox/pkg-size@df42795b6bc793b1558823b7b6ac6993d514ca42
+      - uses: wyvox/pkg-size@4c68a40496b9dd2d228575f8738cdfa4ad277754
         with:
           build-command: "pnpm build"
           display-size: uncompressed, brotli


### PR DESCRIPTION
Includes:
- https://github.com/wyvox/pkg-size/pull/8
  
    <img width="860" height="678" alt="image" src="https://github.com/user-attachments/assets/71ab3629-c2a2-45b8-959f-bf4bcc90ad29" />

    Previously: https://github.com/emberjs/ember.js/pull/21080
    (mismatched rows due to the hash pattern)

- https://github.com/wyvox/pkg-size/pull/9

    <img width="772" height="312" alt="image" src="https://github.com/user-attachments/assets/dc76e145-260d-4c5e-899b-030d10d17564" />

    Previously: https://github.com/emberjs/ember.js/pull/21129
    (giant list due to adding a whole 'nother build