### PR TITLE
Update actions + lock down to shas

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,12 +13,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       name: Install pnpm
       with:
         run_install: false
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '${{ inputs.node-version }}'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/alpha-releases.yml
+++ b/.github/workflows/alpha-releases.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ tests ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup

--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: linting
         run: pnpm lint
@@ -27,7 +27,7 @@ jobs:
     name: Type Checking (current version)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build types
         run: pnpm build:types
@@ -46,7 +46,7 @@ jobs:
       matrix:
         ts-version: ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build stable type definitions
         run: pnpm build:types
@@ -59,7 +59,7 @@ jobs:
     name: Basic Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build
         run: pnpm vite build --mode=development
@@ -93,7 +93,7 @@ jobs:
             ENABLE_OPTIONAL_FEATURES: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build
         run: pnpm vite build --mode=${{ matrix.BUILD || 'development' }}
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [basic-test, lint, types]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build
         env:
@@ -143,7 +143,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.lint.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
           use_lockfile: "false"
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [basic-test, lint, types]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build
         env:
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: test
         run: pnpm test:blueprints
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-22.04 # Firefox is not installing on Ubuntu 24 on GitHub Actions https://github.com/browser-actions/setup-firefox/issues/622
     needs: [basic-test, lint, types]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build
         run: pnpm vite build --mode=development
@@ -199,7 +199,7 @@ jobs:
     name: Perf script still works
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     # Only run on pushes to branches that are not from the cron workflow
     if: github.event_name == 'push' && contains(github.ref, 'cron') != true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build for publish
         run: node bin/build-for-publishing.js
@@ -46,7 +46,7 @@ jobs:
     # Only run on pushes to main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - name: build for publish
         run: node bin/build-for-publishing.js
@@ -65,7 +65,7 @@ jobs:
     needs: [ tests ]
     if: failure() && contains(github.ref, 'cron') == true
     steps:
-      - uses: sarisia/actions-status-discord@v1
+      - uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.FRAMEWORK_WEBHOOK }}
           status: 'Failure'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         branch: [main, beta, release]
     steps:
-      - uses: kategengler/ci-cron@v1.0.2
+      - uses: kategengler/ci-cron@d54b69bfd9147fb125899da4a2891f7fdf35f786 # v1.0.2
         with:
           branch: ${{ matrix.branch }}
           # This must use a personal access token because of a Github Actions

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,31 +15,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ember.js
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: emberjs/ember.js
           path: ember.js
           ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Checkout ember-jsonapi-docs
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: kategengler/ember-jsonapi-docs
           path: ember-jsonapi-docs
 
       - name: Checkout ember-api-docs-data
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ember-learn/ember-api-docs-data
           path: ember-api-docs-data
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm
         with:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
 
@@ -77,7 +77,7 @@ jobs:
         working-directory: ember-api-docs-data
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.DOCS_GITHUB_TOKEN }}
           path: ember-api-docs-data

--- a/.github/workflows/night-ts.yml
+++ b/.github/workflows/night-ts.yml
@@ -8,7 +8,7 @@ jobs:
     name: typescript@latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm build
       - run: pnpm add --save-dev typescript@latest --workspace-root
@@ -19,7 +19,7 @@ jobs:
     needs: [ts-next]
     if: failure()
     steps:
-      - uses: sarisia/actions-status-discord@v1
+      - uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.TYPESCRIPT_WEBHOOK }}
           status: "Failure"

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - uses: wyvox/pkg-size@df42795b6bc793b1558823b7b6ac6993d514ca42
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate title
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || "";
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate title
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || "";

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
           node-version: 20
@@ -39,7 +39,7 @@ jobs:
     needs: [release]
     if: failure()
     steps:
-      - uses: sarisia/actions-status-discord@v1
+      - uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.FRAMEWORK_WEBHOOK }}
           status: 'Failure'
@@ -53,7 +53,7 @@ jobs:
     needs: [release]
     if: success()
     steps:
-      - uses: sarisia/actions-status-discord@v1
+      - uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.FRAMEWORK_WEBHOOK }}
           status: 'Success'

--- a/.github/workflows/smoke-test-app-template-updates.yml
+++ b/.github/workflows/smoke-test-app-template-updates.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: gate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Generate ember-test-app using classic blueprint
         run: |
           set -euo pipefail
@@ -51,7 +51,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.SMOKE_TEST_TEMPLATE_GEN_TOKEN }}
           branch: smoke-tests/update-app-template
@@ -66,13 +66,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: gate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Generate v2-app-template
         run: |
           set -euo pipefail
@@ -87,7 +87,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.SMOKE_TEST_TEMPLATE_GEN_TOKEN }}
           branch: smoke-tests/update-v2-app-template
@@ -106,7 +106,7 @@ jobs:
     if: failure()
     steps:
       - name: Create issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = "Smoke-test app template update failed";

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "url": "git+https://github.com/emberjs/ember.js.git"
   },
   "scripts": {
+    "actions-up": "pnpm dlx actions-up",
     "bench": "node ./bin/benchmark.mjs",
     "build:js": "rollup --config",
     "build:types": "node types/publish.mjs",


### PR DESCRIPTION
- Add a script to run `actions-up` mostly to remember the package name later
- If renovate does not work for actions we can later make a workflow to run `actions-up` and PR the results