### PR TITLE
Enable lock file maintenance and adjust PR limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,11 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
   automerge: false,
+  lockFileMaintenance: true,
   dependencyDashboard: true,
   schedule: ["every weekend"],
   minimumReleaseAge: "10 days",
+  prConcurrentLimit: 5,
   packageRules: [
     {
       description: "All @babel/* packages",


### PR DESCRIPTION
Default PR concurrency is 10, but even that is probably too much for now -- I've lowered it to 5.

I also enabled lockfile re-rolling, which is helpful for seeing if floating deps break anything