### PR TITLE
Get @glimmer/syntax publishable again and get some smoke tests going for prettier

### DIFF
--- a/.github/workflows/glimmer-syntax-prettier-smoke-test.yml
+++ b/.github/workflows/glimmer-syntax-prettier-smoke-test.yml
@@ -1,0 +1,68 @@
+# aka: our primary CLI-land consumer of @glimmer/syntax
+name: "Prettier Smoke Test"
+
+on:
+  push:
+    branches:
+      - main
+      - beta
+      - release
+      - release*
+      - lts*
+    paths:
+      - ".github/workflows/glimmer-syntax-prettier-smoke-test.yml"
+      - ".github/actions/setup/**"
+      - "rollup.config.mjs"
+      - "packages/@glimmer/syntax/**"
+      - "packages/@glimmer/interfaces/**"
+      - "packages/@glimmer/util/**"
+      - "packages/@glimmer/wire-format/**"
+      - "packages/@handlebars/parser/**"
+  pull_request:
+    paths:
+      - ".github/workflows/glimmer-syntax-prettier-smoke-test.yml"
+      - ".github/actions/setup/**"
+      - "rollup.config.mjs"
+      - "packages/@glimmer/syntax/**"
+      - "packages/@glimmer/interfaces/**"
+      - "packages/@glimmer/util/**"
+      - "packages/@glimmer/wire-format/**"
+      - "packages/@handlebars/parser/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prettier-smoke-test:
+    name: Prettier handlebars smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+
+      - name: Pack @glimmer/syntax
+        working-directory: packages/@glimmer/syntax
+        run: pnpm pack --out ${{ github.workspace }}/glimmer-syntax.tgz
+
+      - name: Checkout prettier/prettier
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          repository: prettier/prettier
+          path: prettier-repo
+
+      - name: Install prettier dependencies
+        working-directory: prettier-repo
+        run: yarn install
+
+      - name: Install local @glimmer/syntax into prettier
+        working-directory: prettier-repo
+        run: yarn add "@glimmer/syntax@file:${{ github.workspace }}/glimmer-syntax.tgz"
+
+      - name: Run prettier handlebars tests
+        working-directory: prettier-repo
+        run: yarn jest tests/format/handlebars

--- a/package.json
+++ b/package.json
@@ -295,6 +295,7 @@
       "@ember/template-compiler/lib/-internal/primitives.js": "ember-source/@ember/template-compiler/lib/-internal/primitives.js",
       "@ember/template-compiler/lib/compile-options.js": "ember-source/@ember/template-compiler/lib/compile-options.js",
       "@ember/template-compiler/lib/dasherize-component-name.js": "ember-source/@ember/template-compiler/lib/dasherize-component-name.js",
+      "@ember/template-compiler/lib/plugins/allowed-globals.js": "ember-source/@ember/template-compiler/lib/plugins/allowed-globals.js",
       "@ember/template-compiler/lib/plugins/assert-against-attrs.js": "ember-source/@ember/template-compiler/lib/plugins/assert-against-attrs.js",
       "@ember/template-compiler/lib/plugins/assert-against-named-outlets.js": "ember-source/@ember/template-compiler/lib/plugins/assert-against-named-outlets.js",
       "@ember/template-compiler/lib/plugins/assert-input-helper-without-block.js": "ember-source/@ember/template-compiler/lib/plugins/assert-input-helper-without-block.js",

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -16,17 +16,11 @@
     "access": "public",
     "exports": {
       ".": {
-        "development": {
-          "types": "./dist/dev/index.d.ts",
-          "default": "./dist/dev/index.js"
+        "node": {
+          "require": "./dist/cjs/index.cjs",
+          "import": "./dist/es/index.js"
         },
-        "require": {
-          "default": "./dist/dev/index.cjs"
-        },
-        "default": {
-          "types": "./dist/prod/index.d.ts",
-          "default": "./dist/prod/index.js"
-        }
+        "default": "./dist/es/index.js"
       }
     },
     "types": "dist/dev/index.d.ts"
@@ -35,7 +29,6 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "rollup -c rollup.config.mjs",
     "test:publint": "publint"
   },
   "dependencies": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,6 +42,8 @@ let configs = [
   }),
   templateCompilerConfig(),
   glimmerComponent(),
+  glimmerSyntaxESM(),
+  glimmerSyntaxCJS(),
 ];
 
 if (process.env.DEBUG_SINGLE_CONFIG) {
@@ -112,6 +114,49 @@ function sharedESMConfig({ input, debugMacrosMode }) {
       resolvePackages({ ...exposedDependencies(), ...hiddenDependencies() }),
       pruneEmptyBundles(),
       packageMeta(),
+    ],
+  };
+}
+
+function glimmerSyntaxESM() {
+  return {
+    onLog: handleRollupWarnings,
+    input: './packages/@glimmer/syntax/index.ts',
+    output: {
+      format: 'es',
+      file: 'packages/@glimmer/syntax/dist/es/index.js',
+      hoistTransitiveImports: false,
+    },
+    plugins: [
+      babel({
+        babelHelpers: 'bundled',
+        extensions: ['.js', '.ts'],
+        configFile: false,
+        ...sharedBabelConfig,
+      }),
+      resolveTS(),
+      resolvePackages({ ...exposedDependencies(), ...hiddenDependencies() }),
+    ],
+  };
+}
+function glimmerSyntaxCJS() {
+  return {
+    onLog: handleRollupWarnings,
+    input: './packages/@glimmer/syntax/index.ts',
+    output: {
+      format: 'cjs',
+      file: 'packages/@glimmer/syntax/dist/cjs/index.cjs',
+      hoistTransitiveImports: false,
+    },
+    plugins: [
+      babel({
+        babelHelpers: 'bundled',
+        extensions: ['.js', '.ts'],
+        configFile: false,
+        ...sharedBabelConfig,
+      }),
+      resolveTS(),
+      resolvePackages({ ...exposedDependencies(), ...hiddenDependencies() }),
     ],
   };
 }


### PR DESCRIPTION
From @fisker's comments here: https://github.com/glimmerjs/glimmer-vm/pull/1689 (very helpful! <3 )


This PR:
- prepares `@glimmer/syntax` for publishing -- only supporting node environments for now 
  - `@glimmer/syntax` is used by prettier, ember-template-recast, and more
  - however `@glimmer/component` is published, is how we'd publish `@glimmer/syntax`
- adds a CI workflow for testing against prettier 
  - takes about a minute and a half: https://github.com/emberjs/ember.js/actions/runs/22737030635/job/65940991692?pr=21188