### PR TITLE
Add git diff violation checking after build output

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -165,6 +165,7 @@ jobs:
           use_lockfile: "false"
       - name: build
         run: pnpm build
+      - uses: wyvox/action-no-git-diff@6d1f5759a221e2ea447974af795e395672e33328 # v1.0.1
       - name: test
         working-directory: smoke-tests/scenarios
         run: |

--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -73,6 +73,7 @@ jobs:
         run: pnpm vite build --mode=development
         env:
           NODE_ENV: development
+      - uses: wyvox/action-no-git-diff@6d1f5759a221e2ea447974af795e395672e33328 # v1.0.1
       - name: test
         run: pnpm test
 
@@ -132,6 +133,7 @@ jobs:
           ALL_SUPPORTED_BROWSERS: true
           NODE_ENV: development
         run: pnpm vite build --mode=development
+      - uses: wyvox/action-no-git-diff@6d1f5759a221e2ea447974af795e395672e33328 # v1.0.1
 
       - name: Set BrowserStack Local Identifier
         if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-ember-source')


### PR DESCRIPTION
Uses: https://github.com/wyvox/action-no-git-diff

We keep having issues with the root package.json, and we need our git diffs to be reliable in PRs, so this action will block on uncommitted generated changes -- which should only be an issue until we stabilize the package.json generation (or other generated outputs)