### PR TITLE
 [BUGFIX] `current-when` with nested routes containing dynamic dynamic segments

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -554,12 +554,12 @@ class _LinkTo extends InternalComponent {
     if (typeof currentWhen === 'boolean') {
       return currentWhen;
     } else if (typeof currentWhen === 'string') {
-      let { models, routing } = this;
+      let { routing } = this;
 
       return currentWhen
         .split(' ')
         .some((route) =>
-          routing.isActiveForRoute(models, undefined, this.namespaceRoute(route), state)
+          routing.isActiveForRoute([], undefined, this.namespaceRoute(route), state)
         );
     } else {
       let { route, models, query, routing } = this;

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -925,6 +925,37 @@ moduleFor(
       );
     }
 
+    async [`@test it supports custom, nested, current-when with route params`](assert) {
+      assert.expect(2);
+      this.router.map(function () {
+        this.route('index', { path: '/' });
+        this.route('foo', { path: '/foo/:fooId' }, function () {
+          this.route('bar', { path: '/bar/:barId' });
+        });
+      });
+
+      this.addTemplate('index', `{{outlet}}`);
+      this.addTemplate(
+        'foo',
+        `<LinkTo @route='foo.index' @model={{1}} @current-when='foo.index foo.bar'>Foo Index</LinkTo> {{outlet}}`
+      );
+      this.addTemplate(
+        'foo.bar',
+        `<LinkTo @route='foo.bar' @models={{array 1 2}}>Foo Bar</LinkTo>`
+      );
+
+      await this.visit('/foo/1/bar/2');
+
+      assert.ok(
+        this.$('a[href="/foo/1"]').is('.active'),
+        'The link to foo.index should be active when on foo.bar'
+      );
+      assert.ok(
+        this.$('a[href="/foo/1/bar/2"]').is('.active'),
+        'The link to foo.bar should be active when on foo.bar'
+      );
+    }
+
     async ['@test it does not disregard current-when when it is set via a bound param'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -966,6 +966,37 @@ moduleFor(
       );
     }
 
+    async [`@test it supports custom, nested, current-when with route params`](assert) {
+      assert.expect(2);
+      this.router.map(function () {
+        this.route('index', { path: '/' });
+        this.route('foo', { path: '/foo/:fooId' }, function () {
+          this.route('bar', { path: '/bar/:barId' });
+        });
+      });
+
+      this.addTemplate('index', `{{outlet}}`);
+      this.addTemplate(
+        'foo',
+        `{{#link-to route='foo.index' model=1 current-when='foo.index foo.bar'}}Foo Index{{/link-to}} {{outlet}}`
+      );
+      this.addTemplate(
+        'foo.bar',
+        `{{#link-to route='foo.bar' models=(array 1 2)}}Foo Bar{{/link-to}}`
+      );
+
+      await this.visit('/foo/1/bar/2');
+
+      assert.ok(
+        this.$('a[href="/foo/1"]').is('.active'),
+        'The link to foo.index should be active when on foo.bar'
+      );
+      assert.ok(
+        this.$('a[href="/foo/1/bar/2"]').is('.active'),
+        'The link to foo.bar should be active when on foo.bar'
+      );
+    }
+
     async ['@test it does not disregard current-when when it is set via a bound param'](assert) {
       this.router.map(function () {
         this.route('index', { path: '/' }, function () {


### PR DESCRIPTION
  When `current-when` is a string, pass no models to `isActiveForRoute()`
  since we only need route name matching, not model matching.
  Fixes #14615 and supersedes  #14787. Based on failing test by @amk221