### PR TITLE
Update actions. ci-cron needed internally used actions to be locked

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         branch: [main, beta, release]
     steps:
-      - uses: kategengler/ci-cron@d54b69bfd9147fb125899da4a2891f7fdf35f786 # v1.0.2
+      - uses: kategengler/ci-cron@181db7e5bac13d0b55b6f5c4a8567fd20154576b # v1.0.3
         with:
           branch: ${{ matrix.branch }}
           # This must use a personal access token because of a Github Actions


### PR DESCRIPTION
down.