### PR TITLE
ember-inspector: add parentElement to meta for in-element 

### DIFF
--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -17,6 +17,7 @@ export interface RenderNode {
   args: CapturedArguments;
   instance: unknown;
   template?: string | undefined;
+  meta?: Record<string, any>;
 }
 
 export interface CapturedRenderNode {
@@ -26,6 +27,7 @@ export interface CapturedRenderNode {
   args: Arguments;
   instance: unknown;
   template: string | null;
+  meta: Record<string, any> | null;
   bounds: null | {
     parentElement: SimpleElement;
     firstNode: SimpleNode;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -103,6 +103,9 @@ APPEND_OPCODES.add(VM_PUSH_REMOTE_ELEMENT_OP, (vm) => {
       name: 'in-element',
       args,
       instance: null,
+      meta: {
+        parentElement: vm.elements().element,
+      },
     });
 
     registerDestructor(block, () => {

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -182,11 +182,21 @@ export default class DebugRenderTreeImpl<
 
   private captureNode(id: string, state: TBucket): CapturedRenderNode {
     let node = this.nodeFor(state);
-    let { type, name, args, instance, refs } = node;
+    let { type, name, args, instance, refs, meta = null } = node;
     let template = this.captureTemplate(node);
     let bounds = this.captureBounds(node);
     let children = this.captureRefs(refs);
-    return { id, type, name, args: reifyArgsDebug(args), instance, template, bounds, children };
+    return {
+      id,
+      type,
+      name,
+      args: reifyArgsDebug(args),
+      instance,
+      template,
+      bounds,
+      children,
+      meta,
+    };
   }
 
   private captureTemplate({ template }: InternalRenderNode<TBucket>): Nullable<string> {


### PR DESCRIPTION
continuation of https://github.com/glimmerjs/glimmer-vm/pull/1575

inspector uses it to correctly position the in-element helper in the tree