### PR TITLE
Make the low-level component scope able to be an object instead of an array

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/compile.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/compile.ts
@@ -24,7 +24,10 @@ export function createTemplate(
 ): TemplateFactory {
   options.locals = options.locals ?? Object.keys(scopeValues ?? {});
   let [block, usedLocals] = precompileJSON(templateSource, options);
-  let reifiedScopeValues = usedLocals.map((key) => scopeValues[key]);
+  let reifiedScope: Record<string, unknown> = {};
+  for (let key of usedLocals) {
+    reifiedScope[key] = scopeValues[key];
+  }
 
   if ('emit' in options && options.emit?.debugSymbols) {
     block.push(usedLocals);
@@ -34,7 +37,7 @@ export function createTemplate(
     id: String(templateId++),
     block: JSON.stringify(block),
     moduleName: options.meta?.moduleName ?? '(unknown template module)',
-    scope: reifiedScopeValues.length > 0 ? () => reifiedScopeValues : null,
+    scope: usedLocals.length > 0 ? () => reifiedScope : null,
     isStrictMode: options.strictMode ?? false,
   };
 

--- a/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
@@ -57,7 +57,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       ...WireFormat.Statement[],
     ];
 
-    assert.deepEqual(wire.scope?.(), [hello]);
+    assert.deepEqual(wire.scope?.(), { hello });
 
     assert.deepEqual(
       componentNameExpr,
@@ -84,7 +84,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       ...WireFormat.Statement[],
     ];
 
-    assert.deepEqual(wire.scope?.(), [f]);
+    assert.deepEqual(wire.scope?.(), { f });
     assert.deepEqual(
       componentNameExpr,
       [SexpOpcodes.GetLexicalSymbol, 0, ['hello']],
@@ -218,7 +218,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       _wire = compile(`{{this.message}}`, ['this'], (source) => eval(source));
     }).call(target);
     let wire = _wire!;
-    assert.deepEqual(wire.scope?.(), [target]);
+    assert.deepEqual(wire.scope?.(), { this: target });
     assert.deepEqual(wire.block[0], [
       [SexpOpcodes.Append, [SexpOpcodes.GetLexicalSymbol, 0, ['message']]],
     ]);

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -111,12 +111,10 @@ class DebugRenderTreeTest extends RenderTest {
   }
 
   @test 'strict-mode components without debug symbols preserve names from scope'() {
-    const state = trackedObj({ showSecond: false });
-
     const HelloWorld = defComponent('{{@arg}}');
     const Root = defComponent(
-      `<HelloWorld @arg="first"/>{{#if state.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
-      { scope: { HelloWorld, state }, emit: { moduleName: 'root.hbs', debugSymbols: false } }
+      `<HelloWorld @arg="first"/>`,
+      { scope: { HelloWorld }, emit: { moduleName: 'root.hbs', debugSymbols: false } }
     );
 
     this.renderComponent(Root);
@@ -137,39 +135,6 @@ class DebugRenderTreeTest extends RenderTest {
             instance: null,
             template: '(unknown template module)',
             bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
-            children: [],
-          },
-        ],
-      },
-    ]);
-
-    state['showSecond'] = true;
-
-    this.assertRenderTree([
-      {
-        type: 'component',
-        name: '{ROOT}',
-        args: { positional: [], named: {} },
-        instance: null,
-        template: 'root.hbs',
-        bounds: this.elementBounds(this.delegate.getInitialElement()),
-        children: [
-          {
-            type: 'component',
-            name: 'HelloWorld',
-            args: { positional: [], named: { arg: 'first' } },
-            instance: null,
-            template: '(unknown template module)',
-            bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
-            children: [],
-          },
-          {
-            type: 'component',
-            name: 'HelloWorld',
-            args: { positional: [], named: { arg: 'second' } },
-            instance: null,
-            template: '(unknown template module)',
-            bounds: this.nodeBounds(this.delegate.getInitialElement().lastChild),
             children: [],
           },
         ],

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -110,6 +110,73 @@ class DebugRenderTreeTest extends RenderTest {
     ]);
   }
 
+  @test 'strict-mode components without debug symbols preserve names from scope'() {
+    const state = trackedObj({ showSecond: false });
+
+    const HelloWorld = defComponent('{{@arg}}');
+    const Root = defComponent(
+      `<HelloWorld @arg="first"/>{{#if state.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
+      { scope: { HelloWorld, state }, emit: { moduleName: 'root.hbs', debugSymbols: false } }
+    );
+
+    this.renderComponent(Root);
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: '{ROOT}',
+        args: { positional: [], named: {} },
+        instance: null,
+        template: 'root.hbs',
+        bounds: this.elementBounds(this.delegate.getInitialElement()),
+        children: [
+          {
+            type: 'component',
+            name: 'HelloWorld',
+            args: { positional: [], named: { arg: 'first' } },
+            instance: null,
+            template: '(unknown template module)',
+            bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+            children: [],
+          },
+        ],
+      },
+    ]);
+
+    state['showSecond'] = true;
+
+    this.assertRenderTree([
+      {
+        type: 'component',
+        name: '{ROOT}',
+        args: { positional: [], named: {} },
+        instance: null,
+        template: 'root.hbs',
+        bounds: this.elementBounds(this.delegate.getInitialElement()),
+        children: [
+          {
+            type: 'component',
+            name: 'HelloWorld',
+            args: { positional: [], named: { arg: 'first' } },
+            instance: null,
+            template: '(unknown template module)',
+            bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
+            children: [],
+          },
+          {
+            type: 'component',
+            name: 'HelloWorld',
+            args: { positional: [], named: { arg: 'second' } },
+            instance: null,
+            template: '(unknown template module)',
+            bounds: this.nodeBounds(this.delegate.getInitialElement().lastChild),
+            children: [],
+          },
+        ],
+      },
+    ]);
+  }
+
   @test 'strict-mode modifiers'() {
     const state = trackedObj({ showSecond: false });
 

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -165,7 +165,7 @@ class DebugRenderTreeTest extends RenderTest {
 
     this.assert.strictEqual(
       componentNode?.name,
-      'HelloWorld',
+      'this.HelloWorld',
       `dynamic <this.X> component name (got "${componentNode?.name}")`
     );
   }
@@ -185,10 +185,9 @@ class DebugRenderTreeTest extends RenderTest {
 
     this.assert.ok(componentNode, 'found a component child node');
 
-    // For <@Greeting>, the invocation-site name "Greeting" is used
     this.assert.strictEqual(
       componentNode?.name,
-      'Greeting',
+      '@Greeting',
       `dynamic <@X> component name (got "${componentNode?.name}")`
     );
   }

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -112,10 +112,10 @@ class DebugRenderTreeTest extends RenderTest {
 
   @test 'strict-mode components without debug symbols preserve names from scope'() {
     const HelloWorld = defComponent('{{@arg}}');
-    const Root = defComponent(
-      `<HelloWorld @arg="first"/>`,
-      { scope: { HelloWorld }, emit: { moduleName: 'root.hbs', debugSymbols: false } }
-    );
+    const Root = defComponent(`<HelloWorld @arg="first"/>`, {
+      scope: { HelloWorld },
+      emit: { moduleName: 'root.hbs', debugSymbols: false },
+    });
 
     this.renderComponent(Root);
 

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -142,6 +142,56 @@ class DebugRenderTreeTest extends RenderTest {
     ]);
   }
 
+  @test 'dynamic component via <this.dynamicComponent>'() {
+    const HelloWorld = defComponent('{{@arg}}');
+
+    class Root extends GlimmerishComponent {
+      HelloWorld = HelloWorld;
+    }
+
+    const RootDef = defComponent(`<this.HelloWorld @arg="first"/>`, {
+      component: Root,
+      emit: { moduleName: 'root.hbs' },
+    });
+
+    this.renderComponent(RootDef);
+
+    const rootChildren = this.delegate.getCapturedRenderTree()[0]?.children ?? [];
+    const componentNode = rootChildren.find(
+      (n: CapturedRenderNode) => n.type === 'component' && n.name !== '{ROOT}'
+    );
+
+    this.assert.ok(componentNode, 'found a component child node');
+
+    this.assert.strictEqual(
+      componentNode?.name,
+      'HelloWorld',
+      `dynamic <this.X> component name (got "${componentNode?.name}")`
+    );
+  }
+
+  @test 'dynamic component via <@argComponent>'() {
+    const HelloWorld = defComponent('{{@arg}}');
+    const Root = defComponent(`<@Greeting @arg="first"/>`, {
+      emit: { moduleName: 'root.hbs' },
+    });
+
+    this.renderComponent(Root, { Greeting: HelloWorld });
+
+    const rootChildren = this.delegate.getCapturedRenderTree()[0]?.children ?? [];
+    const componentNode = rootChildren.find(
+      (n: CapturedRenderNode) => n.type === 'component' && n.name !== '{ROOT}'
+    );
+
+    this.assert.ok(componentNode, 'found a component child node');
+
+    this.assert.strictEqual(
+      componentNode?.name,
+      'HelloWorld',
+      `dynamic <@X> component name (got "${componentNode?.name}")`
+    );
+  }
+
   @test 'strict-mode modifiers'() {
     const state = trackedObj({ showSecond: false });
 

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -185,9 +185,10 @@ class DebugRenderTreeTest extends RenderTest {
 
     this.assert.ok(componentNode, 'found a component child node');
 
+    // For <@Greeting>, the invocation-site name "Greeting" is used
     this.assert.strictEqual(
       componentNode?.name,
-      'HelloWorld',
+      'Greeting',
       `dynamic <@X> component name (got "${componentNode?.name}")`
     );
   }

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -11,6 +11,7 @@ import type {
 import type { TemplateOnlyComponent } from '@glimmer/runtime';
 import type { EmberishCurlyComponent } from '@glimmer-workspace/integration-tests';
 import { expect } from '@glimmer/debug-util';
+import { DEBUG } from '@glimmer/env';
 import { modifierCapabilities, setComponentTemplate, setModifierManager } from '@glimmer/manager';
 import { EMPTY_ARGS, templateOnlyComponent, TemplateOnlyComponentManager } from '@glimmer/runtime';
 import { assign } from '@glimmer/util';
@@ -142,7 +143,7 @@ class DebugRenderTreeTest extends RenderTest {
     ]);
   }
 
-  @test 'dynamic component via <this.dynamicComponent>'() {
+  @test({ skip: !DEBUG }) 'dynamic component via <this.dynamicComponent>'() {
     const HelloWorld = defComponent('{{@arg}}');
 
     class Root extends GlimmerishComponent {
@@ -170,7 +171,7 @@ class DebugRenderTreeTest extends RenderTest {
     );
   }
 
-  @test 'dynamic component via <@argComponent>'() {
+  @test({ skip: !DEBUG }) 'dynamic component via <@argComponent>'() {
     const HelloWorld = defComponent('{{@arg}}');
     const Root = defComponent(`<@Greeting @arg="first"/>`, {
       emit: { moduleName: 'root.hbs' },

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -148,7 +148,14 @@ export function precompile(
   let stringified = JSON.stringify(templateJSONObject);
 
   if (usedLocals.length > 0) {
-    const scopeFn = `()=>[${usedLocals.join(',')}]`;
+    const scopeEntries = usedLocals.map((name) => {
+      // Reserved words like "this" can't use shorthand property syntax
+      if (name === 'this') {
+        return `"this":this`;
+      }
+      return name;
+    });
+    const scopeFn = `()=>({${scopeEntries.join(',')}})`;
 
     stringified = stringified.replace(`"${SCOPE_PLACEHOLDER}"`, scopeFn);
   }

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
@@ -397,7 +397,7 @@ export interface SerializedTemplateWithLazyBlock {
   id?: Nullable<string>;
   block: SerializedTemplateBlockJSON;
   moduleName: string;
-  scope?: (() => unknown[]) | undefined | null;
+  scope?: (() => Record<string, unknown>) | undefined | null;
   isStrictMode: boolean;
 }
 

--- a/packages/@glimmer/interfaces/lib/template.d.ts
+++ b/packages/@glimmer/interfaces/lib/template.d.ts
@@ -18,7 +18,7 @@ export interface LayoutWithContext {
   readonly block: SerializedTemplateBlock;
   readonly moduleName: string;
   readonly owner: Owner | null;
-  readonly scope: (() => unknown[]) | undefined | null;
+  readonly scope: (() => Record<string, unknown>) | undefined | null;
   readonly isStrictMode: boolean;
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
@@ -107,14 +107,15 @@ export function CompilePositional(
 
 export function meta(layout: LayoutWithContext): BlockMetadata {
   let [, locals, upvars, lexicalSymbols] = layout.block;
+  let scopeRecord = layout.scope?.() ?? null;
 
   return {
     symbols: {
       locals,
       upvars,
-      lexical: lexicalSymbols,
+      lexical: scopeRecord ? Object.keys(scopeRecord) : lexicalSymbols,
     },
-    scopeValues: layout.scope?.() ?? null,
+    scopeValues: scopeRecord ? Object.values(scopeRecord) : null,
     isStrictMode: layout.isStrictMode,
     moduleName: layout.moduleName,
     owner: layout.owner,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -155,10 +155,7 @@ APPEND_OPCODES.add(VM_PUSH_COMPONENT_DEFINITION_OP, (vm, { op1: handle }) => {
 APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => {
   let stack = vm.stack;
   let ref = check(stack.pop(), CheckReference);
-  let component = check(
-    valueForRef(ref),
-    CheckOr(CheckString, CheckCurriedComponentDefinition)
-  );
+  let component = check(valueForRef(ref), CheckOr(CheckString, CheckCurriedComponentDefinition));
   let constants = vm.constants;
   let owner = vm.getOwner();
   let isStrict = constants.getValue<boolean>(_isStrict);
@@ -225,7 +222,13 @@ APPEND_OPCODES.add(VM_RESOLVE_CURRIED_COMPONENT_OP, (vm) => {
     }
   }
 
-  if (DEBUG && definition && !isCurriedValue(definition) && !definition.resolvedName && !definition.debugName) {
+  if (
+    DEBUG &&
+    definition &&
+    !isCurriedValue(definition) &&
+    !definition.resolvedName &&
+    !definition.debugName
+  ) {
     let debugLabel = ref.debugLabel;
     if (debugLabel) {
       definition.debugName = debugLabel;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -154,8 +154,9 @@ APPEND_OPCODES.add(VM_PUSH_COMPONENT_DEFINITION_OP, (vm, { op1: handle }) => {
 
 APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => {
   let stack = vm.stack;
+  let ref = check(stack.pop(), CheckReference);
   let component = check(
-    valueForRef(check(stack.pop(), CheckReference)),
+    valueForRef(ref),
     CheckOr(CheckString, CheckCurriedComponentDefinition)
   );
   let constants = vm.constants;
@@ -180,6 +181,14 @@ APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => 
     definition = component;
   } else {
     definition = constants.component(component, owner);
+  }
+
+  if (DEBUG && !isCurriedValue(definition) && !definition.resolvedName && !definition.debugName) {
+    let debugLabel = ref.debugLabel;
+    if (debugLabel) {
+      // Extract the last segment of the path (e.g. "this.Foo" → "Foo", "Foo" → "Foo")
+      definition.debugName = debugLabel.split('.').pop();
+    }
   }
 
   stack.push(definition);
@@ -214,6 +223,18 @@ APPEND_OPCODES.add(VM_RESOLVE_CURRIED_COMPONENT_OP, (vm) => {
           ref.debugLabel
         }\`, which was: ${debugToString?.(value) ?? value}`
       );
+    }
+  }
+
+  if (DEBUG && definition && !isCurriedValue(definition) && !definition.resolvedName && !definition.debugName) {
+    let debugLabel = ref.debugLabel;
+    if (debugLabel) {
+      // Extract the component name from the arg path (e.g. "@Greeting" → "Greeting")
+      let name = debugLabel.split('.').pop()!;
+      if (name.startsWith('@')) {
+        name = name.slice(1);
+      }
+      definition.debugName = name;
     }
   }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -186,8 +186,7 @@ APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => 
   if (DEBUG && !isCurriedValue(definition) && !definition.resolvedName && !definition.debugName) {
     let debugLabel = ref.debugLabel;
     if (debugLabel) {
-      // Extract the last segment of the path (e.g. "this.Foo" → "Foo", "Foo" → "Foo")
-      definition.debugName = debugLabel.split('.').pop();
+      definition.debugName = debugLabel;
     }
   }
 
@@ -229,12 +228,7 @@ APPEND_OPCODES.add(VM_RESOLVE_CURRIED_COMPONENT_OP, (vm) => {
   if (DEBUG && definition && !isCurriedValue(definition) && !definition.resolvedName && !definition.debugName) {
     let debugLabel = ref.debugLabel;
     if (debugLabel) {
-      // Extract the component name from the arg path (e.g. "@Greeting" → "Greeting")
-      let name = debugLabel.split('.').pop()!;
-      if (name.startsWith('@')) {
-        name = name.slice(1);
-      }
-      definition.debugName = name;
+      definition.debugName = debugLabel;
     }
   }
 

--- a/packages/internal-test-helpers/lib/compile.ts
+++ b/packages/internal-test-helpers/lib/compile.ts
@@ -24,12 +24,15 @@ export default function compile(
 ): TemplateFactory {
   options.locals = options.locals ?? Object.keys(scopeValues ?? {});
   let [block, usedLocals] = precompileJSON(templateSource, compileOptions(options));
-  let reifiedScopeValues = usedLocals.map((key) => scopeValues[key]);
+  let reifiedScope: Record<string, unknown> = {};
+  for (let key of usedLocals) {
+    reifiedScope[key] = scopeValues[key];
+  }
 
   let templateBlock: SerializedTemplateWithLazyBlock = {
     block: JSON.stringify(block),
     moduleName: options.moduleName ?? options.meta?.moduleName ?? '(unknown template module)',
-    scope: reifiedScopeValues.length > 0 ? () => reifiedScopeValues : null,
+    scope: usedLocals.length > 0 ? () => reifiedScope : null,
     isStrictMode: options.strictMode ?? false,
   };
 

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -223,6 +223,29 @@ function basicTest(scenarios: Scenarios, appName: string) {
 
               });
             `,
+            'debug-render-tree-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render } from '@ember/test-helpers';
+              import { captureRenderTree } from '@ember/debug';
+              import Component from '@glimmer/component';
+
+              class HelloWorld extends Component {
+                <template>{{@arg}}</template>
+              }
+
+              module('Integration | captureRenderTree', function (hooks) {
+                setupRenderingTest(hooks);
+
+                test('scope-based components have correct names in debugRenderTree', async function (assert) {
+                  await render(<template><HelloWorld @arg="first" /></template>);
+
+                  let tree = captureRenderTree(this.owner);
+                  let names = tree.filter(n => n.type === 'component').map(n => n.name);
+                  assert.true(names.includes('HelloWorld'), 'HelloWorld component name is preserved in the render tree (found: ' + names.join(', ') + ')');
+                });
+              });
+            `,
           },
         },
       });

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -230,6 +230,17 @@ function basicTest(scenarios: Scenarios, appName: string) {
               import { captureRenderTree } from '@ember/debug';
               import Component from '@glimmer/component';
 
+              function flattenTree(nodes) {
+                let result = [];
+                for (let node of nodes) {
+                  result.push(node);
+                  if (node.children) {
+                    result.push(...flattenTree(node.children));
+                  }
+                }
+                return result;
+              }
+
               class HelloWorld extends Component {
                 <template>{{@arg}}</template>
               }
@@ -241,7 +252,8 @@ function basicTest(scenarios: Scenarios, appName: string) {
                   await render(<template><HelloWorld @arg="first" /></template>);
 
                   let tree = captureRenderTree(this.owner);
-                  let names = tree.filter(n => n.type === 'component').map(n => n.name);
+                  let allNodes = flattenTree(tree);
+                  let names = allNodes.filter(n => n.type === 'component').map(n => n.name);
                   assert.true(names.includes('HelloWorld'), 'HelloWorld component name is preserved in the render tree (found: ' + names.join(', ') + ')');
                 });
               });


### PR DESCRIPTION
Supersedes
- https://github.com/emberjs/ember.js/pull/21077

good luck lil'bot

description from over there:

-------------

This was really bothering me when I was trying to debug my typedoc renderer 

I need to build this ember and test it in that project before starting review.

As part of debugging this, I think I need a button on the inspector to just show the debugRenderTree node
- https://github.com/emberjs/ember-inspector/pull/2709

## Before

<img width="1075" height="647" alt="image" src="https://github.com/user-attachments/assets/bd156709-7d04-4e01-b518-eeff4b69cd18" />

note for me http://localhost:4201/Runtime/util/page-nav


the failing test result in the first commit:
```
not ok 13 Chrome 145.0 - [9 ms] - [integration] jit :: Application test: debug render tree: strict-mode components without debug symbols preserve names from scope
    ---
        actual: >
            (unknown template-only component)
        expected: >
            HelloWorld
        stack: >
```

there is also a failing smoke test so we can e2e the whole setup:
```gjs
test('scope-based components have correct names in debugRenderTree', async function (assert) {
  await render(<template><HelloWorld @arg="first" /></template>);

  let tree = captureRenderTree(this.owner);
  let names = tree.filter(n => n.type === 'component').map(n => n.name);
  assert.true(
    names.includes('HelloWorld'), 
    'HelloWorld component name is preserved in the render tree (found: ' + names.join(', ') + ')'
  );
});
```     

this also fails
```

not ok 2 Chrome 145.0 - [47 ms] - Integration | captureRenderTree: scope-based components have correct names in debugRenderTree
    ---
        actual: >
            false
        expected: >
            true
        stack: >
                at Object.<anonymous> (http://localhost:7357/assets/tests-DjOElQH7.js:10419:16)
        message: >
            HelloWorld component name is preserved in the render tree (found: )

```



<img width="320" height="336" alt="image" src="https://github.com/user-attachments/assets/78c99c09-1e62-4af1-971e-f6fccb714758" />


## After
<img width="218" height="368" alt="image" src="https://github.com/user-attachments/assets/0f71a75e-3e39-42d6-aab5-f0d645dd0a52" />


from my actual app with recursive type/typedoc rendering:

<img width="1186" height="920" alt="image" src="https://github.com/user-attachments/assets/6ce8b033-c121-496e-9788-8ab5b55e7dda" />


