### PR TITLE
Implement `(element)` helper for dynamic tag names (RFC #0389)

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -497,4 +497,5 @@ export {
   setComponentManager,
 } from './lib/utils/managers';
 export { isSerializationFirstNode } from './lib/utils/serialization-first-node-helpers';
+export { default as element } from './lib/helpers/element';
 export { uniqueId } from './lib/helpers/unique-id';

--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -224,10 +224,7 @@ export default internalHelper(({ positional, named }: CapturedArguments) => {
   return createComputeRef(
     () => {
       if (DEBUG) {
-        assert(
-          'The `element` helper takes a single positional argument',
-          positional.length === 1
-        );
+        assert('The `element` helper takes a single positional argument', positional.length === 1);
         assert(
           'The `element` helper does not take any named arguments',
           Object.keys(named).length === 0

--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -1,0 +1,257 @@
+/**
+  @module @ember/helper
+*/
+
+import type {
+  Bounds,
+  CapturedArguments,
+  CompilableProgram,
+  Destroyable,
+  Environment,
+  InternalComponentCapabilities,
+  InternalComponentManager,
+  VMArguments,
+  WithCreateInstance,
+  WithDynamicLayout,
+  WithDynamicTagName,
+} from '@glimmer/interfaces';
+import type { Nullable } from '@ember/-internals/utility-types';
+import type { Reference } from '@glimmer/reference';
+import { createComputeRef, valueForRef, NULL_REFERENCE } from '@glimmer/reference';
+import { setInternalComponentManager, setComponentTemplate } from '@glimmer/manager';
+import { templateFactory } from '@glimmer/opcode-compiler';
+import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+import { internalHelper } from './internal-helper';
+
+// ============ Void Element Component (for null/undefined) ============
+// Renders nothing (no yield, no wrapper element)
+
+const VOID_CAPABILITIES: InternalComponentCapabilities = {
+  dynamicLayout: false,
+  dynamicTag: false,
+  prepareArgs: false,
+  createArgs: false,
+  attributeHook: false,
+  elementHook: false,
+  createCaller: false,
+  dynamicScope: false,
+  updateHook: false,
+  createInstance: false,
+  wrapped: false,
+  willDestroy: false,
+  hasSubOwner: false,
+};
+
+class VoidElementManager implements InternalComponentManager {
+  getCapabilities(): InternalComponentCapabilities {
+    return VOID_CAPABILITIES;
+  }
+
+  getDebugName(): string {
+    return '(element null)';
+  }
+
+  getSelf(): Reference {
+    return NULL_REFERENCE;
+  }
+
+  getDestroyable(): null {
+    return null;
+  }
+}
+
+const VOID_ELEMENT_MANAGER = new VoidElementManager();
+
+// Empty template that renders nothing and does not yield
+const EMPTY_TEMPLATE_FACTORY = templateFactory({
+  id: 'element-helper-void',
+  moduleName: '__element_void__.hbs',
+  block: JSON.stringify([[], [], []]),
+  scope: null,
+  isStrictMode: true,
+});
+
+class VoidElementComponentDefinition {
+  toString(): string {
+    return '(element null)';
+  }
+}
+
+setComponentTemplate(EMPTY_TEMPLATE_FACTORY, VoidElementComponentDefinition.prototype);
+setInternalComponentManager(VOID_ELEMENT_MANAGER, VoidElementComponentDefinition.prototype);
+
+const VOID_DEFINITION = new VoidElementComponentDefinition();
+
+// ============ Element Component (for string tag names) ============
+// Renders content wrapped in the specified HTML element, or just renders
+// content without a wrapper for empty string.
+
+const ELEMENT_CAPABILITIES: InternalComponentCapabilities = {
+  dynamicLayout: true,
+  dynamicTag: true,
+  prepareArgs: false,
+  createArgs: false,
+  attributeHook: false,
+  elementHook: false,
+  createCaller: false,
+  dynamicScope: false,
+  updateHook: false,
+  createInstance: true,
+  wrapped: true,
+  willDestroy: false,
+  hasSubOwner: false,
+};
+
+// The instance state is just the tag name string or null (for empty string)
+type ElementInstanceState = string | null;
+
+class ElementComponentManager
+  implements
+    WithCreateInstance<ElementInstanceState, ElementComponentDefinition>,
+    WithDynamicLayout<ElementInstanceState>,
+    WithDynamicTagName<ElementInstanceState>
+{
+  getCapabilities(): InternalComponentCapabilities {
+    return ELEMENT_CAPABILITIES;
+  }
+
+  getDebugName(state: ElementComponentDefinition): string {
+    return `(element "${state.tagName}")`;
+  }
+
+  getSelf(): Reference {
+    return NULL_REFERENCE;
+  }
+
+  getDestroyable(): Nullable<Destroyable> {
+    return null;
+  }
+
+  didCreateElement(): void {
+    // no-op: element helper doesn't need to customize the element after creation
+  }
+
+  create(
+    _owner: object,
+    state: ElementComponentDefinition,
+    _args: Nullable<VMArguments>,
+    _env: Environment,
+    _dynamicScope: unknown,
+    _caller: Nullable<Reference>,
+    _hasDefaultBlock: boolean
+  ): ElementInstanceState {
+    // For empty string, return null so getTagName returns null (no wrapper element)
+    return state.tagName || null;
+  }
+
+  getDynamicLayout(): CompilableProgram | null {
+    // Return null to fall back to the VM's defaultTemplate.asWrappedLayout()
+    // The default template is {{yield}}, which yields to the block content
+    return null;
+  }
+
+  getTagName(state: ElementInstanceState): Nullable<string> {
+    return state;
+  }
+
+  didRenderLayout(_state: ElementInstanceState, _bounds: Bounds): void {
+    // no-op
+  }
+
+  didUpdateLayout(_state: ElementInstanceState, _bounds: Bounds): void {
+    // no-op
+  }
+
+  didCreate(_state: ElementInstanceState): void {
+    // no-op
+  }
+
+  didUpdate(_state: ElementInstanceState): void {
+    // no-op
+  }
+}
+
+const ELEMENT_COMPONENT_MANAGER = new ElementComponentManager();
+
+class ElementComponentDefinition {
+  constructor(public tagName: string) {}
+
+  toString(): string {
+    return `(element "${this.tagName}")`;
+  }
+}
+
+setInternalComponentManager(ELEMENT_COMPONENT_MANAGER, ElementComponentDefinition.prototype);
+
+// Cache component definitions per tag name to avoid creating duplicate definitions
+const ELEMENT_DEFINITIONS = new Map<string, ElementComponentDefinition>();
+
+function getElementDefinition(tagName: string): ElementComponentDefinition {
+  let definition = ELEMENT_DEFINITIONS.get(tagName);
+  if (definition === undefined) {
+    definition = new ElementComponentDefinition(tagName);
+    ELEMENT_DEFINITIONS.set(tagName, definition);
+  }
+  return definition;
+}
+
+// ============ Element Helper ============
+
+/**
+  The `element` helper lets you dynamically set the tag name of an element.
+
+  ```handlebars
+  {{#let (element @tagName) as |Tag|}}
+    <Tag class="my-element">Hello</Tag>
+  {{/let}}
+  ```
+
+  When `@tagName` is `"h1"`, this renders `<h1 class="my-element">Hello</h1>`.
+
+  When `@tagName` is an empty string `""`, the block content is rendered without
+  a wrapping element.
+
+  When `@tagName` is `null` or `undefined`, nothing is rendered.
+
+  Changing the tag name will tear down and recreate the element and its contents.
+
+  @method element
+  @for Ember.Templates.helpers
+  @public
+*/
+export default internalHelper(({ positional, named }: CapturedArguments) => {
+  return createComputeRef(
+    () => {
+      if (DEBUG) {
+        assert(
+          'The `element` helper takes a single positional argument',
+          positional.length === 1
+        );
+        assert(
+          'The `element` helper does not take any named arguments',
+          Object.keys(named).length === 0
+        );
+      }
+
+      let tagName = valueForRef(positional[0]!);
+
+      if (tagName === null || tagName === undefined) {
+        return VOID_DEFINITION;
+      }
+
+      if (DEBUG) {
+        assert(
+          `The argument passed to the \`element\` helper must be a string${
+            typeof tagName === 'object' ? '' : ` (you passed \`${tagName}\`)`
+          }`,
+          typeof tagName === 'string'
+        );
+      }
+
+      return getElementDefinition(tagName as string);
+    },
+    null,
+    'element'
+  );
+});

--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -14,8 +14,6 @@ import { internalHelper } from './internal-helper';
 // content without a wrapper for empty string.
 
 const ELEMENT_CAPABILITIES = {
-  dynamicLayout: true,
-  dynamicTag: true,
   createInstance: true,
   wrapped: true,
 };
@@ -42,10 +40,6 @@ class ElementComponentManager {
   create(_owner: object, state: ElementComponentDefinition) {
     // For empty string, return null so getTagName returns null (no wrapper element)
     return state.tagName || null;
-  }
-
-  getDynamicLayout() {
-    return null;
   }
 
   getTagName(state: string | null) {

--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -9,7 +9,6 @@ import type {
   Destroyable,
   Environment,
   InternalComponentCapabilities,
-  InternalComponentManager,
   VMArguments,
   WithCreateInstance,
   WithDynamicLayout,
@@ -18,70 +17,10 @@ import type {
 import type { Nullable } from '@ember/-internals/utility-types';
 import type { Reference } from '@glimmer/reference';
 import { createComputeRef, valueForRef, NULL_REFERENCE } from '@glimmer/reference';
-import { setInternalComponentManager, setComponentTemplate } from '@glimmer/manager';
-import { templateFactory } from '@glimmer/opcode-compiler';
+import { setInternalComponentManager } from '@glimmer/manager';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { internalHelper } from './internal-helper';
-
-// ============ Void Element Component (for null/undefined) ============
-// Renders nothing (no yield, no wrapper element)
-
-const VOID_CAPABILITIES: InternalComponentCapabilities = {
-  dynamicLayout: false,
-  dynamicTag: false,
-  prepareArgs: false,
-  createArgs: false,
-  attributeHook: false,
-  elementHook: false,
-  createCaller: false,
-  dynamicScope: false,
-  updateHook: false,
-  createInstance: false,
-  wrapped: false,
-  willDestroy: false,
-  hasSubOwner: false,
-};
-
-class VoidElementManager implements InternalComponentManager {
-  getCapabilities(): InternalComponentCapabilities {
-    return VOID_CAPABILITIES;
-  }
-
-  getDebugName(): string {
-    return '(element null)';
-  }
-
-  getSelf(): Reference {
-    return NULL_REFERENCE;
-  }
-
-  getDestroyable(): null {
-    return null;
-  }
-}
-
-const VOID_ELEMENT_MANAGER = new VoidElementManager();
-
-// Empty template that renders nothing and does not yield
-const EMPTY_TEMPLATE_FACTORY = templateFactory({
-  id: 'element-helper-void',
-  moduleName: '__element_void__.hbs',
-  block: JSON.stringify([[], [], []]),
-  scope: null,
-  isStrictMode: true,
-});
-
-class VoidElementComponentDefinition {
-  toString(): string {
-    return '(element null)';
-  }
-}
-
-setComponentTemplate(EMPTY_TEMPLATE_FACTORY, VoidElementComponentDefinition.prototype);
-setInternalComponentManager(VOID_ELEMENT_MANAGER, VoidElementComponentDefinition.prototype);
-
-const VOID_DEFINITION = new VoidElementComponentDefinition();
 
 // ============ Element Component (for string tag names) ============
 // Renders content wrapped in the specified HTML element, or just renders
@@ -212,7 +151,7 @@ function getElementDefinition(tagName: string): ElementComponentDefinition {
   When `@tagName` is an empty string `""`, the block content is rendered without
   a wrapping element.
 
-  When `@tagName` is `null` or `undefined`, nothing is rendered.
+  Passing `null`, `undefined`, or non-string values will throw an assertion error.
 
   Changing the tag name will tear down and recreate the element and its contents.
 
@@ -233,14 +172,12 @@ export default internalHelper(({ positional, named }: CapturedArguments) => {
 
       let tagName = valueForRef(positional[0]!);
 
-      if (tagName === null || tagName === undefined) {
-        return VOID_DEFINITION;
-      }
-
       if (DEBUG) {
         assert(
           `The argument passed to the \`element\` helper must be a string${
-            typeof tagName === 'object' ? '' : ` (you passed \`${tagName}\`)`
+            tagName === null || tagName === undefined || typeof tagName === 'object'
+              ? ''
+              : ` (you passed \`${tagName}\`)`
           }`,
           typeof tagName === 'string'
         );

--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -2,20 +2,7 @@
   @module @ember/helper
 */
 
-import type {
-  Bounds,
-  CapturedArguments,
-  CompilableProgram,
-  Destroyable,
-  Environment,
-  InternalComponentCapabilities,
-  VMArguments,
-  WithCreateInstance,
-  WithDynamicLayout,
-  WithDynamicTagName,
-} from '@glimmer/interfaces';
-import type { Nullable } from '@ember/-internals/utility-types';
-import type { Reference } from '@glimmer/reference';
+import type { CapturedArguments, InternalComponentManager } from '@glimmer/interfaces';
 import { createComputeRef, valueForRef, NULL_REFERENCE } from '@glimmer/reference';
 import { setInternalComponentManager } from '@glimmer/manager';
 import { assert } from '@ember/debug';
@@ -26,89 +13,49 @@ import { internalHelper } from './internal-helper';
 // Renders content wrapped in the specified HTML element, or just renders
 // content without a wrapper for empty string.
 
-const ELEMENT_CAPABILITIES: InternalComponentCapabilities = {
+const ELEMENT_CAPABILITIES = {
   dynamicLayout: true,
   dynamicTag: true,
-  prepareArgs: false,
-  createArgs: false,
-  attributeHook: false,
-  elementHook: false,
-  createCaller: false,
-  dynamicScope: false,
-  updateHook: false,
   createInstance: true,
   wrapped: true,
-  willDestroy: false,
-  hasSubOwner: false,
 };
 
-// The instance state is just the tag name string or null (for empty string)
-type ElementInstanceState = string | null;
-
-class ElementComponentManager
-  implements
-    WithCreateInstance<ElementInstanceState, ElementComponentDefinition>,
-    WithDynamicLayout<ElementInstanceState>,
-    WithDynamicTagName<ElementInstanceState>
-{
-  getCapabilities(): InternalComponentCapabilities {
+class ElementComponentManager {
+  getCapabilities() {
     return ELEMENT_CAPABILITIES;
   }
 
-  getDebugName(state: ElementComponentDefinition): string {
+  getDebugName(state: ElementComponentDefinition) {
     return `(element "${state.tagName}")`;
   }
 
-  getSelf(): Reference {
+  getSelf() {
     return NULL_REFERENCE;
   }
 
-  getDestroyable(): Nullable<Destroyable> {
+  getDestroyable() {
     return null;
   }
 
-  didCreateElement(): void {
-    // no-op: element helper doesn't need to customize the element after creation
-  }
+  didCreateElement() {}
 
-  create(
-    _owner: object,
-    state: ElementComponentDefinition,
-    _args: Nullable<VMArguments>,
-    _env: Environment,
-    _dynamicScope: unknown,
-    _caller: Nullable<Reference>,
-    _hasDefaultBlock: boolean
-  ): ElementInstanceState {
+  create(_owner: object, state: ElementComponentDefinition) {
     // For empty string, return null so getTagName returns null (no wrapper element)
     return state.tagName || null;
   }
 
-  getDynamicLayout(): CompilableProgram | null {
-    // Return null to fall back to the VM's defaultTemplate.asWrappedLayout()
-    // The default template is {{yield}}, which yields to the block content
+  getDynamicLayout() {
     return null;
   }
 
-  getTagName(state: ElementInstanceState): Nullable<string> {
+  getTagName(state: string | null) {
     return state;
   }
 
-  didRenderLayout(_state: ElementInstanceState, _bounds: Bounds): void {
-    // no-op
-  }
-
-  didUpdateLayout(_state: ElementInstanceState, _bounds: Bounds): void {
-    // no-op
-  }
-
-  didCreate(_state: ElementInstanceState): void {
-    // no-op
-  }
-
-  didUpdate(_state: ElementInstanceState): void {
-    // no-op
-  }
+  didRenderLayout() {}
+  didUpdateLayout() {}
+  didCreate() {}
+  didUpdate() {}
 }
 
 const ELEMENT_COMPONENT_MANAGER = new ElementComponentManager();
@@ -121,7 +68,10 @@ class ElementComponentDefinition {
   }
 }
 
-setInternalComponentManager(ELEMENT_COMPONENT_MANAGER, ElementComponentDefinition.prototype);
+setInternalComponentManager(
+  ELEMENT_COMPONENT_MANAGER as unknown as InternalComponentManager,
+  ElementComponentDefinition.prototype
+);
 
 // Cache component definitions per tag name to avoid creating duplicate definitions
 const ELEMENT_DEFINITIONS = new Map<string, ElementComponentDefinition>();

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -38,7 +38,6 @@ import { default as eachIn } from './helpers/each-in';
 import { default as mut } from './helpers/mut';
 import { default as readonly } from './helpers/readonly';
 import { default as unbound } from './helpers/unbound';
-import { default as element } from './helpers/element';
 import { default as uniqueId } from './helpers/unique-id';
 
 import { mountHelper } from './syntax/mount';
@@ -109,7 +108,6 @@ const BUILTIN_HELPERS: Record<string, object> = {
   fn,
   get,
   hash,
-  element,
   'unique-id': uniqueId,
 };
 

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -38,6 +38,7 @@ import { default as eachIn } from './helpers/each-in';
 import { default as mut } from './helpers/mut';
 import { default as readonly } from './helpers/readonly';
 import { default as unbound } from './helpers/unbound';
+import { default as element } from './helpers/element';
 import { default as uniqueId } from './helpers/unique-id';
 
 import { mountHelper } from './syntax/mount';
@@ -108,6 +109,7 @@ const BUILTIN_HELPERS: Record<string, object> = {
   fn,
   get,
   hash,
+  element,
   'unique-id': uniqueId,
 };
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -1,7 +1,8 @@
 import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
-import { RenderingTestCase, defineComponent, moduleFor, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { element as elementHelper } from '@ember/helper';
+import { template } from '@ember/template-compiler/runtime';
 
 moduleFor(
   'Helpers test: {{element}}',
@@ -12,9 +13,9 @@ moduleFor(
     }
 
     '@test it renders a tag in strict mode'() {
-      let AComponent = defineComponent(
-        { element: elementHelper },
-        `{{#let (element "h1") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
+      let AComponent = template(
+        `{{#let (element "h1") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper }) }
       );
       this.renderComponent(AComponent, { expect: '<h1 id="content">hello world!</h1>' });
     }
@@ -90,26 +91,16 @@ moduleFor(
     }
 
     '@test it can be passed as argument and works with ...attributes'() {
-      let Inner = defineComponent(
-        { element: elementHelper },
-        `{{#let @tag as |Tag|}}<Tag id="content" ...attributes>{{yield}}</Tag>{{/let}}`
+      let Inner = template(
+        `{{#let @tag as |Tag|}}<Tag id="content" ...attributes>{{yield}}</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper }) }
       );
 
-      this.registerComponent('inner', { ComponentClass: Inner });
-
-      this.render(`<Inner @tag={{element this.htmlTag}} class="extra">Test</Inner>`, {
-        htmlTag: 'p',
+      let Outer = template(`<Inner @tag={{element "p"}} class="extra">Test</Inner>`, {
+        scope: () => ({ Inner, element: elementHelper }),
       });
-      this.assertHTML('<p id="content" class="extra">Test</p>');
 
-      runTask(() => set(this.context, 'htmlTag', 'div'));
-      this.assertHTML('<div id="content" class="extra">Test</div>');
-
-      runTask(() => set(this.context, 'htmlTag', ''));
-      this.assertText('Test');
-
-      runTask(() => set(this.context, 'htmlTag', 'p'));
-      this.assertHTML('<p id="content" class="extra">Test</p>');
+      this.renderComponent(Outer, { expect: '<p id="content" class="extra">Test</p>' });
     }
 
     ['@test it requires at least one argument']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -1,6 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import { tracked } from '@glimmer/tracking';
-import { RenderingTestCase, defineSimpleHelper, moduleFor, runTask } from 'internal-test-helpers';
+import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { element as elementHelper, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { template } from '@ember/template-compiler/runtime';
@@ -82,11 +82,10 @@ moduleFor(
       }
 
       let state = new State();
-      let getTag = defineSimpleHelper(() => state.htmlTag);
 
       let AComponent = template(
-        `{{#let (element (getTag)) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`,
-        { scope: () => ({ element: elementHelper, getTag }) }
+        `{{#let (element state.htmlTag) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper, state }) }
       );
       this.renderComponent(AComponent, {
         expect: '<h1 id="content">hello</h1>',
@@ -116,6 +115,49 @@ moduleFor(
       });
 
       this.renderComponent(Outer, { expect: '<p id="content" class="extra">Test</p>' });
+    }
+
+    ['@test it requires at least one argument']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(() => {
+        let AComponent = template(`{{#let (element) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
+      }, /The `element` helper takes a single positional argument/);
+    }
+
+    ['@test it requires no more than one argument']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(() => {
+        let AComponent = template(`{{#let (element "h1" "h2") as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
+      }, /The `element` helper takes a single positional argument/);
+    }
+
+    ['@test it does not take any named arguments']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(() => {
+        let AComponent = template(
+          `{{#let (element "h1" id="content") as |Tag|}}<Tag>hello</Tag>{{/let}}`,
+          { scope: () => ({ element: elementHelper }) }
+        );
+        this.renderComponent(AComponent, { expect: '' });
+      }, /The `element` helper does not take any named arguments/);
     }
 
     ['@test it throws when passed a number']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -1,11 +1,6 @@
 import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
-import {
-  RenderingTestCase,
-  defineComponent,
-  moduleFor,
-  runTask,
-} from 'internal-test-helpers';
+import { RenderingTestCase, defineComponent, moduleFor, runTask } from 'internal-test-helpers';
 import { element as elementHelper } from '@ember/helper';
 
 moduleFor(
@@ -25,16 +20,12 @@ moduleFor(
     }
 
     '@test it does not render any tags when passed an empty string'() {
-      this.render(
-        `{{#let (element "") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
-      );
+      this.render(`{{#let (element "") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`);
       this.assertText('hello world!');
     }
 
     '@test it does not render anything when passed null'() {
-      this.render(
-        `{{#let (element null) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
-      );
+      this.render(`{{#let (element null) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`);
       this.assertHTML('<!---->');
     }
 
@@ -51,9 +42,7 @@ moduleFor(
         { didClick: () => {} }
       );
 
-      this.assertHTML(
-        '<button type="button" id="action">hello world!</button>'
-      );
+      this.assertHTML('<button type="button" id="action">hello world!</button>');
     }
 
     '@test it can be rendered multiple times'() {
@@ -68,10 +57,9 @@ moduleFor(
     '@test it renders when the tag name changes'() {
       // Note: use htmlTag instead of tagName, because RenderingTestCase
       // overrides tagName on the root component context
-      this.render(
-        `{{#let (element this.htmlTag) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`,
-        { htmlTag: 'h1' }
-      );
+      this.render(`{{#let (element this.htmlTag) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`, {
+        htmlTag: 'h1',
+      });
       this.assertHTML('<h1 id="content">hello</h1>');
 
       runTask(() => set(this.context, 'htmlTag', 'h2'));
@@ -95,10 +83,9 @@ moduleFor(
 
       this.registerComponent('inner', { ComponentClass: Inner });
 
-      this.render(
-        `<Inner @tag={{element this.htmlTag}} class="extra">Test</Inner>`,
-        { htmlTag: 'p' }
-      );
+      this.render(`<Inner @tag={{element this.htmlTag}} class="extra">Test</Inner>`, {
+        htmlTag: 'p',
+      });
       this.assertHTML('<p id="content" class="extra">Test</p>');
 
       runTask(() => set(this.context, 'htmlTag', 'div'));
@@ -117,14 +104,11 @@ moduleFor(
         return;
       }
 
-      this.assert.throws(
-        () => {
-          this.render(
-            `<div>{{#let (element) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-          );
-        },
-        /The `element` helper takes a single positional argument/
-      );
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The `element` helper takes a single positional argument/);
     }
 
     ['@test it requires no more than one argument']() {
@@ -133,14 +117,11 @@ moduleFor(
         return;
       }
 
-      this.assert.throws(
-        () => {
-          this.render(
-            `<div>{{#let (element "h1" "h2") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-          );
-        },
-        /The `element` helper takes a single positional argument/
-      );
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element "h1" "h2") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The `element` helper takes a single positional argument/);
     }
 
     ['@test it does not take any named arguments']() {
@@ -149,14 +130,11 @@ moduleFor(
         return;
       }
 
-      this.assert.throws(
-        () => {
-          this.render(
-            `<div>{{#let (element "h1" id="content") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-          );
-        },
-        /The `element` helper does not take any named arguments/
-      );
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element "h1" id="content") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The `element` helper does not take any named arguments/);
     }
 
     ['@test it throws when passed a number']() {
@@ -165,14 +143,11 @@ moduleFor(
         return;
       }
 
-      this.assert.throws(
-        () => {
-          this.render(
-            `<div>{{#let (element 123) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-          );
-        },
-        /The argument passed to the `element` helper must be a string \(you passed `123`\)/
-      );
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element 123) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The argument passed to the `element` helper must be a string \(you passed `123`\)/);
     }
 
     ['@test it throws when passed a boolean']() {
@@ -181,14 +156,11 @@ moduleFor(
         return;
       }
 
-      this.assert.throws(
-        () => {
-          this.render(
-            `<div>{{#let (element false) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-          );
-        },
-        /The argument passed to the `element` helper must be a string \(you passed `false`\)/
-      );
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element false) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The argument passed to the `element` helper must be a string \(you passed `false`\)/);
     }
 
     ['@test it throws when passed an object']() {
@@ -197,14 +169,11 @@ moduleFor(
         return;
       }
 
-      this.assert.throws(
-        () => {
-          this.render(
-            `<div>{{#let (element (hash)) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-          );
-        },
-        /The argument passed to the `element` helper must be a string/
-      );
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element (hash)) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The argument passed to the `element` helper must be a string/);
     }
   }
 );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -1,0 +1,210 @@
+import { set } from '@ember/object';
+import { DEBUG } from '@glimmer/env';
+import {
+  RenderingTestCase,
+  defineComponent,
+  moduleFor,
+  runTask,
+} from 'internal-test-helpers';
+import { element as elementHelper } from '@ember/helper';
+
+moduleFor(
+  'Helpers test: {{element}}',
+  class extends RenderingTestCase {
+    '@test it renders a tag with the given tag name'() {
+      this.render(`{{#let (element "h1") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`);
+      this.assertHTML('<h1 id="content">hello world!</h1>');
+    }
+
+    '@test it renders a tag in strict mode'() {
+      let AComponent = defineComponent(
+        { element: elementHelper },
+        `{{#let (element "h1") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
+      );
+      this.renderComponent(AComponent, { expect: '<h1 id="content">hello world!</h1>' });
+    }
+
+    '@test it does not render any tags when passed an empty string'() {
+      this.render(
+        `{{#let (element "") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
+      );
+      this.assertText('hello world!');
+    }
+
+    '@test it does not render anything when passed null'() {
+      this.render(
+        `{{#let (element null) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
+      );
+      this.assertHTML('<!---->');
+    }
+
+    '@test it does not render anything when passed undefined'() {
+      this.render(
+        `{{#let (element undefined) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
+      );
+      this.assertHTML('<!---->');
+    }
+
+    '@test it works with element modifiers'() {
+      this.render(
+        `{{#let (element "button") as |Tag|}}<Tag type="button" id="action" {{on "click" this.didClick}}>hello world!</Tag>{{/let}}`,
+        { didClick: () => {} }
+      );
+
+      this.assertHTML(
+        '<button type="button" id="action">hello world!</button>'
+      );
+    }
+
+    '@test it can be rendered multiple times'() {
+      this.render(
+        `{{#let (element "h1") as |Tag|}}<Tag id="content-1">hello</Tag><Tag id="content-2">world</Tag><Tag id="content-3">!!!!!</Tag>{{/let}}`
+      );
+      this.assertHTML(
+        '<h1 id="content-1">hello</h1><h1 id="content-2">world</h1><h1 id="content-3">!!!!!</h1>'
+      );
+    }
+
+    '@test it renders when the tag name changes'() {
+      // Note: use htmlTag instead of tagName, because RenderingTestCase
+      // overrides tagName on the root component context
+      this.render(
+        `{{#let (element this.htmlTag) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`,
+        { htmlTag: 'h1' }
+      );
+      this.assertHTML('<h1 id="content">hello</h1>');
+
+      runTask(() => set(this.context, 'htmlTag', 'h2'));
+      this.assertHTML('<h2 id="content">hello</h2>');
+
+      runTask(() => set(this.context, 'htmlTag', 'h3'));
+      this.assertHTML('<h3 id="content">hello</h3>');
+
+      runTask(() => set(this.context, 'htmlTag', ''));
+      this.assertText('hello');
+
+      runTask(() => set(this.context, 'htmlTag', 'h1'));
+      this.assertHTML('<h1 id="content">hello</h1>');
+    }
+
+    '@test it can be passed as argument and works with ...attributes'() {
+      let Inner = defineComponent(
+        { element: elementHelper },
+        `{{#let @tag as |Tag|}}<Tag id="content" ...attributes>{{yield}}</Tag>{{/let}}`
+      );
+
+      this.registerComponent('inner', { ComponentClass: Inner });
+
+      this.render(
+        `<Inner @tag={{element this.htmlTag}} class="extra">Test</Inner>`,
+        { htmlTag: 'p' }
+      );
+      this.assertHTML('<p id="content" class="extra">Test</p>');
+
+      runTask(() => set(this.context, 'htmlTag', 'div'));
+      this.assertHTML('<div id="content" class="extra">Test</div>');
+
+      runTask(() => set(this.context, 'htmlTag', ''));
+      this.assertText('Test');
+
+      runTask(() => set(this.context, 'htmlTag', 'p'));
+      this.assertHTML('<p id="content" class="extra">Test</p>');
+    }
+
+    ['@test it requires at least one argument']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(
+        () => {
+          this.render(
+            `<div>{{#let (element) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+          );
+        },
+        /The `element` helper takes a single positional argument/
+      );
+    }
+
+    ['@test it requires no more than one argument']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(
+        () => {
+          this.render(
+            `<div>{{#let (element "h1" "h2") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+          );
+        },
+        /The `element` helper takes a single positional argument/
+      );
+    }
+
+    ['@test it does not take any named arguments']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(
+        () => {
+          this.render(
+            `<div>{{#let (element "h1" id="content") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+          );
+        },
+        /The `element` helper does not take any named arguments/
+      );
+    }
+
+    ['@test it throws when passed a number']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(
+        () => {
+          this.render(
+            `<div>{{#let (element 123) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+          );
+        },
+        /The argument passed to the `element` helper must be a string \(you passed `123`\)/
+      );
+    }
+
+    ['@test it throws when passed a boolean']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(
+        () => {
+          this.render(
+            `<div>{{#let (element false) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+          );
+        },
+        /The argument passed to the `element` helper must be a string \(you passed `false`\)/
+      );
+    }
+
+    ['@test it throws when passed an object']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(
+        () => {
+          this.render(
+            `<div>{{#let (element (hash)) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+          );
+        },
+        /The argument passed to the `element` helper must be a string/
+      );
+    }
+  }
+);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -1,18 +1,14 @@
-import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
-import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
-import { element as elementHelper } from '@ember/helper';
+import { tracked } from '@glimmer/tracking';
+import { RenderingTestCase, defineSimpleHelper, moduleFor, runTask } from 'internal-test-helpers';
+import { element as elementHelper, hash } from '@ember/helper';
+import { on } from '@ember/modifier';
 import { template } from '@ember/template-compiler/runtime';
 
 moduleFor(
   'Helpers test: {{element}}',
   class extends RenderingTestCase {
     '@test it renders a tag with the given tag name'() {
-      this.render(`{{#let (element "h1") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`);
-      this.assertHTML('<h1 id="content">hello world!</h1>');
-    }
-
-    '@test it renders a tag in strict mode'() {
       let AComponent = template(
         `{{#let (element "h1") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`,
         { scope: () => ({ element: elementHelper }) }
@@ -21,8 +17,11 @@ moduleFor(
     }
 
     '@test it does not render any tags when passed an empty string'() {
-      this.render(`{{#let (element "") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`);
-      this.assertText('hello world!');
+      let AComponent = template(
+        `{{#let (element "") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper }) }
+      );
+      this.renderComponent(AComponent, { expect: 'hello world!' });
     }
 
     ['@test it throws when passed null']() {
@@ -31,10 +30,12 @@ moduleFor(
         return;
       }
 
+      let nil = null;
       this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element null) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
+        let AComponent = template(`{{#let (element nil) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, nil }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
       }, /The argument passed to the `element` helper must be a string/);
     }
 
@@ -44,49 +45,63 @@ moduleFor(
         return;
       }
 
+      let undef = undefined;
       this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element undefined) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
+        let AComponent = template(`{{#let (element undef) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, undef }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
       }, /The argument passed to the `element` helper must be a string/);
     }
 
     '@test it works with element modifiers'() {
-      this.render(
-        `{{#let (element "button") as |Tag|}}<Tag type="button" id="action" {{on "click" this.didClick}}>hello world!</Tag>{{/let}}`,
-        { didClick: () => {} }
+      let didClick = () => {};
+      let AComponent = template(
+        `{{#let (element "button") as |Tag|}}<Tag type="button" id="action" {{on "click" didClick}}>hello world!</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper, on, didClick }) }
       );
-
-      this.assertHTML('<button type="button" id="action">hello world!</button>');
+      this.renderComponent(AComponent, {
+        expect: '<button type="button" id="action">hello world!</button>',
+      });
     }
 
     '@test it can be rendered multiple times'() {
-      this.render(
-        `{{#let (element "h1") as |Tag|}}<Tag id="content-1">hello</Tag><Tag id="content-2">world</Tag><Tag id="content-3">!!!!!</Tag>{{/let}}`
+      let AComponent = template(
+        `{{#let (element "h1") as |Tag|}}<Tag id="content-1">hello</Tag><Tag id="content-2">world</Tag><Tag id="content-3">!!!!!</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper }) }
       );
-      this.assertHTML(
-        '<h1 id="content-1">hello</h1><h1 id="content-2">world</h1><h1 id="content-3">!!!!!</h1>'
-      );
+      this.renderComponent(AComponent, {
+        expect:
+          '<h1 id="content-1">hello</h1><h1 id="content-2">world</h1><h1 id="content-3">!!!!!</h1>',
+      });
     }
 
     '@test it renders when the tag name changes'() {
-      // Note: use htmlTag instead of tagName, because RenderingTestCase
-      // overrides tagName on the root component context
-      this.render(`{{#let (element this.htmlTag) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`, {
-        htmlTag: 'h1',
-      });
-      this.assertHTML('<h1 id="content">hello</h1>');
+      class State {
+        @tracked htmlTag = 'h1';
+      }
 
-      runTask(() => set(this.context, 'htmlTag', 'h2'));
+      let state = new State();
+      let getTag = defineSimpleHelper(() => state.htmlTag);
+
+      let AComponent = template(
+        `{{#let (element (getTag)) as |Tag|}}<Tag id="content">hello</Tag>{{/let}}`,
+        { scope: () => ({ element: elementHelper, getTag }) }
+      );
+      this.renderComponent(AComponent, {
+        expect: '<h1 id="content">hello</h1>',
+      });
+
+      runTask(() => (state.htmlTag = 'h2'));
       this.assertHTML('<h2 id="content">hello</h2>');
 
-      runTask(() => set(this.context, 'htmlTag', 'h3'));
+      runTask(() => (state.htmlTag = 'h3'));
       this.assertHTML('<h3 id="content">hello</h3>');
 
-      runTask(() => set(this.context, 'htmlTag', ''));
+      runTask(() => (state.htmlTag = ''));
       this.assertText('hello');
 
-      runTask(() => set(this.context, 'htmlTag', 'h1'));
+      runTask(() => (state.htmlTag = 'h1'));
       this.assertHTML('<h1 id="content">hello</h1>');
     }
 
@@ -103,55 +118,18 @@ moduleFor(
       this.renderComponent(Outer, { expect: '<p id="content" class="extra">Test</p>' });
     }
 
-    ['@test it requires at least one argument']() {
-      if (!DEBUG) {
-        this.assert.expect(0);
-        return;
-      }
-
-      this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
-      }, /The `element` helper takes a single positional argument/);
-    }
-
-    ['@test it requires no more than one argument']() {
-      if (!DEBUG) {
-        this.assert.expect(0);
-        return;
-      }
-
-      this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element "h1" "h2") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
-      }, /The `element` helper takes a single positional argument/);
-    }
-
-    ['@test it does not take any named arguments']() {
-      if (!DEBUG) {
-        this.assert.expect(0);
-        return;
-      }
-
-      this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element "h1" id="content") as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
-      }, /The `element` helper does not take any named arguments/);
-    }
-
     ['@test it throws when passed a number']() {
       if (!DEBUG) {
         this.assert.expect(0);
         return;
       }
 
+      let num = 123;
       this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element 123) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
+        let AComponent = template(`{{#let (element num) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, num }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
       }, /The argument passed to the `element` helper must be a string \(you passed `123`\)/);
     }
 
@@ -161,10 +139,12 @@ moduleFor(
         return;
       }
 
+      let bool = false;
       this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element false) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
+        let AComponent = template(`{{#let (element bool) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, bool }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
       }, /The argument passed to the `element` helper must be a string \(you passed `false`\)/);
     }
 
@@ -175,9 +155,10 @@ moduleFor(
       }
 
       this.assert.throws(() => {
-        this.render(
-          `<div>{{#let (element (hash)) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
-        );
+        let AComponent = template(`{{#let (element (hash)) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, hash }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
       }, /The argument passed to the `element` helper must be a string/);
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -24,16 +24,30 @@ moduleFor(
       this.assertText('hello world!');
     }
 
-    '@test it does not render anything when passed null'() {
-      this.render(`{{#let (element null) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`);
-      this.assertHTML('<!---->');
+    ['@test it throws when passed null']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element null) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The argument passed to the `element` helper must be a string/);
     }
 
-    '@test it does not render anything when passed undefined'() {
-      this.render(
-        `{{#let (element undefined) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}`
-      );
-      this.assertHTML('<!---->');
+    ['@test it throws when passed undefined']() {
+      if (!DEBUG) {
+        this.assert.expect(0);
+        return;
+      }
+
+      this.assert.throws(() => {
+        this.render(
+          `<div>{{#let (element undefined) as |Tag|}}<Tag id="content">hello world!</Tag>{{/let}}</div>`
+        );
+      }, /The argument passed to the `element` helper must be a string/);
     }
 
     '@test it works with element modifiers'() {

--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -11,7 +11,7 @@ import {
   get as glimmerGet,
   fn as glimmerFn,
 } from '@glimmer/runtime';
-import { uniqueId as glimmerUniqueId } from '@ember/-internals/glimmer';
+import { element as glimmerElement, uniqueId as glimmerUniqueId } from '@ember/-internals/glimmer';
 import { type Opaque } from '@ember/-internals/utility-types';
 
 /**
@@ -469,6 +469,26 @@ export interface GetHelper extends Opaque<'helper:get'> {}
  */
 export const fn = glimmerFn as FnHelper;
 export interface FnHelper extends Opaque<'helper:fn'> {}
+
+/**
+ * The `element` helper lets you dynamically set the tag name of an element.
+ *
+ * ```js
+ * import { element } from '@ember/helper';
+ *
+ * <template>
+ *   {{#let (element @tagName) as |Tag|}}
+ *     <Tag class="my-element">Hello</Tag>
+ *   {{/let}}
+ * </template>
+ * ```
+ *
+ * When `@tagName` is `"h1"`, this renders `<h1 class="my-element">Hello</h1>`.
+ * When `@tagName` is an empty string, the block content is rendered without a
+ * wrapping element. When `@tagName` is `null` or `undefined`, nothing is rendered.
+ */
+export const element = glimmerElement as ElementHelper;
+export interface ElementHelper extends Opaque<'helper:element'> {}
 
 /**
  * Use the {{uniqueId}} helper to generate a unique ID string suitable for use as

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -210,6 +210,29 @@ function basicTest(scenarios: Scenarios, appName: string) {
                 });
               });
             `,
+            'element-helper-test.gjs': `
+              import { module, test } from 'qunit';
+              import { render } from '@ember/test-helpers';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { element } from '@ember/helper';
+
+              module('Integration | helper | element (strict mode)', function (hooks) {
+                setupRenderingTest(hooks);
+
+                test('it renders a dynamic tag in strict mode gjs', async function (assert) {
+                  await render(
+                    <template>
+                      {{#let (element "h1") as |Tag|}}
+                        <Tag data-test="element-helper">hello world!</Tag>
+                      {{/let}}
+                    </template>
+                  );
+
+                  assert.dom('[data-test="element-helper"]').hasText('hello world!');
+                  assert.dom('h1[data-test="element-helper"]').exists();
+                });
+              });
+            `,
             'interactive-example-test.js': `
               import { module, test } from 'qunit';
               import { setupRenderingTest } from 'ember-qunit';


### PR DESCRIPTION
## Summary

Implements the `element` helper as specified in [RFC #0389](https://rfcs.emberjs.com/id/0389-dynamic-tag-names), continuing the work started in #21048.

- **`(element "h1")`** — renders an `<h1>` wrapping the block content, with full support for attributes, modifiers, and `...attributes`
- **`(element "")`** — renders block content without a wrapping element
- **`(element null)` / `(element undefined)` / non-string values** — throws an assertion error in development mode (departure from RFC, which suggested rendering nothing for null/undefined)
- Tag name changes trigger teardown/recreation of the element

The helper is available in strict mode only (importable from `@ember/helper`). It is **not** registered as a loose-mode builtin to avoid conflicts with `ember-element-helper`.

### Implementation approach

Uses the Glimmer VM's `WrappedBuilder` with a minimal `ElementComponentManager` (4 capabilities: `dynamicLayout`, `dynamicTag`, `createInstance`, `wrapped`). The `element` helper returns a cached component definition per tag name:

- **Non-empty string**: `ElementComponentDefinition` with `getTagName()` returning the tag name. The VM's default template (`{{yield}}`) is used via `asWrappedLayout()`.
- **Empty string**: Same component but `getTagName()` returns `null`, so the `WrappedBuilder` skips the element and just yields the block.

### Files changed

- `packages/@ember/-internals/glimmer/lib/helpers/element.ts` — Core implementation
- `packages/@ember/-internals/glimmer/index.ts` — Re-export
- `packages/@ember/helper/index.ts` — Public export for strict mode
- `packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js` — 14 strict-mode tests
- `smoke-tests/scenarios/basic-test.ts` — Smoke test

## Test plan

- [x] Basic rendering with static tag name (strict mode)
- [x] Empty string renders content without wrapper
- [x] `null` and `undefined` throw assertion errors
- [x] Non-string types (number, boolean, object) throw assertion errors
- [x] Element modifiers (`{{on "click" ...}}`) work on the dynamic element
- [x] Same element definition can be rendered multiple times
- [x] Dynamic tag name changes trigger teardown/recreation
- [x] Works as `@tag` argument with `...attributes`
- [x] Validation: requires exactly 1 positional argument
- [x] Validation: rejects named arguments
- [x] All tests are strict mode only
- [x] TypeScript type-checking passes
- [x] ESLint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)