### PR TITLE
Clean up scope bag, wire format, and debug render tree

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/mount.ts
@@ -123,8 +123,7 @@ class MountManager
   getDebugCustomRenderTree(
     definition: EngineDefinitionState,
     state: EngineState,
-    args: CapturedArguments,
-    templateModuleName?: string
+    args: CapturedArguments
   ): CustomRenderNode[] {
     return [
       {
@@ -140,7 +139,6 @@ class MountManager
         type: 'route-template',
         name: 'application',
         args,
-        template: templateModuleName,
       },
     ];
   }

--- a/packages/@ember/-internals/glimmer/lib/component-managers/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/outlet.ts
@@ -131,7 +131,6 @@ class OutletComponentManager
       name: 'main',
       args: EMPTY_ARGS,
       instance: undefined,
-      template: undefined,
     });
 
     if (state.engine) {
@@ -141,7 +140,6 @@ class OutletComponentManager
         name: state.engine.mountPoint,
         args: EMPTY_ARGS,
         instance: state.engine.instance,
-        template: undefined,
       });
     }
 

--- a/packages/@ember/-internals/glimmer/lib/component-managers/route-template.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/route-template.ts
@@ -28,7 +28,6 @@ interface RouteTemplateInstanceState {
 
 export interface RouteTemplateDefinitionState {
   name: string;
-  templateName: string;
 }
 
 const CAPABILITIES: InternalComponentCapabilities = {
@@ -79,7 +78,7 @@ class RouteTemplateManager
   }
 
   getDebugCustomRenderTree(
-    { name, templateName }: RouteTemplateDefinitionState,
+    { name }: RouteTemplateDefinitionState,
     state: RouteTemplateInstanceState,
     args: CapturedArguments
   ): CustomRenderNode[] {
@@ -90,7 +89,6 @@ class RouteTemplateManager
         name,
         args,
         instance: state.controller,
-        template: templateName,
       },
     ];
   }
@@ -137,7 +135,7 @@ export class RouteTemplate implements ComponentDefinition<
     // outlet's name. Also, setting this overrides `getDebugName()` in that
     // message. Is that desirable?
     this.resolvedName = name;
-    this.state = { name, templateName: unwrapped.moduleName };
+    this.state = { name };
     this.compilable = unwrapped.asLayout();
   }
 }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -46,7 +46,6 @@ interface ExpectedRenderNode {
   name: CapturedRenderNode['name'];
   args: Expected<CapturedRenderNode['args']>;
   instance: Expected<CapturedRenderNode['instance']>;
-  template: Expected<CapturedRenderNode['template']>;
   bounds: Expected<CapturedRenderNode['bounds']>;
   children: Expected<CapturedRenderNode['children']> | ExpectedRenderNode[];
 }
@@ -93,7 +92,6 @@ if (ENV._DEBUG_RENDER_TREE) {
               named: { controller: this.controllerFor('index'), model: undefined },
             },
             instance: this.controllerFor('index'),
-            template: 'my-app/templates/index.hbs',
             bounds: this.elementBounds(this.element!),
             children: [],
           }),
@@ -110,7 +108,6 @@ if (ENV._DEBUG_RENDER_TREE) {
               named: { controller: this.controllerFor('foo'), model: undefined },
             },
             instance: this.controllerFor('foo'),
-            template: 'my-app/templates/foo.hbs',
             bounds: this.elementBounds(this.element!),
             children: [
               this.outlet({
@@ -121,7 +118,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                   named: { controller: this.controllerFor('foo.index'), model: undefined },
                 },
                 instance: this.controllerFor('foo.index'),
-                template: 'my-app/templates/foo/index.hbs',
                 bounds: this.nodeBounds(this.element!.lastChild),
                 children: [],
               }),
@@ -140,7 +136,6 @@ if (ENV._DEBUG_RENDER_TREE) {
               named: { controller: this.controllerFor('foo'), model: undefined },
             },
             instance: this.controllerFor('foo'),
-            template: 'my-app/templates/foo.hbs',
             bounds: this.elementBounds(this.element!),
             children: [
               this.outlet({
@@ -151,7 +146,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                   named: { controller: this.controllerFor('foo.inner'), model: 'wow' },
                 },
                 instance: this.controllerFor('foo.inner'),
-                template: 'my-app/templates/foo/inner.hbs',
                 bounds: this.nodeBounds(this.element!.lastChild),
                 children: [],
               }),
@@ -170,7 +164,6 @@ if (ENV._DEBUG_RENDER_TREE) {
               named: { controller: this.controllerFor('foo'), model: undefined },
             },
             instance: this.controllerFor('foo'),
-            template: 'my-app/templates/foo.hbs',
             bounds: this.elementBounds(this.element!),
             children: [
               this.outlet({
@@ -181,7 +174,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                   named: { controller: this.controllerFor('foo.inner'), model: 'zomg' },
                 },
                 instance: this.controllerFor('foo.inner'),
-                template: 'my-app/templates/foo/inner.hbs',
                 bounds: this.nodeBounds(this.element!.lastChild),
                 children: [],
               }),
@@ -295,7 +287,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static')[0]!),
             children: [
               {
@@ -304,7 +295,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static')[0]!),
                 children: [],
               },
@@ -323,7 +313,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static')[0]!),
             children: [
               {
@@ -332,7 +321,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static')[0]!),
                 children: [],
               },
@@ -344,7 +332,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isBarEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#dynamic')[0]!),
             children: [
               {
@@ -353,7 +340,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'bar/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#dynamic')[0]!),
                 children: [],
               },
@@ -372,7 +358,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static')[0]!),
             children: [
               {
@@ -381,7 +366,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static')[0]!),
                 children: [],
               },
@@ -409,7 +393,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static')[0]!),
             children: [
               {
@@ -418,7 +401,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static')[0]!),
                 children: [],
               },
@@ -430,7 +412,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: { model } },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static-with-model')[0]!),
             children: [
               {
@@ -439,7 +420,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: { model } },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static-with-model')[0]!),
                 children: [
                   {
@@ -447,7 +427,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                     name: 'inspect-model',
                     args: { positional: [], named: { model } },
                     instance: null,
-                    template: 'foo/components/inspect-model.hbs',
                     bounds: this.nodeBounds(this.$('#static-with-model')[0]!.lastChild),
                     children: [],
                   },
@@ -468,7 +447,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static')[0]!),
             children: [
               {
@@ -477,7 +455,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static')[0]!),
                 children: [],
               },
@@ -489,7 +466,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isBarEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#dynamic')[0]!),
             children: [
               {
@@ -498,7 +474,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'bar/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#dynamic')[0]!),
                 children: [],
               },
@@ -510,7 +485,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: { model } },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static-with-model')[0]!),
             children: [
               {
@@ -520,14 +494,12 @@ if (ENV._DEBUG_RENDER_TREE) {
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
                 bounds: this.elementBounds(this.$('#static-with-model')[0]!),
-                template: 'foo/templates/application.hbs',
                 children: [
                   {
                     type: 'component',
                     name: 'inspect-model',
                     args: { positional: [], named: { model } },
                     instance: null,
-                    template: 'foo/components/inspect-model.hbs',
                     bounds: this.nodeBounds(this.$('#static-with-model')[0]!.lastChild),
                     children: [],
                   },
@@ -541,7 +513,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: { model } },
             instance: (instance: Record<string, boolean>) =>
               instance['isBarEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#dynamic-with-model')[0]!),
             children: [
               {
@@ -550,7 +521,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: { model } },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'bar/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#dynamic-with-model')[0]!),
                 children: [
                   {
@@ -558,7 +528,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                     name: 'inspect-model',
                     args: { positional: [], named: { model } },
                     instance: null,
-                    template: 'bar/components/inspect-model.hbs',
                     bounds: this.nodeBounds(this.$('#dynamic-with-model')[0]!.lastChild),
                     children: [],
                   },
@@ -582,7 +551,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: {} },
             instance: (instance: Record<string, boolean>) =>
               instance['isFooEngineInstance'] === true,
-            template: null,
             bounds: this.elementBounds(this.$('#static')[0]!),
             children: [
               {
@@ -591,7 +559,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 args: { positional: [], named: {} },
                 instance: (instance: object) =>
                   instance.toString() === '(generated application controller)',
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.$('#static')[0]!),
                 children: [],
               },
@@ -668,7 +635,6 @@ if (ENV._DEBUG_RENDER_TREE) {
               named: { controller: this.controllerFor('index'), model: undefined },
             },
             instance: this.controllerFor('index'),
-            template: 'my-app/templates/index.hbs',
             bounds: this.elementBounds(this.element!),
             children: [],
           }),
@@ -682,7 +648,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'foo',
             args: { positional: [], named: {} },
             instance: instance!,
-            template: null,
             bounds: this.elementBounds(this.element!),
             children: [
               {
@@ -696,7 +661,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                   },
                 },
                 instance: instance!.lookup('controller:application'),
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.element!),
                 children: [
                   this.outlet({
@@ -707,7 +671,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                       named: { controller: instance!.lookup('controller:index'), model: undefined },
                     },
                     instance: instance!.lookup('controller:index'),
-                    template: 'foo/templates/index.hbs',
                     bounds: this.nodeBounds(this.element!.firstChild),
                     children: [],
                   }),
@@ -729,7 +692,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'foo',
             args: { positional: [], named: {} },
             instance: instance!,
-            template: null,
             bounds: this.elementBounds(this.element!),
             children: [
               {
@@ -743,7 +705,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                   },
                 },
                 instance: instance!.lookup('controller:application'),
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.element!),
                 children: [
                   this.outlet({
@@ -754,7 +715,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                       named: { controller: instance!.lookup('controller:index'), model: undefined },
                     },
                     instance: instance!.lookup('controller:index'),
-                    template: 'foo/templates/index.hbs',
                     bounds: this.nodeBounds(this.element!.firstChild),
                     children: [],
                   }),
@@ -763,7 +723,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                     name: 'hello',
                     args: { positional: [], named: { message: 'World' } },
                     instance: null,
-                    template: 'foo/components/hello.hbs',
                     bounds: this.nodeBounds(this.element!.lastChild),
                     children: [],
                   },
@@ -785,7 +744,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'foo',
             args: { positional: [], named: {} },
             instance: instance!,
-            template: null,
             bounds: this.elementBounds(this.element!),
             children: [
               {
@@ -799,7 +757,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                   },
                 },
                 instance: instance!.lookup('controller:application'),
-                template: 'foo/templates/application.hbs',
                 bounds: this.elementBounds(this.element!),
                 children: [
                   this.outlet({
@@ -810,7 +767,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                       named: { controller: instance!.lookup('controller:index'), model: undefined },
                     },
                     instance: instance!.lookup('controller:index'),
-                    template: 'foo/templates/index.hbs',
                     bounds: this.nodeBounds(this.element!.firstChild),
                     children: [],
                   }),
@@ -831,7 +787,6 @@ if (ENV._DEBUG_RENDER_TREE) {
               named: { controller: this.controllerFor('index'), model: undefined },
             },
             instance: this.controllerFor('index'),
-            template: 'my-app/templates/index.hbs',
             bounds: this.elementBounds(this.element!),
             children: [],
           }),
@@ -863,7 +818,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -879,7 +833,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -888,7 +841,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'second' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -904,7 +856,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -936,7 +887,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -952,7 +902,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -961,7 +910,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'second' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -977,7 +925,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1011,7 +958,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: 'my-app/components/hello-world.hbs',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1027,7 +973,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: 'my-app/components/hello-world.hbs',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1036,7 +981,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'second' } },
             instance: null,
-            template: 'my-app/components/hello-world.hbs',
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -1052,7 +996,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: null,
-            template: 'my-app/components/hello-world.hbs',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1084,7 +1027,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'first',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1100,7 +1042,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'first',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1109,7 +1050,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'second' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'second',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -1125,7 +1065,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'first',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1169,7 +1108,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'first',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1185,7 +1123,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'first',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1194,7 +1131,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'second' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'second',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -1210,7 +1146,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'hello-world',
             args: { positional: [], named: { name: 'first' } },
             instance: (instance: Record<string, string>) => instance['name'] === 'first',
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1241,7 +1176,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'on',
             instance: null,
             args: { named: {}, positional: ['change', anyFunc] },
-            template: null,
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1249,7 +1183,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['input', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1258,7 +1191,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['keyup', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1267,7 +1199,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['paste', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1276,7 +1207,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['cut', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1289,7 +1219,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'input',
             args: { positional: [], named: { type: 'text', value: 'first' } },
             instance: (instance: object) => inputToString.test(instance.toString()),
-            template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [...firstModifiers],
           },
@@ -1303,7 +1232,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'on',
             instance: null,
             args: { named: {}, positional: ['change', anyFunc] },
-            template: null,
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -1311,7 +1239,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['input', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1320,7 +1247,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['keyup', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1329,7 +1255,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['paste', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1338,7 +1263,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['cut', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1351,7 +1275,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'input',
             args: { positional: [], named: { type: 'text', value: 'first' } },
             instance: (instance: object) => inputToString.test(instance.toString()),
-            template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [...firstModifiers],
           },
@@ -1360,7 +1283,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'input',
             args: { positional: [], named: { type: 'checkbox', checked: false } },
             instance: (instance: object) => inputToString.test(instance.toString()),
-            template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [...secondModifiers],
           },
@@ -1374,7 +1296,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'input',
             args: { positional: [], named: { type: 'text', value: 'first' } },
             instance: (instance: object) => inputToString.test(instance.toString()),
-            template: 'packages/@ember/-internals/glimmer/lib/templates/input.hbs',
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [...firstModifiers],
           },
@@ -1401,7 +1322,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'on',
             instance: null,
             args: { named: {}, positional: ['change', anyFunc] },
-            template: null,
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1409,7 +1329,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['input', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1418,7 +1337,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['keyup', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1427,7 +1345,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['paste', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1436,7 +1353,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['cut', anyFunc] },
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
@@ -1454,7 +1370,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             args: { positional: [], named: { value } },
             instance: (instance: Record<string, string>) => instance['value'] === value,
             bounds: this.nodeBounds(node),
-            template: 'packages/@ember/-internals/glimmer/lib/templates/textarea.hbs',
             children,
           };
         };
@@ -1471,7 +1386,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'on',
             instance: null,
             args: { named: {}, positional: ['change', anyFunc] },
-            template: null,
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -1479,7 +1393,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['input', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1488,7 +1401,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['keyup', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1497,7 +1409,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['paste', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1506,7 +1417,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             type: 'modifier',
             name: 'on',
             instance: null,
-            template: null,
             args: { named: {}, positional: ['cut', anyFunc] },
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
@@ -1544,15 +1454,12 @@ if (ENV._DEBUG_RENDER_TREE) {
 
         await this.visit('/');
 
-        let template = `packages/@ember/-internals/glimmer/lib/templates/link-to.hbs`;
-
         const firstModifiers: ExpectedRenderNode['children'] = [
           {
             type: 'modifier',
             name: 'on',
             instance: null,
             args: { named: {}, positional: ['click', anyFunc] },
-            template: null,
             bounds: this.nodeBounds(this.element!.firstChild),
             children: [],
           },
@@ -1564,7 +1471,7 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'link-to',
             args: { positional: [], named: { route: 'foo' } },
             instance: (instance: Record<string, string>) => instance['route'] === 'foo',
-            template,
+
             bounds: this.nodeBounds(this.element!.firstChild),
             children: firstModifiers,
           },
@@ -1580,7 +1487,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'on',
             instance: null,
             args: { named: {}, positional: ['click', anyFunc] },
-            template: null,
             bounds: this.nodeBounds(this.element!.lastChild),
             children: [],
           },
@@ -1592,7 +1498,7 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'link-to',
             args: { positional: [], named: { route: 'foo' } },
             instance: (instance: Record<string, string>) => instance['route'] === 'foo',
-            template,
+
             bounds: this.nodeBounds(this.element!.firstChild),
             children: firstModifiers,
           },
@@ -1601,7 +1507,7 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'link-to',
             args: { positional: [], named: { route: 'bar' } },
             instance: (instance: Record<string, string>) => instance['route'] === 'bar',
-            template,
+
             bounds: this.nodeBounds(this.element!.lastChild),
             children: secondModifiers,
           },
@@ -1617,7 +1523,7 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: 'link-to',
             args: { positional: [], named: { route: 'foo' } },
             instance: (instance: Record<string, string>) => instance['route'] === 'foo',
-            template,
+
             bounds: this.nodeBounds(this.element!.firstChild),
             children: firstModifiers,
           },
@@ -1652,7 +1558,6 @@ if (ENV._DEBUG_RENDER_TREE) {
           name,
           instance: undefined,
           args: { positional: [], named: {} },
-          template: null,
           bounds: node.bounds,
           children: [node],
         };
@@ -1679,7 +1584,6 @@ if (ENV._DEBUG_RENDER_TREE) {
       }
 
       assertRenderTree(expected: ExpectedRenderNode[]): void {
-        let outlet = 'packages/@ember/-internals/glimmer/lib/templates/outlet.hbs';
         let actual = captureRenderTree(this.owner);
         let controller = this.controllerFor('application');
         let wrapped: ExpectedRenderNode[] = [
@@ -1688,7 +1592,6 @@ if (ENV._DEBUG_RENDER_TREE) {
             name: '-top-level',
             args: { positional: [], named: { controller: undefined, model: undefined } },
             instance: undefined,
-            template: outlet,
             bounds: this.elementBounds(this.element!),
             children: [
               this.outlet({
@@ -1696,9 +1599,6 @@ if (ENV._DEBUG_RENDER_TREE) {
                 name: 'application',
                 args: { positional: [], named: { controller, model: undefined } },
                 instance: controller,
-                template: this.owner.hasRegistration('template:application')
-                  ? 'my-app/templates/application.hbs'
-                  : outlet,
                 bounds: this.elementBounds(this.element!),
                 children: expected,
               }),
@@ -1758,7 +1658,6 @@ if (ENV._DEBUG_RENDER_TREE) {
         this.assertProperty(actual.name, expected.name, false, `${path} (name)`);
         this.assertProperty(actual.args, expected.args, true, `${path} (args)`);
         this.assertProperty(actual.instance, expected.instance, false, `${path} (instance)`);
-        this.assertProperty(actual.template, expected.template, false, `${path} (template)`);
         this.assertProperty(actual.bounds, expected.bounds, true, `${path} (bounds)`);
 
         if (Array.isArray(expected.children)) {

--- a/packages/@glimmer-workspace/integration-tests/lib/compile.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/compile.ts
@@ -29,10 +29,6 @@ export function createTemplate(
     reifiedScope[key] = scopeValues[key];
   }
 
-  if ('emit' in options && options.emit?.debugSymbols) {
-    block.push(usedLocals);
-  }
-
   let templateBlock: SerializedTemplateWithLazyBlock = {
     id: String(templateId++),
     block: JSON.stringify(block),

--- a/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
@@ -110,11 +110,7 @@ export function defComponent(
   }
 ) {
   let definition = options?.component ?? templateOnlyComponent();
-  let templateFactory = createTemplate(
-    templateSource,
-    { strictMode: true },
-    options?.scope ?? {}
-  );
+  let templateFactory = createTemplate(templateSource, { strictMode: true }, options?.scope ?? {});
   setComponentTemplate(templateFactory, definition);
   return definition;
 }
@@ -134,11 +130,7 @@ export function defineComponent(
   let keywords = options.keywords ?? [];
 
   let definition = options.definition ?? templateOnlyComponent();
-  let templateFactory = createTemplate(
-    templateSource,
-    { strictMode, keywords },
-    scopeValues ?? {}
-  );
+  let templateFactory = createTemplate(templateSource, { strictMode, keywords }, scopeValues ?? {});
   setComponentTemplate(templateFactory, definition);
   return definition;
 }

--- a/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/test-helpers/define.ts
@@ -5,7 +5,7 @@ import type {
   ModifierManager,
   Owner,
 } from '@glimmer/interfaces';
-import type { PrecompileOptionsWithLexicalScope } from '@glimmer/syntax';
+
 import { registerDestructor } from '@glimmer/destroyable';
 import {
   helperCapabilities,
@@ -100,8 +100,6 @@ export interface DefineComponentOptions {
 
   // additional strict-mode keywords
   keywords?: string[];
-
-  emit?: PrecompileOptionsWithLexicalScope['emit'];
 }
 
 export function defComponent(
@@ -109,20 +107,12 @@ export function defComponent(
   options?: {
     component?: object | undefined;
     scope?: Record<string, unknown> | undefined;
-    emit?: {
-      moduleName?: string;
-      debugSymbols?: boolean;
-    };
   }
 ) {
   let definition = options?.component ?? templateOnlyComponent();
   let templateFactory = createTemplate(
     templateSource,
-    {
-      strictMode: true,
-      meta: { moduleName: options?.emit?.moduleName },
-      emit: { debugSymbols: options?.emit?.debugSymbols ?? true },
-    },
+    { strictMode: true },
     options?.scope ?? {}
   );
   setComponentTemplate(templateFactory, definition);
@@ -146,7 +136,7 @@ export function defineComponent(
   let definition = options.definition ?? templateOnlyComponent();
   let templateFactory = createTemplate(
     templateSource,
-    { strictMode, keywords, emit: options.emit },
+    { strictMode, keywords },
     scopeValues ?? {}
   );
   setComponentTemplate(templateFactory, definition);

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -46,7 +46,6 @@ interface ExpectedRenderNode {
   name: CapturedRenderNode['name'];
   args: Expected<CapturedRenderNode['args']>;
   instance: Expected<CapturedRenderNode['instance']>;
-  template: Expected<CapturedRenderNode['template']>;
   bounds: Expected<CapturedRenderNode['bounds']>;
   children: Expected<CapturedRenderNode['children']> | ExpectedRenderNode[];
 }
@@ -94,7 +93,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: '{ROOT}',
         args: { positional: [], named: {} },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.elementBounds(this.delegate.getInitialElement()),
         children: [
           {
@@ -102,7 +100,6 @@ class DebugRenderTreeTest extends RenderTest {
             name: 'HelloWorld',
             args: { positional: [], named: { arg: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
             children: [],
           },
@@ -125,7 +122,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: '{ROOT}',
         args: { positional: [], named: {} },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.elementBounds(this.delegate.getInitialElement()),
         children: [
           {
@@ -133,7 +129,6 @@ class DebugRenderTreeTest extends RenderTest {
             name: 'HelloWorld',
             args: { positional: [], named: { arg: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
             children: [],
           },
@@ -210,7 +205,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: '{ROOT}',
         args: { positional: [], named: {} },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.elementBounds(element),
         children: [
           {
@@ -218,7 +212,6 @@ class DebugRenderTreeTest extends RenderTest {
             name: 'HelloWorld',
             args: { positional: [], named: { arg: 'first' } },
             instance: null,
-            template: '(unknown template module)',
             bounds: this.nodeBounds(element.firstChild),
             children: [
               {
@@ -226,7 +219,6 @@ class DebugRenderTreeTest extends RenderTest {
                 name: 'noop',
                 args: { positional: [], named: {} },
                 instance: (modifier: unknown) => modifier && Reflect.get(modifier, 'fn') === noopFn,
-                template: null,
                 bounds: this.nodeBounds(element.firstChild),
                 children: [],
               },
@@ -253,7 +245,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -267,7 +258,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -276,7 +266,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'second' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().lastChild),
         children: [],
       },
@@ -290,7 +279,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -336,7 +324,6 @@ class DebugRenderTreeTest extends RenderTest {
           return true;
         },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -352,7 +339,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first', arg2: undefined } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -361,7 +347,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'second' } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'second',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.lastChild),
         children: [],
       },
@@ -375,7 +360,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first', arg2: undefined } },
         instance: (instance: EmberishCurlyComponent) => (instance as any).arg === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -398,7 +382,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -412,7 +395,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -421,7 +403,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'second' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'second',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.lastChild),
         children: [],
       },
@@ -435,7 +416,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -463,7 +443,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: { arg: 'first' } },
         instance: (instance: GlimmerishComponent) => instance.args['arg'] === 'first',
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild!.nextSibling),
         children: [
           {
@@ -471,7 +450,6 @@ class DebugRenderTreeTest extends RenderTest {
             name: 'in-element',
             args: { positional: [this.element.firstChild], named: {} },
             instance: (instance: GlimmerishComponent | null) => instance === null,
-            template: null,
             bounds: this.elementBounds(this.element.firstChild! as unknown as SimpleElement),
             children: [
               {
@@ -479,7 +457,6 @@ class DebugRenderTreeTest extends RenderTest {
                 name: 'HiWorld',
                 args: { positional: [], named: {} },
                 instance: (instance: GlimmerishComponent) => instance,
-                template: '(unknown template module)',
                 bounds: this.nodeBounds(this.element.firstChild!.firstChild),
                 children: [],
               },
@@ -544,7 +521,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'on',
         args: { positional: ['click', didInsert], named: {} },
         instance: null,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -553,7 +529,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'DidInsertModifier',
         args: { positional: [foo], named: { bar } },
         instance: (instance: unknown) => instance instanceof DidInsertModifier,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -562,7 +537,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'MyCustomModifier',
         args: { positional: [bar], named: { foo } },
         instance: (instance: unknown) => instance instanceof MyCustomModifier,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -571,7 +545,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: {} },
         instance: (instance: any) => instance !== undefined,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild!.firstChild),
         children: [],
       },
@@ -587,7 +560,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'on',
         args: { positional: ['click', didInsert], named: {} },
         instance: null,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -596,7 +568,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'DidInsertModifier',
         args: { positional: [foo], named: { bar } },
         instance: (instance: unknown) => instance instanceof DidInsertModifier,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -605,7 +576,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'MyCustomModifier',
         args: { positional: [bar], named: { foo } },
         instance: (instance: unknown) => instance instanceof MyCustomModifier,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -614,7 +584,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: {} },
         instance: (instance: any) => instance !== undefined,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild!.firstChild),
         children: [],
       },
@@ -623,7 +592,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'on',
         args: { positional: ['click', didInsert], named: { passive: true } },
         instance: null,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild!.lastChild),
         children: [],
       },
@@ -639,7 +607,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'on',
         args: { positional: ['click', didInsert], named: {} },
         instance: null,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -648,7 +615,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'DidInsertModifier',
         args: { positional: [foo], named: { bar } },
         instance: (instance: unknown) => instance instanceof DidInsertModifier,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -657,7 +623,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'MyCustomModifier',
         args: { positional: [bar], named: { foo } },
         instance: (instance: unknown) => instance instanceof MyCustomModifier,
-        template: null,
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -666,7 +631,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld',
         args: { positional: [], named: {} },
         instance: (instance: any) => instance !== undefined,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild!.firstChild),
         children: [],
       },
@@ -696,7 +660,6 @@ class DebugRenderTreeTest extends RenderTest {
               name: 'foo',
               instance: instance1,
               args,
-              template: undefined,
             },
             {
               bucket: bucket2,
@@ -704,7 +667,6 @@ class DebugRenderTreeTest extends RenderTest {
               name: 'bar',
               instance: instance2,
               args: EMPTY_ARGS,
-              template: undefined,
             },
           ];
         }
@@ -726,7 +688,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld2',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -740,7 +701,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld2',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -749,7 +709,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'foo',
         args: { positional: [], named: { arg: 'second' } },
         instance: instance1,
-        template: null,
         bounds: this.nodeBounds(this.element.lastChild),
         children: [
           {
@@ -757,7 +716,6 @@ class DebugRenderTreeTest extends RenderTest {
             name: 'bar',
             args: { positional: [], named: {} },
             instance: instance2,
-            template: null,
             bounds: this.nodeBounds(this.element.lastChild),
             children: [],
           },
@@ -773,7 +731,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld2',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -806,7 +763,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld2',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.delegate.getInitialElement().firstChild),
         children: [],
       },
@@ -820,7 +776,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld2',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -834,7 +789,6 @@ class DebugRenderTreeTest extends RenderTest {
         name: 'HelloWorld2',
         args: { positional: [], named: { arg: 'first' } },
         instance: null,
-        template: '(unknown template module)',
         bounds: this.nodeBounds(this.element.firstChild),
         children: [],
       },
@@ -931,7 +885,6 @@ class DebugRenderTreeTest extends RenderTest {
     this.assertProperty(actual.name, expected.name, false, `${path} (name)`);
     this.assertProperty(actual.args, expected.args, true, `${path} (args)`);
     this.assertProperty(actual.instance, expected.instance, false, `${path} (instance)`);
-    this.assertProperty(actual.template, expected.template, false, `${path} (template)`);
     this.assertProperty(actual.bounds, expected.bounds, true, `${path} (bounds)`);
 
     if (Array.isArray(expected.children)) {

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -83,7 +83,7 @@ class DebugRenderTreeTest extends RenderTest {
     const HelloWorld = defComponent('{{@arg}}');
     const Root = defComponent(
       `<HelloWorld @arg="first"/>{{#if state.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
-      { scope: { HelloWorld, state }, emit: { moduleName: 'root.hbs' } }
+      { scope: { HelloWorld, state } }
     );
 
     this.renderComponent(Root);
@@ -94,7 +94,7 @@ class DebugRenderTreeTest extends RenderTest {
         name: '{ROOT}',
         args: { positional: [], named: {} },
         instance: null,
-        template: 'root.hbs',
+        template: '(unknown template module)',
         bounds: this.elementBounds(this.delegate.getInitialElement()),
         children: [
           {
@@ -111,11 +111,10 @@ class DebugRenderTreeTest extends RenderTest {
     ]);
   }
 
-  @test 'strict-mode components without debug symbols preserve names from scope'() {
+  @test 'strict-mode components preserve names from scope'() {
     const HelloWorld = defComponent('{{@arg}}');
     const Root = defComponent(`<HelloWorld @arg="first"/>`, {
       scope: { HelloWorld },
-      emit: { moduleName: 'root.hbs', debugSymbols: false },
     });
 
     this.renderComponent(Root);
@@ -126,7 +125,7 @@ class DebugRenderTreeTest extends RenderTest {
         name: '{ROOT}',
         args: { positional: [], named: {} },
         instance: null,
-        template: 'root.hbs',
+        template: '(unknown template module)',
         bounds: this.elementBounds(this.delegate.getInitialElement()),
         children: [
           {
@@ -152,7 +151,6 @@ class DebugRenderTreeTest extends RenderTest {
 
     const RootDef = defComponent(`<this.HelloWorld @arg="first"/>`, {
       component: Root,
-      emit: { moduleName: 'root.hbs' },
     });
 
     this.renderComponent(RootDef);
@@ -173,9 +171,7 @@ class DebugRenderTreeTest extends RenderTest {
 
   @test({ skip: !DEBUG }) 'dynamic component via <@argComponent>'() {
     const HelloWorld = defComponent('{{@arg}}');
-    const Root = defComponent(`<@Greeting @arg="first"/>`, {
-      emit: { moduleName: 'root.hbs' },
-    });
+    const Root = defComponent(`<@Greeting @arg="first"/>`);
 
     this.renderComponent(Root, { Greeting: HelloWorld });
 
@@ -201,7 +197,7 @@ class DebugRenderTreeTest extends RenderTest {
     const noop = defineSimpleModifier(noopFn);
     const Root = defComponent(
       `<HelloWorld {{noop}} @arg="first"/>{{#if state.showSecond}}<HelloWorld @arg="second"/>{{/if}}`,
-      { scope: { HelloWorld, state, noop }, emit: { moduleName: 'root.hbs' } }
+      { scope: { HelloWorld, state, noop } }
     );
 
     this.renderComponent(Root);
@@ -214,7 +210,7 @@ class DebugRenderTreeTest extends RenderTest {
         name: '{ROOT}',
         args: { positional: [], named: {} },
         instance: null,
-        template: 'root.hbs',
+        template: '(unknown template module)',
         bounds: this.elementBounds(element),
         children: [
           {

--- a/packages/@glimmer/compiler/lib/compiler.ts
+++ b/packages/@glimmer/compiler/lib/compiler.ts
@@ -123,10 +123,6 @@ export function precompile(
 ): TemplateJavascript {
   const [block, usedLocals] = precompileJSON(source, options);
 
-  if ('emit' in options && options.emit?.debugSymbols && usedLocals.length > 0) {
-    block.push(usedLocals);
-  }
-
   const moduleName = options.meta?.moduleName;
   const idFn = options.id || defaultId;
   const blockJSON = JSON.stringify(block);

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
@@ -373,7 +373,6 @@ export type SerializedTemplateBlock = [
   statements: Statements.Statement[],
   locals: string[],
   upvars: string[],
-  lexicalSymbols?: string[],
 ];
 
 /**

--- a/packages/@glimmer/interfaces/lib/managers/internal/component.d.ts
+++ b/packages/@glimmer/interfaces/lib/managers/internal/component.d.ts
@@ -168,8 +168,7 @@ export interface WithCustomDebugRenderTree<
   getDebugCustomRenderTree(
     definition: ComponentDefinitionState,
     state: ComponentInstanceState,
-    args: CapturedArguments,
-    template?: string
+    args: CapturedArguments
   ): CustomRenderNode[];
 }
 

--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -16,7 +16,6 @@ export interface RenderNode {
   name: string;
   args: CapturedArguments;
   instance: unknown;
-  template?: string | undefined;
 }
 
 export interface CapturedRenderNode {
@@ -25,7 +24,6 @@ export interface CapturedRenderNode {
   name: string;
   args: Arguments;
   instance: unknown;
-  template: string | null;
   bounds: null | {
     parentElement: SimpleElement;
     firstNode: SimpleNode;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
@@ -106,14 +106,14 @@ export function CompilePositional(
 }
 
 export function meta(layout: LayoutWithContext): BlockMetadata {
-  let [, locals, upvars, lexicalSymbols] = layout.block;
+  let [, locals, upvars] = layout.block;
   let scopeRecord = layout.scope?.() ?? null;
 
   return {
     symbols: {
       locals,
       upvars,
-      lexical: scopeRecord ? Object.keys(scopeRecord) : lexicalSymbols,
+      lexical: scopeRecord ? Object.keys(scopeRecord) : undefined,
     },
     scopeValues: scopeRecord ? Object.values(scopeRecord) : null,
     isStrictMode: layout.isStrictMode,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -665,7 +665,6 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_SELF_OP, (vm, { op1: register, op2: _names }
       args = vm.args.capture();
     }
 
-    let moduleName: string;
     let compilable: CompilableProgram | null = definition.compilable;
 
     if (compilable === null) {
@@ -680,26 +679,13 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_SELF_OP, (vm, { op1: register, op2: _names }
 
       let resolver = vm.context.resolver;
       compilable = resolver === null ? null : manager.getDynamicLayout(state, resolver);
-
-      if (compilable !== null) {
-        moduleName = compilable.moduleName;
-      } else {
-        moduleName = '__default__.hbs';
-      }
-    } else {
-      moduleName = compilable.moduleName;
     }
 
     // For tearing down the debugRenderTree
     vm.associateDestroyable(instance);
 
     if (hasCustomDebugRenderTreeLifecycle(manager)) {
-      let nodes = manager.getDebugCustomRenderTree(
-        instance.definition.state,
-        instance.state,
-        args,
-        moduleName
-      );
+      let nodes = manager.getDebugCustomRenderTree(instance.definition.state, instance.state, args);
 
       nodes.forEach((node) => {
         let { bucket } = node;
@@ -719,7 +705,6 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_SELF_OP, (vm, { op1: register, op2: _names }
         type: 'component',
         name,
         args,
-        template: moduleName,
         instance: valueForRef(selfRef),
       });
 

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -183,14 +183,9 @@ export default class DebugRenderTreeImpl<
   private captureNode(id: string, state: TBucket): CapturedRenderNode {
     let node = this.nodeFor(state);
     let { type, name, args, instance, refs } = node;
-    let template = this.captureTemplate(node);
     let bounds = this.captureBounds(node);
     let children = this.captureRefs(refs);
-    return { id, type, name, args: reifyArgsDebug(args), instance, template, bounds, children };
-  }
-
-  private captureTemplate({ template }: InternalRenderNode<TBucket>): Nullable<string> {
-    return template || null;
+    return { id, type, name, args: reifyArgsDebug(args), instance, bounds, children };
   }
 
   private captureBounds(node: InternalRenderNode<TBucket>): CapturedRenderNode['bounds'] {

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -688,16 +688,6 @@ export interface PrecompileOptions extends PreprocessOptions {
 
 export interface PrecompileOptionsWithLexicalScope extends PrecompileOptions {
   lexicalScope: (variable: string) => boolean;
-
-  /**
-   * If `emit.debugSymbols` is set to `true`, the name of lexical local variables
-   * will be included in the wire format.
-   */
-  emit?:
-    | {
-        debugSymbols?: boolean;
-      }
-    | undefined;
 }
 
 export interface PreprocessOptions {


### PR DESCRIPTION
## Summary

Follow-up cleanup now that the scope bag is a `Record<string, unknown>` (#21224). Two commits:

### 1. Remove `lexicalSymbols` from wire format and dead `debugSymbols` codepath

Lexical symbol names are now always available via `Object.keys(scope())`, making two things redundant:

- The optional `lexicalSymbols` slot in `SerializedTemplateBlock`
- The `emit.debugSymbols` option — removed from the compiler, `PrecompileOptionsWithLexicalScope` type, test helpers (`defComponent`, `createTemplate`), and all test callsites

### 2. Remove `template` field from debug render tree

The `name` field already identifies components in the render tree (now reliably, thanks to the object-based scope bag). The `template` field (module name of the backing .hbs file) provided no useful information beyond what `name` gives, so it's removed from `RenderNode`, `CapturedRenderNode`, and all producers/consumers.

This deletes the `moduleName` resolution logic from the component opcode, `templateName` from route-template definition state, and the `template` parameter from `getDebugCustomRenderTree`.

### Files changed

| Area | Files | Change |
|------|-------|--------|
| Wire format | `@glimmer/interfaces` (wire-format) | Removed `lexicalSymbols` from `SerializedTemplateBlock` |
| Compiler | `@glimmer/compiler` | Removed `block.push(usedLocals)` debug symbols emission |
| Opcode compiler | `@glimmer/opcode-compiler` (shared.ts) | `meta()` derives `lexical` from scope object keys |
| Syntax | `@glimmer/syntax` | Removed `emit.debugSymbols` from types |
| Render tree types | `@glimmer/interfaces` (debug-render-tree, component manager) | Removed `template` from `RenderNode`, `CapturedRenderNode`, `getDebugCustomRenderTree` |
| Render tree impl | `@glimmer/runtime` (debug-render-tree, component opcode) | Removed `captureTemplate`, `moduleName` resolution |
| Ember managers | route-template, outlet, mount | Removed `template`/`templateName` fields |
| Test helpers | `defComponent`, `createTemplate`, `defineComponent` | Removed `emit`/`moduleName`/`debugSymbols` options |
| Tests | Both debug-render-tree test files | Removed ~190 `template:` assertion lines |

## Test plan

- [x] All 9138 tests pass (0 failures, 14 pre-existing skips)
- [x] Type checking passes (only pre-existing unrelated errors)


🤖 Generated with [Claude Code](https://claude.com/claude-code)