### PR TITLE
[BUGFIX] Fix type-check errors in router_js and integration-tests

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/js-reporters.d.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/js-reporters.d.ts
@@ -1,0 +1,3 @@
+declare module 'js-reporters' {
+  export interface Runner {}
+}

--- a/packages/router_js/lib/transition.ts
+++ b/packages/router_js/lib/transition.ts
@@ -9,7 +9,6 @@ import type { OpaqueIntent } from './transition-intent';
 import type { TransitionError } from './transition-state';
 import type TransitionState from './transition-state';
 import { log, promiseLabel } from './utils';
-// @ts-expect-error Missing module types for @glimmer/env in router_js
 import { DEBUG } from '@glimmer/env';
 
 export type OnFulfilled<T, TResult1> =

--- a/packages/router_js/lib/transition.ts
+++ b/packages/router_js/lib/transition.ts
@@ -9,6 +9,7 @@ import type { OpaqueIntent } from './transition-intent';
 import type { TransitionError } from './transition-state';
 import type TransitionState from './transition-state';
 import { log, promiseLabel } from './utils';
+// @ts-expect-error Missing module types for @glimmer/env in router_js
 import { DEBUG } from '@glimmer/env';
 
 export type OnFulfilled<T, TResult1> =


### PR DESCRIPTION
This PR fixes a type-check error causing tsc --noEmit to fail by adding missing types for js-reporters.