### PR TITLE
Restore ember-template-compiler entrypoint and compilerPath

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -6,6 +6,9 @@
   test suite.
 */
 
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 export default {
   plugins: [
     [
@@ -21,6 +24,14 @@ export default {
         runtime: { import: 'decorator-transforms/runtime' },
       },
     ],
-    ['babel-plugin-ember-template-compilation'],
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        compilerPath: resolve(
+          dirname(fileURLToPath(import.meta.url)),
+          './broccoli/glimmer-template-compiler.mjs'
+        ),
+      },
+    ],
   ],
 };

--- a/packages/ember-template-compiler/index.ts
+++ b/packages/ember-template-compiler/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/public-api';
+import * as ETC from './lib/public-api';
+import { __registerTemplateCompiler } from '@ember/template-compilation';
+
+__registerTemplateCompiler(ETC);


### PR DESCRIPTION
## Summary
- Restores `packages/ember-template-compiler/index.ts` which is still imported by many test files and internal packages
- Restores `compilerPath` in `babel.config.mjs` so the rollup self-build can bootstrap on a clean checkout (before `dist/` exists)

## Test plan
- [x] `pnpm build:js` passes from clean state (no `dist/` dirs)
- [x] `pnpm type-check:internals` no longer has `Cannot find module 'ember-template-compiler'` errors
- [x] `pnpm test` passes (9128/9128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)