### PR TITLE
Fix smoke test failures after template compiler entrypoint removal

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,13 @@ const SupportedBrowsers = require('./browsers');
 const paths = {};
 const absolutePaths = {};
 
+Object.defineProperty(absolutePaths, 'templateCompiler', {
+  configurable: false,
+  get() {
+    return path.join(__dirname, '..', 'dist', 'packages', 'ember-template-compiler', 'index.js');
+  },
+});
+
 const { addonV1Shim } = require('@embroider/addon-shim');
 
 const shim = addonV1Shim(path.join(__dirname, '..'), {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "build-metadata.json",
     "blueprints",
     "dist/packages",
+    "dist/ember-template-compiler.js",
     "dist/dependencies",
     "dist-prod/packages",
+    "dist-prod/ember-template-compiler.js",
     "docs/data.json",
     "lib",
     "types/stable"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -61,6 +61,9 @@ function esmInputs() {
     ...renameEntrypoints(exposedDependencies(), (name) => join('packages', name, 'index')),
     ...renameEntrypoints(packages(), (name) => join('packages', name)),
     'packages/ember-template-compiler/index': 'ember-template-compiler/minimal.ts',
+
+    // @embroider/compat reads this path directly via readFileSync
+    'ember-template-compiler': 'ember-template-compiler/minimal.ts',
   };
 }
 

--- a/smoke-tests/node-template/tests/node/fastboot-sandbox-test.js
+++ b/smoke-tests/node-template/tests/node/fastboot-sandbox-test.js
@@ -61,7 +61,11 @@ QUnit.module('Ember.Application - visit() Integration Tests', function (hooks) {
     app = class extends Application {}.create({
       autoboot: false,
       Resolver: {
-        create: () => registry,
+        create: () => ({
+          resolve(name) {
+            return registry[name];
+          },
+        }),
       },
     });
 


### PR DESCRIPTION
## Summary
- Restore `absolutePaths.templateCompiler` in `lib/index.js` — `ember-cli-htmlbars` uses this to find the template compiler during classic builds
- Add `dist/ember-template-compiler.js` as a rollup output at the root of `dist/` — `@embroider/compat` hardcodes a `readFileSync` of this path in `compat-app.js:246`
- Add the new files to `package.json#files` so they're included when the package is packed (used by scenario-tester)
- Fix node smoke test's `Resolver` to return an object with a `resolve()` method instead of a plain registry object

## Test plan
- [x] All 4 smoke tests pass locally (classic, webpack, vite, node)
- [x] Type checking passes
- [x] `pnpm build` succeeds from clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)