### PR TITLE
Fix smoke tests and remove legacy dist/ember-template-compiler.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
     "build-metadata.json",
     "blueprints",
     "dist/packages",
-    "dist/ember-template-compiler.js",
     "dist/dependencies",
     "dist-prod/packages",
-    "dist-prod/ember-template-compiler.js",
     "docs/data.json",
     "lib",
     "types/stable"
@@ -161,7 +159,8 @@
       "esbuild"
     ],
     "patchedDependencies": {
-      "@tracerbench/core@8.0.1": "patches/@tracerbench__core@8.0.1.patch"
+      "@tracerbench/core@8.0.1": "patches/@tracerbench__core@8.0.1.patch",
+      "@embroider/compat": "patches/@embroider__compat.patch"
     }
   },
   "peerDependencies": {

--- a/patches/@embroider__compat.patch
+++ b/patches/@embroider__compat.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/src/compat-app.js b/dist/src/compat-app.js
+index e22220b687d2434136227e16c15bf1826a483c98..cd7eed7dc02164175d7795318a79836af978b742 100644
+--- a/dist/src/compat-app.js
++++ b/dist/src/compat-app.js
+@@ -239,12 +239,9 @@ class CompatApp {
+             // empty because we're just trying to keep the build from blowing up, the
+             // actual ember modules get loaded as modules instead.
+             //
+-            // The template compiler is still here so that apps using a V2 ember can
+-            // still app.import the traditional runtime template compiler.
+             trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember.js', () => ''));
+             trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember-testing.js', () => ''));
+-            const templateCompilerSrc = (0, fs_1.readFileSync)((0, path_1.join)(emberSource.root, 'dist/ember-template-compiler.js'), 'utf8');
+-            trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember-template-compiler.js', () => templateCompilerSrc));
++            trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember-template-compiler.js', () => ''));
+         }
+         if (this.vendorTree) {
+             trees.push((0, broccoli_funnel_1.default)(this.vendorTree, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ overrides:
   ember-cli-babel: 8.3.1
 
 patchedDependencies:
+  '@embroider/compat':
+    hash: 43fc461e5eabdf6f0cd0ec78cc825fd795ccf69d74997f66165517ae7ce60403
+    path: patches/@embroider__compat.patch
   '@tracerbench/core@8.0.1':
     hash: ee5cfa4adb0f65df07ef51d9be56c31150b4330d7ac7e1fbbb0a87329938af0a
     path: patches/@tracerbench__core@8.0.1.patch
@@ -2950,7 +2953,7 @@ importers:
     devDependencies:
       '@embroider/compat':
         specifier: ^4.1.16
-        version: 4.1.16(@embroider/core@4.4.7)
+        version: 4.1.16(patch_hash=43fc461e5eabdf6f0cd0ec78cc825fd795ccf69d74997f66165517ae7ce60403)(@embroider/core@4.4.7)
       '@embroider/core':
         specifier: ^4.4.7
         version: 4.4.7
@@ -3010,7 +3013,7 @@ importers:
         version: 4.1.1(@babel/core@7.29.0)
       '@embroider/compat':
         specifier: ^4.1.16
-        version: 4.1.16(@embroider/core@4.4.7)
+        version: 4.1.16(patch_hash=43fc461e5eabdf6f0cd0ec78cc825fd795ccf69d74997f66165517ae7ce60403)(@embroider/core@4.4.7)
       '@embroider/config-meta-loader':
         specifier: ^1.0.0
         version: 1.0.0
@@ -13879,7 +13882,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@embroider/compat@4.1.16(@embroider/core@4.4.7)':
+  '@embroider/compat@4.1.16(patch_hash=43fc461e5eabdf6f0cd0ec78cc825fd795ccf69d74997f66165517ae7ce60403)(@embroider/core@4.4.7)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -61,9 +61,6 @@ function esmInputs() {
     ...renameEntrypoints(exposedDependencies(), (name) => join('packages', name, 'index')),
     ...renameEntrypoints(packages(), (name) => join('packages', name)),
     'packages/ember-template-compiler/index': 'ember-template-compiler/minimal.ts',
-
-    // @embroider/compat reads this path directly via readFileSync
-    'ember-template-compiler': 'ember-template-compiler/minimal.ts',
   };
 }
 

--- a/smoke-tests/v2-app-template/package.json
+++ b/smoke-tests/v2-app-template/package.json
@@ -82,5 +82,10 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@embroider/compat": "patches/@embroider__compat.patch"
+    }
   }
 }

--- a/smoke-tests/v2-app-template/patches/@embroider__compat.patch
+++ b/smoke-tests/v2-app-template/patches/@embroider__compat.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/src/compat-app.js b/dist/src/compat-app.js
+index e22220b687d2434136227e16c15bf1826a483c98..cd7eed7dc02164175d7795318a79836af978b742 100644
+--- a/dist/src/compat-app.js
++++ b/dist/src/compat-app.js
+@@ -239,12 +239,9 @@ class CompatApp {
+             // empty because we're just trying to keep the build from blowing up, the
+             // actual ember modules get loaded as modules instead.
+             //
+-            // The template compiler is still here so that apps using a V2 ember can
+-            // still app.import the traditional runtime template compiler.
+             trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember.js', () => ''));
+             trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember-testing.js', () => ''));
+-            const templateCompilerSrc = (0, fs_1.readFileSync)((0, path_1.join)(emberSource.root, 'dist/ember-template-compiler.js'), 'utf8');
+-            trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember-template-compiler.js', () => templateCompilerSrc));
++            trees.push((0, broccoli_file_creator_1.default)('vendor/ember/ember-template-compiler.js', () => ''));
+         }
+         if (this.vendorTree) {
+             trees.push((0, broccoli_funnel_1.default)(this.vendorTree, {


### PR DESCRIPTION
## Summary
- Restore `absolutePaths.templateCompiler` in `lib/index.js` — `ember-cli-htmlbars` uses this to find the template compiler during classic builds
- Fix node smoke test's `Resolver` to return an object with a `resolve()` method
- Remove legacy `dist/ember-template-compiler.js` — resolution now goes through `renamed-modules` → package `exports` → `dist/packages/ember-template-compiler/index.js`
- Patch `@embroider/compat` to stub out the hardcoded `readFileSync` of the removed file (matching how `ember.js` and `ember-testing.js` are already handled)

## Test plan
- [x] All 4 smoke tests pass locally (classic, webpack, vite, node)
- [x] Type checking passes
- [x] `pnpm build` succeeds from clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)