### PR TITLE
[BUGFIX beta] Escape regex special characters in rootURL/baseURL for location getURL()

### DIFF
--- a/packages/@ember/routing/history-location.ts
+++ b/packages/@ember/routing/history-location.ts
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { assert } from '@ember/debug';
 import type { default as EmberLocation, UpdateCallback } from '@ember/routing/location';
-import { getHash } from './lib/location-utils';
+import { getHash, escapeRegExp } from './lib/location-utils';
 
 /**
 @module @ember/routing/history-location
@@ -134,8 +134,8 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
 
     // remove baseURL and rootURL from start of path
     let url = path
-      .replace(new RegExp(`^${baseURL}(?=/|$)`), '')
-      .replace(new RegExp(`^${rootURL}(?=/|$)`), '')
+      .replace(new RegExp(`^${escapeRegExp(baseURL)}(?=/|$)`), '')
+      .replace(new RegExp(`^${escapeRegExp(rootURL)}(?=/|$)`), '')
       .replace(/\/\//g, '/'); // remove extra slashes
 
     let search = location.search || '';

--- a/packages/@ember/routing/lib/location-utils.ts
+++ b/packages/@ember/routing/lib/location-utils.ts
@@ -47,3 +47,13 @@ export function getFullPath(location: Location): string {
 export function replacePath(location: Location, path: string): void {
   location.replace(location.origin + path);
 }
+
+/**
+  Escapes a string for use in a `RegExp` constructor, ensuring that
+  any special regex characters are treated as literal characters.
+
+  @private
+*/
+export function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/@ember/routing/none-location.ts
+++ b/packages/@ember/routing/none-location.ts
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { assert } from '@ember/debug';
 import type { default as EmberLocation, UpdateCallback } from '@ember/routing/location';
+import { escapeRegExp } from './lib/location-utils';
 
 /**
 @module @ember/routing/none-location
@@ -64,7 +65,7 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
     rootURL = rootURL.replace(/\/$/, '');
 
     // remove rootURL from url
-    return path.replace(new RegExp(`^${rootURL}(?=/|$)`), '');
+    return path.replace(new RegExp(`^${escapeRegExp(rootURL)}(?=/|$)`), '');
   }
 
   /**


### PR DESCRIPTION
### Problem

`HistoryLocation.getURL()` and `NoneLocation.getURL()` interpolate `rootURL` and `baseURL` directly into `new RegExp(...)` without escaping regex metacharacters.

If either value contains special regex characters (e.g. `." in "/v2.0/"\), the resulting pattern treats them as regex wildcards instead of literal characters. This can cause incorrect URL path stripping — for example, "/v2.0/foo" would also match paths like "/v2X0/foo" or "/v2_0/foo".

### Solution

Add an `escapeRegExp()` utility to `location-utils.ts` and apply it to `rootURL` and `baseURL` before interpolation into `new RegExp()` in both `HistoryLocation` and `NoneLocation`.

### Impact

- **No breaking changes** — the fix only affects URLs containing regex metacharacters. Standard path-based URLs (e.g. "/app/", "/base/") contain no special characters and behave identically.
- Existing tests continue to pass unchanged.

### Files Changed

- `packages/@ember/routing/lib/location-utils.ts` — Added `escapeRegExp()` helper
- `packages/@ember/routing/history-location.ts` — Escaped `baseURL` and `rootURL` in `getURL()`
- `packages/@ember/routing/none-location.ts` — Escaped `rootURL` in `getURL()`