### PR TITLE
[DOC beta] Fix misleading comment in HashLocation.getURL()

### DIFF
--- a/packages/@ember/routing/hash-location.ts
+++ b/packages/@ember/routing/hash-location.ts
@@ -77,7 +77,7 @@ export default class HashLocation extends EmberObject implements EmberLocation {
       outPath = '/';
 
       // Only add the # if the path isn't empty.
-      // We do NOT want `/#` since the ampersand
+      // We do NOT want `/#` since the hash
       // is only included (conventionally) when
       // the location.hash has a value
       if (originalPath) {


### PR DESCRIPTION
### Problem

In `HashLocation.getURL()`, the inline comment on [line 80](https://github.com/emberjs/ember.js/blob/main/packages/%40ember/routing/hash-location.ts#L80) incorrectly refers to the `#` (hash) character as an "ampersand":

```js
// We do NOT want `/#` since the ampersand
// is only included (conventionally) when
// the location.hash has a value
```

The ampersand is `&`, not `#`. The `#` character is called a "hash" (or "number sign" / "pound sign"). This is misleading for developers reading or debugging the routing code.

### Fix

Changed "ampersand" to "hash" to accurately describe the `#` character being discussed.

```diff
-      // We do NOT want `/#` since the ampersand
+      // We do NOT want `/#` since the hash
       // is only included (conventionally) when
       // the location.hash has a value
```