### PR TITLE
[BUGFIX] Fix incorrect tracking tag meta for arrays in AutoComputedProperty

### DIFF
--- a/packages/@ember/-internals/metal/lib/computed.ts
+++ b/packages/@ember/-internals/metal/lib/computed.ts
@@ -592,7 +592,7 @@ class AutoComputedProperty extends ComputedProperty {
     // Add the tag of the returned value if it is an array, since arrays
     // should always cause updates if they are consumed and then changed
     if (Array.isArray(ret)) {
-      consumeTag(tagFor(ret, '[]', tagMeta));
+      consumeTag(tagFor(ret, '[]'));
     }
 
     return ret;


### PR DESCRIPTION
### Problem

In Ember's internal reactivity layer (`packages/@ember/-internals/metal/lib/computed.ts`), the `AutoComputedProperty.get` method incorrectly passed the host object's `tagMeta` to the `tagFor()` lookup for the returned array:

```typescript
    let tagMeta = tagMetaFor(obj);
    ...
    if (Array.isArray(ret)) {
      consumeTag(tagFor(ret, '[]', tagMeta));
    }
```

By passing `tagMeta` (which is correctly looked up for the host `obj`), the `tagFor` function would cache and associate the array's tracking tag with the host object's metadata. This causes the host object's tracking metadata to be polluted with array tags, which can break tracking cache invalidation heuristics or leak memory over time.

### Solution

Removed the incorrect `tagMeta` argument so `tagFor()` automatically instantiates and associates the correct `tagMeta` for the `ret` array instance itself.

This aligns the `AutoComputedProperty.get` behavior with the standard `ComputedProperty.get` (line 438 in the same file), which handled this correctly:

```typescript
    if (Array.isArray(ret)) {
      consumeTag(tagFor(ret, '[]'));
    }
```