### PR TITLE
update TS config deprecation so that we don't fail the ts-nightly check

### DIFF
--- a/packages/@handlebars/parser/tsconfig.json
+++ b/packages/@handlebars/parser/tsconfig.json
@@ -5,7 +5,6 @@
     "inlineSources": true,
     "inlineSourceMap": true,
     "outDir": "dist",
-    "baseUrl": "lib",
     "rootDir": "lib",
     "esModuleInterop": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
This PR, and https://github.com/emberjs/ember.js/pull/21234 should unblock the ts-nightly workflow