### PR TITLE
Revert unnecessary change to normalize.ts

### DIFF
--- a/packages/@glimmer/syntax/lib/v2/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2/normalize.ts
@@ -2,7 +2,10 @@ import type { PresentArray } from '@glimmer/interfaces';
 import { asPresentArray, isPresentArray, localAssert } from '@glimmer/debug-util';
 import { assign } from '@glimmer/util';
 
-import type { PrecompileOptions } from '../parser/tokenizer-event-handlers';
+import type {
+  PrecompileOptions,
+  PrecompileOptionsWithLexicalScope,
+} from '../parser/tokenizer-event-handlers';
 import type { SourceLocation } from '../source/location';
 import type { Source } from '../source/source';
 import type { SourceSpan } from '../source/span';
@@ -32,7 +35,7 @@ import {
 
 export function normalize(
   source: Source,
-  options: PrecompileOptions & { lexicalScope?: (variable: string) => boolean }
+  options: PrecompileOptionsWithLexicalScope = { lexicalScope: () => false }
 ): [ast: ASTv2.Template, locals: string[]] {
   let ast = preprocess(source, options);
 
@@ -42,12 +45,10 @@ export function normalize(
     locals: ast.blockParams,
     keywords: options.keywords ?? [],
   };
-  let localsSet = new Set(normalizeOptions.locals);
-  let lexicalScope = options.lexicalScope ?? ((name: string) => localsSet.has(name));
 
   let top = SymbolTable.top(normalizeOptions.locals, normalizeOptions.keywords, {
     customizeComponentName: options.customizeComponentName ?? ((name) => name),
-    lexicalScope,
+    lexicalScope: options.lexicalScope,
   });
   let block = new BlockContext(source, normalizeOptions, top);
   let normalizer = new StatementNormalizer(block);


### PR DESCRIPTION
## Summary

- Reverts the change to `packages/@glimmer/syntax/lib/v2/normalize.ts` that made `lexicalScope` optional with a `localsSet` fallback
- This change is never exercised — the only caller (`compiler.ts:86`) always passes `lexicalScope` explicitly: `normalize(source, { lexicalScope: () => false, ...options })`

## Test plan

- [x] 338 keyword tests pass (526 assertions, 0 failures)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)