### PR TITLE
For lts branch, remove use_lockfile option from CI setup

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -135,8 +135,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
-        with:
-          use_lockfile: "false"
       - name: build
         run: pnpm build
       - name: test


### PR DESCRIPTION
Something floats and causes these to not run on the Node that was supported at the time