### PR TITLE
Update template-compiler-test for v7 ESM-only build

### DIFF
--- a/smoke-tests/node-template/tests/node/template-compiler-test.js
+++ b/smoke-tests/node-template/tests/node/template-compiler-test.js
@@ -1,71 +1,23 @@
-import { createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
+import { precompile, _buildCompileOptions } from 'ember-source/ember-template-compiler/index.js';
 
-const require = createRequire(import.meta.url);
-const emberSourceRoot = dirname(require.resolve('ember-source/package.json'));
-const distPath = join(emberSourceRoot, 'dist');
+QUnit.module('ember-template-compiler', function () {
+  QUnit.test('precompile is available', function (assert) {
+    assert.strictEqual(typeof precompile, 'function', 'precompile function is present');
+  });
 
-let templateCompiler;
-
-QUnit.module('ember-template-compiler.js', function () {
-  QUnit.module('modern', function (hooks) {
-    hooks.beforeEach(function () {
-      this.templateCompilerPath = resolve(join(distPath, 'ember-template-compiler.js'));
-      templateCompiler = require(this.templateCompilerPath);
-    });
-
-    hooks.afterEach(function () {
-      // clear the previously cached version of this module
-      delete require.cache[this.templateCompilerPath];
-    });
-
-    QUnit.test('can be required', function (assert) {
-      assert.strictEqual(
-        typeof templateCompiler.precompile,
-        'function',
-        'precompile function is present'
-      );
-      assert.strictEqual(
-        typeof templateCompiler.compile,
-        'function',
-        'compile function is present'
-      );
-    });
-
-    QUnit.test('can access _Ember.ENV (private API used by ember-cli-htmlbars)', function (assert) {
-      assert.equal(typeof templateCompiler._Ember.ENV, 'object', '_Ember.ENV is present');
-      assert.notEqual(typeof templateCompiler._Ember.ENV, null, '_Ember.ENV is not null');
-    });
-
-    QUnit.test('_Ember.ENV (private API used by ember-cli-htmlbars) is stable', function (assert) {
-      assert.strictEqual(
-        templateCompiler._Ember.ENV,
-        templateCompiler._Ember.ENV,
-        '_Ember.ENV is stable'
-      );
-    });
-
-    QUnit.test(
-      'can access _Ember.FEATURES (private API used by ember-cli-htmlbars)',
-      function (assert) {
-        assert.equal(
-          typeof templateCompiler._Ember.FEATURES,
-          'object',
-          '_Ember.FEATURES is present'
-        );
-        assert.notEqual(
-          typeof templateCompiler._Ember.FEATURES,
-          null,
-          '_Ember.FEATURES is not null'
-        );
-      }
+  QUnit.test('_buildCompileOptions is available', function (assert) {
+    assert.strictEqual(
+      typeof _buildCompileOptions,
+      'function',
+      '_buildCompileOptions function is present'
     );
+  });
 
-    QUnit.test(
-      'can access _Ember.VERSION (private API used by ember-cli-htmlbars)',
-      function (assert) {
-        assert.equal(typeof templateCompiler._Ember.VERSION, 'string', '_Ember.VERSION is present');
-      }
-    );
+  QUnit.test('precompile produces a valid template spec', function (assert) {
+    let result = precompile('<h1>Hello</h1>');
+    assert.strictEqual(typeof result, 'string', 'precompile returns a string');
+
+    let parsed = JSON.parse(result);
+    assert.strictEqual(typeof parsed, 'object', 'precompile output is valid JSON');
   });
 });


### PR DESCRIPTION
## Summary

- The legacy CJS bundle at `dist/ember-template-compiler.js` was removed in v7 (the `templateCompilerConfig()` rollup entry was deleted)
- The ESM template compiler uses `minimal.ts` as its entry, which exports `precompile` and `_buildCompileOptions` but not `_Ember`, `compile`, `VERSION`, etc.
- Updated `template-compiler-test.js` to use ESM imports from `ember-source/ember-template-compiler/index.js` (matching the pattern used by the other converted node tests)
- Tests the exports that actually exist in v7

Fixes the 6 node smoke test failures in #21240.

## Test plan

- [ ] Node smoke tests pass (`node-node-tests` scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)