### PR TITLE
Use require.resolve instead of hardcoded dist path in patches

### DIFF
--- a/patches/ember-auto-import@2.13.0.patch
+++ b/patches/ember-auto-import@2.13.0.patch
@@ -1,5 +1,5 @@
 diff --git a/js/package.js b/js/package.js
-index 91c757199e649b581e3064130f35f45d2af771a4..67f1aaebf0f58e51ebb04b992ae89d44f021374d 100644
+index 91c757199e649b581e3064130f35f45d2af771a4..26d3e8bde91cd085e7a035a8520c8485e660be24 100644
 --- a/js/package.js
 +++ b/js/package.js
 @@ -413,7 +413,8 @@ class Package {
@@ -8,7 +8,7 @@ index 91c757199e649b581e3064130f35f45d2af771a4..67f1aaebf0f58e51ebb04b992ae89d44
          let templateCompilerPath = emberSource.absolutePaths
 -            .templateCompiler;
 +            ? emberSource.absolutePaths.templateCompiler
-+            : require('path').join(emberSource.root, 'dist', 'dev', 'packages', 'ember-template-compiler', 'index.js');
++            : require.resolve('ember-source/ember-template-compiler/index.js');
          const babelPluginPrecompile = ensureModuleApiPolyfill
              ? [
                  require.resolve('babel-plugin-htmlbars-inline-precompile'),

--- a/patches/ember-cli-htmlbars@7.0.0.patch
+++ b/patches/ember-cli-htmlbars@7.0.0.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/ember-addon-main.js b/lib/ember-addon-main.js
-index 71c809a11baa57fcc78f10e08176e5d34eaeb62b..158fd9c7707cfe0809eb1cd2bf5ae2cece2b2fde 100644
+index 71c809a11baa57fcc78f10e08176e5d34eaeb62b..6f162e6c4435df6041e943b6382b42272173f206 100644
 --- a/lib/ember-addon-main.js
 +++ b/lib/ember-addon-main.js
 @@ -105,7 +105,13 @@ module.exports = {
@@ -11,9 +11,9 @@ index 71c809a11baa57fcc78f10e08176e5d34eaeb62b..158fd9c7707cfe0809eb1cd2bf5ae2ce
 +      return ember.absolutePaths.templateCompiler;
 +    }
 +
-+    // v7+ ember-source no longer provides absolutePaths; the ESM template
-+    // compiler lives under dist/dev/packages/
-+    return path.join(ember.root, 'dist', 'dev', 'packages', 'ember-template-compiler', 'index.js');
++    // v7+ ember-source no longer provides absolutePaths; resolve through
++    // the package exports map
++    return require.resolve('ember-source/ember-template-compiler/index.js');
    },
  
    astPlugins() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ patchedDependencies:
     hash: 5e48bdb11a088927d3415cc5430bb6c37d5ce66ed2dab1327914b55e4fd5cd13
     path: patches/@tracerbench__core@8.0.1.patch
   ember-auto-import@2.13.0:
-    hash: 1303fba1a35f4858b054774f61b0b3b4c8651f1a90825be1bd2b56224925b368
+    hash: ec8437cb1a9213741af03bade3fc56541ab5120a3f2e979f8d1abfd490f54604
     path: patches/ember-auto-import@2.13.0.patch
   ember-cli-htmlbars@7.0.0:
-    hash: 03c5666262a96427db47f2156d601e45f729568d29ec3f2e4f2210989488148a
+    hash: c09818a05c987d71c1bb858496ab119ab7b2be6f82468ffda0f60d668561baac
     path: patches/ember-cli-htmlbars@7.0.0.patch
 
 importers:
@@ -2797,7 +2797,7 @@ importers:
         version: 9.2.1
       ember-auto-import:
         specifier: ^2.13.0
-        version: 2.13.0(patch_hash=1303fba1a35f4858b054774f61b0b3b4c8651f1a90825be1bd2b56224925b368)(webpack@5.105.4)
+        version: 2.13.0(patch_hash=ec8437cb1a9213741af03bade3fc56541ab5120a3f2e979f8d1abfd490f54604)(webpack@5.105.4)
       ember-cli:
         specifier: ~6.11.1
         version: 6.11.1(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
@@ -2818,7 +2818,7 @@ importers:
         version: 3.4.0(ember-source@)
       ember-cli-htmlbars:
         specifier: ^7.0.0
-        version: 7.0.0(patch_hash=03c5666262a96427db47f2156d601e45f729568d29ec3f2e4f2210989488148a)(@babel/core@7.29.0)(ember-source@)
+        version: 7.0.0(patch_hash=c09818a05c987d71c1bb858496ab119ab7b2be6f82468ffda0f60d668561baac)(@babel/core@7.29.0)(ember-source@)
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
@@ -17706,7 +17706,7 @@ snapshots:
 
   elegant-spinner@1.0.1: {}
 
-  ember-auto-import@2.13.0(patch_hash=1303fba1a35f4858b054774f61b0b3b4c8651f1a90825be1bd2b56224925b368)(webpack@5.105.4):
+  ember-auto-import@2.13.0(patch_hash=ec8437cb1a9213741af03bade3fc56541ab5120a3f2e979f8d1abfd490f54604)(webpack@5.105.4):
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
@@ -17871,7 +17871,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-htmlbars@7.0.0(patch_hash=03c5666262a96427db47f2156d601e45f729568d29ec3f2e4f2210989488148a)(@babel/core@7.29.0)(ember-source@):
+  ember-cli-htmlbars@7.0.0(patch_hash=c09818a05c987d71c1bb858496ab119ab7b2be6f82468ffda0f60d668561baac)(@babel/core@7.29.0)(ember-source@):
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       '@ember/edition-utils': 1.2.0
@@ -18248,7 +18248,7 @@ snapshots:
   ember-tracked-storage-polyfill@1.0.0(@babel/core@7.29.0)(ember-source@):
     dependencies:
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
-      ember-cli-htmlbars: 7.0.0(patch_hash=03c5666262a96427db47f2156d601e45f729568d29ec3f2e4f2210989488148a)(@babel/core@7.29.0)(ember-source@)
+      ember-cli-htmlbars: 7.0.0(patch_hash=c09818a05c987d71c1bb858496ab119ab7b2be6f82468ffda0f60d668561baac)(@babel/core@7.29.0)(ember-source@)
     transitivePeerDependencies:
       - '@babel/core'
       - ember-source


### PR DESCRIPTION
## Summary

Replace hardcoded `dist/dev/packages/ember-template-compiler/index.js` path in the ember-cli-htmlbars and ember-auto-import patches with `require.resolve('ember-source/ember-template-compiler/index.js')`, which resolves through the package exports map.

This makes the patches resilient to dist layout changes.

## Test plan

- [ ] Smoke tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)