### PR TITLE
Fix minor typos

### DIFF
--- a/packages/internal-test-helpers/lib/get-all-property-names.ts
+++ b/packages/internal-test-helpers/lib/get-all-property-names.ts
@@ -1,4 +1,4 @@
-// The `& string` here is to enforce that the propreties are strings since this is expected
+// The `& string` here is to enforce that the properties are strings since this is expected
 // to be the case elsewhere.
 export default function getAllPropertyNames<T>(Klass: { prototype: T }): Set<keyof T & string> {
   let proto = Klass.prototype;

--- a/packages/internal-test-helpers/lib/test-context.ts
+++ b/packages/internal-test-helpers/lib/test-context.ts
@@ -14,7 +14,7 @@ export function setContext(context: BaseContext): void {
 }
 
 /**
- * Retrive the "global testing context" as stored by `setContext`.
+ * Retrieve the "global testing context" as stored by `setContext`.
  *
  * @returns {Object} the previously stored testing context
  */

--- a/packages/router_js/lib/route-info.ts
+++ b/packages/router_js/lib/route-info.ts
@@ -397,7 +397,7 @@ export default class InternalRouteInfo<R extends Route> {
       // Ignore the fulfilled value returned from afterModel.
       // Return the value stashed in resolvedModels, which
       // might have been swapped out in afterModel.
-      // SAFTEY: We expect this to be of type T, though typing it as such is challenging.
+      // SAFETY: We expect this to be of type T, though typing it as such is challenging.
       return transition.resolvedModels[name]! as unknown as ModelFor<R>;
     });
   }

--- a/packages/router_js/lib/transition.ts
+++ b/packages/router_js/lib/transition.ts
@@ -266,7 +266,7 @@ export default class Transition<R extends Route> implements Partial<Promise<R>> 
     @public
    */
   finally<T>(callback?: T | undefined, label?: string) {
-    // @ts-expect-error @types/rsvp doesn't have the correct signiture for RSVP.Promise.finally
+    // @ts-expect-error @types/rsvp doesn't have the correct signature for RSVP.Promise.finally
     return this.promise!.finally(callback, label);
   }
 


### PR DESCRIPTION
Fix minor typos in internal packages such as properties, retrieve, safety, and signature. Found via codespell.