### PR TITLE
docs: fix various typos in comments and documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const shim = addonV1Shim(path.join(__dirname, '..'), {
       // In this case, we need to inject an implicit-modules config to force
       // all the traditionally-included modules to be included whether or not
       // we see an import for them, because ember-auto-import does not have
-      // global visiblity of all imports in all v1 addons.
+      // global visibility of all imports in all v1 addons.
       //
       // This means ember-source is not tree-shakable on classic builds, but
       // that's the normal status quo for classic builds. It's all

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -62,7 +62,7 @@ function matches(el: Element, selector: string): boolean {
 */
 
 interface ComponentMethods {
-  // Overrideable methods are defined here since you can't `declare` a method in a class
+  // Overridable methods are defined here since you can't `declare` a method in a class
 
   /**
    Called when the attributes passed into the component have been updated.
@@ -552,7 +552,7 @@ declare const SIGNATURE: unique symbol;
   ```
 
   Note that the `href` attribute is ultimately set to `http://bing.com`, despite
-  it having attribute binidng to the `url` property, which was set to
+  it having attribute binding to the `url` property, which was set to
   `http://google.com`.
 
   Namespaced attributes (e.g. `xlink:href`) are supported, but have to be
@@ -765,7 +765,7 @@ declare const SIGNATURE: unique symbol;
   * `mouseUp`
   * `contextMenu`
   * `click`
-  * `doubleClick`
+  * `double-click`
   * `focusIn`
   * `focusOut`
 
@@ -826,7 +826,7 @@ class Component<S = unknown>
   // here to preserve the type param.
   declare private [SIGNATURE]: S;
 
-  // SAFTEY: This is set in `init`.
+  // SAFETY: This is set in `init`.
   declare _superRerender: this['rerender'];
 
   declare [IS_DISPATCHING_ATTRS]: boolean;

--- a/packages/@ember/-internals/glimmer/lib/components/internal.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/internal.ts
@@ -39,10 +39,10 @@ export default class InternalComponent {
   /**
    * The default HTML id attribute. We don't really _need_ one, this is just
    * added for compatibility as it's hard to tell if people rely on it being
-   * present, and it doens't really hurt.
+   * present, and it doesn't really hurt.
    *
    * However, don't rely on this internally, like passing it to `getElementId`.
-   * This can be (and often is) overriden by passing an `id` attribute on the
+   * This can be (and often is) overridden by passing an `id` attribute on the
    * invocation, which shadows this default id via `...attributes`.
    */
   get id(): string {
@@ -52,7 +52,7 @@ export default class InternalComponent {
   /**
    * The default HTML class attribute. Similar to the above, we don't _need_
    * them, they are just added for compatibility as it's similarly hard to tell
-   * if people rely on it in their CSS etc, and it doens't really hurt.
+   * if people rely on it in their CSS etc, and it doesn't really hurt.
    */
   get class(): string {
     return 'ember-view';

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -328,7 +328,7 @@ export type FunctionBasedHelper<S> = abstract new () => FunctionBasedHelperInsta
 // This is needful because we lie about what this actually is for Glint's sake:
 // a function-based helper returns a `Factory<SimpleHelper>`, which is designed
 // to be "opaque" from a consumer's POV, i.e. not user-callable or constructible
-// but only useable in a template (or via `invokeHelper()` which also treats it
+// but only usable in a template (or via `invokeHelper()` which also treats it
 // as a fully opaque `object` from a type POV). But Glint needs a `Helper<S>` to
 // make it work the same way as class-based helpers. (Note that this does not
 // hold for plain functions as helpers, which it can handle distinctly.) This

--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -94,7 +94,7 @@ import { internalHelper } from './internal-helper';
   By doing so, Ember will use the value of the property specified (`person.name`
   in the example) to find a "match" from the previous render. That is, if Ember
   has previously seen an object from the `@developers` array with a matching
-  name, its DOM elements will be re-used.
+  name, its DOM elements will be reused.
 
   There are two special values for `key`:
 

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -105,7 +105,7 @@ export class DynamicScope implements GlimmerDynamicScope {
 const NO_OP = () => {};
 
 // This wrapper logic prevents us from rerendering in case of a hard failure
-// during render. This prevents infinite revalidation type loops from occuring,
+// during render. This prevents infinite revalidation type loops from occurring,
 // and ensures that errors are not swallowed by subsequent follow on failures.
 function errorLoopTransaction(fn: () => void) {
   if (DEBUG) {

--- a/packages/@ember/-internals/glimmer/lib/resolver.ts
+++ b/packages/@ember/-internals/glimmer/lib/resolver.ts
@@ -117,7 +117,7 @@ if (DEBUG) {
   // Bug: this may be a quirk of our test setup?
   // In prod builds, this is a no-op helper and is unused in practice. We shouldn't need
   // to add it at all, but the current test build doesn't produce a "prod compiler", so
-  // we ended up running the debug-build for the template compliler in prod tests. Once
+  // we ended up running the debug-build for the template compiler in prod tests. Once
   // that is fixed, this can be removed. For now, this allows the test to work and does
   // not really harm anything, since it's just a no-op pass-through helper and the bytes
   // has to be included anyway. In the future, perhaps we can avoid the latter by using
@@ -125,7 +125,7 @@ if (DEBUG) {
   BUILTIN_HELPERS['-disallow-dynamic-resolution'] = disallowDynamicResolution;
 }
 
-// With the implementation of RFC #1006(https://rfcs.emberjs.com/id/1006-deprecate-action-template-helper), the `action` modifer was removed. It was the
+// With the implementation of RFC #1006(https://rfcs.emberjs.com/id/1006-deprecate-action-template-helper), the `action` modifier was removed. It was the
 // only built-in keyword modifier, so this object is currently empty.
 const BUILTIN_KEYWORD_MODIFIERS: Record<string, ModifierDefinitionState> = {};
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -816,7 +816,7 @@ moduleFor(
 
     ["@test adding parameters to a contextual component's instance does not add it to other instances"]() {
       // If parameters and attributes are not handled correctly, setting a value
-      // in an invokation can leak to others invocation.
+      // in an invocation can leak to others invocation.
       this.registerComponent('select-box', {
         template: '{{yield (hash option=(component "select-box-option"))}}',
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -3239,7 +3239,7 @@ moduleFor(
       this.assertText('|foo||bar||qux||baz|');
     }
 
-    ['@test unimplimented positionalParams do not cause an error GH#14416']() {
+    ['@test unimplemented positionalParams do not cause an error GH#14416']() {
       this.registerComponent('foo-bar', {
         template: 'hello',
       });

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/rendering-angle-test.js
@@ -100,7 +100,7 @@ moduleFor(
       assert.equal(this.firstChild.classList.contains('active'), true);
     }
 
-    async ['@test able to popolate innermost dynamic segment when immediate parent route is active']() {
+    async ['@test able to populate innermost dynamic segment when immediate parent route is active']() {
       this.addTemplate('application', '{{outlet}}');
 
       this.addTemplate('parents', '{{outlet}}');

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -536,7 +536,7 @@ moduleFor(
                 `
                 <h2 id='engine-layout'>Routable Engine</h2>
                 {{outlet}}
-                <LinkTo @route='application' id='engine-application-link'>Engine Appliction</LinkTo>
+                <LinkTo @route='application' id='engine-application-link'>Engine Application</LinkTo>
                 `,
                 {
                   moduleName: 'routable/templates/application.hbs',
@@ -586,7 +586,7 @@ moduleFor(
         `
         <h1 id='application-layout'>Application</h1>
         {{outlet}}
-        <LinkTo @route='application' id='application-link'>Appliction</LinkTo>
+        <LinkTo @route='application' id='application-link'>Application</LinkTo>
         <LinkTo @route='routable' id='engine-link'>Engine</LinkTo>
         `
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-curly-test.js
@@ -566,7 +566,7 @@ moduleFor(
         `
         <h1 id="application-layout">Application</h1>
         {{outlet}}
-        <div id="application-link">{{#link-to route='application'}}Appliction{{/link-to}}</div>
+        <div id="application-link">{{#link-to route='application'}}Application{{/link-to}}</div>
         <div id="engine-link">{{#link-to route='routable'}}Engine{{/link-to}}</div>
         `
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -89,7 +89,7 @@ moduleFor(
       }
     }
 
-    '@test destroy cleans up dom via destrying the test context'() {
+    '@test destroy cleans up dom via destroying the test context'() {
       let Foo = defComponent('Hello, world!');
       let Root = defComponent('<Foo/>', { scope: { Foo } });
 
@@ -100,7 +100,7 @@ moduleFor(
       assertHTML('');
     }
 
-    '@test destroy of the owner cleans up dom via destrying the test context'() {
+    '@test destroy of the owner cleans up dom via destroying the test context'() {
       let Foo = defComponent('Hello, world!');
       let Root = defComponent('<Foo/>', { scope: { Foo } });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -353,7 +353,7 @@ moduleFor(
       }
     };
 
-    '@test modifers only track positional arguments they consume'(assert) {
+    '@test modifiers only track positional arguments they consume'(assert) {
       let insertCount = 0;
       let updateCount = 0;
 
@@ -409,7 +409,7 @@ moduleFor(
       assert.equal(updateCount, 1);
     }
 
-    '@test modifers only track named arguments they consume'(assert) {
+    '@test modifiers only track named arguments they consume'(assert) {
       let insertCount = 0;
       let updateCount = 0;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/event-dispatcher-test.js
@@ -91,7 +91,7 @@ moduleFor(
           click(event) {
             receivedEvent = event;
           }
-          doubleClick(event) {
+          double-click(event) {
             receivedEvent = event;
           }
           focusIn(event) {
@@ -383,7 +383,7 @@ moduleFor(
             assert.ok(false, 'null method was called');
           }
 
-          doubleClick() {
+          double-click() {
             assert.ok(true, 'a non-disabled event is still handled properly');
           }
         },

--- a/packages/@ember/-internals/glimmer/tests/integration/input-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/input-test.js
@@ -150,7 +150,7 @@ moduleFor(
 
       this.assertSelectionRange(1, 3);
 
-      // Note: We should eventually get around to testing reseting, however
+      // Note: We should eventually get around to testing resetting, however
       // browsers handle `selectionStart` and `selectionEnd` differently
       // when are synthetically testing movement of the cursor.
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -846,7 +846,7 @@ class EachTest extends AbstractEachTest {
 
   /* multi each */
 
-  ['@test re-using the same variable with different {{#each}} blocks does not override each other']() {
+  ['@test reusing the same variable with different {{#each}} blocks does not override each other']() {
     let admins = this.createList([{ name: 'Tom Dale' }]);
     let users = this.createList([{ name: 'Yehuda Katz' }]);
 
@@ -1089,7 +1089,7 @@ moduleFor(
       let proxy = class extends ArrayProxy {
         @computed('wrappedItems.[]')
         get arrangedContent() {
-          // Slice the items to ensure that updates must be propogated
+          // Slice the items to ensure that updates must be propagated
           return this.wrappedItems.slice();
         }
       }.create({
@@ -1149,7 +1149,7 @@ moduleFor(
 moduleFor(
   'Syntax test: {{#each}} with sparse arrays',
   class extends RenderingTestCase {
-    ['@test it should itterate over holes']() {
+    ['@test it should iterate over holes']() {
       let sparseArray = [];
       sparseArray[3] = 'foo';
       sparseArray[4] = 'bar';

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
@@ -210,7 +210,7 @@ moduleFor(
 moduleFor(
   'Syntax test: Multiple {{#let as}} helpers',
   class extends RenderingTestCase {
-    ['@test re-using the same variable with different {{#let}} blocks does not override each other']() {
+    ['@test reusing the same variable with different {{#let}} blocks does not override each other']() {
       this.render(
         `Admin: {{#let this.admin as |person|}}{{person.name}}{{/let}} User: {{#let this.user as |person|}}{{person.name}}{{/let}}`,
         {

--- a/packages/@ember/-internals/owner/type-tests/owner.test.ts
+++ b/packages/@ember/-internals/owner/type-tests/owner.test.ts
@@ -43,7 +43,7 @@ aFactory.create({
 });
 
 // NOTE: it would be nice if these could be rejected by way of EPC, but alas: it
-// cannot, because the public contract for `create` allows implementors to
+// cannot, because the public contract for `create` allows implementers to
 // define their `create` config object basically however they like. :-/
 aFactory.create({ unrelatedNonsense: 'yep yep yep' });
 aFactory.create({ hasProps: true, unrelatedNonsense: 'yep yep yep' });
@@ -200,7 +200,7 @@ const Creatable = {
 
 const pojoFactory: Factory<typeof Creatable> = {
   // If you want *real* safety here, alas: you cannot have it. The public
-  // contract for `create` allows implementors to define their `create` config
+  // contract for `create` allows implementers to define their `create` config
   // object basically however they like. As a result, this is the safest version
   // possible: Making it be `Partial<Thing>` is *compatible* with `object`, and
   // requires full checking *inside* the function body. It does not, alas, give

--- a/packages/@ember/-internals/runtime/tests/ext/rsvp_test.js
+++ b/packages/@ember/-internals/runtime/tests/ext/rsvp_test.js
@@ -96,7 +96,7 @@ moduleFor(
       }
     }
 
-    ['@test rejections where the errorThrown is a string should wrap the sting in an error object'](
+    ['@test rejections where the errorThrown is a string should wrap the string in an error object'](
       assert
     ) {
       assert.expect(2);
@@ -163,7 +163,7 @@ function ajax() {
 moduleFor(
   'Ember.test: rejection assertions',
   class extends AbstractTestCase {
-    ['@test unambigiously unhandled rejection'](assert) {
+    ['@test unambiguously unhandled rejection'](assert) {
       assert.throws(function () {
         run(function () {
           RSVP.Promise.reject(reason);

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -87,7 +87,7 @@ moduleFor(
       assert.equal(get(proxy, 'foo'), 'FOO');
     }
 
-    [`@test JSON.stringify doens't assert`](assert) {
+    [`@test JSON.stringify doesn't assert`](assert) {
       let proxy = ObjectProxy.create({
         content: {
           foo: 'FOO',

--- a/packages/@ember/application/index.ts
+++ b/packages/@ember/application/index.ts
@@ -83,7 +83,7 @@ export const setOwner = actualSetOwner;
   `Application` has a number of default events that it listens for, as
   well as a mapping from lowercase events to camel-cased view method names. For
   example, the `keypress` event causes the `keyPress` method on the view to be
-  called, the `dblclick` event causes `doubleClick` to be called, and so on.
+  called, the `dblclick` event causes `double-click` to be called, and so on.
 
   If there is a bubbling browser event that Ember does not listen for by
   default, you can specify custom events and their corresponding view method
@@ -451,7 +451,7 @@ class Application extends Engine {
     This is orthogonal to autoboot: the deprecated instance needs to
     be created at Application construction (not boot) time to expose
     App.__container__. If autoboot sees that this instance exists,
-    it will continue booting it to avoid doing unncessary work (as
+    it will continue booting it to avoid doing unnecessary work (as
     opposed to building a new instance at boot time), but they are
     otherwise unrelated.
 
@@ -937,7 +937,7 @@ class Application extends Engine {
     Ember will boot a default instance for your Application on "DOM ready".
     However, you can customize this behavior by disabling `autoboot`.
 
-    For example, this allows you to render a miniture demo of your application
+    For example, this allows you to render a miniature demo of your application
     into a specific area on your marketing website:
 
     ```javascript

--- a/packages/@ember/application/tests/application_test.js
+++ b/packages/@ember/application/tests/application_test.js
@@ -236,7 +236,7 @@ moduleFor(
       this.assertText('Hello!');
     }
 
-    [`@test Application Controller backs the appplication template`]() {
+    [`@test Application Controller backs the application template`]() {
       runTask(() => {
         this.createApplication();
         this.addTemplate('application', '<h1>{{this.greeting}}</h1>');

--- a/packages/@ember/array/type-tests/index.test.ts
+++ b/packages/@ember/array/type-tests/index.test.ts
@@ -123,7 +123,7 @@ expectTypeOf(arr.findBy('bar')).toEqualTypeOf<Foo | undefined>();
 arr.findBy('bar', 1);
 // TODO: Ideally we'd mark the value as being invalid
 arr.findBy('bar', 'invalid');
-// Allows any value to be passed to an unkown property
+// Allows any value to be passed to an unknown property
 expectTypeOf(arr.findBy('missing', 'whatever')).toEqualTypeOf<Foo | undefined>();
 expectTypeOf(arr.findBy('bar')).toEqualTypeOf<Foo | undefined>();
 

--- a/packages/@ember/component/type-tests/capabilities.test.ts
+++ b/packages/@ember/component/type-tests/capabilities.test.ts
@@ -12,5 +12,5 @@ capabilities('3.4', { asyncLifecycleCallbacks: true });
 
 // @ts-expect-error invalid capabilities
 capabilities('3.13', { asyncLifecycleCallbacks: 1 });
-// @ts-expect-error invalid verison
+// @ts-expect-error invalid version
 capabilities('3.12');

--- a/packages/@ember/helper/type-tests/capabilities.test.ts
+++ b/packages/@ember/helper/type-tests/capabilities.test.ts
@@ -10,5 +10,5 @@ expectTypeOf(capabilities('3.23')).toMatchTypeOf<{
 capabilities('3.23', { hasValue: true });
 // @ts-expect-error invalid capabilities
 capabilities('3.23', { hasValue: 1 });
-// @ts-expect-error invalid verison
+// @ts-expect-error invalid version
 capabilities('3.22');

--- a/packages/@ember/object/core.ts
+++ b/packages/@ember/object/core.ts
@@ -710,10 +710,10 @@ class CoreObject {
     @param {Object} [arguments]* Object containing values to use within the new class
     @public
   */
-  static extend<Statics, Instance, M extends Array<unknown>>(
-    this: Statics & EmberClassConstructor<Instance>,
+  static extend<Statistics, Instance, M extends Array<unknown>>(
+    this: Statistics & EmberClassConstructor<Instance>,
     ...mixins: M
-  ): Readonly<Statics> & EmberClassConstructor<Instance> & MergeArray<M>;
+  ): Readonly<Statistics> & EmberClassConstructor<Instance> & MergeArray<M>;
   static extend(...mixins: any[]) {
     let Class = class extends this {};
     reopen.apply(Class.PrototypeMixin, mixins);

--- a/packages/@ember/object/lib/computed/reduce_computed_macros.ts
+++ b/packages/@ember/object/lib/computed/reduce_computed_macros.ts
@@ -327,7 +327,7 @@ export function map(
   callback?: (value: unknown, index: number) => unknown
 ): PropertyDecorator {
   assert(
-    'You attempted to use @map as a decorator directly, but it requires atleast `dependentKey` and `callback` parameters',
+    'You attempted to use @map as a decorator directly, but it requires at least `dependentKey` and `callback` parameters',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -434,7 +434,7 @@ export function mapBy(dependentKey: string, propertyKey: string) {
   The callback method you provide should have the following signature:
   - `item` is the current item in the iteration.
   - `index` is the integer index of the current item in the iteration.
-  - `array` is the dependant array itself.
+  - `array` is the dependent array itself.
 
   ```javascript
   function filterCallback(item, index, array);
@@ -553,7 +553,7 @@ export function filter(
   callback?: (value: unknown, index: number, array: unknown[] | EmberArray<unknown>) => unknown
 ): PropertyDecorator {
   assert(
-    'You attempted to use @filter as a decorator directly, but it requires atleast `dependentKey` and `callback` parameters',
+    'You attempted to use @filter as a decorator directly, but it requires at least `dependentKey` and `callback` parameters',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -635,7 +635,7 @@ export function filter(
 */
 export function filterBy(dependentKey: string, propertyKey: string, value?: unknown) {
   assert(
-    'You attempted to use @filterBy as a decorator directly, but it requires atleast `dependentKey` and `propertyKey` parameters',
+    'You attempted to use @filterBy as a decorator directly, but it requires at least `dependentKey` and `propertyKey` parameters',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -695,7 +695,7 @@ export function uniq(
   ...additionalDependentKeys: string[]
 ): PropertyDecorator {
   assert(
-    'You attempted to use @uniq/@union as a decorator directly, but it requires atleast one dependent key parameter',
+    'You attempted to use @uniq/@union as a decorator directly, but it requires at least one dependent key parameter',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -863,7 +863,7 @@ export let union = uniq;
 */
 export function intersect(dependentKey: string, ...additionalDependentKeys: string[]) {
   assert(
-    'You attempted to use @intersect as a decorator directly, but it requires atleast one dependent key parameter',
+    'You attempted to use @intersect as a decorator directly, but it requires at least one dependent key parameter',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -952,7 +952,7 @@ export function intersect(dependentKey: string, ...additionalDependentKeys: stri
 */
 export function setDiff(setAProperty: string, setBProperty: string) {
   assert(
-    'You attempted to use @setDiff as a decorator directly, but it requires atleast one dependent key parameter',
+    'You attempted to use @setDiff as a decorator directly, but it requires at least one dependent key parameter',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -1010,7 +1010,7 @@ export function setDiff(setAProperty: string, setBProperty: string) {
 */
 export function collect(dependentKey: string, ...additionalDependentKeys: string[]) {
   assert(
-    'You attempted to use @collect as a decorator directly, but it requires atleast one dependent key parameter',
+    'You attempted to use @collect as a decorator directly, but it requires at least one dependent key parameter',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 
@@ -1187,7 +1187,7 @@ export function sort(
   sortDefinition?: SortDefinition
 ): PropertyDecorator {
   assert(
-    'You attempted to use @sort as a decorator directly, but it requires atleast an `itemsKey` parameter',
+    'You attempted to use @sort as a decorator directly, but it requires at least an `itemsKey` parameter',
     !isElementDescriptor(Array.prototype.slice.call(arguments))
   );
 

--- a/packages/@ember/owner/index.ts
+++ b/packages/@ember/owner/index.ts
@@ -21,7 +21,7 @@
     for mapping string names to the corresponding classes. For example, when you
     write `@service('session')`, a resolver is responsible to map that back to
     the `Session` service class in your codebase. Normally, this is handled for
-    you automatically with `ember-resolver`, which is the main implementor of
+    you automatically with `ember-resolver`, which is the main implementer of
     this interface.
 
   For more details on each, see their per-item docs.

--- a/packages/@ember/owner/type-tests/owner.test.ts
+++ b/packages/@ember/owner/type-tests/owner.test.ts
@@ -44,7 +44,7 @@ aFactory.create({
 });
 
 // NOTE: it would be nice if these could be rejected by way of EPC, but alas: it
-// cannot, because the public contract for `create` allows implementors to
+// cannot, because the public contract for `create` allows implementers to
 // define their `create` config object basically however they like. :-/
 aFactory.create({ unrelatedNonsense: 'yep yep yep' });
 aFactory.create({ hasProps: true, unrelatedNonsense: 'yep yep yep' });
@@ -201,7 +201,7 @@ const Creatable = {
 
 const pojoFactory: Factory<typeof Creatable> = {
   // If you want *real* safety here, alas: you cannot have it. The public
-  // contract for `create` allows implementors to define their `create` config
+  // contract for `create` allows implementers to define their `create` config
   // object basically however they like. As a result, this is the safest version
   // possible: Making it be `Partial<Thing>` is *compatible* with `object`, and
   // requires full checking *inside* the function body. It does not, alas, give

--- a/packages/@ember/routing/history-location.ts
+++ b/packages/@ember/routing/history-location.ts
@@ -66,7 +66,7 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
   _popstateHandler?: EventListener;
 
   /**
-    Will be pre-pended to path upon state change
+    Will be prepended to path upon state change
 
     @property rootURL
     @default '/'

--- a/packages/@ember/routing/lib/utils.ts
+++ b/packages/@ember/routing/lib/utils.ts
@@ -59,7 +59,7 @@ export function extractRouteArgs(args: RouteArgs): ExtractedArgs {
     assert('routeName is a string', typeof routeName === 'string');
   }
 
-  // SAFTEY: We removed the name and options if they existed, only models left.
+  // SAFETY: We removed the name and options if they existed, only models left.
   let models = args;
 
   return { routeName, models, queryParams };
@@ -261,14 +261,14 @@ export function prefixRouteNameArg<T extends NamedRouteArgs | UnnamedRouteArgs>(
 }
 
 export function shallowEqual<A extends object, B extends object>(a: A, b: B): boolean {
-  let aCount = 0;
+  let account = 0;
   let bCount = 0;
   for (let kA in a) {
     if (Object.prototype.hasOwnProperty.call(a, kA)) {
       if (a[kA] !== (b as any)[kA]) {
         return false;
       }
-      aCount++;
+      account++;
     }
   }
 
@@ -278,7 +278,7 @@ export function shallowEqual<A extends object, B extends object>(a: A, b: B): bo
     }
   }
 
-  return aCount === bCount;
+  return account === bCount;
 }
 
 function isRouteOptions(value: unknown): value is RouteOptions {

--- a/packages/@ember/routing/none-location.ts
+++ b/packages/@ember/routing/none-location.ts
@@ -26,7 +26,7 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
   declare path: string;
 
   /**
-    Will be pre-pended to path.
+    Will be prepended to path.
 
     @private
     @property rootURL

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -399,7 +399,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     @since 1.6.0
     @public
   */
-  // Set in reopen so it can be overriden with extend
+  // Set in reopen so it can be overridden with extend
   declare queryParams: Record<
     string,
     {
@@ -439,7 +439,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     @since 1.4.0
     @public
   */
-  // Set in reopen so it can be overriden with extend
+  // Set in reopen so it can be overridden with extend
   declare templateName: string | null;
 
   /**
@@ -462,7 +462,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     @since 1.4.0
     @public
   */
-  // Set in reopen so it can be overriden with extend
+  // Set in reopen so it can be overridden with extend
   declare controllerName: string | null;
 
   /**
@@ -962,7 +962,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
       this[RENDER]();
     }
 
-    // Setup can cause changes to QPs which need to be propogated immediately in
+    // Setup can cause changes to QPs which need to be propagated immediately in
     // some situations. Eventually, we should work on making these async somehow.
     flushAsyncObservers(false);
   }
@@ -1555,7 +1555,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
             `\`${routeName}\` for which Ember requires you provide a ` +
             `data-loading implementation. Commonly, that is done by ` +
             `adding a model hook implementation on the route ` +
-            `(\`model({${name}_id}) {\`) or by injecting an implemention of ` +
+            `(\`model({${name}_id}) {\`) or by injecting an implementation of ` +
             `a data store: \`@service store;\`.`,
           Boolean(modelClass)
         );
@@ -1571,7 +1571,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
             `\`${routeName}\` for which Ember requires you provide a ` +
             `data-loading implementation. Commonly, that is done by ` +
             `adding a model hook implementation on the route ` +
-            `(\`model({${name}_id}) {\`) or by injecting an implemention of ` +
+            `(\`model({${name}_id}) {\`) or by injecting an implementation of ` +
             `a data store: \`@service store;\`.\n\n` +
             `Rarely, applications may attempt to use a legacy behavior where ` +
             `the model class (in this case \`${name}\`) is resolved and the ` +
@@ -2206,7 +2206,7 @@ Route.reopen({
         }
       }
 
-      // Some QPs have been updated, and those changes need to be propogated
+      // Some QPs have been updated, and those changes need to be propagated
       // immediately. Eventually, we should work on making this async somehow.
       if (qpUpdated === true) {
         flushAsyncObservers(false);

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -444,7 +444,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
 
       transitionDidError(error: TransitionError, transition: Transition) {
         if (error.wasAborted || transition.isAborted) {
-          // If the error was a transition erorr or the transition aborted
+          // If the error was a transition error or the transition aborted
           // log the abort.
           return logAbort(transition);
         } else {
@@ -916,7 +916,7 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
 
     @private
     @method _serializeQueryParams
-    @param {Arrray<RouteInfo>} routeInfos
+    @param {Array<RouteInfo>} routeInfos
     @param {Object} queryParams
     @return {Void}
   */
@@ -1813,7 +1813,7 @@ EmberRouter.reopen({
   rootURL: '/',
   location: 'hash',
 
-  // FIXME: Does this need to be overrideable via extend?
+  // FIXME: Does this need to be overridable via extend?
   url: computed(function (this: EmberRouter) {
     let location = get(this, 'location');
 

--- a/packages/@glimmer-workspace/integration-tests/lib/dom/assertions.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/dom/assertions.ts
@@ -233,7 +233,7 @@ export function isMatcher(input: unknown): input is Matcher {
 }
 
 /**
-  Accomodates the various signatures of `assertEmberishElement` and `assertElement`, which can be any of:
+  Accommodates the various signatures of `assertEmberishElement` and `assertElement`, which can be any of:
 
   - element, tagName, attrs, contents
   - element, tagName, contents

--- a/packages/@glimmer-workspace/integration-tests/test/ember-component-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/ember-component-test.ts
@@ -1968,7 +1968,7 @@ class CurlyTeardownTest extends CurlyTest {
       }
     }
 
-    this.registerComponent('Glimmer', 'DestroyMe1', '<div>Destry me!</div>', DestroyMe1Component);
+    this.registerComponent('Glimmer', 'DestroyMe1', '<div>Destroy me!</div>', DestroyMe1Component);
     this.registerComponent('Curly', 'destroy-me2', 'Destroy me too!', DestroyMe2Component);
 
     this.render(`<DestroyMe1 id="destroy-me1"/>{{destroy-me2 id="destroy-me2"}}`);

--- a/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
@@ -1163,7 +1163,7 @@ class DynamicStrictModeTest extends RenderTest {
   }
 
   @test
-  'Can use a nested in scope value as dynamic value in ambigious append position'() {
+  'Can use a nested in scope value as dynamic value in ambiguous append position'() {
     const x = { value: 'Hello, world!' };
     const Bar = defineComponent({ x }, '{{x.value}}');
 

--- a/packages/@glimmer-workspace/integration-tests/test/updating-content-matrix-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/updating-content-matrix-test.ts
@@ -83,13 +83,13 @@ function generateContentTestCase(
       after: '</div>',
     },
     {
-      name: 'HTML context, as a sibling to adjecent text nodes',
+      name: 'HTML context, as a sibling to adjacent text nodes',
       isHTML: true,
       before: '<div>before',
       after: 'after</div>',
     },
     {
-      name: 'HTML context, as a sibling to adjecent elements',
+      name: 'HTML context, as a sibling to adjacent elements',
       isHTML: true,
       before: '<div><b>before</b>',
       after: '<b>after</b></div>',
@@ -101,13 +101,13 @@ function generateContentTestCase(
       after: '</foreignObject></svg>',
     },
     {
-      name: 'SVG foreignObject context, as a sibling to adjecent text nodes',
+      name: 'SVG foreignObject context, as a sibling to adjacent text nodes',
       isHTML: true,
       before: '<svg><foreignObject>before',
       after: 'after</foreignObject></svg>',
     },
     {
-      name: 'SVG foreignObject context, as a sibling to adjecent elements',
+      name: 'SVG foreignObject context, as a sibling to adjacent elements',
       isHTML: true,
       before: '<svg><foreignObject><b>before</b>',
       after: '<b>after</b></foreignObject></svg>',
@@ -119,13 +119,13 @@ function generateContentTestCase(
       after: '</text></svg>',
     },
     {
-      name: 'SVG context, as a sibling to adjecent text nodes',
+      name: 'SVG context, as a sibling to adjacent text nodes',
       isHTML: false,
       before: '<svg><text>before',
       after: 'after</text></svg>',
     },
     {
-      name: 'SVG context, as a sibling to adjecent elements',
+      name: 'SVG context, as a sibling to adjacent elements',
       isHTML: false,
       before: '<svg><text><text>before</text>',
       after: '<text>after</text></text></svg>',

--- a/packages/@glimmer/compiler/lib/wire-encoding.md
+++ b/packages/@glimmer/compiler/lib/wire-encoding.md
@@ -666,5 +666,5 @@ ed the button "
 0C08q times"HGb
 utton"Qonclick"
 UCaction"Cincre
-ment"H8qClick"I
+meant"H8qClick"I
 ```

--- a/packages/@glimmer/component/src/-private/component.ts
+++ b/packages/@glimmer/component/src/-private/component.ts
@@ -20,7 +20,7 @@ interface ArgsSetMap extends WeakMap<Args<unknown>, boolean> {
   has<S>(key: Args<S>): boolean;
 }
 
-// SAFETY: this only holds because we *only* acces this when `DEBUG` is `true`.
+// SAFETY: this only holds because we *only* access this when `DEBUG` is `true`.
 // There is not a great way to connect that data in TS at present.
 export let ARGS_SET: ArgsSetMap;
 

--- a/packages/@glimmer/component/src/index.ts
+++ b/packages/@glimmer/component/src/index.ts
@@ -72,7 +72,7 @@ import { setOwner, type default as Owner } from '@ember/owner';
 
   ## File System Nesting
 
-  Components can be nested inside sub-folders for logical groupping. For
+  Components can be nested inside sub-folders for logical grouping. For
   example, if we placed our template in
   `app/templates/components/person/short-profile.hbs`, we can invoke it as
   `<Person::ShortProfile />`:

--- a/packages/@glimmer/interfaces/lib/managers/internal/modifier.d.ts
+++ b/packages/@glimmer/interfaces/lib/managers/internal/modifier.d.ts
@@ -18,7 +18,7 @@ export interface InternalModifierManager<
     args: CapturedArguments
   ): TModifierInstanceState;
 
-  // Convert the opaque modifier into a `RevisionTag` that determins when
+  // Convert the opaque modifier into a `RevisionTag` that determines when
   // the modifier's update hooks need to be called (if at all).
   getTag(modifier: TModifierInstanceState): UpdatableTag | null;
 

--- a/packages/@glimmer/interfaces/lib/runtime/vm-state.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/vm-state.d.ts
@@ -17,7 +17,7 @@ export type SyscallRegisters = [
  * register numbers are different.
  */
 
-// $0 or $pc (program counter): pointer into `program` for the next insturction; -1 means exit
+// $0 or $pc (program counter): pointer into `program` for the next instruction; -1 means exit
 export type $pc = 0;
 declare const $pc: $pc;
 // $1 or $ra (return address): pointer into `program` for the return

--- a/packages/@glimmer/opcode-compiler/lib/TODO.md
+++ b/packages/@glimmer/opcode-compiler/lib/TODO.md
@@ -11,7 +11,7 @@
 - [x] do we really need the Locator generic?
 
 - [x] Remove stuff from Compiler
-- [x] Remove compiler from CompileTime
+- [x] Remove compiler from compile time
 - [x] Reorient CompilableTemplate around Context
 - [x] Remove OldTemplateCompilationContext
 - [ ] Figure out how to correctly cache CompilableTemplates

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/conditional.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/conditional.ts
@@ -214,7 +214,7 @@ export function ReplayableIf(
     op(VM_JUMP_OP, labelOperand('FINALLY'));
     op(HighLevelBuilderOpcodes.Label, 'ELSE');
 
-    // If the conditional is false, and code associatied ith the
+    // If the conditional is false, and code associated ith the
     // false branch was provided, execute it. If there was no code
     // associated with the false branch, jumping to the else statement
     // has no other behavior.

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -139,11 +139,11 @@ function identityForNthOccurence(value: unknown, count: number) {
  * ```
  *
  * In general, we want to treat these items as _unique within the list_. To do
- * this, we track the occurences of every item as we iterate the list, and when
+ * this, we track the occurrences of every item as we iterate the list, and when
  * an item occurs more than once, we generate a new unique key just for that
- * item, and that occurence within the list. The next time we iterate the list,
+ * item, and that occurrence within the list. The next time we iterate the list,
  * and encounter an item for the nth time, we can get the _same_ key, and let
- * Glimmer know that it should reuse the DOM for the previous nth occurence.
+ * Glimmer know that it should reuse the DOM for the previous nth occurrence.
  */
 function uniqueKeyFor(keyFor: KeyFor) {
   let seen = new WeakMapWithPrimitives<number>();

--- a/packages/@glimmer/syntax/test/generation/print-test.ts
+++ b/packages/@glimmer/syntax/test/generation/print-test.ts
@@ -11,7 +11,7 @@ let templates = [
   '<h1 class={{if foo "foo" "bar"}}>Test</h1>',
   '<h1 class={{color}}>Test</h1>',
   '<h1 class="{{if active "active" "inactive"}} foo">Test</h1>',
-  '<p {{action "activate"}} {{someting foo="bar"}}>Test</p>',
+  '<p {{action "activate"}} {{something foo="bar"}}>Test</p>',
   '<p>{{my-component submit=(action (mut model.name) (full-name model.firstName "Smith"))}}</p>',
   '<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>',
   '{{#if foo}}<p>{{foo}}</p>{{/if}}',

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -179,7 +179,7 @@ test('Handlebars embedded in an attribute (unquoted)', () => {
   );
 });
 
-test('Handlebars embedded in an attribute of a self-closing tag (unqouted)', () => {
+test('Handlebars embedded in an attribute of a self-closing tag (unquoted)', () => {
   let t = '<input value={{foo}}/>';
 
   let el = element('input/', ['attrs', ['value', b.mustache(b.path('foo'))]]);

--- a/packages/@glimmer/syntax/test/plugin-node-test.ts
+++ b/packages/@glimmer/syntax/test/plugin-node-test.ts
@@ -180,7 +180,7 @@ test('AST plugins can access meta from environment', (assert) => {
           assert.strictEqual(
             moduleName,
             'template/module/name',
-            'module was passed in the meta enviornment property'
+            'module was passed in the meta environment property'
           );
         },
       },

--- a/packages/@glimmer/validator/lib/collections/weak-map.ts
+++ b/packages/@glimmer/validator/lib/collections/weak-map.ts
@@ -31,7 +31,7 @@ class TrackedWeakMap<K extends WeakKey = object, V = unknown> implements WeakMap
     options: ReactiveOptions<V>
   ) {
     /**
-     * SAFETY: note that wehn passing in an existing weak map, we can't
+     * SAFETY: note that when passing in an existing weak map, we can't
      *         clone it as it is not iterable and not a supported type of structuredClone
      */
     this.#vals = existing instanceof WeakMap ? existing : new WeakMap<K, V>(existing);

--- a/packages/@glimmer/vm/lib/registers.ts
+++ b/packages/@glimmer/vm/lib/registers.ts
@@ -5,7 +5,7 @@
  * register numbers are different.
  */
 
-// $0 or $pc (program counter): pointer into `program` for the next insturction; -1 means exit
+// $0 or $pc (program counter): pointer into `program` for the next instruction; -1 means exit
 export type $pc = 0;
 export const $pc: $pc = 0;
 // $1 or $ra (return address): pointer into `program` for the return

--- a/packages/@handlebars/parser/spec/visitor.js
+++ b/packages/@handlebars/parser/spec/visitor.js
@@ -62,7 +62,7 @@ describe('Visitor', function () {
         visitor.accept(ast);
         equals(print(ast), '{{ p%foo HASH{foo=n%42} }}\n');
       });
-      it('should treat undefined resonse as identity', function () {
+      it('should treat undefined response as identity', function () {
         let visitor = new Visitor();
         visitor.mutating = true;
 
@@ -130,7 +130,7 @@ describe('Visitor', function () {
         visitor.accept(ast);
         equals(print(ast), '{{ p%foo [n%42] }}\n');
       });
-      it('should treat undefined resonse as identity', function () {
+      it('should treat undefined response as identity', function () {
         let visitor = new Visitor();
         visitor.mutating = true;
 

--- a/packages/ember-template-compiler/minimal.ts
+++ b/packages/ember-template-compiler/minimal.ts
@@ -5,7 +5,7 @@
 // This module exists so that ember-source can build itself -- the
 // ember-template-compiler.js bundle it an output of the build, but the build
 // needs to compile templates. Unlike the full ./index.ts, this module can be
-// directly evaluted in node because it doesn't try to pull in the whole kitchen
+// directly evaluated in node because it doesn't try to pull in the whole kitchen
 // sink.
 export { default as precompile } from './lib/system/precompile';
 export { buildCompileOptions as _buildCompileOptions } from './lib/system/compile-options';

--- a/packages/internal-test-helpers/lib/get-all-property-names.ts
+++ b/packages/internal-test-helpers/lib/get-all-property-names.ts
@@ -1,4 +1,4 @@
-// The `& string` here is to enforce that the propreties are strings since this is expected
+// The `& string` here is to enforce that the properties are strings since this is expected
 // to be the case elsewhere.
 export default function getAllPropertyNames<T>(Klass: { prototype: T }): Set<keyof T & string> {
   let proto = Klass.prototype;

--- a/packages/internal-test-helpers/lib/test-cases/test-resolver-application.ts
+++ b/packages/internal-test-helpers/lib/test-cases/test-resolver-application.ts
@@ -47,7 +47,7 @@ export default abstract class TestResolverApplicationTestCase extends AbstractAp
       // But there are a lot of places where it was expected to have multiple templates associated
       // with the same component class (due to the older resolveable templates)
       //
-      // We'll want to clean thsi up over time, and probably phase out `addComponent` entirely,
+      // We'll want to clean this up over time, and probably phase out `addComponent` entirely,
       // and expclusively use `add` w/ `defineComponent`
       if (ComponentClass === Component) {
         ComponentClass = class extends Component {};

--- a/packages/internal-test-helpers/lib/test-context.ts
+++ b/packages/internal-test-helpers/lib/test-context.ts
@@ -14,7 +14,7 @@ export function setContext(context: BaseContext): void {
 }
 
 /**
- * Retrive the "global testing context" as stored by `setContext`.
+ * Retrieve the "global testing context" as stored by `setContext`.
  *
  * @returns {Object} the previously stored testing context
  */

--- a/packages/router_js/lib/route-info.ts
+++ b/packages/router_js/lib/route-info.ts
@@ -397,7 +397,7 @@ export default class InternalRouteInfo<R extends Route> {
       // Ignore the fulfilled value returned from afterModel.
       // Return the value stashed in resolvedModels, which
       // might have been swapped out in afterModel.
-      // SAFTEY: We expect this to be of type T, though typing it as such is challenging.
+      // SAFETY: We expect this to be of type T, though typing it as such is challenging.
       return transition.resolvedModels[name]! as unknown as ModelFor<R>;
     });
   }

--- a/packages/router_js/lib/transition.ts
+++ b/packages/router_js/lib/transition.ts
@@ -266,7 +266,7 @@ export default class Transition<R extends Route> implements Partial<Promise<R>> 
     @public
    */
   finally<T>(callback?: T | undefined, label?: string) {
-    // @ts-expect-error @types/rsvp doesn't have the correct signiture for RSVP.Promise.finally
+    // @ts-expect-error @types/rsvp doesn't have the correct signature for RSVP.Promise.finally
     return this.promise!.finally(callback, label);
   }
 


### PR DESCRIPTION
This PR fixes a few minor typos in code comments and Markdown documentation across the codebase.