### PR TITLE
Update error patterns in weak map and weak set tests

### DIFF
--- a/packages/@glimmer/validator/test/collections/weak-map-test.ts
+++ b/packages/@glimmer/validator/test/collections/weak-map-test.ts
@@ -19,7 +19,7 @@ module('@glimmer/validator: trackedWeakMap()', function () {
   test('does not work with built-ins', (assert) => {
     const map = trackedWeakMap();
     const pattern =
-      /(Invalid value used as weak map key)|(WeakMap key must be an object)|(Attempted to set a non-object key in a WeakMap)/u;
+      /(Invalid value used as weak map key)|(WeakMap key must be an object)|(Attempted to set a non-object key in a WeakMap)|(must be an object or an unregistered symbol)/u;
 
     assert.throws(
       // @ts-expect-error -- point is testing constructor error

--- a/packages/@glimmer/validator/test/collections/weak-set-test.ts
+++ b/packages/@glimmer/validator/test/collections/weak-set-test.ts
@@ -22,7 +22,7 @@ module('@glimmer/validator: trackedWeakSet()', function () {
   test('does not work with built-ins', (assert) => {
     const set = trackedWeakSet();
     const pattern =
-      /(Invalid value used in weak set)|(WeakSet value must be an object)|(Attempted to add a non-object value to a WeakSet)/u;
+      /(Invalid value used in weak set)|(WeakSet value must be an object)|(Attempted to add a non-object value to a WeakSet)|(must be an object or an unregistered symbol)/u;
 
     // @ts-expect-error -- point is testing constructor error
     assert.throws(() => set.add('aoeu'), pattern);


### PR DESCRIPTION
These two tests failed when run in Firefox as the error message returned differs.