### PR TITLE
Remove unused DEFAULT_HELPER_MANAGER feature flag

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -19,10 +19,6 @@ import toBool from './utils/to-bool';
 // Setup global context
 
 setGlobalContext({
-  FEATURES: {
-    DEFAULT_HELPER_MANAGER: true,
-  },
-
   scheduleRevalidate() {
     _backburner.ensureInstance();
   },

--- a/packages/@glimmer/global-context/index.ts
+++ b/packages/@glimmer/global-context/index.ts
@@ -165,9 +165,6 @@ export interface GlobalContext {
       id: string;
     }
   ) => void;
-  FEATURES?: {
-    DEFAULT_HELPER_MANAGER?: boolean;
-  };
 }
 
 let globalContextWasSet = false;


### PR DESCRIPTION
## Summary
- Remove the `DEFAULT_HELPER_MANAGER` feature flag which was always set to `true` and never consumed by any code
- Remove the `FEATURES` property from the `GlobalContext` interface in `@glimmer/global-context`
- Remove the `FEATURES` initialization in `@ember/-internals/glimmer/lib/environment.ts`

The flag was defined on the `GlobalContext` interface and set during `setGlobalContext()`, but no code anywhere in the codebase ever read `FEATURES.DEFAULT_HELPER_MANAGER`. This is dead code.

## Test plan
- [x] `pnpm run lint` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)