### PR TITLE
address build-info crash on non-ember-source tags

### DIFF
--- a/broccoli/build-info.js
+++ b/broccoli/build-info.js
@@ -75,8 +75,8 @@ function buildGitInfo(root) {
 function buildFromParts(packageVersion, gitInfo) {
   let { tag, branch, sha } = gitInfo;
   let shortSha = sha.slice(0, 8);
-  if (tag) {
-    let tagVersion = parseTagVersion(tag);
+  let tagVersion = tag ? parseTagVersion(tag) : null;
+  if (tag && tagVersion) {
     return {
       tag,
       branch: null,
@@ -126,7 +126,8 @@ function readPackageVersion(root) {
  */
 function parseTagVersion(tag) {
   if (tag) {
-    return semver.parse(tag.replace(/-ember-source$/, '')).version;
+    let parsed = semver.parse(tag.replace(/-ember-source$/, ''));
+    return parsed ? parsed.version : null;
   }
 }
 

--- a/tests/node/build-info-test.js
+++ b/tests/node/build-info-test.js
@@ -62,10 +62,12 @@ QUnit.module('parseTagVersion', () => {
     });
   });
 
-  QUnit.test('parseTagVersion raises on non-semver tags', function (assert) {
-    assert.throws(() => {
-      parseTagVersion('some-non-version-tag');
-    });
+  QUnit.test('parseTagVersion returns null for non-semver tags', function (assert) {
+    assert.equal(parseTagVersion('some-non-version-tag'), null);
+  });
+
+  QUnit.test('parseTagVersion returns null for non-ember-source package tags', function (assert) {
+    assert.equal(parseTagVersion('v2.1.1-@glimmer/component'), null);
   });
 });
 
@@ -132,6 +134,27 @@ QUnit.module('buildFromParts', () => {
         tagVersion: '3.4.4-beta.2',
         version: '3.4.4-beta.2',
         isBuildForTag: true,
+      },
+    },
+    {
+      args: [
+        '3.4.4', // Non-ember-source tag (e.g. @glimmer/component) should be treated as channel build
+        {
+          sha: 'f572d396fae9206628714fb2ce00f72e94f2258f',
+          branch: 'main',
+          tag: 'v2.1.1-@glimmer/component',
+        },
+      ],
+      expected: {
+        tag: null,
+        branch: 'main',
+        sha: 'f572d396fae9206628714fb2ce00f72e94f2258f',
+        shortSha: 'f572d396',
+        channel: 'canary',
+        packageVersion: '3.4.4',
+        tagVersion: null,
+        version: '3.4.4-canary+f572d396',
+        isBuildForTag: false,
       },
     },
   ].forEach(({ args, expected }) => {


### PR DESCRIPTION
## Summary
- Fix `parseTagVersion` in `broccoli/build-info.js` to return `null` instead of crashing when the git tag isn't a valid ember-source version (e.g. `v2.1.1-@glimmer/component`)
- Update `buildFromParts` to fall through to the channel build path when `parseTagVersion` returns `null`, so non-ember-source tags are treated the same as untagged commits
- Add tests for the `@glimmer/component` tag pattern in both `parseTagVersion` and `buildFromParts`
- Copy the fixed `broccoli/build-info.js` into the perf benchmark's control clone so the CI doesn't fail due to the control checkout still having the buggy version from main

## Context
The "Perf script still works" CI job fails because `origin/main` now points at a commit tagged `v2.1.1-@glimmer/component`. The `git-repo-info` library returns this tag, and `parseTagVersion` crashes when `semver.parse()` returns `null` for it:

```
TypeError: Cannot read properties of null (reading 'version')
    at parseTagVersion (broccoli/build-info.js:129)
```

The perf CI clones origin/main into a control directory and runs `build-for-publishing.js` there, so even after fixing `broccoli/build-info.js` in this PR, the control clone still has the buggy version. The second commit fixes this chicken-and-egg problem by copying the fixed build-info.js into the control clone after checkout.

## Test plan
- [x] Existing `parseTagVersion` tests still pass
- [x] New test: `parseTagVersion` returns `null` for `v2.1.1-@glimmer/component`
- [x] New test: `parseTagVersion` returns `null` for arbitrary non-semver tags
- [x] New test: `buildFromParts` treats a non-ember-source tag as a channel build
- [x] ESLint passes on changed files
- [x] Perf CI should now pass since the control clone gets the fixed build-info.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)