### PR TITLE
RFC#562 - {{and}}, {{or}}, {{not}} as keywords

### DIFF
--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -10,6 +10,9 @@ import {
   concat as glimmerConcat,
   get as glimmerGet,
   fn as glimmerFn,
+  and as glimmerAnd,
+  or as glimmerOr,
+  not as glimmerNot,
 } from '@glimmer/runtime';
 import { element as glimmerElement, uniqueId as glimmerUniqueId } from '@ember/-internals/glimmer';
 import { type Opaque } from '@ember/-internals/utility-types';
@@ -510,5 +513,76 @@ export interface ElementHelper extends Opaque<'helper:element'> {}
  */
 export const uniqueId = glimmerUniqueId;
 export type UniqueIdHelper = typeof uniqueId;
+
+/**
+ * The `{{and}}` helper evaluates arguments left to right, returning the first
+ * falsy value (using Handlebars truthiness) or the right-most value if all
+ * are truthy. Requires at least two arguments.
+ *
+ * ```js
+ * import { and } from '@ember/helper';
+ *
+ * <template>
+ *   {{if (and @isAdmin @isLoggedIn) "Welcome, admin!" "Access denied"}}
+ * </template>
+ * ```
+ *
+ * In strict-mode (gjs/gts) templates, `and` is available as a keyword and
+ * does not need to be imported.
+ *
+ * @method and
+ * @param {unknown} args Two or more values to evaluate
+ * @return {unknown} The first falsy value or the last value
+ * @public
+ */
+export const and = glimmerAnd as unknown as AndHelper;
+export interface AndHelper extends Opaque<'helper:and'> {}
+
+/**
+ * The `{{or}}` helper evaluates arguments left to right, returning the first
+ * truthy value (using Handlebars truthiness) or the right-most value if all
+ * are falsy. Requires at least two arguments.
+ *
+ * ```js
+ * import { or } from '@ember/helper';
+ *
+ * <template>
+ *   {{if (or @hasAccess @isAdmin) "Welcome!" "No access"}}
+ * </template>
+ * ```
+ *
+ * In strict-mode (gjs/gts) templates, `or` is available as a keyword and
+ * does not need to be imported.
+ *
+ * @method or
+ * @param {unknown} args Two or more values to evaluate
+ * @return {unknown} The first truthy value or the last value
+ * @public
+ */
+export const or = glimmerOr as unknown as OrHelper;
+export interface OrHelper extends Opaque<'helper:or'> {}
+
+/**
+ * The `{{not}}` helper returns the logical negation of its argument using
+ * Handlebars truthiness. Takes exactly one argument.
+ *
+ * ```js
+ * import { not } from '@ember/helper';
+ *
+ * <template>
+ *   {{if (not @isDisabled) "Enabled" "Disabled"}}
+ * </template>
+ * ```
+ *
+ * In strict-mode (gjs/gts) templates, `not` is available as a keyword and
+ * does not need to be imported.
+ *
+ * @method not
+ * @param {unknown} value The value to negate
+ * @return {boolean}
+ * @public
+ */
+export const not = glimmerNot as unknown as NotHelper;
+export interface NotHelper extends Opaque<'helper:not'> {}
 
 /* eslint-enable @typescript-eslint/no-empty-object-type */

--- a/packages/@ember/template-compiler/lib/compile-options.ts
+++ b/packages/@ember/template-compiler/lib/compile-options.ts
@@ -1,4 +1,4 @@
-import { fn } from '@ember/helper';
+import { and, fn, not, or } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { assert } from '@ember/debug';
 import {
@@ -25,8 +25,11 @@ function malformedComponentLookup(string: string) {
 export const RUNTIME_KEYWORDS_NAME = '__ember_keywords__';
 
 export const keywords: Record<string, unknown> = {
+  and,
   fn,
+  not,
   on,
+  or,
 };
 
 function buildCompileOptions(_options: EmberPrecompileOptions): EmberPrecompileOptions {

--- a/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
+++ b/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
@@ -30,10 +30,28 @@ export default function autoImportBuiltins(env: EmberASTPluginEnvironment): ASTP
         if (isFn(node, hasLocal)) {
           rewriteKeyword(env, node, 'fn', '@ember/helper');
         }
+        if (isAnd(node, hasLocal)) {
+          rewriteKeyword(env, node, 'and', '@ember/helper');
+        }
+        if (isOr(node, hasLocal)) {
+          rewriteKeyword(env, node, 'or', '@ember/helper');
+        }
+        if (isNot(node, hasLocal)) {
+          rewriteKeyword(env, node, 'not', '@ember/helper');
+        }
       },
       MustacheStatement(node: AST.MustacheStatement) {
         if (isFn(node, hasLocal)) {
           rewriteKeyword(env, node, 'fn', '@ember/helper');
+        }
+        if (isAnd(node, hasLocal)) {
+          rewriteKeyword(env, node, 'and', '@ember/helper');
+        }
+        if (isOr(node, hasLocal)) {
+          rewriteKeyword(env, node, 'or', '@ember/helper');
+        }
+        if (isNot(node, hasLocal)) {
+          rewriteKeyword(env, node, 'not', '@ember/helper');
         }
       },
     },
@@ -67,4 +85,25 @@ function isFn(
   hasLocal: (k: string) => boolean
 ): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
   return isPath(node.path) && node.path.original === 'fn' && !hasLocal('fn');
+}
+
+function isAnd(
+  node: AST.MustacheStatement | AST.SubExpression,
+  hasLocal: (k: string) => boolean
+): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
+  return isPath(node.path) && node.path.original === 'and' && !hasLocal('and');
+}
+
+function isOr(
+  node: AST.MustacheStatement | AST.SubExpression,
+  hasLocal: (k: string) => boolean
+): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
+  return isPath(node.path) && node.path.original === 'or' && !hasLocal('or');
+}
+
+function isNot(
+  node: AST.MustacheStatement | AST.SubExpression,
+  hasLocal: (k: string) => boolean
+): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
+  return isPath(node.path) && node.path.original === 'not' && !hasLocal('not');
 }

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/and-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/and-runtime-test.ts
@@ -1,0 +1,54 @@
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+
+class KeywordAndRuntime extends RenderTest {
+  static suiteName = 'keyword helper: and (runtime)';
+
+  @test
+  'explicit scope without import'() {
+    const compiled = template('{{if (and a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ a: true, b: true }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'implicit scope (eval)'() {
+    let a = true;
+    let b = 'hello';
+
+    hide(a);
+    hide(b);
+
+    const compiled = template('{{if (and a b) "yes" "no"}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'returns falsy when one arg is falsy'() {
+    const compiled = template('{{if (and a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ a: true, b: 0 }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('no');
+  }
+}
+
+jitSuite(KeywordAndRuntime);
+
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/and-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/and-test.ts
@@ -1,0 +1,76 @@
+import { DEBUG } from '@glimmer/env';
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler';
+import { and } from '@ember/helper';
+
+class KeywordAnd extends RenderTest {
+  static suiteName = 'keyword helper: and';
+
+  @test
+  'returns right-most value when all are truthy'() {
+    let a = 1;
+    let b = 'hello';
+    const compiled = template('{{and a b}}', {
+      strictMode: true,
+      scope: () => ({ and, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('hello');
+  }
+
+  @test
+  'returns first falsy value'() {
+    let a = 0;
+    let b = 'hello';
+    const compiled = template('{{and a b}}', {
+      strictMode: true,
+      scope: () => ({ and, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('0');
+  }
+
+  @test
+  'works as a SubExpression with if'() {
+    let a = true;
+    let b = true;
+    const compiled = template('{{if (and a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ and, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'treats empty array as falsy'() {
+    let a = true;
+    let b: unknown[] = [];
+    const compiled = template('{{if (and a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ and, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('no');
+  }
+
+  @test({ skip: !DEBUG })
+  'throws if called with less than two arguments'(assert: Assert) {
+    let a = true;
+    const compiled = template('{{and a}}', {
+      strictMode: true,
+      scope: () => ({ and, a }),
+    });
+
+    assert.throws(() => {
+      this.renderComponent(compiled);
+    }, /`and` expects at least two arguments/);
+  }
+}
+
+jitSuite(KeywordAnd);

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/not-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/not-runtime-test.ts
@@ -1,0 +1,52 @@
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+
+class KeywordNotRuntime extends RenderTest {
+  static suiteName = 'keyword helper: not (runtime)';
+
+  @test
+  'explicit scope without import'() {
+    const compiled = template('{{if (not a) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ a: false }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'implicit scope (eval)'() {
+    let a = false;
+
+    hide(a);
+
+    const compiled = template('{{if (not a) "yes" "no"}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'returns no for truthy'() {
+    const compiled = template('{{if (not a) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ a: 'hello' }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('no');
+  }
+}
+
+jitSuite(KeywordNotRuntime);
+
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/not-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/not-test.ts
@@ -1,0 +1,61 @@
+import { DEBUG } from '@glimmer/env';
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler';
+import { not } from '@ember/helper';
+
+class KeywordNot extends RenderTest {
+  static suiteName = 'keyword helper: not';
+
+  @test
+  'returns true for falsy value'() {
+    let a = false;
+    const compiled = template('{{if (not a) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ not, a }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'returns false for truthy value'() {
+    let a = true;
+    const compiled = template('{{if (not a) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ not, a }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('no');
+  }
+
+  @test
+  'works with MustacheStatement'() {
+    let a = false;
+    const compiled = template('{{not a}}', {
+      strictMode: true,
+      scope: () => ({ not, a }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('true');
+  }
+
+  @test({ skip: !DEBUG })
+  'throws if called with more than one argument'(assert: Assert) {
+    let a = true;
+    let b = false;
+    const compiled = template('{{not a b}}', {
+      strictMode: true,
+      scope: () => ({ not, a, b }),
+    });
+
+    assert.throws(() => {
+      this.renderComponent(compiled);
+    }, /`not` expects exactly one argument/);
+  }
+}
+
+jitSuite(KeywordNot);

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/or-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/or-runtime-test.ts
@@ -1,0 +1,54 @@
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+
+class KeywordOrRuntime extends RenderTest {
+  static suiteName = 'keyword helper: or (runtime)';
+
+  @test
+  'explicit scope without import'() {
+    const compiled = template('{{if (or a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ a: false, b: true }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'implicit scope (eval)'() {
+    let a = false;
+    let b = 'hello';
+
+    hide(a);
+    hide(b);
+
+    const compiled = template('{{if (or a b) "yes" "no"}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'returns no when all falsy'() {
+    const compiled = template('{{if (or a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ a: false, b: 0 }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('no');
+  }
+}
+
+jitSuite(KeywordOrRuntime);
+
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/or-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/or-test.ts
@@ -1,0 +1,76 @@
+import { DEBUG } from '@glimmer/env';
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler';
+import { or } from '@ember/helper';
+
+class KeywordOr extends RenderTest {
+  static suiteName = 'keyword helper: or';
+
+  @test
+  'returns first truthy value'() {
+    let a = false;
+    let b = 'hello';
+    const compiled = template('{{or a b}}', {
+      strictMode: true,
+      scope: () => ({ or, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('hello');
+  }
+
+  @test
+  'returns right-most value when all are falsy'() {
+    let a = 0;
+    let b = '';
+    const compiled = template('{{or a b}}', {
+      strictMode: true,
+      scope: () => ({ or, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('');
+  }
+
+  @test
+  'works as a SubExpression with if'() {
+    let a = false;
+    let b = true;
+    const compiled = template('{{if (or a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ or, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('yes');
+  }
+
+  @test
+  'treats empty array as falsy'() {
+    let a: unknown[] = [];
+    let b = false;
+    const compiled = template('{{if (or a b) "yes" "no"}}', {
+      strictMode: true,
+      scope: () => ({ or, a, b }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('no');
+  }
+
+  @test({ skip: !DEBUG })
+  'throws if called with less than two arguments'(assert: Assert) {
+    let a = true;
+    const compiled = template('{{or a}}', {
+      strictMode: true,
+      scope: () => ({ or, a }),
+    });
+
+    assert.throws(() => {
+      this.renderComponent(compiled);
+    }, /`or` expects at least two arguments/);
+  }
+}
+
+jitSuite(KeywordOr);

--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -31,12 +31,15 @@ export {
   inTransaction,
   runtimeOptions,
 } from './lib/environment';
+export { and } from './lib/helpers/and';
 export { array } from './lib/helpers/array';
 export { concat } from './lib/helpers/concat';
 export { fn } from './lib/helpers/fn';
 export { get } from './lib/helpers/get';
 export { hash } from './lib/helpers/hash';
 export { invokeHelper } from './lib/helpers/invoke';
+export { not } from './lib/helpers/not';
+export { or } from './lib/helpers/or';
 export { on } from './lib/modifiers/on';
 export { renderComponent, renderMain, renderSync } from './lib/render';
 export { DynamicScopeImpl, ScopeImpl } from './lib/scope';

--- a/packages/@glimmer/runtime/lib/helpers/and.ts
+++ b/packages/@glimmer/runtime/lib/helpers/and.ts
@@ -1,0 +1,13 @@
+import { DEBUG } from '@glimmer/env';
+import { toBool } from '@glimmer/global-context';
+
+export const and = (...args: unknown[]) => {
+  if (DEBUG && args.length < 2) {
+    throw new Error(`\`and\` expects at least two arguments, but received ${args.length}.`);
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    if (!toBool(args[i])) return args[i];
+  }
+  return args[args.length - 1];
+};

--- a/packages/@glimmer/runtime/lib/helpers/not.ts
+++ b/packages/@glimmer/runtime/lib/helpers/not.ts
@@ -1,0 +1,10 @@
+import { DEBUG } from '@glimmer/env';
+import { toBool } from '@glimmer/global-context';
+
+export const not = (...args: unknown[]) => {
+  if (DEBUG && args.length !== 1) {
+    throw new Error(`\`not\` expects exactly one argument, but received ${args.length}.`);
+  }
+
+  return !toBool(args[0]);
+};

--- a/packages/@glimmer/runtime/lib/helpers/or.ts
+++ b/packages/@glimmer/runtime/lib/helpers/or.ts
@@ -1,0 +1,13 @@
+import { DEBUG } from '@glimmer/env';
+import { toBool } from '@glimmer/global-context';
+
+export const or = (...args: unknown[]) => {
+  if (DEBUG && args.length < 2) {
+    throw new Error(`\`or\` expects at least two arguments, but received ${args.length}.`);
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    if (toBool(args[i])) return args[i];
+  }
+  return args[args.length - 1];
+};


### PR DESCRIPTION
## Summary

Implements [RFC #562](https://github.com/emberjs/rfcs/blob/master/text/0562-add-logical-operators.md) — adds `and`, `or`, `not` as new helpers and strict-mode keywords.

- Implements three logical helpers as plain functions in `@glimmer/runtime`
- Uses `toBool` from `@glimmer/global-context` for **Handlebars truthiness** (empty arrays are falsy)
- `and` returns the first falsy value or the right-most value if all are truthy
- `or` returns the first truthy value or the right-most value if all are falsy
- `not` returns the boolean negation of its argument
- Re-exports from `@ember/helper` with YUIDoc and Opaque type interfaces
- Registers as keywords in the template compiler (strict-mode only, not available in loose mode)
- `and`/`or` throw in DEBUG mode if called with fewer than two arguments
- `not` throws in DEBUG mode if called with more than one argument

### New files
- `packages/@glimmer/runtime/lib/helpers/{and,or,not}.ts` — helper implementations
- `packages/@glimmer-workspace/integration-tests/test/keywords/{and,or,not}-test.ts` — tests with explicit scope
- `packages/@glimmer-workspace/integration-tests/test/keywords/{and,or,not}-runtime-test.ts` — runtime keyword tests

### Modified files
- `packages/@glimmer/runtime/index.ts` — exports
- `packages/@ember/helper/index.ts` — re-exports with docs
- `packages/@ember/template-compiler/lib/compile-options.ts` — keyword registration
- `packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts` — AST rewriting

## Test plan
- [x] `and`: returns right-most truthy, first falsy, empty array as falsy
- [x] `or`: returns first truthy, right-most falsy, empty array as falsy
- [x] `not`: negates truthy/falsy, works as MustacheStatement
- [x] Runtime keyword tests (explicit scope, eval)
- [x] DEBUG arity error tests for all three
- [x] Uses Handlebars truthiness (empty arrays are falsy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)