### PR TITLE
add mitata harness for precompile (parse/normalize/precompile)

### DIFF
--- a/bin/precompile.bench.mjs
+++ b/bin/precompile.bench.mjs
@@ -1,0 +1,84 @@
+/**
+ * Mitata benchmark for `@glimmer/syntax` parse (`preprocess`), normalize
+ * (ASTv1 → ASTv2 — where the loc-conversion hot path lives), and full
+ * `precompile()` (via `ember-template-compiler`, which inlines
+ * `@glimmer/compiler`).
+ *
+ * Run:
+ *   pnpm build     # produces the dist artifacts this bench imports
+ *   pnpm bench:precompile
+ *
+ * To compare branches, check out each branch, build, run the bench, and diff
+ * the ms/iter numbers.
+ *
+ * Sizes:
+ *   small  — ~1.5k chars (route-template fragment)
+ *   medium — small × 3   (~4.5k chars)
+ *   large  — small × 22  (~33k chars, scale of the largest real route
+ *                         templates, e.g. Discourse's admin-user/index.gjs)
+ */
+
+import { bench, do_not_optimize as doNotOptimize, run } from 'mitata';
+
+/* eslint n/no-missing-import: "off" -- dist/ is built by `pnpm build`; may not exist at lint time */
+import { normalize, preprocess, src } from '../packages/@glimmer/syntax/dist/es/index.js';
+import { precompile } from '../dist/prod/packages/ember-template-compiler/index.js';
+
+const SMALL = `<div class='user-profile {{if this.isPremium "premium"}}'>
+  <header class='profile-header'>
+    <img src={{this.avatarUrl}} alt={{this.username}} class='avatar' />
+    <h2>{{this.displayName}}</h2>
+    <p class='bio'>{{this.bio}}</p>
+    {{#if this.isOwnProfile}}
+      <button {{on 'click' this.editProfile}}>Edit Profile</button>
+    {{/if}}
+  </header>
+  <nav class='profile-tabs'>
+    {{#each this.tabs as |tab|}}
+      <button
+        class='tab {{if (eq tab.id this.activeTab) "active"}}'
+        {{on 'click' (fn this.setTab tab.id)}}
+      >
+        {{tab.label}}{{#if tab.count}}<span class='count'>{{tab.count}}</span>{{/if}}
+      </button>
+    {{/each}}
+  </nav>
+  <section class='profile-content'>
+    {{#if (eq this.activeTab 'posts')}}
+      {{#each this.posts as |post|}}
+        <article class='post-card'>
+          <h3>{{post.title}}</h3><p>{{post.excerpt}}</p>
+          <footer><time>{{post.createdAt}}</time><span>{{post.views}} views</span></footer>
+        </article>
+      {{else}}
+        <p class='empty-state'>No posts yet.</p>
+      {{/each}}
+    {{else if (eq this.activeTab 'followers')}}
+      {{#each this.followers as |follower|}}
+        <div class='follower-card'>
+          <img src={{follower.avatar}} alt={{follower.name}} />
+          <span>{{follower.name}}</span>
+          <button {{on 'click' (fn this.followUser follower.id)}}>
+            {{if follower.isFollowing 'Unfollow' 'Follow'}}
+          </button>
+        </div>
+      {{/each}}
+    {{/if}}
+  </section>
+</div>
+`;
+
+const FIXTURES = {
+  small: SMALL,
+  medium: SMALL.repeat(3),
+  large: SMALL.repeat(22),
+};
+
+for (const [size, source] of Object.entries(FIXTURES)) {
+  const chars = source.length;
+  bench(`parse      ${size} (${chars}c)`, () => doNotOptimize(preprocess(source)));
+  bench(`normalize  ${size} (${chars}c)`, () => doNotOptimize(normalize(new src.Source(source))));
+  bench(`precompile ${size} (${chars}c)`, () => doNotOptimize(precompile(source)));
+}
+
+await run({ throw: true });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "actions-up": "pnpm dlx actions-up",
     "bench": "node ./bin/benchmark.mjs",
+    "bench:precompile": "node --expose-gc bin/precompile.bench.mjs",
     "build:js": "rollup --config",
     "build:types": "node types/publish.mjs",
     "build": "npm-run-all build:*",
@@ -122,6 +123,7 @@
     "glob": "^8.0.3",
     "globals": "^16.0.0",
     "kill-port-process": "^3.2.1",
+    "mitata": "^1.0.34",
     "mocha": "^11.0.0",
     "npm-run-all2": "^8.0.0",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 2.1.0
       ember-cli-dependency-checker:
         specifier: ^3.3.1
-        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15))
       ember-cli-yuidoc:
         specifier: ^0.9.1
         version: 0.9.1
@@ -201,6 +201,9 @@ importers:
       kill-port-process:
         specifier: ^3.2.1
         version: 3.2.1
+      mitata:
+        specifier: ^1.0.34
+        version: 1.0.34
       mocha:
         specifier: ^11.0.0
         version: 11.7.5
@@ -2812,7 +2815,7 @@ importers:
         version: 3.0.0
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15))
       ember-cli-deprecation-workflow:
         specifier: ^3.4.0
         version: 3.4.0(ember-source@)
@@ -9626,6 +9629,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mitata@1.0.34:
+    resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
 
   mkdirp-infer-owner@2.0.0:
     resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
@@ -17455,7 +17461,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)):
+  ember-cli-dependency-checker@3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)):
     dependencies:
       chalk: 2.4.2
       ember-cli: 6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
@@ -20261,6 +20267,8 @@ snapshots:
   minipass@4.2.8: {}
 
   minipass@7.1.3: {}
+
+  mitata@1.0.34: {}
 
   mkdirp-infer-owner@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Split out from #21314 so reviewers can run the bench on `main` and on any perf branch independently.

Adds a reproducible mitata harness for the template compile pipeline:

- `parse` — `preprocess` (HBS → ASTv1, `@glimmer/syntax`)
- `normalize` — `normalize(new src.Source(src))` (ASTv1 → ASTv2, `@glimmer/syntax`, loc-conversion hot path)
- `precompile` — full `ember-template-compiler` entry (all phases + ember AST plugins)

Three fixture sizes — small (~1.5k chars), medium (small × 3), large (small × 22, ~33k chars, scale of the largest real route templates, e.g. Discourse's `admin-user/index.gjs`).

Run:

```
pnpm build
pnpm bench:precompile
```

To compare branches, check out each branch, build, run the bench, and diff the ms/iter numbers. Emits mitata's standard ms/iter + boxplot + summary output.

## Scope

- `bin/precompile.bench.mjs` — new bench harness (83 lines), sibling to existing `bin/benchmark.mjs`
- `package.json` — adds `bench:precompile` script and `mitata` devDependency
- `pnpm-lock.yaml` — lockfile update for mitata

No runtime or library code changes. Public-API-only — works on any branch.

## Test plan

- [ ] `pnpm install && pnpm build && pnpm bench:precompile` runs to completion on `main`
- [ ] Same on any feature branch under review — diff ms/iter to measure impact