### PR TITLE
Add tests for parser escape-sequence and error-case contract

### DIFF
--- a/packages/@glimmer/syntax/test/parser-error-test.ts
+++ b/packages/@glimmer/syntax/test/parser-error-test.ts
@@ -7,7 +7,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
   test('empty mustache {{}} is a parse error (invalid-3.hbs)', (assert) => {
     assert.throws(
       () => {
-        parse('<a>\n\n{{}}\n', { meta: { moduleName: 'test-module' } });
+        parse('<a>\n\n{{}}\n');
       },
       /./u,
       'empty mustache should throw a parse error'
@@ -18,7 +18,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
   test('unclosed mustache {{@name} is a parse error (invalid.hbs)', (assert) => {
     assert.throws(
       () => {
-        parse('<A >\nx, {{@name}\n', { meta: { moduleName: 'test-module' } });
+        parse('<A >\nx, {{@name}\n');
       },
       /./u,
       'unclosed mustache should throw a parse error'
@@ -29,7 +29,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
   test('bare tilde mustache {{~}} is a parse error (tilde-comments-1.hbs)', (assert) => {
     assert.throws(
       () => {
-        parse('{{~}}\n', { meta: { moduleName: 'test-module' } });
+        parse('{{~}}\n');
       },
       /./u,
       'bare tilde mustache should throw a parse error'
@@ -40,7 +40,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
   test('double tilde mustache {{~~}} is a parse error (tilde-comments-2.hbs)', (assert) => {
     assert.throws(
       () => {
-        parse('{{~~}}\n', { meta: { moduleName: 'test-module' } });
+        parse('{{~~}}\n');
       },
       /./u,
       'double tilde mustache should throw a parse error'
@@ -51,7 +51,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
   test('mustache with bare @ is a parse error ({{@}})', (assert) => {
     assert.throws(
       () => {
-        parse('{{@}}', { meta: { moduleName: 'test-module' } });
+        parse('{{@}}');
       },
       /./u,
       'mustache with bare @ should throw a parse error'
@@ -62,7 +62,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
   test('mustache with @<digit> is a parse error ({{@0}})', (assert) => {
     assert.throws(
       () => {
-        parse('{{@0}}', { meta: { moduleName: 'test-module' } });
+        parse('{{@0}}');
       },
       /./u,
       '@<digit> is not a valid identifier'
@@ -74,7 +74,7 @@ module('[glimmer-syntax] Parser - parse error regression fixtures', function () 
     for (const input of ['{{@@}}', '{{@=}}', '{{@!}}']) {
       assert.throws(
         () => {
-          parse(input, { meta: { moduleName: 'test-module' } });
+          parse(input);
         },
         /./u,
         `${input} should throw a parse error`

--- a/packages/@glimmer/syntax/test/parser-error-test.ts
+++ b/packages/@glimmer/syntax/test/parser-error-test.ts
@@ -1,0 +1,84 @@
+import { preprocess as parse } from '@glimmer/syntax';
+
+const { module, test } = QUnit;
+
+module('[glimmer-syntax] Parser - parse error regression fixtures', function () {
+  // prettier tests/format/handlebars/_errors_/invalid-3.hbs
+  test('empty mustache {{}} is a parse error (invalid-3.hbs)', (assert) => {
+    assert.throws(
+      () => {
+        parse('<a>\n\n{{}}\n', { meta: { moduleName: 'test-module' } });
+      },
+      /./u,
+      'empty mustache should throw a parse error'
+    );
+  });
+
+  // prettier tests/format/handlebars/_errors_/invalid.hbs
+  test('unclosed mustache {{@name} is a parse error (invalid.hbs)', (assert) => {
+    assert.throws(
+      () => {
+        parse('<A >\nx, {{@name}\n', { meta: { moduleName: 'test-module' } });
+      },
+      /./u,
+      'unclosed mustache should throw a parse error'
+    );
+  });
+
+  // prettier tests/format/handlebars/_errors_/tilde-comments-1.hbs
+  test('bare tilde mustache {{~}} is a parse error (tilde-comments-1.hbs)', (assert) => {
+    assert.throws(
+      () => {
+        parse('{{~}}\n', { meta: { moduleName: 'test-module' } });
+      },
+      /./u,
+      'bare tilde mustache should throw a parse error'
+    );
+  });
+
+  // prettier tests/format/handlebars/_errors_/tilde-comments-2.hbs
+  test('double tilde mustache {{~~}} is a parse error (tilde-comments-2.hbs)', (assert) => {
+    assert.throws(
+      () => {
+        parse('{{~~}}\n', { meta: { moduleName: 'test-module' } });
+      },
+      /./u,
+      'double tilde mustache should throw a parse error'
+    );
+  });
+
+  // assert-reserved-named-arguments-test: '@' alone is reserved / parse error
+  test('mustache with bare @ is a parse error ({{@}})', (assert) => {
+    assert.throws(
+      () => {
+        parse('{{@}}', { meta: { moduleName: 'test-module' } });
+      },
+      /./u,
+      'mustache with bare @ should throw a parse error'
+    );
+  });
+
+  // assert-reserved-named-arguments-test: '@0' is not a valid path
+  test('mustache with @<digit> is a parse error ({{@0}})', (assert) => {
+    assert.throws(
+      () => {
+        parse('{{@0}}', { meta: { moduleName: 'test-module' } });
+      },
+      /./u,
+      '@<digit> is not a valid identifier'
+    );
+  });
+
+  // assert-reserved-named-arguments-test: '@@', '@=', '@!' etc.
+  test('mustache with @<non-id-char> is a parse error ({{@@}}, {{@=}}, {{@!}})', (assert) => {
+    for (const input of ['{{@@}}', '{{@=}}', '{{@!}}']) {
+      assert.throws(
+        () => {
+          parse(input, { meta: { moduleName: 'test-module' } });
+        },
+        /./u,
+        `${input} should throw a parse error`
+      );
+    }
+  });
+});

--- a/packages/@glimmer/syntax/test/parser-escape-test.ts
+++ b/packages/@glimmer/syntax/test/parser-escape-test.ts
@@ -1,0 +1,130 @@
+import type { ASTv1 } from '@glimmer/syntax';
+import { builders as b, preprocess as parse } from '@glimmer/syntax';
+
+import { element } from './parser-node-test';
+import { astEqual } from './support';
+
+const { module, test } = QUnit;
+
+module('[glimmer-syntax] Parser - backslash escape sequences', function () {
+  // k=1: \{{ → escape. Backslash consumed, {{content}} becomes literal text.
+  test('\\{{ produces literal {{ in a TextNode', () => {
+    astEqual('\\{{foo}}', b.template([b.text('{{foo}}')]));
+  });
+
+  test('\\{{ merges escaped content with following text (emu-state behaviour)', () => {
+    astEqual('\\{{foo}} bar baz', b.template([b.text('{{foo}} bar baz')]));
+  });
+
+  test('text before \\{{ is emitted as a separate TextNode', () => {
+    astEqual('prefix\\{{foo}} suffix', b.template([b.text('prefix'), b.text('{{foo}} suffix')]));
+  });
+
+  test('\\{{ followed by a real mustache stops the emu-state merge', () => {
+    astEqual('\\{{foo}}{{bar}}', b.template([b.text('{{foo}}'), b.mustache(b.path('bar'))]));
+  });
+
+  test('emu-state merge stops at \\{{ (another escape)', () => {
+    astEqual(
+      '\\{{foo}} text \\{{bar}} done {{baz}}',
+      b.template([b.text('{{foo}} text '), b.text('{{bar}} done '), b.mustache(b.path('baz'))])
+    );
+  });
+
+  // k=2: \\{{ → real mustache, ONE literal backslash emitted as TextNode.
+  test('\\\\{{ emits one literal backslash and a real mustache', () => {
+    astEqual('\\\\{{foo}}', b.template([b.text('\\'), b.mustache(b.path('foo'))]));
+  });
+
+  // k=3: \\\{{ → real mustache, TWO literal backslashes emitted as TextNode.
+  test('\\\\\\{{ emits two literal backslashes and a real mustache', () => {
+    astEqual('\\\\\\{{foo}}', b.template([b.text('\\\\'), b.mustache(b.path('foo'))]));
+  });
+
+  test('full escaped.hbs sequence produces correct AST', () => {
+    const input =
+      'an escaped mustache:\n\\{{my-component}}\na non-escaped mustache:\n' +
+      '\\\\{{my-component}}\nanother non-escaped mustache:\n\\\\\\{{my-component}}\n';
+    astEqual(
+      input,
+      b.template([
+        b.text('an escaped mustache:\n'),
+        b.text('{{my-component}}\na non-escaped mustache:\n'),
+        b.text('\\'),
+        b.mustache(b.path('my-component')),
+        b.text('\nanother non-escaped mustache:\n\\\\'),
+        b.mustache(b.path('my-component')),
+        b.text('\n'),
+      ])
+    );
+  });
+
+  // Inside HTML elements
+
+  test('\\{{ in element text content produces literal {{', () => {
+    astEqual('<div>\\{{foo}}</div>', b.template([element('div', ['body', b.text('{{foo}}')])]));
+  });
+
+  test('\\\\{{ in element text content produces one backslash + real mustache', () => {
+    astEqual(
+      '<div>\\\\{{foo}}</div>',
+      b.template([element('div', ['body', b.text('\\'), b.mustache(b.path('foo'))])])
+    );
+  });
+
+  // Inside quoted attribute values
+
+  test('\\{{ inside a quoted attribute value emits {{ as literal text', (assert) => {
+    const ast = parse('<div title="foo \\{{"></div>');
+    const el = ast.body[0] as ASTv1.ElementNode;
+    const attr = el.attributes[0] as ASTv1.AttrNode;
+    const value = attr.value as ASTv1.TextNode;
+    assert.strictEqual(value.chars, 'foo {{');
+  });
+
+  // Backslash NOT before {{ passes through unchanged
+
+  test('plain backslash not before {{ is preserved in text', () => {
+    astEqual('foo\\bar', b.template([b.text('foo\\bar')]));
+  });
+
+  test('double backslash not before {{ is preserved in text', () => {
+    astEqual('foo\\\\bar', b.template([b.text('foo\\\\bar')]));
+  });
+
+  test('triple backslash not before {{ is preserved in text (backslashes.hbs)', () => {
+    astEqual('<p>\\\\\\</p>', b.template([element('p', ['body', b.text('\\\\\\')])]));
+  });
+
+  test('triple backslash + \\\\{{ in element text (backslashes.hbs)', () => {
+    astEqual(
+      '<p>\\\\\\ \\\\{{foo}}</p>',
+      b.template([element('p', ['body', b.text('\\\\\\ \\'), b.mustache(b.path('foo'))])])
+    );
+  });
+
+  test('plain backslash in attribute value is preserved (backslashes-in-attributes.hbs)', (assert) => {
+    const ast = parse('<p data-attr="backslash \\\\ in an attribute"></p>');
+    const attr = (ast.body[0] as ASTv1.ElementNode).attributes[0] as ASTv1.AttrNode;
+    assert.strictEqual((attr.value as ASTv1.TextNode).chars, 'backslash \\\\ in an attribute');
+  });
+
+  test('\\{{ in quoted class attribute value (mustache.hbs)', (assert) => {
+    const ast = parse('<div class=" bar \\{{"></div>');
+    const attr = (ast.body[0] as ASTv1.ElementNode).attributes[0] as ASTv1.AttrNode;
+    assert.strictEqual((attr.value as ASTv1.TextNode).chars, ' bar {{');
+  });
+
+  // Unclosed escape
+
+  test('\\{{ without closing }} emits {{ and following text up to end', () => {
+    astEqual('\\{{ unclosed', b.template([b.text('{{ unclosed')]));
+  });
+
+  test('\\{{ without closing }} stops at < (HTML element boundary)', () => {
+    astEqual(
+      '<div>\\{{ unclosed</div>',
+      b.template([element('div', ['body', b.text('{{ unclosed')])])
+    );
+  });
+});

--- a/packages/@glimmer/syntax/test/parser-whitespace-test.ts
+++ b/packages/@glimmer/syntax/test/parser-whitespace-test.ts
@@ -1,0 +1,98 @@
+import type { ASTv1 } from '@glimmer/syntax';
+import { preprocess as parse } from '@glimmer/syntax';
+
+const { module, test } = QUnit;
+
+module('[glimmer-syntax] Parser - whitespace control (tilde and standalone)', function () {
+  // Tilde (whitespace stripping)
+
+  test('tilde on mustache strips adjacent whitespace text nodes, which are then removed', (assert) => {
+    const ast = parse('  {{~comment~}} ');
+    assert.strictEqual(ast.body.length, 1, 'empty text nodes are removed after tilde stripping');
+    assert.strictEqual(ast.body[0]?.type, 'MustacheStatement');
+  });
+
+  test('tilde on block open/close strips program body content', (assert) => {
+    const ast = parse('x{{# comment~}} \nfoo\n {{~/comment}}y');
+    const block = ast.body[1] as ASTv1.BlockStatement;
+    assert.strictEqual((block.program.body[0] as ASTv1.TextNode).chars, 'foo');
+  });
+
+  // ignoreStandalone (parseWithoutProcessing equivalent)
+
+  test('ignoreStandalone: tilde still strips adjacent text nodes', (assert) => {
+    const ast = parse('  {{~comment~}} ', { parseOptions: { ignoreStandalone: true } });
+    assert.strictEqual(
+      ast.body.length,
+      1,
+      'tilde-stripped empty nodes are removed even without standalone detection'
+    );
+    assert.strictEqual(ast.body[0]?.type, 'MustacheStatement');
+  });
+
+  // Standalone block detection
+
+  test('standalone block: surrounding whitespace text nodes are removed after stripping', (assert) => {
+    const ast = parse(' {{#comment}} \nfoo\n {{/comment}} ');
+    assert.strictEqual(ast.body.length, 1, 'surrounding empty text nodes are removed');
+    const block = ast.body[0] as ASTv1.BlockStatement;
+    assert.strictEqual((block.program.body[0] as ASTv1.TextNode).chars, 'foo\n');
+  });
+
+  test('standalone block with else: surrounding nodes removed, inner content standalone-stripped', (assert) => {
+    const ast = parse(' {{#comment}} \nfoo\n {{else}} \n  bar \n  {{/comment}} ');
+    assert.strictEqual(ast.body.length, 1);
+    const block = ast.body[0] as ASTv1.BlockStatement;
+    assert.strictEqual((block.program.body[0] as ASTv1.TextNode).chars, 'foo\n');
+    assert.strictEqual(
+      ((block.inverse as ASTv1.Block).body[0] as ASTv1.TextNode).chars,
+      '  bar \n'
+    );
+  });
+
+  test('standalone block at start of line: program body strips leading newline', (assert) => {
+    const ast = parse('{{#comment}} \nfoo\n {{/comment}}');
+    const block = ast.body[0] as ASTv1.BlockStatement;
+    assert.strictEqual((block.program.body[0] as ASTv1.TextNode).chars, 'foo\n');
+  });
+
+  test('standalone block containing mustache: surrounding text is stripped and empty node removed', (assert) => {
+    const ast = parse('{{#comment}} \n{{foo}}\n {{/comment}}');
+    const block = ast.body[0] as ASTv1.BlockStatement;
+    assert.strictEqual(block.program.body.length, 2);
+    assert.strictEqual(block.program.body[0]?.type, 'MustacheStatement');
+    assert.strictEqual((block.program.body[1] as ASTv1.TextNode).chars, '\n');
+  });
+
+  test('non-standalone block (inline): whitespace is NOT stripped', (assert) => {
+    const ast = parse('{{#foo}} {{#comment}} \nfoo\n {{/comment}} {{/foo}}');
+    const outerBlock = ast.body[0] as ASTv1.BlockStatement;
+    const innerBlock = outerBlock.program.body[1] as ASTv1.BlockStatement;
+    assert.strictEqual(innerBlock.type, 'BlockStatement');
+    assert.strictEqual((innerBlock.program.body[0] as ASTv1.TextNode).chars, ' \nfoo\n ');
+  });
+
+  // Standalone comment detection
+
+  test('standalone comment: trailing whitespace node is removed after stripping', (assert) => {
+    const ast = parse('{{! comment }} ');
+    assert.strictEqual(ast.body.length, 1);
+    assert.strictEqual(ast.body[0]?.type, 'MustacheCommentStatement');
+  });
+
+  test('standalone comment: both surrounding text nodes are removed after stripping', (assert) => {
+    const ast = parse('  {{! comment }} ');
+    assert.strictEqual(ast.body.length, 1);
+    assert.strictEqual(ast.body[0]?.type, 'MustacheCommentStatement');
+  });
+
+  // ignoreStandalone: standalone detection is skipped
+
+  test('ignoreStandalone: standalone block is NOT stripped', (assert) => {
+    const ast = parse('{{#comment}} \nfoo\n {{/comment}}', {
+      parseOptions: { ignoreStandalone: true },
+    });
+    const block = ast.body[0] as ASTv1.BlockStatement;
+    assert.strictEqual((block.program.body[0] as ASTv1.TextNode).chars, ' \nfoo\n ');
+  });
+});


### PR DESCRIPTION
Adds regression tests for parser behaviors that downstream tools (prettier, ember-cli) rely on — escape sequences (`\{{`, `\\{{`, `\\\{{`), error cases (`{{}}`, `{{~}}`, `{{@}}`), whitespace control, and standalone stripping.

Found by hitting real prettier smoke-test failures while exploring the parser (index-based & single-pass index-based). No behavior change; tests pass against current Jison parser.

### Why upstream these if the prettier smoke test already catches them?

The prettier smoke test catches these — but only after cloning prettier, installing deps, and running jest (~2 min). These tests catch the same regressions in the normal qunit suite with specific AST assertions — faster feedback, clearer failure messages, and no external dependency.

### Prettier fixtures that caught the regressions

Error cases (different error message text):
- [`_errors_/invalid-3.hbs`](https://github.com/prettier/prettier/blob/main/tests/format/handlebars/_errors_/invalid-3.hbs) — `{{}}`
- [`_errors_/invalid.hbs`](https://github.com/prettier/prettier/blob/main/tests/format/handlebars/_errors_/invalid.hbs) — `{{@name}` (unclosed)
- [`_errors_/tilde-comments-1.hbs`](https://github.com/prettier/prettier/blob/main/tests/format/handlebars/_errors_/tilde-comments-1.hbs) — `{{~}}`
- [`_errors_/tilde-comments-2.hbs`](https://github.com/prettier/prettier/blob/main/tests/format/handlebars/_errors_/tilde-comments-2.hbs) — `{{~~}}`

Escape-handling (different AST shape → different formatted output):
- [`mustache-statement/escaped.hbs`](https://github.com/prettier/prettier/blob/main/tests/format/handlebars/mustache-statement/escaped.hbs) — `\{{`, `\\{{`, `\\\{{` sequences
- [snapshot](https://github.com/prettier/prettier/blob/main/tests/format/handlebars/mustache-statement/__snapshots__/format.test.js.snap) with expected output