### PR TITLE
Perf: Eliminate double normalization of params in callParts

### DIFF
--- a/packages/@glimmer/syntax/lib/v2/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2/normalize.ts
@@ -267,10 +267,7 @@ class ExpressionNormalizer {
     let namedLoc = this.block.loc(hash.loc);
     let argsLoc = SpanList.range([paramLoc, namedLoc]);
 
-    let positional = this.block.builder.positional(
-      params.map((p) => this.normalize(p, ASTv2.STRICT_RESOLUTION)),
-      paramLoc
-    );
+    let positional = this.block.builder.positional(paramList, paramLoc);
 
     let named = this.block.builder.named(
       hash.pairs.map((p) => this.namedArgument(p)),


### PR DESCRIPTION
Eliminates redundant work in `packages/@glimmer/syntax/lib/v2/normalize.ts`. Parser-independent — works with current Jison pipeline.

## The fix

`callParts()` was normalizing all parameters twice — once to calculate `paramLoc` via `SpanList.range()`, then again to build the positional args. The `paramList` from the first pass is already `ASTv2.ExpressionNode[]` and can be passed directly to `builder.positional()`.

The duplication dates back to the [original 2020 commit](https://github.com/emberjs/ember.js/blob/8e11b91167d55995c7400135460a0d4c8b2a4164/packages/%40glimmer/syntax/lib/v2-a/normalize.ts#L224-L235) where `paramList` was computed at line 228 but not reused at line 234, with an identical `.map(normalize)` call created instead.

**Why it's safe:** symbol allocations (`allocateFree`/`allocateNamed`) are idempotent (indexOf/cache check before allocating), `PositionalArguments` stores exprs as `readonly`, and `SpanList.range()` only reads `.loc` from the nodes.

**Where the savings come from:** `callParts()` is called once per helper/component invocation that has params — `{{helper a b}}`, `{{#if cond}}`, `(subexpr a)`, etc. Plain path expressions like `{{this.name}}` don't go through `callParts` and are unaffected. The benchmark fixture has 12 param-bearing invocations per ~1.5k chars (36% of all mustaches), which is representative of a typical route template with moderate interactivity. Templates with higher helper/sub-expression density will see larger gains.

## Benchmark (`pnpm bench:precompile`, averaged over 5 paired runs)

Apple M1 Max, Node 24.14.

### Prod build

| size | main | this PR | speedup |
|---|---:|---:|---:|
| small (1517c) | 1.80 ms | 1.76 ms | **2%** |
| medium (4551c) | 5.54 ms | 5.40 ms | **3%** |
| large (33374c) | 44.29 ms | 43.05 ms | **3%** |

### Dev build

| size | main | this PR | speedup |
|---|---:|---:|---:|
| small (1517c) | 1.89 ms | 1.78 ms | **6%** |
| medium (4551c) | 5.57 ms | 5.31 ms | **5%** |
| large (33374c) | 45.69 ms | 42.26 ms | **8%** |

Dev build shows a larger improvement because the redundant normalization also triggers DEBUG assertions (e.g. the `charPosFor` round-trip check) that are eliminated along with the duplicate pass.

Reproduce: `pnpm build && pnpm bench:precompile`
