### PR TITLE
[CLEANUP] Guard runtime localAssert calls with DEBUG/LOCAL_DEBUG for prod tree-shaking

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -21,6 +21,7 @@ import type {
   ScopeSlot,
   UpdatingOpcode,
   VMArguments,
+  WithDynamicLayout,
   WithDynamicTagName,
   WithElementHook,
   WithUpdateHook,
@@ -135,7 +136,9 @@ export interface PartialComponentDefinition {
 
 APPEND_OPCODES.add(VM_PUSH_COMPONENT_DEFINITION_OP, (vm, { op1: handle }) => {
   let definition = vm.constants.getValue<ComponentDefinition>(handle);
-  localAssert(!!definition, `Missing component for ${handle}`);
+  if (DEBUG) {
+    localAssert(!!definition, `Missing component for ${handle}`);
+  }
 
   let { manager, capabilities } = definition;
 
@@ -288,10 +291,12 @@ APPEND_OPCODES.add(VM_PREPARE_ARGS_OP, (vm, { op1: register }) => {
   let { definition } = instance;
 
   if (isCurriedType(definition, CURRIED_COMPONENT)) {
-    localAssert(
-      !definition.manager,
-      "If the component definition was curried, we don't yet have a manager"
-    );
+    if (DEBUG) {
+      localAssert(
+        !definition.manager,
+        "If the component definition was curried, we don't yet have a manager"
+      );
+    }
 
     let constants = vm.constants;
 
@@ -543,9 +548,15 @@ export class ComponentElementOperations implements ElementOperations {
       let name = definition.resolvedName ?? manager.getDebugName(definition.state);
       let instance = manager.getDebugInstance(state);
 
-      localAssert(constructing, `Expected a constructing element in addModifier`);
+      if (DEBUG) {
+        localAssert(constructing, `Expected a constructing element in addModifier`);
+      }
 
-      let bounds = new ConcreteBounds(element, constructing, constructing);
+      let bounds = new ConcreteBounds(
+        element,
+        constructing as NonNullable<typeof constructing>,
+        constructing as NonNullable<typeof constructing>
+      );
 
       vm.env.debugRenderTree.create(state, {
         type: 'modifier',
@@ -668,17 +679,20 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_SELF_OP, (vm, { op1: register, op2: _names }
     let compilable: CompilableProgram | null = definition.compilable;
 
     if (compilable === null) {
-      localAssert(
-        managerHasCapability(
-          manager,
-          instance.capabilities,
-          InternalComponentCapabilities.dynamicLayout
-        ),
-        'BUG: No template was found for this component, and the component did not have the dynamic layout capability'
-      );
+      if (DEBUG) {
+        localAssert(
+          managerHasCapability(
+            manager,
+            instance.capabilities,
+            InternalComponentCapabilities.dynamicLayout
+          ),
+          'BUG: No template was found for this component, and the component did not have the dynamic layout capability'
+        );
+      }
 
       let resolver = vm.context.resolver;
-      compilable = resolver === null ? null : manager.getDynamicLayout(state, resolver);
+      compilable =
+        resolver === null ? null : (manager as WithDynamicLayout).getDynamicLayout(state, resolver);
     }
 
     // For tearing down the debugRenderTree
@@ -746,13 +760,18 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_LAYOUT_OP, (vm, { op1: register }) => {
   if (compilable === null) {
     let { capabilities } = instance;
 
-    localAssert(
-      managerHasCapability(manager, capabilities, InternalComponentCapabilities.dynamicLayout),
-      'BUG: No template was found for this component, and the component did not have the dynamic layout capability'
-    );
+    if (DEBUG) {
+      localAssert(
+        managerHasCapability(manager, capabilities, InternalComponentCapabilities.dynamicLayout),
+        'BUG: No template was found for this component, and the component did not have the dynamic layout capability'
+      );
+    }
 
     let resolver = vm.context.resolver;
-    compilable = resolver === null ? null : manager.getDynamicLayout(instance.state, resolver);
+    compilable =
+      resolver === null
+        ? null
+        : (manager as WithDynamicLayout).getDynamicLayout(instance.state, resolver);
 
     if (compilable === null) {
       if (managerHasCapability(manager, capabilities, InternalComponentCapabilities.wrapped)) {

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -137,10 +137,12 @@ export class EnvironmentImpl implements Environment {
   }
 
   begin() {
-    localAssert(
-      !this[TRANSACTION],
-      'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.'
-    );
+    if (DEBUG) {
+      localAssert(
+        !this[TRANSACTION],
+        'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.'
+      );
+    }
 
     this.debugRenderTree?.begin();
 

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -190,16 +190,20 @@ export class AppendOpcodes {
     let operation = unwrap(this.evaluateOpcode[type]);
 
     if (operation.syscall) {
-      localAssert(
-        !opcode.isMachine,
-        `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
-      );
+      if (LOCAL_DEBUG) {
+        localAssert(
+          !opcode.isMachine,
+          `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
+        );
+      }
       operation.evaluate(vm, opcode);
     } else {
-      localAssert(
-        opcode.isMachine,
-        `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
-      );
+      if (LOCAL_DEBUG) {
+        localAssert(
+          opcode.isMachine,
+          `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
+        );
+      }
       operation.evaluate(vm.lowlevel, opcode);
     }
   }

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -574,7 +574,9 @@ export class AppendingBlockList implements AppendingBlock {
   didAppendBounds(_bounds: Bounds) {}
 
   finalize(_stack: TreeBuilder) {
-    localAssert(this.boundList.length > 0, 'boundsList cannot be empty');
+    if (LOCAL_DEBUG) {
+      localAssert(this.boundList.length > 0, 'boundsList cannot be empty');
+    }
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import type {
   AttrNamespace,
   Bounds,
@@ -58,9 +59,11 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
       node = node.nextSibling;
     }
 
-    localAssert(node, 'Must have opening comment for rehydration.');
+    if (DEBUG) {
+      localAssert(node, 'Must have opening comment for rehydration.');
+    }
     this.candidate = node;
-    const startingBlockOffset = getBlockDepth(node);
+    const startingBlockOffset = getBlockDepth(node as SimpleComment);
     if (startingBlockOffset !== 0) {
       // We are rehydrating from a partial tree and not the root component
       // We need to add an extra block before the first block to rehydrate correctly
@@ -69,8 +72,8 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
       const newCandidate = this.dom.createComment(`%+b:${newBlockDepth}%`);
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-      node.parentNode!.insertBefore(newCandidate, this.candidate);
-      let closingNode = node.nextSibling;
+      (node as SimpleComment).parentNode!.insertBefore(newCandidate, this.candidate);
+      let closingNode = (node as SimpleComment).nextSibling;
       while (closingNode !== null) {
         if (isCloseBlock(closingNode) && getBlockDepth(closingNode) === startingBlockOffset) {
           break;
@@ -78,10 +81,15 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
         closingNode = closingNode.nextSibling;
       }
 
-      localAssert(closingNode, 'Must have closing comment for starting block comment');
+      if (DEBUG) {
+        localAssert(closingNode, 'Must have closing comment for starting block comment');
+      }
       const newClosingBlock = this.dom.createComment(`%-b:${newBlockDepth}%`);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-      node.parentNode!.insertBefore(newClosingBlock, closingNode.nextSibling);
+      (node as SimpleComment).parentNode!.insertBefore(
+        newClosingBlock,
+        (closingNode as NonNullable<typeof closingNode>).nextSibling
+      );
       this.candidate = newCandidate;
       this.startingBlockOffset = newBlockDepth;
     } else {
@@ -470,10 +478,12 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
   ): RemoteBlock {
     const marker = this.getMarker(castToBrowser(element, 'HTML'), cursorId);
 
-    localAssert(
-      !marker || marker.parentNode === element,
-      `expected remote element marker's parent node to match remote element`
-    );
+    if (DEBUG) {
+      localAssert(
+        !marker || marker.parentNode === element,
+        `expected remote element marker's parent node to match remote element`
+      );
+    }
 
     // when insertBefore is not present, we clear the element
     if (insertBefore === undefined) {


### PR DESCRIPTION
Wraps 13 `localAssert()` calls in 5 `@glimmer/runtime` files with `if (DEBUG)` / `if (LOCAL_DEBUG)` guards so the entire call — including message string — is stripped from prod builds.

Each guard was verified by clean-building before/after. Files and guards with zero prod effect were excluded.

## The problem

`localAssert(condition, message)` is an empty function in prod. But JavaScript evaluates all arguments before calling it, so the call sites + message strings remain in the prod bundle as dead code.

## The fix

```ts
// Before: call + string always in prod bundle
localAssert(condition, 'message');

// After: entire block stripped from prod
if (DEBUG) {
  localAssert(condition, 'message');
}
```

## Bundle size impact (verified per-file, clean builds)

| Source file | Guards | Prod chunk | Delta |
|---|---:|---|---:|
| `environment.ts` | 1 | `render` | **-84** |
| `component.ts` | 6 | `on` | **-248** |
| `rehydrate-builder.ts` | 3 | `rehydrate-builder` | **-106** |
| `element-builder.ts` | 1 | `element-builder` | **-91** |
| `opcodes.ts` | 2 | `on` | **-321** |
| **Total** | **13** | | **-850 bytes** |

<details>
<summary>Methodology: why per-file, not per-guard</summary>

Per-guard measurement doesn't work because individual guards often **increase** size (+15-35 bytes of `if (DEBUG) { }` wrapper). The savings come from **all guards in a file together** enabling tree-shaking of the `localAssert` import chain — when all calls are inside `if (DEBUG)`, rollup eliminates the import entirely.

Example from `rehydrate-builder.ts` (3 guards):
- Guard 1 alone: **+23 bytes** (wrapper cost > string savings)
- Guard 2 alone: **+25 bytes**
- Guard 3 alone: **+31 bytes**
- All 3 together: **-106 bytes** (import chain tree-shaken)

This is why the correct unit is per-file: the savings are non-linear.
</details>

<details>
<summary>Excluded files and guards (verified zero effect)</summary>

**Files excluded** (build already strips their `localAssert` calls via rollup inlining the empty function and eliminating the dead call):
- `expressions.ts` (2 calls) — 0 bytes
- `vm.ts` (1 call) — 0 bytes
- `stack.ts` (1 call) — 0 bytes
- `low-level.ts` (3 calls) — 0 bytes
- `constants.ts` (3 calls) — 0 bytes

**Guards excluded within included files:**
- `element-builder.ts` L257 (`block instanceof RemoteBlock`) — 0 bytes
- `element-builder.ts` L563 (`false, 'Cannot openElement...'`) — 0 bytes
- `element-builder.ts` L567 (`false, 'Cannot closeElement...'`) — 0 bytes
- `element-builder.ts` L571 (`false, 'Cannot create...'`) — 0 bytes

Only `element-builder.ts` L577 (`this.boundList.length > 0`) saves bytes (-91).
</details>

## Type narrowing casts

9 of the 13 wrapped calls provide type narrowing via `localAssert`'s `asserts` signature. Wrapping loses the narrowing, requiring `as` casts:

| Cast | Why needed | Safe? |
|---|---|---|
| `constructing as NonNullable<...>` (×2) | Null guard lost | Yes — only reached during element construction |
| `manager as WithDynamicLayout` (×2) | `managerHasCapability` is a [type guard](https://github.com/emberjs/ember.js/blob/main/packages/%40glimmer/manager/lib/util/capabilities.ts#L104-L108) that narrows manager | Yes — code only entered when `compilable === null` |
| `node as SimpleComment` (×3) | Null check lost | Yes — loop above searches for comment node |
| `closingNode as NonNullable<...>` | Null check lost | Yes — loop above searches for close comment |
