### PR TITLE
[CLEANUP] Rename localAssert → assert, enable babel-plugin-debug-macros stripping

### DIFF
--- a/babel.test.config.mjs
+++ b/babel.test.config.mjs
@@ -27,5 +27,5 @@ export default {
     ],
   ],
 
-  plugins: [...baseConfig.plugins, buildDebugMacroPlugin(!isProduction)],
+  plugins: [...baseConfig.plugins, ...buildDebugMacroPlugin(!isProduction)],
 };

--- a/broccoli/build-debug-macro-plugin.js
+++ b/broccoli/build-debug-macro-plugin.js
@@ -1,16 +1,33 @@
 module.exports = function buildDebugMacrosPlugin(isDebug) {
   return [
-    require.resolve('babel-plugin-debug-macros'),
-    {
-      debugTools: {
-        source: '@ember/debug',
-        assertPredicateIndex: 1,
-        isDebug,
+    [
+      require.resolve('babel-plugin-debug-macros'),
+      {
+        debugTools: {
+          source: '@ember/debug',
+          assertPredicateIndex: 1,
+          isDebug,
+        },
+        externalizeHelpers: {
+          module: true,
+        },
+        flags: [{ source: '@glimmer/env', flags: { DEBUG: isDebug } }],
       },
-      externalizeHelpers: {
-        module: true,
+      'ember-debug',
+    ],
+    [
+      require.resolve('babel-plugin-debug-macros'),
+      {
+        debugTools: {
+          source: '@glimmer/debug-util',
+          assertPredicateIndex: 0,
+          isDebug,
+        },
+        externalizeHelpers: {
+          module: true,
+        },
       },
-      flags: [{ source: '@glimmer/env', flags: { DEBUG: isDebug } }],
-    },
+      'glimmer-debug',
+    ],
   ];
 };

--- a/packages/@glimmer-workspace/integration-tests/lib/modes/jit/registry.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/modes/jit/registry.ts
@@ -8,7 +8,7 @@ import type {
   ResolvedComponentDefinition,
   Template,
 } from '@glimmer/interfaces';
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 import { getComponentTemplate } from '@glimmer/manager';
 import { dict } from '@glimmer/util';
 
@@ -88,7 +88,7 @@ export class TestJitRegistry {
     if (definition.template === null) {
       let templateFactory = getComponentTemplate(state);
 
-      localAssert(
+      assert(
         templateFactory || capabilities.dynamicLayout,
         'expected a template to be associated with this component'
       );

--- a/packages/@glimmer-workspace/integration-tests/lib/render-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/render-test.ts
@@ -11,7 +11,7 @@ import type {
 } from '@glimmer/interfaces';
 import type { ASTPluginBuilder } from '@glimmer/syntax';
 import type { NTuple } from '@glimmer-workspace/test-utils';
-import { expect, isPresent, localAssert, unwrap } from '@glimmer/debug-util';
+import { expect, isPresent, assert, unwrap } from '@glimmer/debug-util';
 import { destroy } from '@glimmer/destroyable';
 import { inTransaction } from '@glimmer/runtime';
 import { clearElement, dict } from '@glimmer/util';
@@ -401,7 +401,7 @@ export class RenderTest implements IRenderTest {
       // couldn't stringify, possibly has a circular dependency
     }
 
-    localAssert(
+    assert(
       !!this.delegate.renderComponent,
       'Attempted to render a component, but the delegate did not implement renderComponent'
     );

--- a/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
@@ -1,7 +1,7 @@
 import type { WireFormat } from '@glimmer/interfaces';
 import type { TemplateWithIdAndReferrer } from '@glimmer/opcode-compiler';
 import { precompile } from '@glimmer/compiler';
-import { localAssert, unwrapTemplate } from '@glimmer/debug-util';
+import { assert as debugAssert, unwrapTemplate } from '@glimmer/debug-util';
 import { SexpOpcodes } from '@glimmer/wire-format';
 import { preprocess } from '@glimmer-workspace/integration-tests';
 
@@ -110,7 +110,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
     let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
     let [[, componentNameExpr]] = block[0] as [WireFormat.Statements.Component];
 
-    localAssert(
+    debugAssert(
       Array.isArray(componentNameExpr) &&
         componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
       `component name is a free variable lookup`
@@ -134,7 +134,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
     let [[, , letBlock]] = block[0] as [WireFormat.Statements.Let];
     let [[, componentNameExpr]] = letBlock[0] as [WireFormat.Statements.Component];
 
-    localAssert(
+    debugAssert(
       Array.isArray(componentNameExpr) &&
         componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
       `component name is a free variable lookup`
@@ -157,7 +157,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
 
     let [[, componentNameExpr]] = block[0] as [WireFormat.Statements.Block];
 
-    localAssert(
+    debugAssert(
       Array.isArray(componentNameExpr) &&
         componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
       `component name is a free variable lookup`
@@ -180,7 +180,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
 
     let [[, componentNameExpr]] = block[0] as [WireFormat.Statements.Block];
 
-    localAssert(
+    debugAssert(
       Array.isArray(componentNameExpr) &&
         componentNameExpr[0] === SexpOpcodes.GetFreeAsComponentHead,
       `component name is a free variable lookup`
@@ -202,7 +202,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
     let block: WireFormat.SerializedTemplateBlock = JSON.parse(wire.block);
     let [openElementExpr] = block[0];
 
-    localAssert(
+    debugAssert(
       Array.isArray(openElementExpr) && openElementExpr[0] === SexpOpcodes.OpenElement,
       `expr is open element`
     );

--- a/packages/@glimmer/compiler/lib/builder/builder.ts
+++ b/packages/@glimmer/compiler/lib/builder/builder.ts
@@ -38,7 +38,7 @@ import {
   SPLAT_HEAD,
   THIS_VAR,
 } from '@glimmer/constants';
-import { exhausted, expect, isPresentArray, localAssert } from '@glimmer/debug-util';
+import { exhausted, expect, isPresentArray, assert } from '@glimmer/debug-util';
 import { assertNever, dict, values } from '@glimmer/util';
 import { SexpOpcodes as Op, VariableResolutionContext } from '@glimmer/wire-format';
 
@@ -383,7 +383,7 @@ function buildElement(
   if (attrs) {
     let { params, args } = buildElementParams(attrs, symbols);
     out.push(...params);
-    localAssert(args === null, `Can't pass args to a simple element`);
+    assert(args === null, `Can't pass args to a simple element`);
   }
   out.push([Op.FlushElement]);
 
@@ -391,7 +391,7 @@ function buildElement(
     block.forEach((s) => out.push(...buildStatement(s, symbols)));
   } else {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    localAssert(block === null, `The only remaining type of 'block' is 'null'`);
+    assert(block === null, `The only remaining type of 'block' is 'null'`);
   }
 
   out.push([Op.CloseElement]);
@@ -681,7 +681,7 @@ export function buildVar(
   if (path === undefined || path.length === 0) {
     return [op, sym];
   } else {
-    localAssert(op !== Op.GetStrictKeyword, '[BUG] keyword with a path');
+    assert(op !== Op.GetStrictKeyword, '[BUG] keyword with a path');
     return [op, sym, path];
   }
 }

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/expressions.ts
@@ -1,11 +1,6 @@
 import type { PresentArray, WireFormat } from '@glimmer/interfaces';
 import type { ASTv2 } from '@glimmer/syntax';
-import {
-  assertPresentArray,
-  isPresentArray,
-  localAssert,
-  mapPresentArray,
-} from '@glimmer/debug-util';
+import { assertPresentArray, isPresentArray, assert, mapPresentArray } from '@glimmer/debug-util';
 import { SexpOpcodes } from '@glimmer/wire-format';
 
 import type * as mir from './mir';
@@ -99,7 +94,7 @@ export class ExpressionEncoder {
 
   PathExpression({ head, tail }: mir.PathExpression): WireFormat.Expressions.GetPath {
     let getOp = EXPR.expr(head) as WireFormat.Expressions.GetVar;
-    localAssert(getOp[0] !== SexpOpcodes.GetStrictKeyword, '[BUG] keyword in a PathExpression');
+    assert(getOp[0] !== SexpOpcodes.GetStrictKeyword, '[BUG] keyword in a PathExpression');
     return [...getOp, EXPR.Tail(tail)];
   }
 

--- a/packages/@glimmer/constants/lib/immediate.ts
+++ b/packages/@glimmer/constants/lib/immediate.ts
@@ -1,4 +1,4 @@
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 
 /*
@@ -71,7 +71,7 @@ export function isSmallInt(value: number) {
 
 export function encodeNegative(num: number) {
   if (LOCAL_DEBUG) {
-    localAssert(num % 1 === 0 && num >= MIN_INT && num < 0, `Could not encode negative: ${num}`);
+    assert(num % 1 === 0 && num >= MIN_INT && num < 0, `Could not encode negative: ${num}`);
   }
 
   return num & SIGN_BIT;
@@ -79,10 +79,7 @@ export function encodeNegative(num: number) {
 
 export function decodeNegative(num: number) {
   if (LOCAL_DEBUG) {
-    localAssert(
-      num % 1 === 0 && num < ~MAX_INT && num >= MIN_SMI,
-      `Could not decode negative: ${num}`
-    );
+    assert(num % 1 === 0 && num < ~MAX_INT && num >= MIN_SMI, `Could not decode negative: ${num}`);
   }
 
   return num | ~SIGN_BIT;
@@ -90,7 +87,7 @@ export function decodeNegative(num: number) {
 
 export function encodePositive(num: number) {
   if (LOCAL_DEBUG) {
-    localAssert(num % 1 === 0 && num >= 0 && num <= MAX_INT, `Could not encode positive: ${num}`);
+    assert(num % 1 === 0 && num >= 0 && num <= MAX_INT, `Could not encode positive: ${num}`);
   }
 
   return ~num;
@@ -98,7 +95,7 @@ export function encodePositive(num: number) {
 
 export function decodePositive(num: number) {
   if (LOCAL_DEBUG) {
-    localAssert(num % 1 === 0 && num <= 0 && num >= ~MAX_INT, `Could not decode positive: ${num}`);
+    assert(num % 1 === 0 && num <= 0 && num >= ~MAX_INT, `Could not decode positive: ${num}`);
   }
 
   return ~num;
@@ -106,7 +103,7 @@ export function decodePositive(num: number) {
 
 export function encodeHandle(num: number) {
   if (LOCAL_DEBUG) {
-    localAssert(num % 1 === 0 && num >= 0 && num <= MAX_SMI, `Could not encode handle: ${num}`);
+    assert(num % 1 === 0 && num >= 0 && num <= MAX_SMI, `Could not encode handle: ${num}`);
   }
 
   return num;
@@ -114,7 +111,7 @@ export function encodeHandle(num: number) {
 
 export function decodeHandle(num: number) {
   if (LOCAL_DEBUG) {
-    localAssert(num % 1 === 0 && num <= MAX_SMI && num >= 0, `Could not decode handle: ${num}`);
+    assert(num % 1 === 0 && num <= MAX_SMI && num >= 0, `Could not decode handle: ${num}`);
   }
 
   return num;

--- a/packages/@glimmer/debug-util/index.ts
+++ b/packages/@glimmer/debug-util/index.ts
@@ -1,4 +1,4 @@
-export { assertNever, deprecate, default as localAssert } from './lib/assert';
+export { assertNever, deprecate, default as assert } from './lib/assert';
 export * from './lib/debug-brand';
 export { default as debugToString } from './lib/debug-to-string';
 export * from './lib/platform-utils';

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -17,7 +17,7 @@ import type {
   STDLib,
 } from '@glimmer/interfaces';
 import { encodeHandle, isMachineOp, VM_PRIMITIVE_OP, VM_RETURN_OP } from '@glimmer/constants';
-import { expect, isPresentArray, localAssert } from '@glimmer/debug-util';
+import { expect, isPresentArray, assert } from '@glimmer/debug-util';
 import { InstructionEncoderImpl } from '@glimmer/encoder';
 import { dict, Stack } from '@glimmer/util';
 import { ARG_SHIFT, MACHINE_MASK, TYPE_SIZE } from '@glimmer/vm';
@@ -52,10 +52,7 @@ export class Labels {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       let address = labels[target]! - at;
 
-      localAssert(
-        heap.getbyaddr(at) === -1,
-        'Expected heap to contain a placeholder, but it did not'
-      );
+      assert(heap.getbyaddr(at) === -1, 'Expected heap to contain a placeholder, but it did not');
 
       heap.setbyaddr(at, address);
     }

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/resolution.ts
@@ -15,7 +15,7 @@ import type {
   ResolveOptionalComponentOrHelperOp,
   SexpOpcode,
 } from '@glimmer/interfaces';
-import { debugToString, expect, localAssert, unwrap } from '@glimmer/debug-util';
+import { debugToString, expect, assert, unwrap } from '@glimmer/debug-util';
 import { SexpOpcodes } from '@glimmer/wire-format';
 
 function isGetLikeTuple(opcode: Expressions.Expression): opcode is Expressions.TupleExpression {
@@ -84,12 +84,12 @@ export function resolveComponent(
   meta: BlockMetadata,
   [, expr, then]: ResolveComponentOp
 ): void {
-  localAssert(isGetFreeComponent(expr), 'Attempted to resolve a component with incorrect opcode');
+  assert(isGetFreeComponent(expr), 'Attempted to resolve a component with incorrect opcode');
 
   let type = expr[0];
 
   if (DEBUG && expr[0] === SexpOpcodes.GetStrictKeyword) {
-    localAssert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
+    assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
     throw new Error(
       `Attempted to resolve a component in a strict mode template, but that value was not in scope: ${
@@ -127,10 +127,7 @@ export function resolveComponent(
     let definition = resolver?.lookupComponent?.(name, owner) ?? null;
 
     if (DEBUG && (typeof definition !== 'object' || definition === null)) {
-      localAssert(
-        !meta.isStrictMode,
-        'Strict mode errors should already be handled at compile time'
-      );
+      assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
       throw new Error(
         `Attempted to resolve \`${name}\`, which was expected to be a component, but nothing was found.`
@@ -152,7 +149,7 @@ export function resolveHelper(
   meta: BlockMetadata,
   [, expr, then]: ResolveHelperOp
 ): void {
-  localAssert(isGetFreeHelper(expr), 'Attempted to resolve a helper with incorrect opcode');
+  assert(isGetFreeHelper(expr), 'Attempted to resolve a helper with incorrect opcode');
 
   let type = expr[0];
 
@@ -177,10 +174,7 @@ export function resolveHelper(
     let helper = resolver?.lookupHelper?.(name, owner) ?? null;
 
     if (DEBUG && helper === null) {
-      localAssert(
-        !meta.isStrictMode,
-        'Strict mode errors should already be handled at compile time'
-      );
+      assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
       throw new Error(
         `Attempted to resolve \`${name}\`, which was expected to be a helper, but nothing was found.`
@@ -203,7 +197,7 @@ export function resolveModifier(
   meta: BlockMetadata,
   [, expr, then]: ResolveModifierOp
 ): void {
-  localAssert(isGetFreeModifier(expr), 'Attempted to resolve a modifier with incorrect opcode');
+  assert(isGetFreeModifier(expr), 'Attempted to resolve a modifier with incorrect opcode');
 
   let type = expr[0];
 
@@ -225,10 +219,7 @@ export function resolveModifier(
     let modifier = resolver?.lookupBuiltInModifier?.(name) ?? null;
 
     if (DEBUG && modifier === null) {
-      localAssert(
-        !meta.isStrictMode,
-        'Strict mode errors should already be handled at compile time'
-      );
+      assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
       throw new Error(
         `Attempted to resolve a modifier in a strict mode template, but it was not in scope: ${name}`
@@ -246,10 +237,7 @@ export function resolveModifier(
     let modifier = resolver?.lookupModifier?.(name, owner) ?? null;
 
     if (DEBUG && modifier === null) {
-      localAssert(
-        !meta.isStrictMode,
-        'Strict mode errors should already be handled at compile time'
-      );
+      assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
       throw new Error(
         `Attempted to resolve \`${name}\`, which was expected to be a modifier, but nothing was found.`
@@ -270,7 +258,7 @@ export function resolveComponentOrHelper(
   meta: BlockMetadata,
   [, expr, { ifComponent, ifHelper }]: ResolveComponentOrHelperOp
 ): void {
-  localAssert(
+  assert(
     isGetFreeComponentOrHelper(expr),
     'Attempted to resolve a component or helper with incorrect opcode'
   );
@@ -302,10 +290,7 @@ export function resolveComponentOrHelper(
     let helper = constants.helper(definition as object, null, true);
 
     if (DEBUG && helper === null) {
-      localAssert(
-        !meta.isStrictMode,
-        'Strict mode errors should already be handled at compile time'
-      );
+      assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
       throw new Error(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
@@ -341,10 +326,7 @@ export function resolveComponentOrHelper(
       let helper = resolver?.lookupHelper?.(name, owner) ?? null;
 
       if (DEBUG && helper === null) {
-        localAssert(
-          !meta.isStrictMode,
-          'Strict mode errors should already be handled at compile time'
-        );
+        assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
         throw new Error(
           `Attempted to resolve \`${name}\`, which was expected to be a component or helper, but nothing was found.`
@@ -366,7 +348,7 @@ export function resolveOptionalComponentOrHelper(
   meta: BlockMetadata,
   [, expr, { ifComponent, ifHelper, ifValue }]: ResolveOptionalComponentOrHelperOp
 ): void {
-  localAssert(
+  assert(
     isGetFreeComponentOrHelper(expr),
     'Attempted to resolve an optional component or helper with incorrect opcode'
   );
@@ -453,7 +435,7 @@ function lookupBuiltInHelper(
   let helper = resolver?.lookupBuiltInHelper?.(name) ?? null;
 
   if (DEBUG && helper === null) {
-    localAssert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
+    assert(!meta.isStrictMode, 'Strict mode errors should already be handled at compile time');
 
     // Keyword helper did not exist, which means that we're attempting to use a
     // value of some kind that is not in scope

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/operands.ts
@@ -21,7 +21,7 @@ import type {
   SymbolTableOperandType,
 } from '@glimmer/interfaces';
 import { isSmallInt } from '@glimmer/constants';
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 
 export const HighLevelOperands = {
   Label: 1 satisfies LabelOperandType,
@@ -66,7 +66,7 @@ export function stdlibOperand(
 }
 
 export function nonSmallIntOperand(value: number): NonSmallIntOperand {
-  localAssert(
+  assert(
     !isSmallInt(value),
     'Attempted to make a operand for an int that was not a small int, you should encode this as an immediate'
   );

--- a/packages/@glimmer/opcode-compiler/lib/syntax/compilers.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/compilers.ts
@@ -1,5 +1,5 @@
 import type { BuilderOp, HighLevelOp, SexpOpcode, SexpOpcodeMap } from '@glimmer/interfaces';
-import { localAssert, unwrap } from '@glimmer/debug-util';
+import { assert, unwrap } from '@glimmer/debug-util';
 
 export type PushExpressionOp = (...op: BuilderOp | HighLevelOp) => void;
 
@@ -33,7 +33,7 @@ export class Compilers<PushOp extends PushExpressionOp, TSexpOpcodes extends Sex
     let name = sexp[0];
     let index = unwrap(this.names[name]);
     let func = this.funcs[index];
-    localAssert(func, `expected an implementation for ${sexp[0]}`);
+    assert(func, `expected an implementation for ${sexp[0]}`);
 
     func(op, sexp);
   }

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -10,7 +10,7 @@ import type {
   Template,
 } from '@glimmer/interfaces';
 import { constants } from '@glimmer/constants';
-import { expect, localAssert, unwrapTemplate } from '@glimmer/debug-util';
+import { expect, assert, unwrapTemplate } from '@glimmer/debug-util';
 import {
   capabilityFlagsFrom,
   getComponentTemplate,
@@ -120,7 +120,7 @@ export class ConstantsImpl implements ProgramConstants {
         return null;
       }
 
-      localAssert(managerOrHelper, 'BUG: expected manager or helper');
+      assert(managerOrHelper, 'BUG: expected manager or helper');
 
       let helper =
         typeof managerOrHelper === 'function'
@@ -189,7 +189,7 @@ export class ConstantsImpl implements ProgramConstants {
         return null;
       }
 
-      localAssert(manager, 'BUG: expected manager');
+      assert(manager, 'BUG: expected manager');
 
       let capabilities = capabilityFlagsFrom(manager.getCapabilities(definitionState));
 
@@ -288,7 +288,7 @@ export class ConstantsImpl implements ProgramConstants {
   }
 
   getValue<T>(index: number) {
-    localAssert(index >= 0, `cannot get value for handle: ${index}`);
+    assert(index >= 0, `cannot get value for handle: ${index}`);
 
     return this.values[index] as T;
   }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -67,7 +67,7 @@ import {
   CheckString,
   CheckSyscallRegister,
 } from '@glimmer/debug';
-import { debugToString, expect, localAssert, unwrap, unwrapTemplate } from '@glimmer/debug-util';
+import { debugToString, expect, assert, unwrap, unwrapTemplate } from '@glimmer/debug-util';
 import { registerDestructor } from '@glimmer/destroyable';
 import { managerHasCapability } from '@glimmer/manager';
 import { isConstRef, valueForRef } from '@glimmer/reference';
@@ -135,7 +135,7 @@ export interface PartialComponentDefinition {
 
 APPEND_OPCODES.add(VM_PUSH_COMPONENT_DEFINITION_OP, (vm, { op1: handle }) => {
   let definition = vm.constants.getValue<ComponentDefinition>(handle);
-  localAssert(!!definition, `Missing component for ${handle}`);
+  assert(!!definition, `Missing component for ${handle}`);
 
   let { manager, capabilities } = definition;
 
@@ -288,7 +288,7 @@ APPEND_OPCODES.add(VM_PREPARE_ARGS_OP, (vm, { op1: register }) => {
   let { definition } = instance;
 
   if (isCurriedType(definition, CURRIED_COMPONENT)) {
-    localAssert(
+    assert(
       !definition.manager,
       "If the component definition was curried, we don't yet have a manager"
     );
@@ -543,7 +543,7 @@ export class ComponentElementOperations implements ElementOperations {
       let name = definition.resolvedName ?? manager.getDebugName(definition.state);
       let instance = manager.getDebugInstance(state);
 
-      localAssert(constructing, `Expected a constructing element in addModifier`);
+      assert(constructing, `Expected a constructing element in addModifier`);
 
       let bounds = new ConcreteBounds(element, constructing, constructing);
 
@@ -668,7 +668,7 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_SELF_OP, (vm, { op1: register, op2: _names }
     let compilable: CompilableProgram | null = definition.compilable;
 
     if (compilable === null) {
-      localAssert(
+      assert(
         managerHasCapability(
           manager,
           instance.capabilities,
@@ -746,7 +746,7 @@ APPEND_OPCODES.add(VM_GET_COMPONENT_LAYOUT_OP, (vm, { op1: register }) => {
   if (compilable === null) {
     let { capabilities } = instance;
 
-    localAssert(
+    assert(
       managerHasCapability(manager, capabilities, InternalComponentCapabilities.dynamicLayout),
       'BUG: No template was found for this component, and the component did not have the dynamic layout capability'
     );

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -37,7 +37,7 @@ import {
   CheckNullable,
   CheckOr,
 } from '@glimmer/debug';
-import { debugToString, localAssert } from '@glimmer/debug-util';
+import { debugToString, assert } from '@glimmer/debug-util';
 import { _hasDestroyableChildren, associateDestroyableChild, destroy } from '@glimmer/destroyable';
 import { debugAssert, toBool } from '@glimmer/global-context';
 import { getInternalHelperManager } from '@glimmer/manager';
@@ -154,7 +154,7 @@ function resolveHelper(definition: HelperDefinitionState, ref: Reference): Helpe
       typeof managerOrHelper === 'function'
         ? managerOrHelper
         : managerOrHelper.getHelper(definition);
-    localAssert(managerOrHelper, 'BUG: expected manager or helper');
+    assert(managerOrHelper, 'BUG: expected manager or helper');
   }
 
   debugAssert(
@@ -237,7 +237,7 @@ APPEND_OPCODES.add(VM_SPREAD_BLOCK_OP, (vm) => {
 });
 
 function isUndefinedReference(input: ScopeBlock | Reference): input is Reference {
-  localAssert(
+  assert(
     Array.isArray(input) || input === UNDEFINED_REFERENCE,
     'a reference other than UNDEFINED_REFERENCE is illegal here'
   );

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -41,7 +41,7 @@ import {
   CheckRegister,
   CheckSyscallRegister,
 } from '@glimmer/debug';
-import { expect, localAssert, unwrap } from '@glimmer/debug-util';
+import { expect, assert, unwrap } from '@glimmer/debug-util';
 import { toBool } from '@glimmer/global-context';
 import {
   createComputeRef,
@@ -181,7 +181,7 @@ APPEND_OPCODES.add(VM_INVOKE_YIELD_OP, (vm) => {
   let args = check(stack.pop(), CheckInstanceof(VMArgumentsImpl));
 
   if (table === null || handle === null) {
-    localAssert(
+    assert(
       handle === null && table === null,
       `Expected both handle and table to be null if either is null`
     );

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -13,7 +13,7 @@ import type {
   Transaction,
   TransactionSymbol,
 } from '@glimmer/interfaces';
-import { expect, localAssert } from '@glimmer/debug-util';
+import { expect, assert } from '@glimmer/debug-util';
 import { ProgramImpl } from '@glimmer/program';
 import { track, updateTag } from '@glimmer/validator';
 
@@ -137,7 +137,7 @@ export class EnvironmentImpl implements Environment {
   }
 
   begin() {
-    localAssert(
+    assert(
       !this[TRANSACTION],
       'A glimmer transaction was begun, but one already exists. You may have a nested transaction, possibly caused by an earlier runtime exception while rendering. Please check your console for the stack trace of any prior exceptions.'
     );

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -21,7 +21,7 @@ import {
   recordStackSize,
   VmSnapshot,
 } from '@glimmer/debug';
-import { dev, localAssert, unwrap } from '@glimmer/debug-util';
+import { dev, assert, unwrap } from '@glimmer/debug-util';
 import { LOCAL_DEBUG, LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 import { LOCAL_LOGGER } from '@glimmer/util';
 import { $pc, $ra, $s0, $s1, $sp, $t0, $t1, $v0 } from '@glimmer/vm';
@@ -190,13 +190,13 @@ export class AppendOpcodes {
     let operation = unwrap(this.evaluateOpcode[type]);
 
     if (operation.syscall) {
-      localAssert(
+      assert(
         !opcode.isMachine,
         `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
       );
       operation.evaluate(vm, opcode);
     } else {
-      localAssert(
+      assert(
         opcode.isMachine,
         `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
       );

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -18,7 +18,7 @@ import type {
   SimpleText,
   TreeBuilder,
 } from '@glimmer/interfaces';
-import { expect, localAssert, setLocalDebugType } from '@glimmer/debug-util';
+import { expect, assert, setLocalDebugType } from '@glimmer/debug-util';
 import { destroy, registerDestructor } from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { Stack } from '@glimmer/util';
@@ -254,7 +254,7 @@ export class NewTreeBuilder implements TreeBuilder {
 
   popRemoteElement(): RemoteBlock {
     const block = this.popBlock();
-    localAssert(block instanceof RemoteBlock, '[BUG] expecting a RemoteBlock');
+    assert(block instanceof RemoteBlock, '[BUG] expecting a RemoteBlock');
     this.popElement();
     return block;
   }
@@ -560,21 +560,21 @@ export class AppendingBlockList implements AppendingBlock {
   }
 
   openElement(_element: SimpleElement) {
-    localAssert(false, 'Cannot openElement directly inside a block list');
+    assert(false, 'Cannot openElement directly inside a block list');
   }
 
   closeElement() {
-    localAssert(false, 'Cannot closeElement directly inside a block list');
+    assert(false, 'Cannot closeElement directly inside a block list');
   }
 
   didAppendNode(_node: SimpleNode) {
-    localAssert(false, 'Cannot create a new node directly inside a block list');
+    assert(false, 'Cannot create a new node directly inside a block list');
   }
 
   didAppendBounds(_bounds: Bounds) {}
 
   finalize(_stack: TreeBuilder) {
-    localAssert(this.boundList.length > 0, 'boundsList cannot be empty');
+    assert(this.boundList.length > 0, 'boundsList cannot be empty');
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -9,7 +9,7 @@ import {
   VM_RETURN_OP,
   VM_RETURN_TO_OP,
 } from '@glimmer/constants';
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { $fp, $pc, $ra, $sp } from '@glimmer/vm';
 
@@ -75,7 +75,7 @@ export class LowLevelVM {
   }
 
   setPc(pc: number): void {
-    localAssert(typeof pc === 'number' && !isNaN(pc), 'pc is set to a number');
+    assert(typeof pc === 'number' && !isNaN(pc), 'pc is set to a number');
     this.registers[$pc] = pc;
   }
 
@@ -112,7 +112,7 @@ export class LowLevelVM {
 
   // Save $pc into $ra, then jump to a new address in `program` (jal in MIPS)
   call(handle: number) {
-    localAssert(handle < 0xffffffff, `Jumping to placeholder address`);
+    assert(handle < 0xffffffff, `Jumping to placeholder address`);
 
     this.registers[$ra] = this.registers[$pc];
     this.setPc(this.context.program.heap.getaddr(handle));
@@ -133,7 +133,7 @@ export class LowLevelVM {
 
     let pc = registers[$pc];
 
-    localAssert(typeof pc === 'number', 'pc is a number');
+    assert(typeof pc === 'number', 'pc is a number');
 
     if (pc === -1) {
       return null;

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -13,7 +13,7 @@ import type {
 } from '@glimmer/interfaces';
 import type { Stack } from '@glimmer/util';
 import { COMMENT_NODE, ELEMENT_NODE, NS_SVG, TEXT_NODE } from '@glimmer/constants';
-import { castToBrowser, castToSimple, expect, localAssert } from '@glimmer/debug-util';
+import { castToBrowser, castToSimple, expect, assert } from '@glimmer/debug-util';
 
 import { ConcreteBounds, CursorImpl } from '../bounds';
 import { NewTreeBuilder, RemoteBlock } from './element-builder';
@@ -58,7 +58,7 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
       node = node.nextSibling;
     }
 
-    localAssert(node, 'Must have opening comment for rehydration.');
+    assert(node, 'Must have opening comment for rehydration.');
     this.candidate = node;
     const startingBlockOffset = getBlockDepth(node);
     if (startingBlockOffset !== 0) {
@@ -78,7 +78,7 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
         closingNode = closingNode.nextSibling;
       }
 
-      localAssert(closingNode, 'Must have closing comment for starting block comment');
+      assert(closingNode, 'Must have closing comment for starting block comment');
       const newClosingBlock = this.dom.createComment(`%-b:${newBlockDepth}%`);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       node.parentNode!.insertBefore(newClosingBlock, closingNode.nextSibling);
@@ -470,7 +470,7 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
   ): RemoteBlock {
     const marker = this.getMarker(castToBrowser(element, 'HTML'), cursorId);
 
-    localAssert(
+    assert(
       !marker || marker.parentNode === element,
       `expected remote element marker's parent node to match remote element`
     );

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -1,4 +1,4 @@
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { $fp, $pc, $sp } from '@glimmer/vm';
 
@@ -27,7 +27,7 @@ export default class EvaluationStackImpl implements EvaluationStack {
   static restore(snapshot: unknown[], pc: number): EvaluationStackImpl {
     const stack = new this(snapshot.slice(), initializeRegistersWithSP(snapshot.length - 1));
 
-    localAssert(typeof pc === 'number', 'pc is a number');
+    assert(typeof pc === 'number', 'pc is a number');
 
     stack.registers[$pc] = pc;
     stack.registers[$sp] = snapshot.length - 1;

--- a/packages/@glimmer/syntax/lib/parser.ts
+++ b/packages/@glimmer/syntax/lib/parser.ts
@@ -1,5 +1,5 @@
 import type { Nullable } from '@glimmer/interfaces';
-import { asPresentArray, expect, getLast, localAssert, unwrap } from '@glimmer/debug-util';
+import { asPresentArray, expect, getLast, assert, unwrap } from '@glimmer/debug-util';
 import { assign } from '@glimmer/util';
 import {
   EntityParser,
@@ -133,31 +133,31 @@ export abstract class Parser {
 
   get currentTag(): ParserNodeBuilder<StartTag> | ParserNodeBuilder<EndTag> {
     let node = this.currentNode;
-    localAssert(node && (node.type === 'StartTag' || node.type === 'EndTag'), 'expected tag');
+    assert(node && (node.type === 'StartTag' || node.type === 'EndTag'), 'expected tag');
     return node;
   }
 
   get currentStartTag(): ParserNodeBuilder<StartTag> {
     let node = this.currentNode;
-    localAssert(node && node.type === 'StartTag', 'expected start tag');
+    assert(node && node.type === 'StartTag', 'expected start tag');
     return node;
   }
 
   get currentEndTag(): ParserNodeBuilder<EndTag> {
     let node = this.currentNode;
-    localAssert(node && node.type === 'EndTag', 'expected end tag');
+    assert(node && node.type === 'EndTag', 'expected end tag');
     return node;
   }
 
   get currentComment(): ParserNodeBuilder<ASTv1.CommentStatement> {
     let node = this.currentNode;
-    localAssert(node && node.type === 'CommentStatement', 'expected a comment');
+    assert(node && node.type === 'CommentStatement', 'expected a comment');
     return node;
   }
 
   get currentData(): ParserNodeBuilder<ASTv1.TextNode> {
     let node = this.currentNode;
-    localAssert(node && node.type === 'TextNode', 'expected a text node');
+    assert(node && node.type === 'TextNode', 'expected a text node');
     return node;
   }
 

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 import type { Nullable, Recast } from '@glimmer/interfaces';
 import type { TokenizerState } from 'simple-html-tokenizer';
-import { getLast, isPresentArray, localAssert, unwrap } from '@glimmer/debug-util';
+import { getLast, isPresentArray, assert, unwrap } from '@glimmer/debug-util';
 
 import type { ParserNodeBuilder, StartTag } from '../parser';
 import type * as src from '../source/api';
@@ -38,7 +38,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
   abstract override finishAttributeValue(): void;
 
   parse(program: HBS.UpstreamProgram, blockParams: string[]): ASTv1.Template {
-    localAssert(program.loc, '[BUG] Program in parser unexpectedly did not have loc');
+    assert(program.loc, '[BUG] Program in parser unexpectedly did not have loc');
 
     let node = b.template({
       body: [],
@@ -61,12 +61,12 @@ export abstract class HandlebarsNodeVisitors extends Parser {
     // The abstract signature doesn't have the blockParams argument, but in
     // practice we can only come from this.BlockStatement() which adds the
     // extra argument for us
-    localAssert(
+    assert(
       Array.isArray(blockParams),
       '[BUG] Program in parser unexpectedly called without block params'
     );
 
-    localAssert(
+    assert(
       program.loc,
       '[BUG] Program in parser unexpectedly did not have loc. This should have been fixed in BlockStatement'
     );
@@ -105,8 +105,8 @@ export abstract class HandlebarsNodeVisitors extends Parser {
       } else {
         // If the stack is not balanced, then it is likely our own bug, because
         // any unclosed Handlebars blocks should already been caught by now
-        localAssert(poppedNode !== undefined, '[BUG] empty parser elementStack');
-        localAssert(false, `[BUG] mismatched parser elementStack node: ${node.type}`);
+        assert(poppedNode !== undefined, '[BUG] empty parser elementStack');
+        assert(false, `[BUG] mismatched parser elementStack node: ${node.type}`);
       }
     }
 
@@ -115,7 +115,7 @@ export abstract class HandlebarsNodeVisitors extends Parser {
 
   BlockStatement(block: HBS.UpstreamBlockStatement): ASTv1.BlockStatement | void {
     if (this.tokenizer.state === 'comment') {
-      localAssert(block.loc, '[BUG] BlockStatement in parser unexpectedly did not have loc');
+      assert(block.loc, '[BUG] BlockStatement in parser unexpectedly did not have loc');
       this.appendToCommentData(this.sourceForNode(block as HBS.Node));
       return;
     }

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -6,7 +6,7 @@ import {
   getFirst,
   getLast,
   isPresentArray,
-  localAssert,
+  assert,
 } from '@glimmer/debug-util';
 import { assign } from '@glimmer/util';
 import { parse, parseWithoutProcessing } from '@handlebars/parser';
@@ -128,7 +128,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       }
     } else {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- exhaustive
-      localAssert(tag.type === 'EndTag', `Invalid tag type ${tag.type}`);
+      assert(tag.type === 'EndTag', `Invalid tag type ${tag.type}`);
       this.finishEndTag(false);
     }
   }
@@ -137,9 +137,9 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     let { name, nameStart, nameEnd } = this.currentStartTag;
 
     // <> should probably be a syntax error, but s-h-t is currently broken for that case
-    localAssert(name !== '', 'tag name cannot be empty');
-    localAssert(nameStart !== null, 'nameStart unexpectedly null');
-    localAssert(nameEnd !== null, 'nameEnd unexpectedly null');
+    assert(name !== '', 'tag name cannot be empty');
+    assert(nameStart !== null, 'nameStart unexpectedly null');
+    assert(nameEnd !== null, 'nameEnd unexpectedly null');
 
     let nameLoc = nameStart.until(nameEnd);
     let [head, ...tail] = asPresentArray(name.split('.'));
@@ -180,7 +180,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
     if (isVoid) {
       element.closeTag = null;
     } else if (element.selfClosing) {
-      localAssert(element.closeTag === null, 'element.closeTag unexpectedly present');
+      assert(element.closeTag === null, 'element.closeTag unexpectedly present');
     } else {
       element.closeTag = closeTagStart.until(this.offset());
     }
@@ -213,7 +213,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       let offset = this.offset();
 
       if (tag.nameStart === null) {
-        localAssert(tag.nameEnd === null, 'nameStart and nameEnd must both be null');
+        assert(tag.nameEnd === null, 'nameStart and nameEnd must both be null');
 
         // Note that the tokenizer already consumed the token here
         tag.nameStart = offset.move(-1);
@@ -346,7 +346,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
 
     type Handler = (next: string) => void;
 
-    localAssert(this.tokenizer.state === ATTRIBUTE_NAME, 'must be in TokenizerState.attributeName');
+    assert(this.tokenizer.state === ATTRIBUTE_NAME, 'must be in TokenizerState.attributeName');
 
     const element = this.currentStartTag;
     const as = this.currentAttr;
@@ -355,7 +355,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
 
     const handlers = {
       PossibleAs: (next: string) => {
-        localAssert(state.state === 'PossibleAs', 'bug in block params parser');
+        assert(state.state === 'PossibleAs', 'bug in block params parser');
 
         if (isSpace(next)) {
           // " as ..."
@@ -377,7 +377,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       },
 
       BeforeStartPipe: (next: string) => {
-        localAssert(state.state === 'BeforeStartPipe', 'bug in block params parser');
+        assert(state.state === 'BeforeStartPipe', 'bug in block params parser');
 
         if (isSpace(next)) {
           this.tokenizer.consume();
@@ -393,7 +393,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       },
 
       BeforeBlockParamName: (next: string) => {
-        localAssert(state.state === 'BeforeBlockParamName', 'bug in block params parser');
+        assert(state.state === 'BeforeBlockParamName', 'bug in block params parser');
 
         if (isSpace(next)) {
           this.tokenizer.consume();
@@ -443,7 +443,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       },
 
       BlockParamName: (next: string) => {
-        localAssert(state.state === 'BlockParamName', 'bug in block params parser');
+        assert(state.state === 'BlockParamName', 'bug in block params parser');
 
         if (next === '') {
           // The HTML tokenizer ran out of characters, so we are either
@@ -491,7 +491,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       },
 
       AfterEndPipe: (next: string) => {
-        localAssert(state.state === 'AfterEndPipe', 'bug in block params parser');
+        assert(state.state === 'AfterEndPipe', 'bug in block params parser');
 
         if (isSpace(next)) {
           this.tokenizer.consume();
@@ -530,7 +530,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       },
 
       Error: (next: string) => {
-        localAssert(state.state === 'Error', 'bug in block params parser');
+        assert(state.state === 'Error', 'bug in block params parser');
 
         if (next === '' || next === '/' || next === '>' || isSpace(next)) {
           throw generateSyntaxError(state.message, state.start.until(this.offset()));
@@ -541,7 +541,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       },
 
       Done: () => {
-        localAssert(false, 'This should never be called');
+        assert(false, 'This should never be called');
       },
     } as const satisfies {
       [S in keyof States]: Handler;
@@ -554,7 +554,7 @@ export class TokenizerEventHandlers extends HandlebarsNodeVisitors {
       handlers[state.state](next);
     } while (state.state !== 'Done' && next !== '');
 
-    localAssert(state.state === 'Done', 'bug in block params parser');
+    assert(state.state === 'Done', 'bug in block params parser');
   }
 
   reportSyntaxError(message: string): void {

--- a/packages/@glimmer/syntax/lib/source/loc/match.ts
+++ b/packages/@glimmer/syntax/lib/source/loc/match.ts
@@ -1,4 +1,4 @@
-import { isPresentArray, localAssert } from '@glimmer/debug-util';
+import { isPresentArray, assert } from '@glimmer/debug-util';
 
 import type { CharOffsetKind, HbsPositionKind, OffsetKind } from './kinds';
 import type { CharPosition, HbsPosition, InvisiblePosition, PositionData } from './offset';
@@ -119,14 +119,14 @@ class Matcher<Out, M extends Matches = Matches> {
   ): (left: PositionData, right: PositionData) => Out {
     const nesteds = this._whens.match(left);
 
-    localAssert(
+    assert(
       isPresentArray(nesteds),
       `no match defined for (${left}, ${right}) and no AnyMatch defined either`
     );
 
     const callback = new WhenList(nesteds).first(right);
 
-    localAssert(
+    assert(
       callback !== null,
       `no match defined for (${left}, ${right}) and no AnyMatch defined either`
     );

--- a/packages/@glimmer/syntax/lib/source/loc/span.ts
+++ b/packages/@glimmer/syntax/lib/source/loc/span.ts
@@ -1,4 +1,4 @@
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { assertNever } from '@glimmer/util';
 
@@ -212,7 +212,7 @@ export class SourceSpan implements SourceLocation {
   toSlice(expected?: string): SourceSlice {
     const chars = this.data.asString();
 
-    localAssert(
+    assert(
       expected === undefined || expected === chars,
       `unexpectedly found ${JSON.stringify(chars)} when slicing source, ` +
         `but expected ${JSON.stringify(expected)}`

--- a/packages/@glimmer/syntax/lib/source/source.ts
+++ b/packages/@glimmer/syntax/lib/source/source.ts
@@ -1,6 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import type { Nullable } from '@glimmer/interfaces';
-import { localAssert, setLocalDebugType } from '@glimmer/debug-util';
+import { assert, setLocalDebugType } from '@glimmer/debug-util';
 
 import type { PrecompileOptions } from '../parser/tokenizer-event-handlers';
 import type { SourceLocation, SourcePosition } from './location';
@@ -64,9 +64,9 @@ export class Source {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (DEBUG) {
         const roundTrip = this.hbsPosFor(target);
-        localAssert(roundTrip !== null, `the returned offset failed to round-trip`);
-        localAssert(roundTrip.line === line, `line round-trip mismatch`);
-        localAssert(roundTrip.column === column, `column round-trip mismatch`);
+        assert(roundTrip !== null, `the returned offset failed to round-trip`);
+        assert(roundTrip.line === line, `line round-trip mismatch`);
+        assert(roundTrip.column === column, `column round-trip mismatch`);
       }
       return target;
     }

--- a/packages/@glimmer/syntax/lib/v1/parser-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/parser-builders.ts
@@ -1,5 +1,5 @@
 import type { Nullable, Optional, PresentArray } from '@glimmer/interfaces';
-import { localAssert } from '@glimmer/debug-util';
+import { assert } from '@glimmer/debug-util';
 
 import type * as ASTv1 from './api';
 
@@ -338,8 +338,8 @@ class Builders {
         return _name;
       },
       set name(value) {
-        localAssert(value[0] === '@', `call builders.at() with a string that starts with '@'`);
-        localAssert(
+        assert(value[0] === '@', `call builders.at() with a string that starts with '@'`);
+        assert(
           value.indexOf('.') === -1,
           `builder.at() should not be called with a name with dots in it`
         );
@@ -369,15 +369,15 @@ class Builders {
         return _name;
       },
       set name(value) {
-        localAssert(
+        assert(
           value !== 'this',
           `You called builders.var() with 'this'. Call builders.this instead`
         );
-        localAssert(
+        assert(
           value[0] !== '@',
           `You called builders.var() with '${name}'. Call builders.at('${name}') instead`
         );
-        localAssert(
+        assert(
           value.indexOf('.') === -1,
           `builder.var() should not be called with a name with dots in it`
         );

--- a/packages/@glimmer/syntax/lib/v1/public-builders.ts
+++ b/packages/@glimmer/syntax/lib/v1/public-builders.ts
@@ -1,5 +1,5 @@
 import type { Dict, Maybe, Nullable } from '@glimmer/interfaces';
-import { asPresentArray, deprecate, isPresentArray, localAssert } from '@glimmer/debug-util';
+import { asPresentArray, deprecate, isPresentArray, assert } from '@glimmer/debug-util';
 
 import type { SourceLocation, SourcePosition } from '../source/location';
 import type * as ASTv1 from './api';
@@ -78,7 +78,7 @@ function buildBlock(
 
   if (_elseBlock?.type === 'Template') {
     deprecate(`b.program is deprecated. Use b.blockItself instead.`);
-    localAssert(_elseBlock.blockParams.length === 0, '{{else}} block cannot have block params');
+    assert(_elseBlock.blockParams.length === 0, '{{else}} block cannot have block params');
 
     elseBlock = b.blockItself({
       params: [],
@@ -212,11 +212,11 @@ function buildElement(tag: TagDescriptor, options: BuildElementOptions = {}): AS
     }
   } else if ('type' in tag) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- supports JS users
-    localAssert(tag.type === 'PathExpression', `Invalid tag type ${tag.type}`);
+    assert(tag.type === 'PathExpression', `Invalid tag type ${tag.type}`);
     path = tag;
   } else if ('path' in tag) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- supports JS users
-    localAssert(tag.path.type === 'PathExpression', `Invalid tag type ${tag.path.type}`);
+    assert(tag.path.type === 'PathExpression', `Invalid tag type ${tag.path.type}`);
     path = tag.path;
     selfClosing = tag.selfClosing;
   } else {
@@ -225,7 +225,7 @@ function buildElement(tag: TagDescriptor, options: BuildElementOptions = {}): AS
   }
 
   if (selfClosing) {
-    localAssert(
+    assert(
       _closeTag === null || _closeTag === undefined,
       'Cannot build a self-closing tag with a closeTag source location'
     );
@@ -341,7 +341,7 @@ function buildPath(
     if ('type' in path) {
       return path;
     } else {
-      localAssert(
+      assert(
         path.head.indexOf('.') === -1,
         `builder.path({ head, tail }) should not be called with a head with dots in it`
       );

--- a/packages/@glimmer/syntax/lib/v2/builders.ts
+++ b/packages/@glimmer/syntax/lib/v2/builders.ts
@@ -1,5 +1,5 @@
 import type { PresentArray } from '@glimmer/interfaces';
-import { assertPresentArray, localAssert } from '@glimmer/debug-util';
+import { assertPresentArray, assert } from '@glimmer/debug-util';
 import { assign } from '@glimmer/util';
 
 import type { SourceSpan } from '../source/span';
@@ -165,7 +165,7 @@ export class Builder {
 
   at(name: string, symbol: number, loc: SourceSpan): ASTv2.VariableReference {
     // the `@` should be included so we have a complete source range
-    localAssert(name[0] === '@', `call builders.at() with a string that starts with '@'`);
+    assert(name[0] === '@', `call builders.at() with a string that starts with '@'`);
 
     return new ASTv2.ArgReference({
       loc,
@@ -185,11 +185,11 @@ export class Builder {
     symbol: number;
     loc: SourceSpan;
   }): ASTv2.FreeVarReference {
-    localAssert(
+    assert(
       name !== 'this',
       `You called builders.freeVar() with 'this'. Call builders.this instead`
     );
-    localAssert(
+    assert(
       name[0] !== '@',
       `You called builders.freeVar() with '${name}'. Call builders.at('${name}') instead`
     );
@@ -208,7 +208,7 @@ export class Builder {
     isTemplateLocal: boolean,
     loc: SourceSpan
   ): ASTv2.VariableReference {
-    localAssert(
+    assert(
       name[0] !== '@',
       `You called builders.var() with '${name}'. Call builders.at('${name}') instead`
     );

--- a/packages/@glimmer/syntax/lib/v2/normalize.ts
+++ b/packages/@glimmer/syntax/lib/v2/normalize.ts
@@ -1,5 +1,5 @@
 import type { PresentArray } from '@glimmer/interfaces';
-import { asPresentArray, isPresentArray, localAssert } from '@glimmer/debug-util';
+import { asPresentArray, isPresentArray, assert } from '@glimmer/debug-util';
 import { assign } from '@glimmer/util';
 
 import type {
@@ -191,7 +191,7 @@ class ExpressionNormalizer {
       case 'UndefinedLiteral':
         return this.block.builder.literal(expr.value, this.block.loc(expr.loc));
       case 'PathExpression':
-        localAssert(resolution, '[BUG] resolution is required');
+        assert(resolution, '[BUG] resolution is required');
         return this.path(expr, resolution);
       case 'SubExpression': {
         // expr.path used to incorrectly have the type ASTv1.Expression
@@ -408,7 +408,7 @@ class StatementNormalizer {
     let span = loc;
 
     if (node.value.startsWith('-')) {
-      localAssert(
+      assert(
         /^\{\{~?!---/u.test(source),
         `to start a comment's content with a '-', it must have started with {{!--`
       );
@@ -417,7 +417,7 @@ class StatementNormalizer {
         chars: node.value.length,
       });
     } else if (node.value.endsWith('-')) {
-      localAssert(
+      assert(
         /--~?\}\}/u.test(source),
         `to end a comment's content with a '-', it must have ended with --}}`
       );
@@ -709,7 +709,7 @@ class ElementNormalizer {
   }
 
   private attr(m: ASTv1.AttrNode): ASTv2.HtmlOrSplatAttr {
-    localAssert(m.name[0] !== '@', 'An attr name must not start with `@`');
+    assert(m.name[0] !== '@', 'An attr name must not start with `@`');
 
     if (m.name === '...attributes') {
       return this.ctx.builder.splatAttr(this.ctx.table.allocateBlock('attrs'), this.ctx.loc(m.loc));
@@ -767,7 +767,7 @@ class ElementNormalizer {
   }
 
   private arg(arg: ASTv1.AttrNode): ASTv2.ComponentArg {
-    localAssert(arg.name[0] === '@', 'An arg name must start with `@`');
+    assert(arg.name[0] === '@', 'An arg name must start with `@`');
     this.checkArgCall(arg);
 
     let offsets = this.ctx.loc(arg.loc);

--- a/packages/@glimmer/util/lib/debug-steps.ts
+++ b/packages/@glimmer/util/lib/debug-steps.ts
@@ -1,6 +1,6 @@
 /// <reference types="qunit" />
 
-import { expect, localAssert } from '@glimmer/debug-util';
+import { expect, assert } from '@glimmer/debug-util';
 import { LOCAL_DEBUG, LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 
 import { LOCAL_LOGGER } from './local-logger';
@@ -17,13 +17,13 @@ if (LOCAL_DEBUG) {
   let LOGGED_STEPS: Record<string, unknown[]> | null = null;
 
   beginTestSteps = () => {
-    localAssert(LOGGED_STEPS === null, 'attempted to start steps, but it already began');
+    assert(LOGGED_STEPS === null, 'attempted to start steps, but it already began');
 
     LOGGED_STEPS = {};
   };
 
   endTestSteps = () => {
-    localAssert(LOGGED_STEPS, 'attempted to end steps, but they were not started');
+    assert(LOGGED_STEPS, 'attempted to end steps, but they were not started');
 
     LOGGED_STEPS = null;
   };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -76,7 +76,7 @@ function sharedESMConfig({ input, debugMacrosMode, includePackageMeta = false })
   let babelConfig = { ...sharedBabelConfig };
   babelConfig.plugins = [
     ...babelConfig.plugins,
-    buildDebugMacroPlugin(debugMacrosMode),
+    ...buildDebugMacroPlugin(debugMacrosMode),
     canaryFeatures(),
   ];
 


### PR DESCRIPTION
Renames the `@glimmer/debug-util` export from `localAssert` to `assert`, aligning it with the `SUPPORTED_MACROS` list in `babel-plugin-debug-macros`. This enables the existing debug macro infrastructure to automatically strip all `assert()` calls from `@glimmer/debug-util` in prod builds — the same way it already strips `assert()` from `@ember/debug`.

## Motivation:  Bundle size stripping

`localAssert` was a legacy name from when glimmer-vm was a separate repo. After the merge into ember.js, no file imports assert from both `@ember/debug` and `@glimmer/debug-util` (verified: zero collisions), making the `local` prefix unnecessary.

Previously, `localAssert()` compiled to an empty function in prod, but the **call sites and their string arguments remained in the bundle** as dead code — rollup could strip some calls where arguments were side-effect-free, but calls with template literals or property accesses survived. With this rename, `babel-plugin-debug-macros` strips all calls unconditionally.

## Changes

- `@glimmer/debug-util/index.ts`: `export { default as assert }` (was `localAssert`)
- 31 source files: `import { assert }` (was `localAssert`), all call sites renamed
- `broccoli/build-debug-macro-plugin.js`: add second plugin instance for `@glimmer/debug-util` (`assertPredicateIndex: 0`, since condition is the first argument — unlike `@ember/debug` where description is first)
- `rollup.config.mjs` + `babel.test.config.mjs`: spread the now-array plugin config

## Bundle size impact

| | Before | After | Delta |
|---|---:|---:|---:|
| **Prod shared-chunks** | 1,018,769 bytes | 1,014,858 bytes | **-3,911 bytes** |
| **Prod shared-chunks** (brotli) | 221,609 bytes | 220,835 bytes | **-774 bytes** |

The `assert` shared chunk (`assert-*.js`) is entirely eliminated — no runtime code imports it anymore.

<details>
<summary>Post-fix prod dist audit</summary>

Remaining `assert()` calls in prod are all from `@ember/debug` (not `@glimmer/debug-util`):
- `throw assert('Use constructor...')` — `@ember/debug` pattern
- `(false && !(root) && assert('has root', root))` — `@ember/debug` macro output
- `assert(test, msg, options)` — QUnit assert method definition (not a debug call)
- `//assert(` — a comment in rehydrate-builder

Zero `@glimmer/debug-util` assert messages survive in prod. Strings like `BUG:` that appear are legitimate runtime `throw new Error()` statements, not assert leftovers.
</details>

No `if (DEBUG)` wrappers. No type casts. No code changes beyond the mechanical rename + build config.

## Alternatives considered

### Patching `babel-plugin-debug-macros
Patching `babel-plugin-debug-macros` to add `localAssert` to its `SUPPORTED_MACROS` list and `Builder` class. Rejected because the rename is cleaner, eliminates legacy naming, and requires no dependency patches.

Reproduce: `pnpm build && wc -c dist/prod/packages/shared-chunks/*.js`

### Importing from @ember/debug instead
Would break the "standalone" parts of glimmer, did not dare to touch that
