### PR TITLE
Perf: avoid array spread in PathExpression.original getter

### DIFF
--- a/packages/@glimmer/syntax/lib/v1/legacy-interop.ts
+++ b/packages/@glimmer/syntax/lib/v1/legacy-interop.ts
@@ -48,7 +48,8 @@ export function buildLegacyPath({ head, tail, loc }: PathExpressionParams): ASTv
     head,
     tail,
     get original() {
-      return [this.head.original, ...this.tail].join('.');
+      const head = this.head.original;
+      return this.tail.length === 0 ? head : `${head}.${this.tail.join('.')}`;
     },
     set original(value: string) {
       let [head, ...tail] = asPresentArray(value.split('.'));


### PR DESCRIPTION
## Summary
Micro optimization for small memory and speed improvement in precompile.

`PathExpression.original` in `packages/@glimmer/syntax/lib/v1/legacy-interop.ts` is the canonical way to read the dotted-path string form of a `PathExpression`. It is read by `@glimmer/syntax` framework internals during parse and print — `parser/handlebars-node-visitors.ts` (mustache/sexpr/string-literal paths), `v1/parser-builders.ts`, `v1/public-builders.ts`, and `generation/printer.ts` — so on a build with many templates it accumulates to tens of thousands of reads. (Note: the Ember template-compiler plugins themselves do not call this getter; the framework does, on paths visited during normalization and printing.)

Previous form allocated a fresh array every call:

```js
return [this.head.original, ...this.tail].join('.');
```

The `...this.tail` spread produces a new array per invocation; it feeds immediately into `.join('.')` and is thrown away. Pure nursery pressure.

Patched form avoids the spread:

```js
const head = this.head.original;
return this.tail.length === 0 ? head : `${head}.${this.tail.join('.')}`;
```

## Why this is spec-identical

For any `(head, tail)` pair, `[H, ...T].join('.')` equals `T.length === 0 ? H : H + '.' + T.join('.')`:

- If `tail.length === 0`: `[H].join('.')` = `H` (single-element join emits no separators).
- If `tail.length >= 1`: `[H, T0, T1, …, Tn].join('.')` = `H + '.' + T0 + '.' + … + '.' + Tn` = `H + '.' + T.join('.')`.

Both branches produce the same string for every legal input. Pure allocation reduction; no behaviour change.


## Before / after — `pnpm bench:precompile`

Measured on the existing mitata harness in `bin/precompile.bench.mjs`, interleaved A/B across N=20 pairs (ordering alternated PR-first / main-first per pair to cancel first-slot bias), M1 Max / Node 24.14. Each pair swaps pre-built `dist/` snapshots — no rebuild between runs.

 **precompile heap allocated**                                                                                                                                                                                                                                                                                                                                                             
| size   | main   | PR     | Δ bytes/iter | **Δ %**     | 95% CI    | PR<main |                                                                                                                                       
  |--------|-------:|-------:|-------------:|--------:|----------:|--------:|                                                                                                                                       
  | small  | 2.95mb | 2.89mb |     −59.5 kb |  **−1.97%** |  ±5.8 kb  | 20/20   |                                                                                                                                       
  | medium | 8.81mb | 8.61mb |    −202.4 kb |  **−2.24%** |  ±9.3 kb  | 20/20   |                                                                                                                                       
  | large  | 12.1mb | 9.73mb |    −2.25 mb  | **−18.76%** |   ±414 kb | 20/20 | 

**precompile speed**

| size   | main median | PR median   | **Δ%** | PR<main |
|--------|------------:|------------:|--------------:|-------------:|
| small  |   1.68 ms  |   1.66 ms  | **−1.2 %**    | 13/20     |
| medium |   5.11 ms  |  5.06 ms  | **−1.0 %**     | 16/20     |
| large  |  40.75 ms  |  40.11 ms  |   **−1.6 %**    | 13/20     |

Cowritten by claude