### PR TITLE
CI: retry testem ci once on failure (Browserstack flake rescue)

### DIFF
--- a/bin/run-browserstack-tests.js
+++ b/bin/run-browserstack-tests.js
@@ -17,7 +17,7 @@ async function run(command, args = []) {
       // Calling testem directly here instead of `ember test` so that
       // we do not have to do a double build (by the time this is run
       // we have already ran `ember build`).
-      await run('testem', [
+      const testemArgs = [
         'ci',
         '-f',
         'testem.browserstack.js',
@@ -25,7 +25,16 @@ async function run(command, args = []) {
         '127.0.0.1',
         '--port',
         '7774',
-      ]);
+      ];
+
+      // Absorb flaky single-launcher BrowserStack failures so they
+      // don't fail otherwise-green CI.
+      try {
+        await run('testem', testemArgs);
+      } catch (e) {
+        console.log(chalk.yellow(`testem ci failed (${e.shortMessage}); retrying once.`));
+        await run('testem', testemArgs);
+      }
 
       console.log('success');
       process.exit(0); // eslint-disable-line n/no-process-exit


### PR DESCRIPTION
Wraps `testem ci` in `bin/run-browserstack-tests.js` in a 2-attempt retry. If the second attempt also fails, the job fails normally. Avoiding ~15 false-positive CI failures per quarter is considered a bigger win than wasting ~9 unnecessary retries on failures the retry can't help.

## Occurrences last three months:
| Run | Pattern | Possible effect of PR |
|---|---|---|
| [22652639356](https://github.com/emberjs/ember.js/actions/runs/22652639356)<br>(2026-03-04) | `TypeError: Load failed` (Safari) | ✅️ autorecover? |
| [24045457073](https://github.com/emberjs/ember.js/actions/runs/24045457073)<br>(2026-04-06) | `TypeError: Load failed` (Safari) | ✅️ autorecover? |
| [24562736533](https://github.com/emberjs/ember.js/actions/runs/24562736533)<br>(2026-04-17) | `TypeError: Load failed` (Safari) | ✅️ autorecover? |
| [24655116088](https://github.com/johanrd/ember.js/actions/runs/24655116088/job/72087152175)<br>(2026-04-20) | `TypeError: Load failed` (Safari, PR #32 motivating) | ✅️ autorecover? |
| [23318447222](https://github.com/emberjs/ember.js/actions/runs/23318447222)<br>(2026-03-19) | `Assertion occurred after test finished` (Safari) | ✅️ autorecover? |
| [23374608293](https://github.com/emberjs/ember.js/actions/runs/23374608293)<br>(2026-03-21) | `Assertion occurred after test finished` (Safari, on `Can use hash` test) | ⚠️ recurred 6× on Safari; retry unlikely to recover |
| [23398101871](https://github.com/emberjs/ember.js/actions/runs/23398101871)<br>(2026-03-22) | `Assertion occurred after test finished` (Safari, on `Can use hash` test) | ⚠️ recurred 6× on Safari; retry unlikely to recover |
| [23426251444](https://github.com/emberjs/ember.js/actions/runs/23426251444)<br>(2026-03-23) | `Assertion occurred after test finished` (Safari, on `Can use hash` test) | ⚠️ recurred 6× on Safari; retry unlikely to recover |
| [23430422282](https://github.com/emberjs/ember.js/actions/runs/23430422282)<br>(2026-03-23) | `Assertion occurred after test finished` (Safari, on `Can use hash` test) | ⚠️ recurred 6× on Safari; retry unlikely to recover |
| [23455894140](https://github.com/emberjs/ember.js/actions/runs/23455894140)<br>(2026-03-23) | `Assertion occurred after test finished` (Safari, on `Can use hash` test) | ⚠️ recurred 6× on Safari; retry unlikely to recover |
| [23456175289](https://github.com/emberjs/ember.js/actions/runs/23456175289)<br>(2026-03-23) | `Assertion occurred after test finished` (Safari, on `Can use hash` test) | ⚠️ recurred 6× on Safari; retry unlikely to recover |
| [21239406320](https://github.com/emberjs/ember.js/actions/runs/21239406320)<br>(2026-01-22) | `Browser timeout exceeded: 120s` (Safari) | ✅️ autorecover? |
| [22476826260](https://github.com/emberjs/ember.js/actions/runs/22476826260)<br>(2026-02-27) | `Browser timeout exceeded: 120s` (Safari) | ✅️ autorecover? |
| [22634897665](https://github.com/emberjs/ember.js/actions/runs/22634897665)<br>(2026-03-03) | `Browser timeout exceeded: 120s` (Chrome, on `instance tracking: tracks built instances`) | ✅️ autorecover? |
| [22650604376](https://github.com/emberjs/ember.js/actions/runs/22650604376)<br>(2026-03-04) | `Browser timeout exceeded: 120s` (Chrome, on same `Can use hash` test) | ⚠️ same recurring test; retry unlikely to recover |
| [22735732561](https://github.com/emberjs/ember.js/actions/runs/22735732561)<br>(2026-03-05) | `Browser timeout exceeded: 120s` (Safari, on `Registry: knownForType`) | ✅️ autorecover? |
| [22736088751](https://github.com/emberjs/ember.js/actions/runs/22736088751)<br>(2026-03-05) | `Browser timeout exceeded: 120s` (Safari, on `Can use Textarea`) | ✅️ autorecover? |
| [22736440360](https://github.com/emberjs/ember.js/actions/runs/22736440360)<br>(2026-03-05) | `Browser timeout exceeded: 120s` (Safari, on `Dynamic content tests`) | ✅️ autorecover? |
| [21349229095](https://github.com/emberjs/ember.js/actions/runs/21349229095)<br>(2026-01-26) | `Browser exited unexpectedly` (Chrome only; Safari + Edge passed) | ✅️ autorecover? |
| [22201213313](https://github.com/emberjs/ember.js/actions/runs/22201213313)<br>(2026-02-19) | All launchers fail at startup (BrowserStack Cloudflare challenge) | ⚠️ not recover and double ci time |
| [22651153617](https://github.com/emberjs/ember.js/actions/runs/22651153617)<br>(2026-03-04) | `Browser exited unexpectedly` (Chrome only; Safari + Edge passed) | ✅️ autorecover? |
| [23040545692](https://github.com/emberjs/ember.js/actions/runs/23040545692)<br>(2026-03-13) | `Browser exited unexpectedly` (Chrome + Edge; Safari passed) | ✅️ autorecover? |
| [23662618302](https://github.com/emberjs/ember.js/actions/runs/23662618302)<br>(2026-03-27) | All launchers fail at startup (BrowserStack Cloudflare challenge) | ⚠️ not recover and double ci time |
| [23967918042](https://github.com/emberjs/ember.js/actions/runs/23967918042)<br>(2026-04-04) | `Browser exited unexpectedly` (Chrome only; Safari + Edge passed) | ✅️ autorecover? |

## Caveats

- Helps only for **independent** per-attempt failures. Correlated failures fail both attempts.
- Worst-case CI time and BrowserStack session minutes roughly double on a retry.
- Deterministic bugs still surface — they fail both attempts.

Scoped to the BrowserStack-only job; Firefox/Chrome coverage in the regular browser-test job is unchanged. Testem doesn't expose a native retry option.

Cowritten by claude