### PR TITLE
Register ember-page-title service in the strict-resolver scenario

### DIFF
--- a/smoke-tests/scenarios/scenarios.ts
+++ b/smoke-tests/scenarios/scenarios.ts
@@ -32,10 +32,17 @@ function strictResolver(project: Project) {
       'app.js': `
         import Application from '@ember/application';
         import Router from './router';
+        // v2 addons don't auto-register with the strict resolver the way
+        // classic ember-resolver + compat-modules does; we have to explicitly
+        // wire each addon-provided module into \`modules\`. The
+        // v2-app-template uses \`{{pageTitle}}\` in application.gjs, which
+        // injects \`@service('page-title')\`, so we need to register it here.
+        import PageTitleService from 'ember-page-title/services/page-title';
 
         export default class App extends Application {
           modules = {
             './router': { default: Router },
+            './services/page-title': { default: PageTitleService },
             ...import.meta.glob('./services/**/*.{js,ts}', { eager: true }),
             ...import.meta.glob('./controllers/**/*.{js,ts}', { eager: true }),
             ...import.meta.glob('./routes/**/*.{js,ts}', { eager: true }),


### PR DESCRIPTION
## Summary

CI on \`nvp/strict-resolver-rfc-1132\` started failing \`tests / Smoke tests (Full Ember Apps) (strictResolver-basics)\` after 9b0f351 added the \`strictResolver\` variant to \`v2AppScenarios\`. The failure is in the _Acceptance | example gjs route_ test.

## Root cause

\`v2-app-template\`'s default \`application.gjs\` contains \`{{pageTitle \"V2AppTemplate\"}}\`. The \`pageTitle\` helper does \`@service('page-title')\` in its constructor, so rendering the application route triggers \`owner.lookup('service:page-title')\`. Under the classic ember-resolver + compat-modules pipeline the addon's service is surfaced automatically; under the strict resolver, addons don't contribute modules unless the app explicitly wires them into \`modules\`. The lookup missed, the helper initialized with \`this.tokens\` undefined, and \`.push\` threw:

```
TypeError: Cannot read properties of undefined (reading 'push')
  at new PageTitle
  at ClassicHelperManager.createHelper
  …
```

(Confirmed locally with a printf trace on \`StrictResolver.resolve\` — \`service:page-title\` MISSes — and an \`unhandledrejection\` listener that surfaced the \`PageTitle\` stack.)

## Fix

Explicitly register the addon service in the \`strictResolver\` variant's \`app.js\`:

\`\`\`js
import PageTitleService from 'ember-page-title/services/page-title';

modules = {
  './services/page-title': { default: PageTitleService },
  …
};
\`\`\`

This matches the intended strict-resolver ergonomics (no implicit addon registration; the app declares its modules) and aligns with RFC #1132.

## Test plan

- [x] \`pnpm test --filter strict\` passes all three: \`strictResolver-basics\`, \`strictResolver-strict-resolver\`, \`strictResolver-strict-resolver-substates\`
- [x] \`pnpm type-check:internals\`, \`pnpm lint:format\`, eslint all clean
- [ ] CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)