### PR TITLE
Fill the nested-route gaps in the strict-resolver scenario

### DIFF
--- a/packages/@ember/engine/tests/resolver/registry_test.ts
+++ b/packages/@ember/engine/tests/resolver/registry_test.ts
@@ -60,38 +60,4 @@ module('strict-resolver | Application with modules', function (hooks) {
     assert.ok(service, 'service was found');
     assert.ok(service.weDidIt, 'service has the right property');
   });
-
-  test('resolves shorthand modules (without default wrapper)', async function (assert) {
-    class MyService extends Service {
-      shorthand = true;
-    }
-
-    app = Application.create({
-      modules: {
-        './services/shorthand-svc': MyService,
-      },
-      rootElement: '#qunit-fixture',
-      autoboot: false,
-    });
-
-    instance = (await app.visit('/', {})) as ApplicationInstance;
-    let service = instance.lookup('service:shorthand-svc') as MyService;
-
-    assert.ok(service, 'service was found');
-    assert.ok(service.shorthand, 'service has the right property');
-  });
-
-  test('resolves router:main via ./router module', async function (assert) {
-    app = Application.create({
-      modules: {},
-      rootElement: '#qunit-fixture',
-      autoboot: false,
-    });
-
-    instance = (await app.visit('/', {})) as ApplicationInstance;
-
-    let router = instance.lookup('router:main');
-
-    assert.ok(router, 'router was resolved');
-  });
 });

--- a/smoke-tests/scenarios/strict-resolver-substates-test.ts
+++ b/smoke-tests/scenarios/strict-resolver-substates-test.ts
@@ -8,11 +8,12 @@ const { module: Qmodule, test } = QUnit;
 // Ember's auto-generated loading/error substates through real route
 // transitions. Covers:
 //
-//   - visiting /                       (plain route + template)
-//   - visiting /slow                   (async model -> loading substate)
-//   - visiting /broken                 (rejected model -> error substate)
-//   - visiting a nested dynamic route  (posts/:post_id) to prove the
-//     resolver handles sub-route templates via default lookup
+//   - visiting /         (plain route + template — sanity)
+//   - visiting /slow     (async model -> loading substate)
+//   - visiting /broken   (rejected model -> error substate)
+//
+// Nested/dynamic route coverage lives in strict-resolver-test.ts so we
+// don't pay to rebuild it here.
 strictAppScenarios
   .map('strict-resolver-substates', (project) => {
     project.mergeFiles({
@@ -43,9 +44,6 @@ strictAppScenarios
           Router.map(function () {
             this.route('slow');
             this.route('broken');
-            this.route('posts', function () {
-              this.route('show', { path: '/:post_id' });
-            });
           });
         `,
         services: {
@@ -103,27 +101,6 @@ strictAppScenarios
               }
             }
           `,
-          'posts.js': `
-            import Route from '@ember/routing/route';
-            export default class extends Route {
-              model() {
-                return [
-                  { id: 1, title: 'First Post' },
-                  { id: 2, title: 'Second Post' },
-                ];
-              }
-            }
-          `,
-          'posts': {
-            'show.js': `
-              import Route from '@ember/routing/route';
-              export default class extends Route {
-                model(params) {
-                  return { id: params.post_id, title: 'Post ' + params.post_id };
-                }
-              }
-            `,
-          },
         },
         templates: {
           'application.hbs': `
@@ -148,19 +125,6 @@ strictAppScenarios
           'broken-error.hbs': `
             <div data-test="broken-error">Caught error: {{@model.message}}</div>
           `,
-          'posts.hbs': `
-            <div data-test="posts-list">
-              {{#each @model as |post|}}
-                <div data-test="post-card">{{post.title}}</div>
-              {{/each}}
-            </div>
-            {{outlet}}
-          `,
-          'posts': {
-            'show.hbs': `
-              <div data-test="post-detail">{{@model.title}}</div>
-            `,
-          },
         },
       },
       tests: {
@@ -225,19 +189,6 @@ strictAppScenarios
                 assert.dom('[data-test="broken-error"]').hasText(
                   'Caught error: intentional model failure'
                 );
-              });
-
-              test('visiting /posts renders the list', async function (assert) {
-                await visit('/posts');
-                assert.strictEqual(currentURL(), '/posts');
-                assert.dom('[data-test="posts-list"]').exists();
-                assert.dom('[data-test="post-card"]').exists({ count: 2 });
-              });
-
-              test('visiting a nested dynamic sub-route renders the detail template', async function (assert) {
-                await visit('/posts/42');
-                assert.strictEqual(currentURL(), '/posts/42');
-                assert.dom('[data-test="post-detail"]').hasText('Post 42');
               });
             });
           `,

--- a/smoke-tests/scenarios/strict-resolver-test.ts
+++ b/smoke-tests/scenarios/strict-resolver-test.ts
@@ -162,21 +162,19 @@ strictAppScenarios
                 assert.dom('[data-test="site-header"] h1').hasText('Strict App');
               });
 
-              test('sub-route with nested model', async function (assert) {
+              test('sub-route with nested model renders a gjs component per item', async function (assert) {
                 await visit('/posts');
                 assert.strictEqual(currentURL(), '/posts');
                 assert.dom('[data-test="post-card"]').exists({ count: 2 });
+                assert.dom('[data-test="post-card"] h2').exists(
+                  'PostCard gjs template renders inside the nested route'
+                );
               });
 
               test('dynamic segment sub-route', async function (assert) {
                 await visit('/posts/42');
                 assert.strictEqual(currentURL(), '/posts/42');
                 assert.dom('[data-test="post-detail"]').hasText('Post 42');
-              });
-
-              test('gjs component resolves from modules', async function (assert) {
-                await visit('/posts');
-                assert.dom('[data-test="post-card"] h2').exists();
               });
             });
           `,

--- a/smoke-tests/scenarios/strict-resolver-test.ts
+++ b/smoke-tests/scenarios/strict-resolver-test.ts
@@ -37,7 +37,9 @@ strictAppScenarios
 
           Router.map(function () {
             this.route('posts', function () {
-              this.route('show', { path: '/:post_id' });
+              this.route('show', { path: '/:post_id' }, function () {
+                this.route('comments');
+              });
             });
           });
         `,
@@ -79,6 +81,16 @@ strictAppScenarios
                 }
               }
             `,
+            'show': {
+              'comments.js': `
+                import Route from '@ember/routing/route';
+                export default class extends Route {
+                  model() {
+                    return ['great post!', 'meh'];
+                  }
+                }
+              `,
+            },
           },
         },
         controllers: {
@@ -129,9 +141,20 @@ strictAppScenarios
             {{outlet}}
           `,
           'posts': {
+            'index.hbs': `
+              <div data-test="posts-index">posts index page</div>
+            `,
             'show.hbs': `
               <div data-test="post-detail">{{@model.title}}</div>
+              {{outlet}}
             `,
+            'show': {
+              'comments.hbs': `
+                <ul data-test="post-comments">
+                  {{#each @model as |c|}}<li>{{c}}</li>{{/each}}
+                </ul>
+              `,
+            },
           },
         },
       },
@@ -162,19 +185,50 @@ strictAppScenarios
                 assert.dom('[data-test="site-header"] h1').hasText('Strict App');
               });
 
-              test('sub-route with nested model renders a gjs component per item', async function (assert) {
+              test('parent route with auto-generated index renders both templates', async function (assert) {
+                // Visiting /posts activates posts + posts.index. Both
+                // templates must resolve: posts.hbs (with {{outlet}}) and
+                // posts/index.hbs (nested under a folder). Proves the
+                // strict resolver handles both the parent and the nested
+                // \`type:name.index\` -> \`type/name/index\` path.
                 await visit('/posts');
                 assert.strictEqual(currentURL(), '/posts');
+                assert.dom('[data-test="posts"]').exists('parent template rendered');
                 assert.dom('[data-test="post-card"]').exists({ count: 2 });
                 assert.dom('[data-test="post-card"] h2').exists(
                   'PostCard gjs template renders inside the nested route'
                 );
+                assert.dom('[data-test="posts-index"]').exists(
+                  'posts.index template rendered inside the parent outlet'
+                );
               });
 
-              test('dynamic segment sub-route', async function (assert) {
+              test('dynamic nested child renders alongside its parent template', async function (assert) {
+                // /posts/42 activates both posts (parent) and posts.show
+                // (child). The parent template must still be present —
+                // the child renders into its {{outlet}}.
                 await visit('/posts/42');
                 assert.strictEqual(currentURL(), '/posts/42');
+                assert.dom('[data-test="posts"]').exists('parent template still rendered');
+                assert.dom('[data-test="post-card"]').exists({ count: 2 });
                 assert.dom('[data-test="post-detail"]').hasText('Post 42');
+              });
+
+              test('three-level nested route resolves every level', async function (assert) {
+                // /posts/42/comments activates posts -> posts.show ->
+                // posts.show.comments. Every template in the chain must
+                // resolve, and the strict resolver must walk
+                // template:posts.show.comments -> templates/posts/show/comments.
+                await visit('/posts/42/comments');
+                assert.strictEqual(currentURL(), '/posts/42/comments');
+                assert.dom('[data-test="posts"]').exists('level 1: posts.hbs');
+                assert.dom('[data-test="post-detail"]').hasText(
+                  'Post 42',
+                  'level 2: posts/show.hbs'
+                );
+                assert.dom('[data-test="post-comments"] li').exists({ count: 2 },
+                  'level 3: posts/show/comments.hbs'
+                );
               });
             });
           `,


### PR DESCRIPTION
## Summary

Stacked on #21332 (trim-redundant-resolver-tests-2). The existing strict-resolver smoke test exercises a two-level nested route via `/posts/42`, but only asserts the child template rendered. Three concrete gaps:

1. **Parent template isn't asserted to render alongside the child.** A regression where `posts.hbs`'s `{{outlet}}` stopped propagating `@model` or the parent route stopped activating would pass today.
2. **No `templates/posts/index.hbs`**, so we don't prove the resolver walks `template:posts.index` → `templates/posts/index` (the `name.index → name/index` nested-folder path).
3. **No 3-level nesting coverage**, so a regression in the `type:a.b.c → a/b/c` normalization path would slip through.

## Changes

- Add `this.route('comments')` under `posts.show` in the router, plus `routes/posts/show/comments.js` and `templates/posts/show/comments.hbs`. Give `posts/show.hbs` a `{{outlet}}` so the grandchild has somewhere to render.
- Add `templates/posts/index.hbs` so the `posts.index` template path is actually resolvable.
- Promote the two existing sub-route tests to also assert the parent template is in the DOM.
- New test: `three-level nested route resolves every level` — visits `/posts/42/comments` and checks all three levels (`[data-test="posts"]`, `[data-test="post-detail"]`, `[data-test="post-comments"] li`) are in the DOM.

No resolver changes. One file changed (`smoke-tests/scenarios/strict-resolver-test.ts`, +57/−3).

## Test plan

- [x] `pnpm test --filter strict` passes all three scenarios (`strictResolver-basics`, `strictResolver-strict-resolver`, `strictResolver-strict-resolver-substates`)
- [x] `pnpm type-check:internals`, `pnpm prettier --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)