### PR TITLE
RFC#999 - {{hash}} as keyword

### DIFF
--- a/packages/@ember/template-compiler/lib/compile-options.ts
+++ b/packages/@ember/template-compiler/lib/compile-options.ts
@@ -1,4 +1,4 @@
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { assert } from '@ember/debug';
 import {
@@ -26,6 +26,7 @@ export const RUNTIME_KEYWORDS_NAME = '__ember_keywords__';
 
 export const keywords: Record<string, unknown> = {
   fn,
+  hash,
   on,
 };
 

--- a/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
+++ b/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
@@ -30,10 +30,16 @@ export default function autoImportBuiltins(env: EmberASTPluginEnvironment): ASTP
         if (isFn(node, hasLocal)) {
           rewriteKeyword(env, node, 'fn', '@ember/helper');
         }
+        if (isHash(node, hasLocal)) {
+          rewriteKeyword(env, node, 'hash', '@ember/helper');
+        }
       },
       MustacheStatement(node: AST.MustacheStatement) {
         if (isFn(node, hasLocal)) {
           rewriteKeyword(env, node, 'fn', '@ember/helper');
+        }
+        if (isHash(node, hasLocal)) {
+          rewriteKeyword(env, node, 'hash', '@ember/helper');
         }
       },
     },
@@ -67,4 +73,11 @@ function isFn(
   hasLocal: (k: string) => boolean
 ): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
   return isPath(node.path) && node.path.original === 'fn' && !hasLocal('fn');
+}
+
+function isHash(
+  node: AST.MustacheStatement | AST.SubExpression,
+  hasLocal: (k: string) => boolean
+): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
+  return isPath(node.path) && node.path.original === 'hash' && !hasLocal('hash');
 }

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/hash-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/hash-runtime-test.ts
@@ -1,0 +1,139 @@
+import { castToBrowser } from '@glimmer/debug-util';
+import {
+  GlimmerishComponent,
+  jitSuite,
+  RenderTest,
+  test,
+} from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+
+class KeywordHashRuntime extends RenderTest {
+  static suiteName = 'keyword helper: hash (runtime)';
+
+  @test
+  'explicit scope'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    let capture = (data: Record<string, unknown>) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (hash greeting="hello"))}}>Click</button>',
+      {
+        strictMode: true,
+        scope: () => ({
+          capture,
+        }),
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+  }
+
+  @test
+  'implicit scope'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    let capture = (data: Record<string, unknown>) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    hide(capture);
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (hash greeting="hello"))}}>Click</button>',
+      {
+        strictMode: true,
+        eval() {
+          return eval(arguments[0]);
+        },
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+  }
+
+  @test
+  'MustacheStatement with explicit scope'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    let capture = (data: Record<string, unknown>) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const Child = template('<button {{on "click" (fn capture @data)}}>Click</button>', {
+      strictMode: true,
+      scope: () => ({ capture }),
+    });
+
+    const compiled = template('<Child @data={{hash greeting="hello"}} />', {
+      strictMode: true,
+      scope: () => ({
+        Child,
+      }),
+    });
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+  }
+
+  @test
+  'no eval and no scope'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    class Foo extends GlimmerishComponent {
+      static {
+        template(
+          '<button {{on "click" (fn this.capture (hash greeting="hello"))}}>Click</button>',
+          {
+            strictMode: true,
+            component: this,
+          }
+        );
+      }
+
+      capture = (data: Record<string, unknown>) => {
+        receivedData = data;
+        assert.step('captured');
+      };
+    }
+
+    this.renderComponent(Foo);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+  }
+}
+
+jitSuite(KeywordHashRuntime);
+
+/**
+ * This function is used to hide a variable from the transpiler, so that it
+ * doesn't get removed as "unused". It does not actually do anything with the
+ * variable, it just makes it be part of an expression that the transpiler
+ * won't remove.
+ *
+ * It's a bit of a hack, but it's necessary for testing.
+ *
+ * @param variable The variable to hide.
+ */
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/hash-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/hash-runtime-test.ts
@@ -66,6 +66,28 @@ class KeywordHashRuntime extends RenderTest {
   }
 
   @test
+  'implicit scope (shadowing)'(assert: Assert) {
+    let receivedData: string | undefined;
+
+    const hash = (data: string) => {
+      receivedData = data;
+    };
+
+    hide(hash);
+
+    const compiled = template('{{hash "hello"}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
+
+    this.renderComponent(compiled);
+
+    assert.strictEqual(receivedData, 'hello');
+  }
+
+  @test
   'MustacheStatement with explicit scope'(assert: Assert) {
     let receivedData: Record<string, unknown> | undefined;
 

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/hash-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/hash-runtime-test.ts
@@ -20,21 +20,18 @@ class KeywordHashRuntime extends RenderTest {
       assert.step('captured');
     };
 
-    const compiled = template(
-      '<button {{on "click" (fn capture (hash greeting="hello"))}}>Click</button>',
-      {
-        strictMode: true,
-        scope: () => ({
-          capture,
-        }),
-      }
-    );
+    const compiled = template('{{capture (hash greeting="hello" farewell="goodbye")}}', {
+      strictMode: true,
+      scope: () => ({
+        capture,
+      }),
+    });
 
     this.renderComponent(compiled);
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
     assert.verifySteps(['captured']);
     assert.strictEqual(receivedData?.['greeting'], 'hello');
+    assert.strictEqual(receivedData?.['farewell'], 'goodbye');
   }
 
   @test
@@ -48,19 +45,15 @@ class KeywordHashRuntime extends RenderTest {
 
     hide(capture);
 
-    const compiled = template(
-      '<button {{on "click" (fn capture (hash greeting="hello"))}}>Click</button>',
-      {
-        strictMode: true,
-        eval() {
-          return eval(arguments[0]);
-        },
-      }
-    );
+    const compiled = template('{{capture (hash greeting="hello")}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
 
     this.renderComponent(compiled);
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
     assert.verifySteps(['captured']);
     assert.strictEqual(receivedData?.['greeting'], 'hello');
   }
@@ -96,7 +89,7 @@ class KeywordHashRuntime extends RenderTest {
       assert.step('captured');
     };
 
-    const Child = template('<button {{on "click" (fn capture @data)}}>Click</button>', {
+    const Child = template('{{capture @data}}', {
       strictMode: true,
       scope: () => ({ capture }),
     });
@@ -110,7 +103,6 @@ class KeywordHashRuntime extends RenderTest {
 
     this.renderComponent(compiled);
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
     assert.verifySteps(['captured']);
     assert.strictEqual(receivedData?.['greeting'], 'hello');
   }

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/hash-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/hash-test.ts
@@ -1,7 +1,7 @@
 import { castToBrowser } from '@glimmer/debug-util';
 import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
 
-import { template } from '@ember/template-compiler/runtime';
+import { template } from '@ember/template-compiler';
 import { fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/hash-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/hash-test.ts
@@ -1,0 +1,113 @@
+import { castToBrowser } from '@glimmer/debug-util';
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+import { fn, hash } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+class KeywordHash extends RenderTest {
+  static suiteName = 'keyword helper: hash';
+
+  @test
+  'it works'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    let capture = (data: Record<string, unknown>) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (hash greeting="hello" farewell="goodbye"))}}>Click</button>',
+      {
+        strictMode: true,
+        scope: () => ({
+          capture,
+          fn,
+          hash,
+          on,
+        }),
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+    assert.strictEqual(receivedData?.['farewell'], 'goodbye');
+  }
+
+  @test
+  'it works with the runtime compiler'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    let capture = (data: Record<string, unknown>) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    hide(capture);
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (hash greeting="hello"))}}>Click</button>',
+      {
+        strictMode: true,
+        eval() {
+          return eval(arguments[0]);
+        },
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+  }
+
+  @test
+  'it works as a MustacheStatement'(assert: Assert) {
+    let receivedData: Record<string, unknown> | undefined;
+
+    let capture = (data: Record<string, unknown>) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const Child = template('<button {{on "click" (fn capture @data)}}>Click</button>', {
+      strictMode: true,
+      scope: () => ({ on, fn, capture }),
+    });
+
+    const compiled = template('<Child @data={{hash greeting="hello"}} />', {
+      strictMode: true,
+      scope: () => ({
+        hash,
+        Child,
+      }),
+    });
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.strictEqual(receivedData?.['greeting'], 'hello');
+  }
+}
+
+jitSuite(KeywordHash);
+
+/**
+ * This function is used to hide a variable from the transpiler, so that it
+ * doesn't get removed as "unused". It does not actually do anything with the
+ * variable, it just makes it be part of an expression that the transpiler
+ * won't remove.
+ *
+ * It's a bit of a hack, but it's necessary for testing.
+ *
+ * @param variable The variable to hide.
+ */
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/hash-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/hash-test.ts
@@ -1,9 +1,6 @@
-import { castToBrowser } from '@glimmer/debug-util';
 import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
 
 import { template } from '@ember/template-compiler';
-import { fn, hash } from '@ember/helper';
-import { on } from '@ember/modifier';
 
 class KeywordHash extends RenderTest {
   static suiteName = 'keyword helper: hash';
@@ -17,29 +14,42 @@ class KeywordHash extends RenderTest {
       assert.step('captured');
     };
 
-    const compiled = template(
-      '<button {{on "click" (fn capture (hash greeting="hello" farewell="goodbye"))}}>Click</button>',
-      {
-        strictMode: true,
-        scope: () => ({
-          capture,
-          fn,
-          hash,
-          on,
-        }),
-      }
-    );
+    const compiled = template('{{capture (hash greeting="hello" farewell="goodbye")}}', {
+      strictMode: true,
+      scope: () => ({
+        capture,
+      }),
+    });
 
     this.renderComponent(compiled);
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
     assert.verifySteps(['captured']);
     assert.strictEqual(receivedData?.['greeting'], 'hello');
     assert.strictEqual(receivedData?.['farewell'], 'goodbye');
   }
 
   @test
-  'it works with the runtime compiler'(assert: Assert) {
+  'it can be shadowed'(assert: Assert) {
+    let receivedData: string | undefined;
+
+    let hash = (data: string) => {
+      receivedData = data;
+    };
+
+    hide(hash);
+
+    const compiled = template('{{hash "hello"}}', {
+      strictMode: true,
+      scope: () => ({ hash }),
+    });
+
+    this.renderComponent(compiled);
+
+    assert.strictEqual(receivedData, 'hello');
+  }
+
+  @test
+  'it works with implicit scope form'(assert: Assert) {
     let receivedData: Record<string, unknown> | undefined;
 
     let capture = (data: Record<string, unknown>) => {
@@ -49,19 +59,15 @@ class KeywordHash extends RenderTest {
 
     hide(capture);
 
-    const compiled = template(
-      '<button {{on "click" (fn capture (hash greeting="hello"))}}>Click</button>',
-      {
-        strictMode: true,
-        eval() {
-          return eval(arguments[0]);
-        },
-      }
-    );
+    const compiled = template('{{capture (hash greeting="hello")}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
 
     this.renderComponent(compiled);
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
     assert.verifySteps(['captured']);
     assert.strictEqual(receivedData?.['greeting'], 'hello');
   }
@@ -75,22 +81,20 @@ class KeywordHash extends RenderTest {
       assert.step('captured');
     };
 
-    const Child = template('<button {{on "click" (fn capture @data)}}>Click</button>', {
+    const Child = template('{{capture @data}}', {
       strictMode: true,
-      scope: () => ({ on, fn, capture }),
+      scope: () => ({ capture }),
     });
 
     const compiled = template('<Child @data={{hash greeting="hello"}} />', {
       strictMode: true,
       scope: () => ({
-        hash,
         Child,
       }),
     });
 
     this.renderComponent(compiled);
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
     assert.verifySteps(['captured']);
     assert.strictEqual(receivedData?.['greeting'], 'hello');
   }

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -454,6 +454,40 @@ function basicTest(scenarios: Scenarios, appName: string) {
                 });
               });
             `,
+            'hash-as-keyword-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render, click } from '@ember/test-helpers';
+
+              import Component from '@glimmer/component';
+              import { tracked } from '@glimmer/tracking';
+
+              class Demo extends Component {
+                @tracked data = null;
+                setData = (d) => this.data = d;
+
+                <template>
+                  <button {{on 'click' (fn this.setData (hash greeting="hello" farewell="goodbye"))}}>
+                    {{#if this.data}}
+                      {{this.data.greeting}} {{this.data.farewell}}
+                    {{else}}
+                      click me
+                    {{/if}}
+                  </button>
+                </template>
+              }
+
+              module('{{hash}} as keyword', function(hooks) {
+                setupRenderingTest(hooks);
+
+                test('it works', async function(assert) {
+                  await render(Demo);
+                  assert.dom('button').hasText('click me');
+                  await click('button');
+                  assert.dom('button').hasText('hello goodbye');
+                });
+              });
+            `,
           },
         },
       });

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -488,6 +488,21 @@ function basicTest(scenarios: Scenarios, appName: string) {
                 });
               });
             `,
+            'hash-as-keyword-shadowed-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render } from '@ember/test-helpers';
+
+              module('{{hash}} as keyword', function(hooks) {
+                setupRenderingTest(hooks);
+
+                test('it works', async function(assert) {
+                  const hash = (data) => data;
+                  await render(<template>{{hash "hello"}}</template>);
+                  assert.dom().hasText('hello');
+                });
+              });
+            `,
           },
         },
       });


### PR DESCRIPTION
Add hash to the built-in keywords map so it no longer needs to be imported in strict-mode (gjs/gts) templates.

Implements RFC 999: https://rfcs.emberjs.com/id/0999-make-hash-built-in