### PR TITLE
RFC#1000 - {{array}} as keyword

### DIFF
--- a/packages/@ember/template-compiler/lib/compile-options.ts
+++ b/packages/@ember/template-compiler/lib/compile-options.ts
@@ -1,4 +1,4 @@
-import { fn, hash } from '@ember/helper';
+import { array, fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { assert } from '@ember/debug';
 import {
@@ -25,6 +25,7 @@ function malformedComponentLookup(string: string) {
 export const RUNTIME_KEYWORDS_NAME = '__ember_keywords__';
 
 export const keywords: Record<string, unknown> = {
+  array,
   fn,
   hash,
   on,

--- a/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
+++ b/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
@@ -27,6 +27,9 @@ export default function autoImportBuiltins(env: EmberASTPluginEnvironment): ASTP
         }
       },
       SubExpression(node: AST.SubExpression) {
+        if (isArray(node, hasLocal)) {
+          rewriteKeyword(env, node, 'array', '@ember/helper');
+        }
         if (isFn(node, hasLocal)) {
           rewriteKeyword(env, node, 'fn', '@ember/helper');
         }
@@ -35,6 +38,9 @@ export default function autoImportBuiltins(env: EmberASTPluginEnvironment): ASTP
         }
       },
       MustacheStatement(node: AST.MustacheStatement) {
+        if (isArray(node, hasLocal)) {
+          rewriteKeyword(env, node, 'array', '@ember/helper');
+        }
         if (isFn(node, hasLocal)) {
           rewriteKeyword(env, node, 'fn', '@ember/helper');
         }
@@ -66,6 +72,13 @@ function isOn(
   hasLocal: (k: string) => boolean
 ): node is AST.ElementModifierStatement & { path: AST.PathExpression } {
   return isPath(node.path) && node.path.original === 'on' && !hasLocal('on');
+}
+
+function isArray(
+  node: AST.MustacheStatement | AST.SubExpression,
+  hasLocal: (k: string) => boolean
+): node is (AST.MustacheStatement | AST.SubExpression) & { path: AST.PathExpression } {
+  return isPath(node.path) && node.path.original === 'array' && !hasLocal('array');
 }
 
 function isFn(

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/array-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/array-runtime-test.ts
@@ -1,0 +1,139 @@
+import { castToBrowser } from '@glimmer/debug-util';
+import {
+  GlimmerishComponent,
+  jitSuite,
+  RenderTest,
+  test,
+} from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+
+class KeywordArrayRuntime extends RenderTest {
+  static suiteName = 'keyword helper: array (runtime)';
+
+  @test
+  'explicit scope'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    let capture = (data: unknown[]) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
+      {
+        strictMode: true,
+        scope: () => ({
+          capture,
+        }),
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+
+  @test
+  'implicit scope'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    let capture = (data: unknown[]) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    hide(capture);
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
+      {
+        strictMode: true,
+        eval() {
+          return eval(arguments[0]);
+        },
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+
+  @test
+  'MustacheStatement with explicit scope'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    let capture = (data: unknown[]) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const Child = template('<button {{on "click" (fn capture @items)}}>Click</button>', {
+      strictMode: true,
+      scope: () => ({ capture }),
+    });
+
+    const compiled = template('<Child @items={{array "hello" "goodbye"}} />', {
+      strictMode: true,
+      scope: () => ({
+        Child,
+      }),
+    });
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+
+  @test
+  'no eval and no scope'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    class Foo extends GlimmerishComponent {
+      static {
+        template(
+          '<button {{on "click" (fn this.capture (array "hello" "goodbye"))}}>Click</button>',
+          {
+            strictMode: true,
+            component: this,
+          }
+        );
+      }
+
+      capture = (data: unknown[]) => {
+        receivedData = data;
+        assert.step('captured');
+      };
+    }
+
+    this.renderComponent(Foo);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+}
+
+jitSuite(KeywordArrayRuntime);
+
+/**
+ * This function is used to hide a variable from the transpiler, so that it
+ * doesn't get removed as "unused". It does not actually do anything with the
+ * variable, it just makes it be part of an expression that the transpiler
+ * won't remove.
+ *
+ * It's a bit of a hack, but it's necessary for testing.
+ *
+ * @param variable The variable to hide.
+ */
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/array-runtime-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/array-runtime-test.ts
@@ -12,85 +12,56 @@ class KeywordArrayRuntime extends RenderTest {
   static suiteName = 'keyword helper: array (runtime)';
 
   @test
-  'explicit scope'(assert: Assert) {
-    let receivedData: unknown[] | undefined;
-
-    let capture = (data: unknown[]) => {
-      receivedData = data;
-      assert.step('captured');
-    };
-
-    const compiled = template(
-      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
-      {
-        strictMode: true,
-        scope: () => ({
-          capture,
-        }),
-      }
-    );
-
-    this.renderComponent(compiled);
-
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
-    assert.verifySteps(['captured']);
-    assert.deepEqual(receivedData, ['hello', 'goodbye']);
-  }
-
-  @test
-  'implicit scope'(assert: Assert) {
-    let receivedData: unknown[] | undefined;
-
-    let capture = (data: unknown[]) => {
-      receivedData = data;
-      assert.step('captured');
-    };
-
-    hide(capture);
-
-    const compiled = template(
-      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
-      {
-        strictMode: true,
-        eval() {
-          return eval(arguments[0]);
-        },
-      }
-    );
-
-    this.renderComponent(compiled);
-
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
-    assert.verifySteps(['captured']);
-    assert.deepEqual(receivedData, ['hello', 'goodbye']);
-  }
-
-  @test
-  'MustacheStatement with explicit scope'(assert: Assert) {
-    let receivedData: unknown[] | undefined;
-
-    let capture = (data: unknown[]) => {
-      receivedData = data;
-      assert.step('captured');
-    };
-
-    const Child = template('<button {{on "click" (fn capture @items)}}>Click</button>', {
+  'it works'() {
+    const compiled = template('{{JSON.stringify (array "hello" "goodbye")}}', {
       strictMode: true,
-      scope: () => ({ capture }),
-    });
-
-    const compiled = template('<Child @items={{array "hello" "goodbye"}} />', {
-      strictMode: true,
-      scope: () => ({
-        Child,
-      }),
+      scope: () => ({ JSON }),
     });
 
     this.renderComponent(compiled);
+    this.assertHTML('["hello","goodbye"]');
+  }
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
-    assert.verifySteps(['captured']);
-    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  @test
+  'it works (shadowed)'() {
+    const array = (x: string) => x.toUpperCase();
+    const compiled = template('{{array "hello"}}', {
+      strictMode: true,
+      scope: () => ({ JSON, array }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('HELLO');
+  }
+
+  @test
+  'implicit scope'() {
+    const compiled = template('{{JSON.stringify (array "hello" "goodbye")}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('["hello","goodbye"]');
+  }
+
+  @test
+  'implicit scope (shadowed)'() {
+    const array = (...data: string[]) => data.reverse();
+
+    hide(array);
+
+    const compiled = template('{{JSON.stringify (array "hello" "goodbye")}}', {
+      strictMode: true,
+      eval() {
+        return eval(arguments[0]);
+      },
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('["goodbye","hello"]');
   }
 
   @test

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/array-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/array-test.ts
@@ -1,0 +1,112 @@
+import { castToBrowser } from '@glimmer/debug-util';
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+import { template } from '@ember/template-compiler/runtime';
+import { array, fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+class KeywordArray extends RenderTest {
+  static suiteName = 'keyword helper: array';
+
+  @test
+  'it works'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    let capture = (data: unknown[]) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
+      {
+        strictMode: true,
+        scope: () => ({
+          capture,
+          fn,
+          array,
+          on,
+        }),
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+
+  @test
+  'it works with the runtime compiler'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    let capture = (data: unknown[]) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    hide(capture);
+
+    const compiled = template(
+      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
+      {
+        strictMode: true,
+        eval() {
+          return eval(arguments[0]);
+        },
+      }
+    );
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+
+  @test
+  'it works as a MustacheStatement'(assert: Assert) {
+    let receivedData: unknown[] | undefined;
+
+    let capture = (data: unknown[]) => {
+      receivedData = data;
+      assert.step('captured');
+    };
+
+    const Child = template('<button {{on "click" (fn capture @items)}}>Click</button>', {
+      strictMode: true,
+      scope: () => ({ on, fn, capture }),
+    });
+
+    const compiled = template('<Child @items={{array "hello" "goodbye"}} />', {
+      strictMode: true,
+      scope: () => ({
+        array,
+        Child,
+      }),
+    });
+
+    this.renderComponent(compiled);
+
+    castToBrowser(this.element, 'div').querySelector('button')!.click();
+    assert.verifySteps(['captured']);
+    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  }
+}
+
+jitSuite(KeywordArray);
+
+/**
+ * This function is used to hide a variable from the transpiler, so that it
+ * doesn't get removed as "unused". It does not actually do anything with the
+ * variable, it just makes it be part of an expression that the transpiler
+ * won't remove.
+ *
+ * It's a bit of a hack, but it's necessary for testing.
+ *
+ * @param variable The variable to hide.
+ */
+const hide = (variable: unknown) => {
+  new Function(`return (${JSON.stringify(variable)});`);
+};

--- a/packages/@glimmer-workspace/integration-tests/test/keywords/array-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/array-test.ts
@@ -1,97 +1,31 @@
-import { castToBrowser } from '@glimmer/debug-util';
 import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
 
-import { template } from '@ember/template-compiler/runtime';
-import { array, fn } from '@ember/helper';
-import { on } from '@ember/modifier';
+import { template } from '@ember/template-compiler';
 
 class KeywordArray extends RenderTest {
   static suiteName = 'keyword helper: array';
 
   @test
-  'it works'(assert: Assert) {
-    let receivedData: unknown[] | undefined;
-
-    let capture = (data: unknown[]) => {
-      receivedData = data;
-      assert.step('captured');
-    };
-
-    const compiled = template(
-      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
-      {
-        strictMode: true,
-        scope: () => ({
-          capture,
-          fn,
-          array,
-          on,
-        }),
-      }
-    );
-
-    this.renderComponent(compiled);
-
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
-    assert.verifySteps(['captured']);
-    assert.deepEqual(receivedData, ['hello', 'goodbye']);
-  }
-
-  @test
-  'it works with the runtime compiler'(assert: Assert) {
-    let receivedData: unknown[] | undefined;
-
-    let capture = (data: unknown[]) => {
-      receivedData = data;
-      assert.step('captured');
-    };
-
-    hide(capture);
-
-    const compiled = template(
-      '<button {{on "click" (fn capture (array "hello" "goodbye"))}}>Click</button>',
-      {
-        strictMode: true,
-        eval() {
-          return eval(arguments[0]);
-        },
-      }
-    );
-
-    this.renderComponent(compiled);
-
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
-    assert.verifySteps(['captured']);
-    assert.deepEqual(receivedData, ['hello', 'goodbye']);
-  }
-
-  @test
-  'it works as a MustacheStatement'(assert: Assert) {
-    let receivedData: unknown[] | undefined;
-
-    let capture = (data: unknown[]) => {
-      receivedData = data;
-      assert.step('captured');
-    };
-
-    const Child = template('<button {{on "click" (fn capture @items)}}>Click</button>', {
+  'it works'() {
+    const compiled = template('{{JSON.stringify (array "hello" "goodbye")}}', {
       strictMode: true,
-      scope: () => ({ on, fn, capture }),
-    });
-
-    const compiled = template('<Child @items={{array "hello" "goodbye"}} />', {
-      strictMode: true,
-      scope: () => ({
-        array,
-        Child,
-      }),
+      scope: () => ({ JSON }),
     });
 
     this.renderComponent(compiled);
+    this.assertHTML('["hello","goodbye"]');
+  }
 
-    castToBrowser(this.element, 'div').querySelector('button')!.click();
-    assert.verifySteps(['captured']);
-    assert.deepEqual(receivedData, ['hello', 'goodbye']);
+  @test
+  'it works (shadowed)'() {
+    const array = (x: string) => x.toUpperCase();
+    const compiled = template('{{array "hello"}}', {
+      strictMode: true,
+      scope: () => ({ JSON, array }),
+    });
+
+    this.renderComponent(compiled);
+    this.assertHTML('HELLO');
   }
 }
 

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -540,7 +540,7 @@ function basicTest(scenarios: Scenarios, appName: string) {
                       {{JSON.stringify (array "hello" "goodbye")}}
                     </template>
                   );
-                  assert.dom().hasText('["hello", "goodbye"]');
+                  assert.dom().hasText('["hello","goodbye"]');
                 });
               });
             `,

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -516,12 +516,45 @@ function basicTest(scenarios: Scenarios, appName: string) {
               import { setupRenderingTest } from 'ember-qunit';
               import { render } from '@ember/test-helpers';
 
-              module('{{hash}} as keyword', function(hooks) {
+              module('{{hash}} as keyword (shadowed)', function(hooks) {
                 setupRenderingTest(hooks);
 
                 test('it works', async function(assert) {
                   const hash = (data) => data;
                   await render(<template>{{hash "hello"}}</template>);
+                  assert.dom().hasText('hello');
+                });
+              });
+            `,
+            'array-as-keyword-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render } from '@ember/test-helpers';
+
+              module('{{array}} as keyword', function(hooks) {
+                setupRenderingTest(hooks);
+
+                test('it works', async function(assert) {
+                  await render(
+                    <template>
+                      {{JSON.stringify (array "hello" "goodbye")}}
+                    </template>
+                  );
+                  assert.dom().hasText('["hello", "goodbye"]');
+                });
+              });
+            `,
+            'array-as-keyword-shadowed-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render } from '@ember/test-helpers';
+
+              module('{{array}} as keyword (shadowed)', function(hooks) {
+                setupRenderingTest(hooks);
+
+                test('it works', async function(assert) {
+                  const array = (data) => data;
+                  await render(<template>{{array "hello"}}</template>);
                   assert.dom().hasText('hello');
                 });
               });


### PR DESCRIPTION
Add array to the built-in keywords map so it no longer needs to be imported in strict-mode (gjs/gts) templates.

RFC: https://rfcs.emberjs.com/id/1000-make-array-built-in