### PR TITLE
Add EmberENV.LOG_INSPECTOR_HINT flag

### DIFF
--- a/packages/@ember/-internals/environment/lib/env.ts
+++ b/packages/@ember/-internals/environment/lib/env.ts
@@ -56,6 +56,18 @@ export const ENV = {
   */
   LOG_VERSION: true,
 
+  /**
+    The `LOG_INSPECTOR_HINT` property, when true, tells Ember to log a hint
+    suggesting the Ember Inspector browser extension when it is not detected.
+
+    @property LOG_INSPECTOR_HINT
+    @type Boolean
+    @default true
+    @for EmberENV
+    @public
+  */
+  LOG_INSPECTOR_HINT: true,
+
   RAISE_ON_DEPRECATION: false,
 
   STRUCTURED_PROFILE: false,

--- a/packages/@ember/debug/index.ts
+++ b/packages/@ember/debug/index.ts
@@ -1,4 +1,5 @@
 import { isChrome, isFirefox } from '@ember/-internals/browser-environment';
+import { ENV } from '@ember/-internals/environment';
 import type { AnyFn } from '@ember/-internals/utility-types';
 import { DEBUG } from '@glimmer/env';
 import type { DeprecateFunc, DeprecationOptions } from './lib/deprecate';
@@ -273,7 +274,7 @@ if (DEBUG) {
 
 let _warnIfUsingStrippedFeatureFlags;
 
-if (DEBUG && !isTesting()) {
+if (DEBUG && !isTesting() && ENV.LOG_INSPECTOR_HINT) {
   if (typeof window !== 'undefined' && (isFirefox || isChrome) && window.addEventListener) {
     window.addEventListener(
       'load',

--- a/tests/docs/expected.js
+++ b/tests/docs/expected.js
@@ -4,6 +4,7 @@ module.exports = {
     'EXTEND_PROTOTYPES',
     'GUID_KEY',
     'GUID_PREFIX',
+    'LOG_INSPECTOR_HINT',
     'LOG_STACKTRACE_ON_DEPRECATION',
     'LOG_VERSION',
     '[]',


### PR DESCRIPTION
Gates the "install the Ember Inspector" hint logged on window.load. This allows to skip it e.g. in test/CI runs.

Default: true (no behavior change)
`EmberENV.LOG_INSPECTOR_HINT = false` to silence.

This one is more difficult to test than `LOG_VERSION` since it runs at module load. I did confirm locally that this ~oneliner works.