### PR TITLE
Preserve barrel side effects when rewriting deep imports

### DIFF
--- a/packages/@glimmer/runtime/index.ts
+++ b/packages/@glimmer/runtime/index.ts
@@ -1,8 +1,3 @@
-/**
- * @deprecated use RichIteratorResult<Tick, Return> or TemplateIterator instead
- */
-import './lib/bootstrap';
-
 import type { RichIteratorResult } from '@glimmer/interfaces';
 
 export { clear, ConcreteBounds, CursorImpl } from './lib/bounds';

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -16,6 +16,11 @@ import { $fp, $pc, $ra, $sp } from '@glimmer/vm/lib/registers';
 import type { DebugState } from '../opcodes';
 import type { VM } from './append';
 
+// Loading the VM is what creates the demand for opcode handlers — its
+// `evaluateSyscall` calls `APPEND_OPCODES.evaluate(...)`. Pull bootstrap in
+// here (rather than at the package barrel) so consumers using deep imports
+// still get every opcode handler registered before the VM runs.
+import '../bootstrap';
 import { APPEND_OPCODES } from '../opcodes';
 
 export type LowLevelRegisters = [$pc: number, $ra: number, $sp: number, $fp: number];


### PR DESCRIPTION
## Summary

Fixes the failing smoke tests on #21350 with a 5-line change in `@glimmer/runtime`. No lint-rule changes.

The failure (`Cannot read properties of null (reading 'syscall')` in `AppendOpcodes.evaluate`) was a real correctness issue — not a flake. After the lint autofix replaced barrel imports with deep imports, **nothing imported `@glimmer/runtime/index.ts` anymore**, and that index's `import './lib/bootstrap';` was the only thing loading the opcode handler files. Each `lib/compiled/opcodes/*.ts` registers handlers via top-level `APPEND_OPCODES.add(...)`, so when the bootstrap chain stopped, 28 of 90 handlers stayed unregistered — opcodes those handlers cover (`{{on}}`, dynamic helpers, etc.) hit `null.syscall` at evaluation.

## Approach

Own the bootstrap from the file that actually consumes registered handlers — `lib/vm/low-level.ts`, where `evaluateSyscall` calls `APPEND_OPCODES.evaluate(...)`. Any deep-import path that uses the VM (directly or transitively) now triggers bootstrap; consumers that don't need the VM don't pay for opcode handlers in their bundle. Removed the equivalent side-effect import from the package barrel since it's now redundant.

I considered solving this in the lint rule (detect side-effect imports in barrels and re-emit `import 'BARREL';` to preserve them) — pushed up an earlier version of this PR doing exactly that. But adding bare side-effect imports of whole barrels back undoes the whole tree-shaking point of #21350. Better to put the trigger where the demand actually is.

## Verified

I built `dist/dev` from each version and counted top-level `APPEND_OPCODES.add(...)` calls in chunks that are actually loaded:

| Branch | reachable adds | trapped adds |
|---|---|---|
| origin/main | 90 | 0 |
| `nvp/remove-barrel-imports` | 62 | **28 stuck in unused `@glimmer/runtime/index.js`** |
| this PR | 90 | 0 |

The 90 handlers in this PR's `dist/dev` are reachable from `@ember/-internals/glimmer/index.js` → `setup-registry-...js` → `render-...js` (28 adds, plus a side-effect `import './untouchable-this-...js'` for the other 62).

## Note for reviewers

Two other barrel-only side effects in this PR's diff that might be worth a follow-up:

- `@glimmer/validator/index.ts` has a `globalThis`-based duplicate-package guard. It becomes dormant under deep imports — silent corruption is now possible if two copies ship. Move the registration check into a shared leaf module (e.g. `lib/meta.ts`) to keep it firing.
- `@ember/object/index.ts` runs `class EmberObject extends CoreObject.extend(Observable)` at module load. This one's actually fine: `import EmberObject from '@ember/object'` is a default import, which the rule's `kept` mechanism preserves on the barrel. Anyone using `EmberObject` still triggers the extension.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm build:js` succeeds
- [x] All 90 `APPEND_OPCODES.add(...)` calls reachable from `@ember/-internals/glimmer/index.js` in `dist/dev`
- [x] `pnpm test:node` passes
- [x] `pnpm type-check:internals` reports same 10 pre-existing errors as the base branch
- [ ] Smoke tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)