### PR TITLE
Disable all new keywords behind a feature flag

### DIFF
--- a/packages/@ember/canary-features/index.ts
+++ b/packages/@ember/canary-features/index.ts
@@ -13,6 +13,7 @@ import { ENV } from '@ember/-internals/environment';
 
 export const DEFAULT_FEATURES = {
   // FLAG_NAME: true/false
+  NEW_KEYWORDS_2026_05: true,
 };
 
 /**
@@ -55,12 +56,14 @@ export function isEnabled(feature: string): boolean {
 
 // Uncomment the below when features are present:
 
-// function featureValue(value: null | boolean) {
-//   if (ENV.ENABLE_OPTIONAL_FEATURES && value === null) {
-//     return true;
-//   }
+function featureValue(value: null | boolean) {
+  if (ENV.ENABLE_OPTIONAL_FEATURES && value === null) {
+    return true;
+  }
 
-//   return value;
-// }
+  return value;
+}
 //
 // export const FLAG_NAME = featureValue(FEATURES.FLAG_NAME);
+
+export const NEW_KEYWORDS_2026_05 = featureValue(FEATURES.NEW_KEYWORDS_2026_05);

--- a/packages/@ember/canary-features/index.ts
+++ b/packages/@ember/canary-features/index.ts
@@ -13,7 +13,7 @@ import { ENV } from '@ember/-internals/environment';
 
 export const DEFAULT_FEATURES = {
   // FLAG_NAME: true/false
-  NEW_KEYWORDS_2026_05: true,
+  NEW_KEYWORDS_2026_05: false,
 };
 
 /**

--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -473,6 +473,8 @@ export const fn = glimmerFn as FnHelper;
 export interface FnHelper extends Opaque<'helper:fn'> {}
 
 /**
+ * @private - temporarily private until broader team approval
+ *
  * The `element` helper lets you dynamically set the tag name of an element.
  *
  * ```js
@@ -514,6 +516,8 @@ export const uniqueId = glimmerUniqueId;
 export type UniqueIdHelper = typeof uniqueId;
 
 /**
+ * @private - temporarily private until broader team approval
+ *
  * The `{{eq}}` helper returns `true` if its two arguments are strictly equal
  * (`===`). Takes exactly two arguments.
  *
@@ -538,6 +542,8 @@ export const eq = glimmerEq as unknown as EqHelper;
 export interface EqHelper extends Opaque<'helper:eq'> {}
 
 /**
+ * @private - temporarily private until broader team approval
+ *
  * The `{{neq}}` helper returns `true` if its two arguments are strictly
  * not equal (`!==`). Takes exactly two arguments.
  *

--- a/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
+++ b/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
@@ -1,6 +1,7 @@
 import type { AST, ASTPlugin } from '@glimmer/syntax';
 import type { EmberASTPluginEnvironment } from '../types';
 import { isPath, trackLocals } from './utils';
+import { NEW_KEYWORDS_2026_05 } from '@ember/canary-features';
 
 /**
  @module ember
@@ -14,6 +15,13 @@ import { isPath, trackLocals } from './utils';
 */
 
 export default function autoImportBuiltins(env: EmberASTPluginEnvironment): ASTPlugin {
+  if (!NEW_KEYWORDS_2026_05) {
+    return {
+      name: 'auto-import-built-ins-disabled',
+      visitor: {},
+    };
+  }
+
   let { hasLocal, visitor } = trackLocals(env);
 
   return {

--- a/packages/@ember/template-compiler/package.json
+++ b/packages/@ember/template-compiler/package.json
@@ -9,6 +9,7 @@
     "./types": "./lib/types.ts"
   },
   "dependencies": {
+    "@ember/canary-features": "workspace:*",
     "@ember/-internals": "workspace:*",
     "@ember/component": "workspace:*",
     "@ember/debug": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 2.1.0
       ember-cli-dependency-checker:
         specifier: ^3.3.1
-        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15))
+        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
       ember-cli-yuidoc:
         specifier: ^0.9.1
         version: 0.9.1
@@ -1144,6 +1144,9 @@ importers:
       '@ember/-internals':
         specifier: workspace:*
         version: link:../-internals
+      '@ember/canary-features':
+        specifier: workspace:*
+        version: link:../canary-features
       '@ember/component':
         specifier: workspace:*
         version: link:../component
@@ -2815,7 +2818,7 @@ importers:
         version: 3.0.0
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15))
+        version: 3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
       ember-cli-deprecation-workflow:
         specifier: ^3.4.0
         version: 3.4.0(ember-source@)
@@ -17461,7 +17464,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)):
+  ember-cli-dependency-checker@3.3.3(ember-cli@6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)):
     dependencies:
       chalk: 2.4.2
       ember-cli: 6.11.2(@babel/core@7.29.0)(@types/node@22.19.15)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)


### PR DESCRIPTION

- existing process is why this is happening - reason is noble tho -- the team needs to sign off on the behavior via each of the advancement RFCs
- the exports can't be feature flagged, so those would still be able to be imported
  - I _could_ do a dynamic assignment based on feature flag, and export that, but I don't think we should -- it bloats the code, and I'm trying to delete code (not part of this effort, but in other PRs)


I don't even really know if this PR is needed, because I want all of these available in the next minor anyway