### PR TITLE
Update pkg-size action version in workflow

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: wyvox/pkg-size@753879fd95db4f76879aad06a169d72a95fa6d64
+      - uses: wyvox/pkg-size@0a5aff49240f000d8a31ec18ebb86bbf8ee9190e
         with:
           build-command: "./bin/build-size-comparison-dists.sh"
           display-size: uncompressed, brotli

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: wyvox/pkg-size@e7bc11305b41e63cf7e95cddb904b4fba1b0c31d
+      - uses: wyvox/pkg-size@f1e6283bb99d2cf2afebab9cef02bc7d94d7b2c0
         with:
           build-command: "./bin/build-size-comparison-dists.sh"
           display-size: uncompressed, brotli

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: wyvox/pkg-size@0a5aff49240f000d8a31ec18ebb86bbf8ee9190e
+      - uses: wyvox/pkg-size@eb961b34bacc861ee43ae1b0377f6a97a1bfa3d6
         with:
           build-command: "./bin/build-size-comparison-dists.sh"
           display-size: uncompressed, brotli

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: wyvox/pkg-size@eb961b34bacc861ee43ae1b0377f6a97a1bfa3d6
+      - uses: wyvox/pkg-size@7f3620bec74b6d954a57f69a86fe4f01cb189eb2
         with:
           build-command: "./bin/build-size-comparison-dists.sh"
           display-size: uncompressed, brotli

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: wyvox/pkg-size@f1e6283bb99d2cf2afebab9cef02bc7d94d7b2c0
+      - uses: wyvox/pkg-size@753879fd95db4f76879aad06a169d72a95fa6d64
         with:
           build-command: "./bin/build-size-comparison-dists.sh"
           display-size: uncompressed, brotli


### PR DESCRIPTION
In particular,
- fixes the non-tarball-containing dist measurement
- moves the tarball change to the top, since both dev and prod are in the same tarball