### PR TITLE
[BUGFIX] renderComponent: don't depend on globalThis.Element

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -670,9 +670,19 @@ export function renderComponent(
    * We can only replace the inner HTML the first time.
    * Because destruction is async, it won't be safe to
    * do this again, and we'll have to rely on the above destroy.
+   *
+   * Use a structural check instead of `into instanceof Element` so the
+   * renderer doesn't depend on the `Element` constructor being a
+   * global. Browsers always have it; Node / Bun servers running with a
+   * bare simple-dom Document do not, and would otherwise hit
+   * `ReferenceError: Element is not defined` here. The `'element' in
+   * into` test matches the existing `intoTarget()` helper above:
+   * `Cursor` has `element`; `Element` / `SimpleElement` do not. The
+   * `'innerHTML' in into` follow-up keeps the clearing scoped to the
+   * real-Element case (`SimpleElement` has no `innerHTML` setter).
    */
-  if (!existing && into instanceof Element) {
-    into.innerHTML = '';
+  if (!existing && !('element' in into) && 'innerHTML' in into) {
+    (into as Element).innerHTML = '';
   }
 
   /**
@@ -689,8 +699,11 @@ export function renderComponent(
    */
   let renderTarget: IntoTarget = into;
   if (existing?.glimmerResult) {
-    let parentElement =
-      into instanceof Element ? (into as unknown as SimpleElement) : (into as Cursor).element;
+    // Reuse the same `intoTarget()` shape used by the lower-level
+    // `BaseRenderer#render` path so all code that needs a parent
+    // Element from an `IntoTarget` agrees on the discriminator. As a
+    // bonus, this avoids the `globalThis.Element` dependency above.
+    let parentElement = intoTarget(into).element;
     let firstNode = existing.glimmerResult.firstNode();
     renderTarget = { element: parentElement, nextSibling: firstNode };
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -186,6 +186,56 @@ moduleFor(
       assertHTML('');
       this.assertStableRerender();
     }
+
+    '@test renderComponent does not depend on a global Element constructor'(
+      assert: Assert
+    ) {
+      // Stash and unset `globalThis.Element` so the previous
+      // `into instanceof Element` check would crash with
+      // `ReferenceError: Element is not defined`. After the structural-
+      // check fix, `renderComponent` should still resolve the parent
+      // element and render without consulting any global. This matters
+      // for non-browser hosts (Node / Bun servers, edge workers) that
+      // don't ship a DOM Element constructor by default — only the
+      // simple-dom node types they were given via `env.document`.
+      let saved = (globalThis as { Element?: unknown }).Element;
+      (globalThis as { Element?: unknown }).Element = undefined;
+
+      try {
+        let Foo = setComponentTemplate(
+          precompileTemplate('Hello, world!'),
+          templateOnly()
+        );
+
+        let owner = buildOwner({});
+        let manualDestroy: () => void;
+
+        run(() => {
+          let result = renderComponent(Foo, {
+            owner,
+            into: this.element,
+          });
+          manualDestroy = result.destroy;
+          this.component = {
+            ...result,
+            rerender() {
+              // unused, but asserted against
+            },
+          };
+        });
+
+        assertHTML('Hello, world!');
+        assert.ok(
+          true,
+          'renderComponent ran to completion with `globalThis.Element` undefined'
+        );
+
+        run(() => manualDestroy());
+        run(() => destroy(owner));
+      } finally {
+        (globalThis as { Element?: unknown }).Element = saved;
+      }
+    }
   }
 );
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-component-test.ts
@@ -187,9 +187,7 @@ moduleFor(
       this.assertStableRerender();
     }
 
-    '@test renderComponent does not depend on a global Element constructor'(
-      assert: Assert
-    ) {
+    '@test renderComponent does not depend on a global Element constructor'(assert: Assert) {
       // Stash and unset `globalThis.Element` so the previous
       // `into instanceof Element` check would crash with
       // `ReferenceError: Element is not defined`. After the structural-
@@ -202,10 +200,7 @@ moduleFor(
       (globalThis as { Element?: unknown }).Element = undefined;
 
       try {
-        let Foo = setComponentTemplate(
-          precompileTemplate('Hello, world!'),
-          templateOnly()
-        );
+        let Foo = setComponentTemplate(precompileTemplate('Hello, world!'), templateOnly());
 
         let owner = buildOwner({});
         let manualDestroy: () => void;
@@ -225,10 +220,7 @@ moduleFor(
         });
 
         assertHTML('Hello, world!');
-        assert.ok(
-          true,
-          'renderComponent ran to completion with `globalThis.Element` undefined'
-        );
+        assert.ok(true, 'renderComponent ran to completion with `globalThis.Element` undefined');
 
         run(() => manualDestroy());
         run(() => destroy(owner));


### PR DESCRIPTION
Fixes #21363.

`renderComponent` does `into instanceof Element` in two places to discriminate `Cursor` from `Element` / `SimpleElement` in the `IntoTarget` union. That works in a browser (where `Element` is a built-in) and inside FastBoot (which patches a simulated `Element` onto `globalThis`), but throws `ReferenceError: Element is not defined` on a plain Node or Bun host that calls `renderComponent` with a fresh `@simple-dom/document` node as `into`.

The function already has an `intoTarget()` helper a few lines up that classifies the same union without touching any global:

```ts
function intoTarget(into: IntoTarget): Cursor {
  if ('element' in into) {
    return into;
  } else {
    return { element: into as SimpleElement, nextSibling: null };
  }
}
```

This PR aligns the two `into instanceof Element` outliers with that helper.

## Changes

* **First-render `innerHTML` clearing** becomes a structural check —
  `!('element' in into) && 'innerHTML' in into` — so it fires only on a real DOM `Element` and skips on `SimpleElement` (no `innerHTML` setter) and `Cursor` (has `.element`).
* **Re-render `parentElement` extraction** calls `intoTarget(into)` directly instead of duplicating the discriminator. Drive-by fix: the previous `(into as Cursor).element` cast on the else branch was incorrect for `SimpleElement` input — `SimpleElement` has no `.element` property — though that path is rare in practice.

## Behavior

| `into` shape | Before | After |
| --- | --- | --- |
| Real DOM `Element` (browser) | clears `innerHTML`, uses self as `parentElement` | identical |
| `SimpleElement` (server, no FastBoot) | crashes on `Element is not defined` | skips `innerHTML` clearing, uses self as `parentElement` |
| `Cursor` | skips `innerHTML` clearing, uses `.element` | identical |
| Real DOM `Element` (browser, no `globalThis.Element` for some reason) | crashes on `Element is not defined` | works |

No behavior change for in-browser callers. New behavior for non-browser hosts that pass `SimpleElement` directly.

## Test

Adds a regression test in `render-component-test.ts` that:

1. Stashes `globalThis.Element` and sets it to `undefined`.
2. Calls `renderComponent` with a real DOM target (which would have crashed at `into instanceof undefined`).
3. Asserts the render completed and produced the expected HTML.
4. Restores `globalThis.Element`.

## Notes

* No new exports.
* No public-API surface change.
* Aligns with the FastBoot-codepath-removal direction in #21349 — the renderer becomes one fewer thing tied to the FastBoot environment-setup story.
* This unblocks calling `renderComponent` from bare Node / Bun / edge / worker hosts that supply a simple-dom Document via `env.document`.

Happy to iterate on review feedback.
