### PR TITLE
Declare side-effecting modules so bundlers have better hints for what can be tree-shaken

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     },
     "./package.json": "./package.json"
   },
+  "sideEffects": false,
   "homepage": "https://emberjs.com/",
   "bugs": {
     "url": "https://github.com/emberjs/ember.js/issues"


### PR DESCRIPTION
> [!IMPORTANT]
> The key thing is that the side-effects signal is only relevant if nothing is imported from a file.


----------

Demo: 
- repl
  - https://github.com/NullVoxPopuli/limber/pull/2160
  - [Deploy Preview](https://test-ember-source-nvp-config.limber-glimdown.pages.dev/edit?c=JYWwDg9gTgLgBAYQuCA7Apq%2BAzKy4DkAAgOYA2oI6UA9AMbKQZYEDcAUKJLHAN5wwoAQzoBrdABM4AXzi58xcpWo1BI0cFQk2nFD35oZcvCEJF0IAEYqQECcGzBqO9ugAe3eBPTYhAVzJ4OjIhAGdQuAAJdDIyCAB1aDIpdxhMCQikFGZ4XnY4OCI1MUk4Bj8sOABeOAAGDny4TTooC0x4GoAKAEpqgD4BAAtgUIA6csqAahqARgaCgB408BC0vsbFsD6ATQg-OEGhADd0MooSqRhB08s-GBhDXl4rkfG9rGlZGFB0MYWaLbsDZwBa3e6GGAATzA6CqACIwQ9UHC%2BLxDHDgsAxCiXmNmq0qB9pH0EOdRP9EWh1otVBYwKt0OtpOwgA&format=gjs)
- ember-auto-import
  - https://github.com/embroider-build/ember-auto-import/pull/711  

---------------

bundler hints that let consumer bundlers (vite/rolldown, webpack, esbuild) tree-shake aggressively through ember-source's internal barrel re-exports without requiring any source-file restructuring.

for the ember-source dist/tarball, the result is that chunks shake out a bit differently.


on webpack docs:
> the "sideEffects" package.json property to denote which _files_ in your project are "pure" and therefore safe to prune **if unused**.
https://webpack.js.org/guides/tree-shaking/

on svelte's docs
https://github.com/sveltejs/kit/pull/10691/changes#diff-4b03f147d0e7e4750663fcdb0ef3bf8ba11ad0bc47204456bf5d7aa5fd9a7e00R129

They _do_ recommend explicitly declaring which modules have side-effects (which is something I want to do, I just want it generated)


this person says sideEffects is "standard" https://github.com/vitejs/vite/issues/14321#issuecomment-1713248582

from rollup:
> assume modules and external dependencies from which nothing is imported do not have other side effects like mutating global variables or logging without checking
https://rollupjs.org/configuration-options/#treeshake-modulesideeffects
<img width="459" height="373" alt="image" src="https://github.com/user-attachments/assets/f01ce07a-c29e-4d36-9f4a-80a23ef93864" />

-------



I believe this means that it happens that if _something_ is used from a file, it can have side-effects within that file -- which is good.

Because, say you never use helpers:

we want:
```
import '@ember/helper`
```
to be removed, because you never used them.
let's say that file also registers helper managers.
the output removes the import entirely.
but because you don't use helpers, there is no behavior loss.

If you did
```
import { element } from '@ember/helper'
```
then the file is used, and any side-effects within would remain, because deeper analysis occurs.

_however_, if we _declared_ `@ember/helper` as having side-effects in pacakge.json, we'd likely not get the correct stripping behavior that we want.

_so_, it is "less scary" to have all side-effects actually live in private files so that this "did you import it?" check and deeper analysis trigger isn't directly controlled by users



