### PR TITLE
Drop dead PURE_INTERNAL_PACKAGES entries

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -114,26 +114,17 @@ function sharedESMConfig({ input, debugMacrosMode, includePackageMeta = false })
   };
 }
 
-// Tell rollup which source files actually have top-level side effects.
-// Anything matched by `pure` is treated as side-effect-free: unused
-// imports of it can be dropped rather than carried into a downstream
-// shared chunk. The packages here are either explicitly
-// `sideEffects: false` in their own package.json (which gets lost once
-// files are co-bundled into shared chunks across packages) or are pure
-// utility / data-shape packages with no top-level mutation.
+// `@glimmer/debug` declares `sideEffects: false` in its own package.json,
+// but rolldown loses that signal when files from it get co-bundled into
+// shared chunks alongside non-pure code. Re-asserting purity at the
+// chunk-level callback recovers ~8 KB raw on the hello-world bundle by
+// letting unused imports of `@glimmer/debug` content drop out of those
+// chunks. Add other packages here only after measuring an actual
+// reduction.
 function moduleHasSideEffects(id) {
-  if (!id.includes('/packages/')) return true;
-  for (const pkg of PURE_INTERNAL_PACKAGES) {
-    if (id.includes(`/packages/${pkg}/`)) return false;
-  }
+  if (id.includes('/packages/@glimmer/debug/')) return false;
   return true;
 }
-
-const PURE_INTERNAL_PACKAGES = [
-  '@glimmer/debug',
-  '@glimmer/debug-util',
-  '@glimmer/local-debug-flags',
-];
 
 function glimmerSyntaxESM() {
   return {


### PR DESCRIPTION
Stacks on `nvp/configure-side-effects`.

Tested each entry in `PURE_INTERNAL_PACKAGES` individually against the hello-world smoke-test bundle. Only `@glimmer/debug` actually contributes:

| array contents | raw | gzip |
| - | - | - |
| `[]` (no callback) | 181.12 KB | 57.82 KB |
| `['@glimmer/debug-util']` | 181.12 KB | 57.82 KB |
| `['@glimmer/local-debug-flags']` | 181.12 KB | 57.82 KB |
| `['@glimmer/debug']` | **172.99 KB** | **55.35 KB** |
| all three | 172.99 KB | 55.31 KB |

`@glimmer/debug-util` and `@glimmer/local-debug-flags` are already inferred pure by rolldown's static analysis — their content either has no top-level statements that look like side effects, or gets fully stripped by the `LOCAL_DEBUG` macro in prod builds. Re-asserting them adds nothing.

Inlined the array since the callback now checks a single path prefix, and updated the comment to reference the measurement so the next person adding entries does so with data, not pattern-matching.

## Test plan

- [x] hello-world smoke build: 172.99 KB / 55.35 KB (matches the prior all-three result within gzip noise)
- [x] `smoke-tests/v2-app-template` (classic v2 app) builds + 1/1 test passes
- [x] `pnpm test:tree-shake` — 23 pure + 43 impure entries match expectations
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)