### PR TITLE
Remove RSVP from internal code

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -48,7 +48,6 @@ import { dict } from '@glimmer/util';
 import { unwrapTemplate } from './component-managers/unwrap-template';
 import { CURRENT_TAG, validateTag, valueForTag } from '@glimmer/validator';
 import type { SimpleDocument, SimpleElement, SimpleNode } from '@simple-dom/interface';
-import RSVP from 'rsvp';
 import type Component from './component';
 import { hasDOM } from '../../browser-environment';
 import type ClassicComponent from './component';
@@ -297,7 +296,8 @@ function loopBegin(): void {
   }
 }
 
-let renderSettledDeferred: RSVP.Deferred<void> | null = null;
+let renderSettledPromise: Promise<void> | null = null;
+let renderSettledResolve: (() => void) | null = null;
 /*
   Returns a promise which will resolve when rendering has settled. Settled in
   this context is defined as when all of the tags in use are "current" (e.g.
@@ -308,8 +308,10 @@ let renderSettledDeferred: RSVP.Deferred<void> | null = null;
   @returns {Promise<void>} a promise which fulfills when rendering has settled
 */
 export function renderSettled() {
-  if (renderSettledDeferred === null) {
-    renderSettledDeferred = RSVP.defer();
+  if (renderSettledPromise === null) {
+    renderSettledPromise = new Promise<void>((resolve) => {
+      renderSettledResolve = resolve;
+    });
     // if there is no current runloop, the promise created above will not have
     // a chance to resolve (because its resolved in backburner's "end" event)
     if (!_getCurrentRunLoop()) {
@@ -318,13 +320,14 @@ export function renderSettled() {
     }
   }
 
-  return renderSettledDeferred.promise;
+  return renderSettledPromise;
 }
 
 function resolveRenderPromise() {
-  if (renderSettledDeferred !== null) {
-    let resolve = renderSettledDeferred.resolve;
-    renderSettledDeferred = null;
+  if (renderSettledResolve !== null) {
+    let resolve = renderSettledResolve;
+    renderSettledPromise = null;
+    renderSettledResolve = null;
 
     _backburner.join(null, resolve);
   }

--- a/packages/@ember/application/index.ts
+++ b/packages/@ember/application/index.ts
@@ -10,7 +10,6 @@ import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import { join, once, run, schedule } from '@ember/runloop';
 import { libraries } from '@ember/-internals/metal';
-import { RSVP } from '@ember/-internals/runtime';
 import { EventDispatcher } from '@ember/-internals/views';
 import Route from '@ember/routing/route';
 import Router from '@ember/routing/router';
@@ -681,7 +680,10 @@ class Application extends Engine {
     return this._bootPromise;
   }
 
-  _bootResolver: ReturnType<(typeof RSVP)['defer']> | null = null;
+  _bootResolver: {
+    resolve: (value: Application) => void;
+    reject: (reason?: unknown) => void;
+  } | null = null;
 
   /**
     Unfortunately, a lot of existing code assumes the booting process is
@@ -705,8 +707,11 @@ class Application extends Engine {
     // boot promise exists for book-keeping purposes: if anything went wrong in
     // the boot process, we need to store the error as a rejection on the boot
     // promise so that a future caller of `boot()` can tell what failed.
-    let defer = (this._bootResolver = RSVP.defer());
-    this._bootPromise = defer.promise as Promise<this>;
+    let resolver!: { resolve: (value: Application) => void; reject: (reason?: unknown) => void };
+    this._bootPromise = new Promise<this>((resolve, reject) => {
+      resolver = { resolve: resolve as (value: Application) => void, reject };
+    });
+    this._bootResolver = resolver;
 
     try {
       this.runInitializers();
@@ -714,7 +719,7 @@ class Application extends Engine {
       // Continues to `didBecomeReady`
     } catch (error) {
       // For the asynchronous boot path
-      defer.reject(error);
+      resolver.reject(error);
 
       // For the synchronous boot path
       throw error;

--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -3,7 +3,6 @@
 */
 
 import EmberObject from '@ember/object';
-import { RSVP } from '@ember/-internals/runtime';
 import { assert } from '@ember/debug';
 import { Registry, privatize as P } from '@ember/-internals/container';
 import { guidFor } from '@ember/-internals/utils';
@@ -101,7 +100,7 @@ class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerPro
     this._booted = false;
   }
 
-  _bootPromise: RSVP.Promise<this> | null = null;
+  _bootPromise: Promise<this> | null = null;
 
   /**
     Initialize the `EngineInstance` and return a promise that resolves
@@ -121,7 +120,7 @@ class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerPro
       return this._bootPromise;
     }
 
-    this._bootPromise = new RSVP.Promise((resolve) => {
+    this._bootPromise = new Promise((resolve) => {
       resolve(this._bootSync(options));
     });
 

--- a/packages/@ember/object/promise-proxy-mixin.ts
+++ b/packages/@ember/object/promise-proxy-mixin.ts
@@ -1,14 +1,13 @@
 import { get, setProperties, computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import type { AnyFn, MethodNamesOf } from '@ember/-internals/utility-types';
-import type RSVP from 'rsvp';
 import type CoreObject from '@ember/object/core';
 
 /**
   @module @ember/object/promise-proxy-mixin
 */
 
-function tap<T>(proxy: PromiseProxyMixin<T>, promise: RSVP.Promise<T>) {
+function tap<T>(proxy: PromiseProxyMixin<T>, promise: Promise<T>) {
   setProperties(proxy, {
     isFulfilled: false,
     isRejected: false,
@@ -38,8 +37,7 @@ function tap<T>(proxy: PromiseProxyMixin<T>, promise: RSVP.Promise<T>) {
         });
       }
       throw reason;
-    },
-    'Ember: PromiseProxy'
+    }
   );
 }
 
@@ -47,7 +45,6 @@ function tap<T>(proxy: PromiseProxyMixin<T>, promise: RSVP.Promise<T>) {
   A low level mixin making ObjectProxy promise-aware.
 
   ```javascript
-  import { resolve } from 'rsvp';
   import $ from 'jquery';
   import ObjectProxy from '@ember/object/proxy';
   import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
@@ -55,7 +52,7 @@ function tap<T>(proxy: PromiseProxyMixin<T>, promise: RSVP.Promise<T>) {
   let ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
   let proxy = ObjectPromiseProxy.create({
-    promise: resolve($.getJSON('/some/remote/data.json'))
+    promise: Promise.resolve($.getJSON('/some/remote/data.json'))
   });
 
   proxy.then(function(json){
@@ -78,7 +75,7 @@ function tap<T>(proxy: PromiseProxyMixin<T>, promise: RSVP.Promise<T>) {
   When the $.getJSON completes, and the promise is fulfilled
   with json, the life cycle attributes will update accordingly.
   Note that $.getJSON doesn't return an ECMA specified promise,
-  it is useful to wrap this with an `RSVP.resolve` so that it behaves
+  it is useful to wrap this with `Promise.resolve` so that it behaves
   as a spec compliant promise.
 
   ```javascript
@@ -176,22 +173,22 @@ interface PromiseProxyMixin<T> {
   /**
     An alias to the proxied promise's `then`.
 
-    See RSVP.Promise.then.
+    See Promise.prototype.then.
 
     @method then
     @param {Function} callback
-    @return {RSVP.Promise}
+    @return {Promise}
     @public
   */
   then: this['promise']['then'];
   /**
     An alias to the proxied promise's `catch`.
 
-    See RSVP.Promise.catch.
+    See Promise.prototype.catch.
 
     @method catch
     @param {Function} callback
-    @return {RSVP.Promise}
+    @return {Promise}
     @since 1.3.0
     @public
   */
@@ -199,11 +196,11 @@ interface PromiseProxyMixin<T> {
   /**
     An alias to the proxied promise's `finally`.
 
-    See RSVP.Promise.finally.
+    See Promise.prototype.finally.
 
     @method finally
     @param {Function} callback
-    @return {RSVP.Promise}
+    @return {Promise}
     @since 1.3.0
     @public
   */
@@ -228,7 +225,7 @@ const PromiseProxyMixin = Mixin.create({
     get() {
       throw new Error("PromiseProxy's promise must be set");
     },
-    set(_key, promise: RSVP.Promise<unknown>) {
+    set(_key, promise: Promise<unknown>) {
       return tap(this, promise);
     },
   }),

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -198,7 +198,6 @@ interface Route<Model = unknown> extends IRoute<Model>, ActionHandler, Evented {
     as well as any unhandled errors from child routes:
 
     ```app/routes/admin.js
-    import { reject } from 'rsvp';
     import Route from '@ember/routing/route';
     import { action } from '@ember/object';
     import { service } from '@ember/service';
@@ -207,7 +206,7 @@ interface Route<Model = unknown> extends IRoute<Model>, ActionHandler, Evented {
       @service router;
 
       beforeModel() {
-        return reject('bad things!');
+        return Promise.reject('bad things!');
       }
 
       @action

--- a/packages/internal-test-helpers/lib/module-for.ts
+++ b/packages/internal-test-helpers/lib/module-for.ts
@@ -2,7 +2,6 @@
 import { isEnabled } from '@ember/canary-features';
 import { assertDestroyablesDestroyed, enableDestroyableTracking } from '@glimmer/destroyable';
 import { DEBUG } from '@glimmer/env';
-import { all } from 'rsvp';
 import type { Generator, Mixin } from './apply-mixins';
 import applyMixins from './apply-mixins';
 import getAllPropertyNames from './get-all-property-names';
@@ -122,7 +121,7 @@ export function setupTestClass<T extends TestCase, G extends Generator>(
     // promise when it is not needed
     let filteredPromises = promises.filter(Boolean);
     if (filteredPromises.length > 0) {
-      return all(filteredPromises)
+      return Promise.all(filteredPromises)
         .finally(afterEachFinally)
         .then(() => {});
     }

--- a/packages/internal-test-helpers/lib/run.ts
+++ b/packages/internal-test-helpers/lib/run.ts
@@ -1,8 +1,6 @@
 import { next, run, _getCurrentRunLoop, _hasScheduledTimers } from '@ember/runloop';
 import { destroy } from '@glimmer/destroyable';
 
-import { Promise } from 'rsvp';
-
 export function runAppend(view: any): void {
   run(view, 'appendTo', document.getElementById('qunit-fixture'));
 }

--- a/packages/router_js/lib/route-info.ts
+++ b/packages/router_js/lib/route-info.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-prototype-builtins */
-import { Promise } from 'rsvp';
 import type { Dict, Option } from './core';
 import type { SerializerFunc } from './router';
 import type Router from './router';
@@ -234,8 +233,8 @@ export default class InternalRouteInfo<R extends Route> {
     }
   }
 
-  getModel(_transition: InternalTransition<R>) {
-    return Promise.resolve(this.context);
+  getModel(_transition: InternalTransition<R>): Promise<ModelFor<R> | undefined> {
+    return Promise.resolve<ModelFor<R> | undefined>(this.context);
   }
 
   serialize(_context?: ModelFor<R> | null): Dict<unknown> | undefined {
@@ -477,7 +476,7 @@ export class UnresolvedRouteInfoByParam<R extends Route> extends InternalRouteIn
     }
   }
 
-  getModel(transition: InternalTransition<R>): Promise<ModelFor<R>> {
+  getModel(transition: InternalTransition<R>): Promise<ModelFor<R> | undefined> {
     let fullParams = this.params;
     if (transition && transition[QUERY_PARAMS_SYMBOL]) {
       fullParams = {};
@@ -506,7 +505,7 @@ export class UnresolvedRouteInfoByParam<R extends Route> extends InternalRouteIn
       result = undefined;
     }
 
-    return Promise.resolve(result);
+    return Promise.resolve<ModelFor<R> | undefined>(result);
   }
 }
 

--- a/packages/router_js/lib/router.ts
+++ b/packages/router_js/lib/router.ts
@@ -255,11 +255,9 @@ export default abstract class Router<R extends Route> {
     // Transition promises by default resolve with resolved state.
     // For our purposes, swap out the promise to resolve
     // after the transition has been finalized.
-    newTransition.promise = newTransition.promise!.then(
-      (result: TransitionState<R>) => {
-        return this.finalizeTransition(newTransition, result);
-      }
-    );
+    newTransition.promise = newTransition.promise!.then((result: TransitionState<R>) => {
+      return this.finalizeTransition(newTransition, result);
+    });
 
     if (!wasTransitioning) {
       this.notifyExistingHandlers(newState, newTransition);

--- a/packages/router_js/lib/router.ts
+++ b/packages/router_js/lib/router.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 import type { MatchCallback, Params, QueryParams } from 'route-recognizer';
 import RouteRecognizer from 'route-recognizer';
-import { Promise } from 'rsvp';
 import type { Dict, Maybe, Option } from './core';
 import type { ModelFor, Route, RouteInfo, RouteInfoWithAttributes } from './route-info';
 import type InternalRouteInfo from './route-info';
@@ -15,7 +14,7 @@ import URLTransitionIntent from './transition-intent/url-transition-intent';
 import type { TransitionError } from './transition-state';
 import TransitionState from './transition-state';
 import type { ChangeList, ModelsAndQueryParams } from './utils';
-import { extractQueryParams, forEach, getChangelist, log, merge, promiseLabel } from './utils';
+import { extractQueryParams, forEach, getChangelist, log, merge } from './utils';
 
 export interface SerializerFunc<T> {
   (model: T, params: string[]): Dict<unknown>;
@@ -132,9 +131,7 @@ export default abstract class Router<R extends Route> {
             this.routeDidChange(newTransition);
           }
           return result;
-        },
-        null,
-        promiseLabel('Transition complete')
+        }
       );
 
       return newTransition;
@@ -261,9 +258,7 @@ export default abstract class Router<R extends Route> {
     newTransition.promise = newTransition.promise!.then(
       (result: TransitionState<R>) => {
         return this.finalizeTransition(newTransition, result);
-      },
-      null,
-      promiseLabel('Settle transition promise when transition is finalized')
+      }
     );
 
     if (!wasTransitioning) {

--- a/packages/router_js/lib/transition-state.ts
+++ b/packages/router_js/lib/transition-state.ts
@@ -1,4 +1,3 @@
-import { Promise } from 'rsvp';
 import type { Dict } from './core';
 import type { Route, ResolvedRouteInfo } from './route-info';
 import type InternalRouteInfo from './route-info';
@@ -47,7 +46,7 @@ function resolveOneRouteInfo<R extends Route>(
     resolvedRouteInfo: ResolvedRouteInfo<R>
   ) => void | Promise<void>;
 
-  return routeInfo.resolve(transition).then(callback, null, currentState.promiseLabel('Proceed'));
+  return routeInfo.resolve(transition).then(callback);
 }
 
 function proceed<R extends Route>(
@@ -112,10 +111,10 @@ export default class TransitionState<R extends Route> {
     let callback = resolveOneRouteInfo.bind(null, this, transition);
     let errorHandler = handleError.bind(null, this, transition);
 
-    // The prelude RSVP.resolve() async moves us into the promise land.
-    return Promise.resolve(null, this.promiseLabel('Start transition'))
-      .then(callback, null, this.promiseLabel('Resolve route'))
-      .catch(errorHandler, this.promiseLabel('Handle error'))
+    // The prelude Promise.resolve() async moves us into the promise land.
+    return Promise.resolve(null)
+      .then(callback)
+      .catch(errorHandler)
       .then(() => this);
   }
 }

--- a/packages/router_js/lib/transition.ts
+++ b/packages/router_js/lib/transition.ts
@@ -1,4 +1,3 @@
-import { Promise } from 'rsvp';
 import type { Dict, Maybe, Option } from './core';
 import type { ModelFor, Route, RouteInfo, RouteInfoWithAttributes } from './route-info';
 import type InternalRouteInfo from './route-info';
@@ -8,7 +7,7 @@ import { buildTransitionAborted } from './transition-aborted-error';
 import type { OpaqueIntent } from './transition-intent';
 import type { TransitionError } from './transition-state';
 import type TransitionState from './transition-state';
-import { log, promiseLabel } from './utils';
+import { log } from './utils';
 import { DEBUG } from '@glimmer/env';
 
 export type OnFulfilled<T, TResult1> =
@@ -179,7 +178,7 @@ export default class Transition<R extends Route> implements Partial<Promise<R>> 
         let error = this.router.transitionDidError(result, this);
 
         throw error;
-      }, promiseLabel('Handle Abort'));
+      });
     } else {
       this.promise = Promise.resolve(this[STATE_SYMBOL]!);
       this[PARAMS_SYMBOL] = {};
@@ -230,9 +229,9 @@ export default class Transition<R extends Route> implements Partial<Promise<R>> 
   then<TResult1 = R, TResult2 = never>(
     onFulfilled?: ((value: R) => TResult1 | PromiseLike<TResult1>) | undefined | null,
     onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
-    label?: string
+    _label?: string
   ): Promise<TResult1 | TResult2> {
-    return this.promise!.then(onFulfilled, onRejected, label);
+    return this.promise!.then(onFulfilled, onRejected);
   }
 
   /**
@@ -248,8 +247,8 @@ export default class Transition<R extends Route> implements Partial<Promise<R>> 
     @return {Promise}
     @public
    */
-  catch<T>(onRejection?: OnRejected<TransitionState<any>, T>, label?: string) {
-    return this.promise!.catch(onRejection, label);
+  catch<T>(onRejection?: OnRejected<TransitionState<any>, T>, _label?: string) {
+    return this.promise!.catch(onRejection);
   }
 
   /**
@@ -265,9 +264,8 @@ export default class Transition<R extends Route> implements Partial<Promise<R>> 
     @return {Promise}
     @public
    */
-  finally<T>(callback?: T | undefined, label?: string) {
-    // @ts-expect-error @types/rsvp doesn't have the correct signiture for RSVP.Promise.finally
-    return this.promise!.finally(callback, label);
+  finally<T>(callback?: T | undefined, _label?: string) {
+    return this.promise!.finally(callback as never);
   }
 
   /**

--- a/packages/router_js/lib/utils.ts
+++ b/packages/router_js/lib/utils.ts
@@ -1,5 +1,4 @@
 import type { QueryParams } from 'route-recognizer';
-import type { Promise } from 'rsvp';
 import type { Dict } from './core';
 import type Router from './router';
 

--- a/packages/router_js/tests/async_get_handler_test.ts
+++ b/packages/router_js/tests/async_get_handler_test.ts
@@ -1,6 +1,5 @@
 import type { Route } from '../index';
 import type { Dict } from '../lib/core';
-import { Promise } from 'rsvp';
 import { createHandler, TestRouter } from './test_helpers';
 
 function map(router: TestRouter) {

--- a/packages/router_js/tests/query_params_test.ts
+++ b/packages/router_js/tests/query_params_test.ts
@@ -4,7 +4,6 @@ import type { Route, Transition } from '../index';
 import type Router from '../index';
 import type { Dict, Maybe } from '../lib/core';
 import type RouteInfo from '../lib/route-info';
-import { Promise } from 'rsvp';
 import { createHandler, TestRouter, trigger, ignoreTransitionError } from './test_helpers';
 
 let router: Router<Route>, handlers: Dict<Route>, expectedUrl: Maybe<string>;

--- a/packages/router_js/tests/route_info_test.ts
+++ b/packages/router_js/tests/route_info_test.ts
@@ -9,7 +9,6 @@ import {
 } from '../lib/route-info';
 import InternalTransition from '../lib/transition';
 import URLTransitionIntent from '../lib/transition-intent/url-transition-intent';
-import { resolve } from 'rsvp';
 import { createHandler, createHandlerInfo, TestRouter } from './test_helpers';
 
 QUnit.module('RouteInfo');
@@ -122,11 +121,11 @@ QUnit.skip('RouteInfo#resolve runs afterModel hook on handler', function (assert
       afterModel(resolvedModel: Dict<unknown>, payload: Dict<unknown>) {
         assert.equal(resolvedModel, model, 'afterModel receives the value resolved by model');
         assert.equal(payload, transition);
-        return resolve(123); // 123 should get ignored
+        return Promise.resolve(123); // 123 should get ignored
       },
     }),
     getModel() {
-      return resolve(model);
+      return Promise.resolve(model);
     },
   });
 
@@ -186,7 +185,7 @@ QUnit.test('UnresolvedRouteInfoByObject does NOT get its model hook called', fun
     new TestRouter(),
     'unresolved',
     ['wat'],
-    resolve({ name: 'dorkletons' })
+    Promise.resolve({ name: 'dorkletons' })
   );
 
   routeInfo.resolve({} as Transition).then((resolvedRouteInfo) => {

--- a/packages/router_js/tests/router_test.ts
+++ b/packages/router_js/tests/router_test.ts
@@ -12,7 +12,6 @@ import type RouteInfo from '../lib/route-info';
 import type { SerializerFunc } from '../lib/router';
 import { logAbort, PARAMS_SYMBOL, QUERY_PARAMS_SYMBOL, STATE_SYMBOL } from '../lib/transition';
 import type { TransitionError } from '../lib/transition-state';
-import { Promise, reject } from 'rsvp';
 import {
   assertAbort,
   createHandler,
@@ -3320,7 +3319,7 @@ scenarios.forEach(function (scenario) {
 
       function redirectToAbout() {
         if (returnPromise) {
-          return reject().then(null, function () {
+          return Promise.reject().then(null, function () {
             router.transitionTo(redirectTo);
           });
         } else {
@@ -3427,7 +3426,7 @@ scenarios.forEach(function (scenario) {
     let expectedReason = { reason: 'No funciona, mon frere.' };
 
     function throwAnError() {
-      return reject(expectedReason);
+      return Promise.reject(expectedReason);
     }
 
     routes = {
@@ -3611,7 +3610,7 @@ scenarios.forEach(function (scenario) {
 
       showPost: createHandler('showPost', {
         model: function () {
-          return reject('borf!');
+          return Promise.reject('borf!');
         },
         events: {
           error: function (e: Error) {
@@ -3624,7 +3623,7 @@ scenarios.forEach(function (scenario) {
               if (errorCount === 1) {
                 // transition back here to test transitionTo error handling.
                 return router
-                  .transitionTo('showPost', reject('borf!'))
+                  .transitionTo('showPost', Promise.reject('borf!'))
                   .then(shouldNotHappen(assert), function (e: Error) {
                     assert.equal(e, 'borf!', 'got thing');
                   });
@@ -5686,7 +5685,7 @@ scenarios.forEach(function (scenario) {
         foo: createHandler('foo', {
           model: function () {
             router.intermediateTransitionTo('loading');
-            return new Promise(function (resolve) {
+            return new Promise<void>(function (resolve) {
               resolve();
             });
           },

--- a/packages/router_js/tests/transition_intent_test.ts
+++ b/packages/router_js/tests/transition_intent_test.ts
@@ -11,7 +11,6 @@ import {
   UnresolvedRouteInfoByObject,
   UnresolvedRouteInfoByParam,
 } from '../lib/route-info';
-import { Promise } from 'rsvp';
 
 let handlers: Dict<Route>, recognizer: any;
 

--- a/packages/router_js/tests/transition_state_test.ts
+++ b/packages/router_js/tests/transition_state_test.ts
@@ -6,7 +6,6 @@ import {
   UnresolvedRouteInfoByParam,
 } from '../lib/route-info';
 import TransitionState, { type TransitionError } from '../lib/transition-state';
-import { Promise, resolve } from 'rsvp';
 import { createHandler, createHandlerInfo, TestRouter } from './test_helpers';
 
 QUnit.module('TransitionState');
@@ -30,14 +29,14 @@ QUnit.test("#resolve delegates to handleInfo objects' resolve()", function (asse
       resolve: function () {
         ++counter;
         assert.equal(counter, 1);
-        return resolve(resolvedHandlerInfos[0]);
+        return Promise.resolve(resolvedHandlerInfos[0]);
       },
     }),
     createHandlerInfo('two', {
       resolve: function () {
         ++counter;
         assert.equal(counter, 2);
-        return resolve(resolvedHandlerInfos[1]);
+        return Promise.resolve(resolvedHandlerInfos[1]);
       },
     }),
   ];
@@ -90,11 +89,11 @@ QUnit.test('Integration w/ HandlerInfos', function (assert) {
         model: function (params: Dict<unknown>, payload: Dict<unknown>) {
           assert.equal(payload, transition);
           assert.equal(params['foo_id'], '123', 'foo#model received expected params');
-          return resolve(fooModel);
+          return Promise.resolve(fooModel);
         },
       })
     ),
-    new UnresolvedRouteInfoByObject(router, 'bar', ['bar_id'], resolve(barModel)),
+    new UnresolvedRouteInfoByObject(router, 'bar', ['bar_id'], Promise.resolve(barModel)),
   ];
 
   state

--- a/type-tests/@ember/routing-test/router-service.ts
+++ b/type-tests/@ember/routing-test/router-service.ts
@@ -3,7 +3,6 @@ import type RouteInfo from '@ember/routing/route-info';
 import RouterService from '@ember/routing/router-service';
 import type Transition from '@ember/routing/transition';
 import { expectTypeOf } from 'expect-type';
-import type { Promise as RSVPPromise } from 'rsvp';
 
 declare let router: RouterService;
 
@@ -28,21 +27,21 @@ const transition = router.transitionTo('someRoute');
 
 expectTypeOf(transition.abort()).toEqualTypeOf<Transition>();
 
-expectTypeOf(transition.catch()).toEqualTypeOf<RSVPPromise<any>>();
+expectTypeOf(transition.catch()).toEqualTypeOf<Promise<any>>();
 transition.catch((err) => console.log(err), 'label');
 
-expectTypeOf(transition.finally()).toEqualTypeOf<RSVPPromise<unknown>>();
+expectTypeOf(transition.finally()).toEqualTypeOf<Promise<unknown>>();
 transition.finally(() => console.log('finally!'));
 transition.finally(() => console.log('finally!'), 'label');
 
-expectTypeOf(transition.followRedirects()).toEqualTypeOf<RSVPPromise<unknown>>();
+expectTypeOf(transition.followRedirects()).toEqualTypeOf<Promise<unknown>>();
 
 expectTypeOf(transition.method('refresh')).toEqualTypeOf<Transition>();
 transition.method('replace');
 
 expectTypeOf(transition.retry()).toEqualTypeOf<Transition>();
 
-expectTypeOf(transition.then()).toEqualTypeOf<RSVPPromise<unknown>>();
+expectTypeOf(transition.then()).toEqualTypeOf<Promise<unknown>>();
 transition.then(
   (result) => console.log(result),
   (err) => console.log(err),
@@ -59,7 +58,7 @@ expectTypeOf(transition.from).toEqualTypeOf<RouteInfoWithAttributes | null | und
 // @ts-expect-error
 transition.from = 'from';
 
-expectTypeOf(transition.promise).toEqualTypeOf<RSVPPromise<any> | undefined>();
+expectTypeOf(transition.promise).toEqualTypeOf<Promise<any> | undefined>();
 // @ts-expect-error
 transition.promise = 'promise';
 

--- a/type-tests/@ember/rsvp-compat-tests.ts
+++ b/type-tests/@ember/rsvp-compat-tests.ts
@@ -1,0 +1,30 @@
+import { expectTypeOf } from 'expect-type';
+
+/**
+ * We no longer use RSVP internally, 
+ * but to ensure we don't accidentally break compatibility
+ * with users who are still using it, I wanted verification
+ * that apis RSVP promises satisfy native promise types.
+ */
+import RSVP from 'rsvp';
+
+const nativePromise = new Promise((resolve) => resolve(0));
+
+expectTypeOf(nativePromise).not.toMatchTypeOf<RSVP.Promise<any>>();
+expectTypeOf(nativePromise).toMatchTypeOf<Promise<any>>();
+
+const rsvpPromise = new RSVP.Promise((resolve) => resolve(0));
+
+expectTypeOf(rsvpPromise).toMatchTypeOf<RSVP.Promise<any>>();
+expectTypeOf(rsvpPromise).toMatchTypeOf<Promise<any>>();
+
+function takesNativePromise(p: Promise<any>) {}
+
+function takesRSVPPromise(p: RSVP.Promise<any>) {}
+
+takesNativePromise(nativePromise);
+takesNativePromise(rsvpPromise);
+
+takesRSVPPromise(rsvpPromise); 
+// @ts-expect-error RSVP.Promise is not a native Promise
+takesRSVPPromise(nativePromise);


### PR DESCRIPTION
We don't need to use RSVP, so we can ship less bytes for consumers who also don't use it.

Unfortunately, we still need a tiny abstraction, because all these Promises have a timing behavior that I don't want to mess with right now, and that all that stuff is ran during the "async phase" of backburner