### PR TITLE
Fix new keywords polluting the JS namespace

### DIFF
--- a/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
+++ b/packages/@ember/template-compiler/lib/plugins/auto-import-builtins.ts
@@ -60,7 +60,7 @@ function rewriteKeyword(
 ) {
   if (env.meta?.jsutils) {
     node.original = env.meta.jsutils.bindImport(moduleSpecifier, name, node, {
-      name,
+      nameHint: `__keyword__${name}`,
     });
   } else if (env.meta?.emberRuntime) {
     node.original = env.meta.emberRuntime.lookupKeyword(name);

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -447,17 +447,21 @@ function basicTest(scenarios: Scenarios, appName: string) {
               import { setupRenderingTest } from 'ember-qunit';
               import { render } from '@ember/test-helpers';
 
-              function localLteHelper() {
-                // this should not be define because it is not imported
-                return lte(...arguments);
-              }
-
               module('Using {{lte}} in a template should not bleed into outer javascript scope', function(hooks) {
                 setupRenderingTest(hooks);
 
                 test('it works - but it should not', async function(assert) {
                   let a = 1;
                   let b = 2;
+
+                  function localLteHelper() {
+                    try {
+                      // this should not be define because it is not imported
+                      return lte(...arguments);
+                    } catch {
+                      return 'WE COULD NOT FIND IT'
+                    }
+                  }
 
                   await render(
                     <template>
@@ -466,7 +470,7 @@ function basicTest(scenarios: Scenarios, appName: string) {
                     </template>
                   );
 
-                  assert.dom('[data-local-lte]').hasText('true');
+                  assert.dom('[data-local-lte]').hasText('WE COULD NOT FIND IT');
                   assert.dom('[data-lte]').hasText('true');
                 });
               });

--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -442,6 +442,35 @@ function basicTest(scenarios: Scenarios, appName: string) {
                 });
               });
             `,
+            'lte-js-scope-polution-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render } from '@ember/test-helpers';
+
+              function localLteHelper() {
+                // this should not be define because it is not imported
+                return lte(...arguments);
+              }
+
+              module('Using {{lte}} in a template should not bleed into outer javascript scope', function(hooks) {
+                setupRenderingTest(hooks);
+
+                test('it works - but it should not', async function(assert) {
+                  let a = 1;
+                  let b = 2;
+
+                  await render(
+                    <template>
+                      <span data-local-lte>{{localLteHelper a b}}</span>
+                      <span data-lte>{{lte a a}}</span>
+                    </template>
+                  );
+
+                  assert.dom('[data-local-lte]').hasText('true');
+                  assert.dom('[data-lte]').hasText('true');
+                });
+              });
+            `,
             'lt-lte-gt-gte-as-keyword-test.gjs': `
               import { module, test } from 'qunit';
               import { setupRenderingTest } from 'ember-qunit';


### PR DESCRIPTION
I discussed this with @NullVoxPopuli last week, but the way that we have implemented all the "X as keyword" PRs (where they automatically add an import) means that the named import now pollutes the JS namespace for the whole file.

~The example is a bit contrived in this PR but it demos the problem e.g. we expect this smoke test to fail but it doesn't 🙈~

Edit: thanks to @kategengler for the hint on how to make this fail when we have the bad behaviour 🎉 