### PR TITLE
[BUGFIX] #private field access in class-based components

### DIFF
--- a/smoke-tests/scenarios/basic-test.ts
+++ b/smoke-tests/scenarios/basic-test.ts
@@ -120,6 +120,29 @@ function basicTest(scenarios: Scenarios, appName: string) {
             `,
           },
           integration: {
+            'private-field-access-test.gjs': `
+              import { module, test } from 'qunit';
+              import { setupRenderingTest } from 'ember-qunit';
+              import { render } from '@ember/test-helpers';
+              import Component from '@glimmer/component';
+
+              module('private field access', function (hooks) {
+                setupRenderingTest(hooks);
+
+                test('it works', async function (assert) {
+                  class HelloWorld extends Component {
+                    #foo = 'hello there';
+
+                    <template>
+                      {{this.#foo}}
+                    </template>
+                  }
+                  await render(HelloWorld);
+
+                  assert.dom().hasText('hello there');
+                });
+              });
+            `,
             'tracked-built-ins-macro-test.gjs': `
               import { module, test } from 'qunit';
               import { TrackedArray } from 'tracked-built-ins';


### PR DESCRIPTION
I forgot to follow up on this since the e2e / scenario tests have been added.

I noticed this wasn't working in my REPL, which (at the time of writing), is on 7.1.0-alpha.2

https://limber.glimdown.com/edit?c=JYWwDg9gTgLgBAYQuCA7Apq%2BAzKy4DkAAgOYA2oI6UA9AMbKQZYEDcAUO%2BgB6SxwATdNgCGAVzLw6ZEQGdZcABLoyZCAHVoZAXB4xMAhUhTN4Ab3Zw4AYmwQIcALyEAFirVwYbqOjaW4-gA8%2BuAy%2BgB8-lZmZl7AsgB0tvYAvilBNCFgYeiR6UA&format=gjs



Fixes: https://github.com/emberjs/ember.js/issues/21007