### PR TITLE
Fix URL sanitization bypasses in DOM sanitizer

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -719,3 +719,56 @@ jitSuite(
     protected isSelfClosing = false;
   }
 );
+
+class SvgXlinkHrefSanitizationTests extends RenderTest {
+  static suiteName = 'svg xlink:href sanitization';
+
+  @test
+  'marks javascript: protocol as unsafe on xlink:href'() {
+    this.render(
+      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href={{this.foo}}></use></svg>`,
+      { foo: 'javascript:foo()' }
+    );
+
+    this.assertHTML(
+      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="unsafe:javascript:foo()"></use></svg>`
+    );
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'http://example.com' });
+    this.assertHTML(
+      `<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="http://example.com"></use></svg>`
+    );
+    this.assertStableNodes();
+  }
+}
+
+jitSuite(SvgXlinkHrefSanitizationTests);
+
+class CaseInsensitiveSanitizationTests extends RenderTest {
+  static suiteName = 'attribute-name case-insensitive sanitization';
+
+  @test
+  'marks javascript: protocol as unsafe on uppercase HREF'() {
+    this.render(`<a HREF={{this.foo}}></a>`, { foo: 'javascript:foo()' });
+    this.assertHTML(`<a HREF="unsafe:javascript:foo()"></a>`);
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'http://example.com' });
+    this.assertHTML(`<a HREF="http://example.com"></a>`);
+    this.assertStableNodes();
+  }
+
+  @test
+  'marks javascript: protocol as unsafe on mixed-case Src'() {
+    this.render(`<img Src={{this.foo}} />`, { foo: 'javascript:foo()' });
+    this.assertHTML(`<img Src="unsafe:javascript:foo()" />`);
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'http://example.com/x.png' });
+    this.assertHTML(`<img Src="http://example.com/x.png" />`);
+    this.assertStableNodes();
+  }
+}
+
+jitSuite(CaseInsensitiveSanitizationTests);

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -16,13 +16,25 @@ function has(array: Array<string>, item: string): boolean {
   return array.indexOf(item) !== -1;
 }
 
+function normalizeAttributeName(attribute: string): string {
+  return attribute.toLowerCase();
+}
+
+function isNamespacedHref(attribute: string): boolean {
+  return normalizeAttributeName(attribute).endsWith(':href');
+}
+
 function checkURI(tagName: Nullable<string>, attribute: string): boolean {
-  return (tagName === null || has(badTags, tagName)) && has(badAttributes, attribute);
+  if (isNamespacedHref(attribute)) {
+    return true;
+  }
+
+  return (tagName === null || has(badTags, tagName)) && has(badAttributes, normalizeAttributeName(attribute));
 }
 
 function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
   if (tagName === null) return false;
-  return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, attribute);
+  return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, normalizeAttributeName(attribute));
 }
 
 export function requiresSanitization(tagName: string, attribute: string): boolean {


### PR DESCRIPTION
This patch fixes two reachable XSS sanitization bypasses in packages/@glimmer/runtime/lib/dom/sanitized-values.ts.

Previously sanitization checks relied on exact lowercase attribute matches (`href`, `src`, etc.). Some template/property normalization paths preserve original attribute casing (`HREF`, `Src`), allowing dangerous `javascript:` URLs to bypass sanitization and reach the DOM unsafely.

Additionally SVG `xlink:href` attributes bypassed the standard normalization path and were not treated as URI-bearing attributes requiring sanitization. This allowed unsafe URLs on SVG `<use>` elements.

Changes included in this patch:
- Normalize attribute names before sanitizer lookups
- Treat namespaced `*:href` attributes as URI-bearing attributes
- Add regression tests for:
  - uppercase `HREF`
  - mixed-case `Src`
  - SVG `xlink:href`

The new tests verify both unsafe and safe rerender behavior to ensure the sanitizer remains correctly enforced going forward.