### PR TITLE
fix(glimmer): add assertion for invalid dynamic component argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-source",
-  "version": "7.1.0-alpha.1",
+  "version": "7.2.0-alpha.1",
   "description": "A JavaScript framework for creating ambitious web applications",
   "keywords": [
     "ember-addon"

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -87,6 +87,19 @@ moduleFor(
       });
     }
 
+    ['@test it throws a useful assertion when dynamic component name is an object'](assert) {
+      if (!DEBUG) {
+        assert.expect(0);
+        return;
+      }
+
+      assert.throws(() => {
+        this.render('{{component this.componentName}}', {
+          componentName: { name: 'not-a-component' },
+        });
+      }, /The `{{component}}` helper only accepts strings or components/);
+    }
+
     ['@test it has an element']() {
       let instance;
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -72,6 +72,7 @@ import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import assert from '@glimmer/debug-util/lib/assert';
 import { unwrapTemplate } from '@glimmer/debug-util/lib/template';
 import { registerDestructor } from '@glimmer/destroyable';
+import { hasInternalComponentManager } from '@glimmer/manager/lib/internal/api';
 import { managerHasCapability } from '@glimmer/manager/lib/util/capabilities';
 import { isConstRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { assign } from '@glimmer/util/lib/object-utils';
@@ -167,6 +168,18 @@ APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => 
   let isStrict = constants.getValue<boolean>(_isStrict);
 
   vm.loadValue($t1, null); // Clear the temp register
+
+  if (DEBUG) {
+    assert(
+      component === null ||
+        component === undefined ||
+        typeof component === 'string' ||
+        isCurriedValue(component) ||
+        ((typeof component === 'object' || typeof component === 'function') &&
+          hasInternalComponentManager(component)),
+      'The `{{component}}` helper only accepts strings or components'
+    );
+  }
 
   let definition: ComponentDefinition | CurriedValue;
 


### PR DESCRIPTION
Fixes #18072

Adds a debug assertion in the dynamic component resolution opcode to throw a useful error when the `{{component}}` helper receives an invalid argument type, e.g. an object, instead of failing with a cryptic error.

Adds a test to verify the assertion fires with the expected message.

Tested with:

- `pnpm test:wip`