### PR TITLE
[BUGFIX] Add assertion for invalid component helper argument

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -1,5 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask, runAppend } from 'internal-test-helpers';
 
 import { set, computed } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
@@ -87,7 +87,9 @@ moduleFor(
       });
     }
 
-    ['@test it throws a useful assertion when dynamic component name is an object'](assert) {
+    ['@test it throws a useful assertion for an invalid dynamic component value in non-strict mode'](
+      assert
+    ) {
       if (!DEBUG) {
         assert.expect(0);
         return;
@@ -97,7 +99,36 @@ moduleFor(
         this.render('{{component this.componentName}}', {
           componentName: { name: 'not-a-component' },
         });
-      }, /The `{{component}}` helper received an invalid value\. It expects a component definition, or a string component name in non-strict mode\./);
+      }, /The `{{component}}` helper received an invalid value\. It expects a component definition or a string component name\./);
+    }
+
+    ['@test it throws a useful assertion for an invalid dynamic component value in strict mode'](
+      assert
+    ) {
+      if (!DEBUG) {
+        assert.expect(0);
+        return;
+      }
+
+      assert.throws(() => {
+        this.owner.register(
+          'template:-top-level',
+          this.compile('{{component this.componentName}}', {
+            moduleName: '-top-level',
+            strictMode: true,
+          })
+        );
+
+        let attrs = {
+          componentName: { name: 'not-a-component' },
+          tagName: '',
+          layoutName: '-top-level',
+        };
+
+        this.owner.register('component:-top-level', Component.extend(attrs));
+        this.component = this.owner.lookup('component:-top-level');
+        runAppend(this.component);
+      }, /The `{{component}}` helper received an invalid value\. In strict mode, it expects a component definition\./);
     }
 
     ['@test it has an element']() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -87,6 +87,19 @@ moduleFor(
       });
     }
 
+    ['@test it throws a useful assertion when dynamic component name is an object'](assert) {
+      if (!DEBUG) {
+        assert.expect(0);
+        return;
+      }
+
+      assert.throws(() => {
+        this.render('{{component this.componentName}}', {
+          componentName: { name: 'not-a-component' },
+        });
+      }, /The `{{component}}` helper received an invalid value\. It expects a component definition, or a string component name in non-strict mode\./);
+    }
+
     ['@test it has an element']() {
       let instance;
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -1,5 +1,5 @@
 import { DEBUG } from '@glimmer/env';
-import { moduleFor, RenderingTestCase, strip, runTask, runAppend } from 'internal-test-helpers';
+import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 
 import { set, computed } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
@@ -7,6 +7,7 @@ import { setComponentTemplate } from '@glimmer/manager';
 
 import { Component } from '../../utils/helpers';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
+import GlimmerishComponent from '../../utils/glimmerish-component';
 
 moduleFor(
   'Components test: dynamic components',
@@ -110,24 +111,19 @@ moduleFor(
         return;
       }
 
+      let Bar = setComponentTemplate(
+        precompileTemplate('{{component this.componentName}}', {
+          strictMode: true,
+        }),
+        class extends GlimmerishComponent {
+          componentName = { name: 'not-a-component' };
+        }
+      );
+
+      this.owner.register('component:bar', Bar);
+
       assert.throws(() => {
-        this.owner.register(
-          'template:-top-level',
-          this.compile('{{component this.componentName}}', {
-            moduleName: '-top-level',
-            strictMode: true,
-          })
-        );
-
-        let attrs = {
-          componentName: { name: 'not-a-component' },
-          tagName: '',
-          layoutName: '-top-level',
-        };
-
-        this.owner.register('component:-top-level', Component.extend(attrs));
-        this.component = this.owner.lookup('component:-top-level');
-        runAppend(this.component);
+        this.render('<Bar/>');
       }, /The `{{component}}` helper received an invalid value\. In strict mode, it expects a component definition\./);
     }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -72,6 +72,7 @@ import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import assert from '@glimmer/debug-util/lib/assert';
 import { unwrapTemplate } from '@glimmer/debug-util/lib/template';
 import { registerDestructor } from '@glimmer/destroyable';
+import { hasInternalComponentManager } from '@glimmer/manager/lib/internal/api';
 import { managerHasCapability } from '@glimmer/manager/lib/util/capabilities';
 import { isConstRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { assign } from '@glimmer/util/lib/object-utils';
@@ -167,6 +168,18 @@ APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => 
   let isStrict = constants.getValue<boolean>(_isStrict);
 
   vm.loadValue($t1, null); // Clear the temp register
+
+  if (DEBUG) {
+    assert(
+      component === null ||
+        component === undefined ||
+        typeof component === 'string' ||
+        isCurriedValue(component) ||
+        ((typeof component === 'object' || typeof component === 'function') &&
+          hasInternalComponentManager(component)),
+      'The `{{component}}` helper received an invalid value. It expects a component definition, or a string component name in non-strict mode.'
+    );
+  }
 
   let definition: ComponentDefinition | CurriedValue;
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -177,7 +177,9 @@ APPEND_OPCODES.add(VM_RESOLVE_DYNAMIC_COMPONENT_OP, (vm, { op1: _isStrict }) => 
         isCurriedValue(component) ||
         ((typeof component === 'object' || typeof component === 'function') &&
           hasInternalComponentManager(component)),
-      'The `{{component}}` helper received an invalid value. It expects a component definition, or a string component name in non-strict mode.'
+      isStrict
+        ? 'The `{{component}}` helper received an invalid value. In strict mode, it expects a component definition.'
+        : 'The `{{component}}` helper received an invalid value. It expects a component definition or a string component name.'
     );
   }
 


### PR DESCRIPTION
Fixes #18072

Adds a debug assertion in the dynamic component resolution opcode to throw a useful error when the `{{component}}` helper receives an invalid argument type, e.g. an object, instead of failing with a cryptic error.

Adds a test to verify the assertion fires with the expected message.

Tested with:

- `pnpm test:wip`