### PR TITLE
[BUGFIX] Improve debugger message for template-only components

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/suites/debugger.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/debugger.ts
@@ -113,6 +113,36 @@ export class DebuggerSuite extends RenderTest {
   }
 
   @test
+  'debugger in class-backed component logs context message with named argument hint'() {
+    let originalInfo = console.info;
+    let messages: string[] = [];
+
+    console.info = (...args: unknown[]) => {
+      messages.push(args.join(' '));
+    };
+
+    try {
+      resetDebuggerCallback();
+
+      this.registerComponent(
+        'Glimmer',
+        'DebugTest',
+        '{{debugger}}',
+        class extends GlimmerishComponent {}
+      );
+
+      this.render('<DebugTest @foo="bar" />', {});
+
+      this.assert.deepEqual(messages, [
+        "Use `context`, and `get(<path>)` to debug this template. For named arguments, use `get('@argName')`.",
+      ]);
+    } finally {
+      console.info = originalInfo;
+      resetDebuggerCallback();
+    }
+  }
+
+  @test
   'can get locals'() {
     let expectedContext = {
       foo: 'bar',

--- a/packages/@glimmer-workspace/integration-tests/lib/suites/debugger.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/debugger.ts
@@ -87,6 +87,31 @@ export class DebuggerSuite extends RenderTest {
     this.assertStableNodes();
   }
 
+  @test({ kind: 'templateOnly' })
+  'debugger in template-only component logs template-only message'() {
+    let originalInfo = console.info;
+    let messages: string[] = [];
+
+    console.info = (...args: unknown[]) => {
+      messages.push(args.join(' '));
+    };
+
+    try {
+      resetDebuggerCallback();
+
+      this.registerComponent('TemplateOnly', 'DebugTest', '{{debugger}}');
+
+      this.render('<DebugTest @foo="bar" />', {});
+
+      this.assert.deepEqual(messages, [
+        "Use `get(<path>)` to debug this template. For named arguments, use `get('@argName')`.",
+      ]);
+    } finally {
+      console.info = originalInfo;
+      resetDebuggerCallback();
+    }
+  }
+
   @test
   'can get locals'() {
     let expectedContext = {

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -14,11 +14,18 @@ export type DebugGet = (path: string) => unknown;
 export type DebugCallback = (context: unknown, get: DebugGet) => void;
 
 function debugCallback(context: unknown, get: DebugGet): void {
-  // eslint-disable-next-line no-console
-  console.info('Use `context`, and `get(<path>)` to debug this template.');
+  if (context !== null && context !== undefined) {
+    // eslint-disable-next-line no-console
+    console.info('Use `context`, and `get(<path>)` to debug this template.');
 
-  // for example...
-  context === get('this');
+    // for example...
+    context === get('this');
+  } else {
+    // eslint-disable-next-line no-console
+    console.info(
+      "Use `get(<path>)` to debug this template. For named arguments, use `get('@argName')`."
+    );
+  }
 
   // eslint-disable-next-line no-debugger
   debugger;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debugger.ts
@@ -16,7 +16,9 @@ export type DebugCallback = (context: unknown, get: DebugGet) => void;
 function debugCallback(context: unknown, get: DebugGet): void {
   if (context !== null && context !== undefined) {
     // eslint-disable-next-line no-console
-    console.info('Use `context`, and `get(<path>)` to debug this template.');
+    console.info(
+      "Use `context`, and `get(<path>)` to debug this template. For named arguments, use `get('@argName')`."
+    );
 
     // for example...
     context === get('this');


### PR DESCRIPTION
Fixes #17962

Updates the default `{{debugger}}` callback to show a template-only-friendly message when there is no backing context.

Adds a regression test for the template-only debugger message.

Tested with:

- `pnpm test:wip`