### PR TITLE
Document legacy action modifier interaction with component event handlers

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -784,6 +784,18 @@ declare const SIGNATURE: unique symbol;
   * `dragEnd`
   * `drop`
 
+  > **Note on legacy `{{action}}` usage:** In Ember versions where the legacy
+  > `{{action}}` modifier was available, classic component event handler methods
+  > could be combined with `{{action}}`, including action modifiers forwarded
+  > through `...attributes`. This combination relied on Ember's legacy event
+  > dispatching system and had subtle ordering semantics, particularly when
+  > handlers were placed on the same element versus nested elements.
+  >
+  > The `{{action}}` modifier was deprecated and is no longer available in
+  > current Ember. See the
+  > [template-action deprecation guide](https://deprecations.emberjs.com/id/template-action/)
+  > for migration details. Use the `{{on}}` modifier instead.
+
   @class Component
   @extends Ember.CoreView
   @uses Ember.TargetActionSupport


### PR DESCRIPTION
This adds a legacy note to the `@ember/component` API docs under the "Event Handler Methods" section.

Issue #17877 asked about documenting ordering semantics between classic component event handler methods, legacy `{{action}}`, and actions forwarded through `...attributes`. Since `{{action}}` is no longer available in current Ember, this note avoids documenting it as current API and instead points readers to `{{on}}`.

The note links to the template-action deprecation guide for migration details.

I intentionally avoided stating a specific same-element ordering because I could not find an existing test covering classic component event handlers and `{{action}}` on the same element. The note only calls out that this combination relied on legacy event dispatching and had subtle ordering semantics.

Refs #17877