### PR TITLE
Cover RouterService query params during beforeModel redirect

### DIFF
--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -1,4 +1,4 @@
-import { service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { Component } from '@ember/-internals/glimmer';
 import Route from '@ember/routing/route';
 import NoneLocation from '@ember/routing/none-location';
@@ -519,6 +519,72 @@ moduleFor(
       );
 
       assert.equal(this.routerService.get('currentRouteName'), 'parent.child');
+    }
+
+    async ['@test RouterService#transitionTo supports query params from a service during beforeModel'](
+      assert
+    ) {
+      assert.expect(3);
+
+      let router = this.router;
+      router.dslCallbacks.length = 0;
+      router.map(function () {
+        this.route('parent');
+
+        this.route('child', function () {});
+      });
+
+      this.add(
+        'controller:parent',
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = null;
+        }
+      );
+
+      this.add(
+        'service:parent',
+        class extends Service {
+          @service
+          router;
+
+          transitionToParent() {
+            return this.router.transitionTo('parent', {
+              queryParams: {
+                foo: 'bar',
+              },
+            });
+          }
+        }
+      );
+
+      this.add(
+        'route:child.index',
+        class extends Route {
+          @service
+          parent;
+
+          beforeModel() {
+            return this.parent.transitionToParent();
+          }
+        }
+      );
+
+      await this.visit('/child');
+
+      assert.equal(
+        this.routerService.get('currentRouteName'),
+        'parent',
+        'redirects to the target route'
+      );
+
+      let currentURL = this.routerService.get('currentURL');
+
+      assert.equal(currentURL, '/parent?foo=bar', 'uses the query param in the final URL');
+
+      let controller = this.controllerFor('parent');
+
+      assert.equal(controller.get('foo'), 'bar', 'sets the controller query param');
     }
   }
 );


### PR DESCRIPTION
Adds regression coverage for #17494.

This test covers RouterService#transitionTo with query params when the transition is initiated from an injected service during beforeModel, while another transition is already active.

It verifies that the redirect completes to the target route with the expected URL and controller query param state.

Part of #19609