### PR TITLE
Revert "Update pnpm/action-setup action to v6.0.6"

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,7 +20,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+      uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       with:
         run_install: false
     - name: Install Node.js (WITH cache)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           path: ember-api-docs-data
           persist-credentials: false
 
-      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/smoke-test-app-template-updates.yml
+++ b/.github/workflows/smoke-test-app-template-updates.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Generate ember-test-app using classic blueprint
         run: |
           set -euo pipefail
@@ -88,7 +88,7 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Generate v2-app-template
         run: |
           set -euo pipefail


### PR DESCRIPTION
Reverts emberjs/ember.js#21400


Looks like 6.0.6 forced pnpm 11... which we can't upgrade to without dropping node 20



wut

 https://github.com/emberjs/ember.js/actions/runs/26130096859/job/76853044446?pr=21416#step:3:74