### PR TITLE
Disable workflow caches. 

### DIFF
--- a/.github/READ_THIS.md
+++ b/.github/READ_THIS.md
@@ -1,0 +1,29 @@
+# READ THIS
+
+_not named README because GitHub will display a README.md from this directory at the root_
+
+## Workflows
+
+## Guidelines
+
+### Avoid caches
+
+We first disabled caches for publish due to the risk of cache poisoning.
+
+Later we found caches were allowing CI to pass when updating actions. They would
+later fail when the caches were cycled. To avoid this, and after testing to ensure
+the slowdown was acceptable, we have disabled all caching on actions/setup-node
+and pnpm/action-setup.
+
+### Actions must be pinned to shas
+
+Actions are pinned to shas and this is a requirement of the GitHub organization. 
+This prevents the risk of a malicious action being used -- as releases can be reset
+to different shas. 
+
+To update actions to shas run `pnpm actions-up`.
+
+### Run Zizmor
+
+The workflow-lint.yml workflow runs [Zizmor](https://github.com/zizmorcore/zizmor)
+on all workflows and actions to statically check for insecure patterns.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,7 +14,7 @@ inputs:
   use-node-modules-cache:
     description: "Whether to use the node-modules cache"
     required: false
-    default: "true"
+    default: "false" # We don't want to use the cache. It causes false passes of CI when updating actions and workflows.
 
 runs:
   using: "composite"
@@ -22,6 +22,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
       with:
+        cache: false
         version: 10.33.2
         run_install: false
     - name: Install Node.js (WITH cache)
@@ -35,6 +36,7 @@ runs:
       if: ${{ inputs.use-node-modules-cache != 'true' }}
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
+        package-manager-cache: false
         node-version: "${{ inputs.node-version }}"
         registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         name: Install pnpm
         with:
+          cache: false
           version: 10.33.2
           run_install: false
 

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           node-version: 20
-          use-node-modules-cache: false
+          use-node-modules-cache: false # Absolutely no cache should be used when publishing due to the potential of cache-poisoning.
       - name: Update npm
         run: npm install -g npm@latest # npm >= 11.5.1 is needed
       - name: Build for Publish (Alpha)

--- a/.github/workflows/smoke-test-app-template-updates.yml
+++ b/.github/workflows/smoke-test-app-template-updates.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
+          package-manager-cache: false
           node-version: 20
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
+          cache: false
           version: 10.33.2
       - name: Generate ember-test-app using classic blueprint
         run: |
@@ -88,10 +90,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
+          package-manager-cache: false
           node-version: 20
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
+          cache: false
           version: 10.33.2
       - name: Generate v2-app-template
         run: |


### PR DESCRIPTION
They allowed workflows to continue to pass when upgrading pnpm/action-setup even though the version we upgraded to required changes for the workflows to actually work.

Add a READ_THIS.md to the .github directory with some guidelines for workflows and actions. To be fleshed out later.