### PR TITLE
Convert cjs blueprint index.js files to 'cjs masquerading as esm' (in…

### DIFF
--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,14 +1,12 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import pathUtil from 'ember-cli-path-utils';
+import stringUtils from 'ember-cli-string-utils';
 
-const fs = require('fs');
-const path = require('path');
-const pathUtil = require('ember-cli-path-utils');
-const stringUtils = require('ember-cli-string-utils');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates an acceptance test for a feature.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -1,11 +1,9 @@
-'use strict';
+import path from 'node:path';
+import stringUtil from 'ember-cli-string-utils';
+import getPathOption from 'ember-cli-get-component-path-option';
+import normalizeEntityName from 'ember-cli-normalize-entity-name';
 
-const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
-const getPathOption = require('ember-cli-get-component-path-option');
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
-
-module.exports = {
+export default {
   description: 'Generates a component.',
 
   fileMapTokens: function () {

--- a/blueprints/component-class-addon/index.js
+++ b/blueprints/component-class-addon/index.js
@@ -1,11 +1,9 @@
-'use strict';
+import path from 'node:path';
+import stringUtil from 'ember-cli-string-utils';
+import getPathOption from 'ember-cli-get-component-path-option';
+import normalizeEntityName from 'ember-cli-normalize-entity-name';
 
-const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
-const getPathOption = require('ember-cli-get-component-path-option');
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
-
-module.exports = {
+export default {
   description: 'Generates a component class.',
 
   fileMapTokens: function () {

--- a/blueprints/component-class/index.js
+++ b/blueprints/component-class/index.js
@@ -1,14 +1,12 @@
-'use strict';
+import stringUtil from 'ember-cli-string-utils';
+import getPathOption from 'ember-cli-get-component-path-option';
+import normalizeEntityName from 'ember-cli-normalize-entity-name';
+import { generateComponentSignature } from '../-utils.js';
 
-const stringUtil = require('ember-cli-string-utils');
-const getPathOption = require('ember-cli-get-component-path-option');
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
-const { generateComponentSignature } = require('../-utils');
-
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
 // intentionally avoiding use-edition-detector
-module.exports = {
+export default {
   description: 'Generates a component class.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -1,12 +1,10 @@
-'use strict';
+import path from 'node:path';
+import stringUtil from 'ember-cli-string-utils';
+import getPathOption from 'ember-cli-get-component-path-option';
+import semver from 'semver';
 
-const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
-const getPathOption = require('ember-cli-get-component-path-option');
-const semver = require('semver');
-
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
 function invocationFor(options) {
   let parts = options.entity.name.split('/');
@@ -19,7 +17,7 @@ function invocationForStrictComponentAuthoringFormat(options) {
   return stringUtil.classify(componentName);
 }
 
-module.exports = {
+export default {
   description: 'Generates a component integration or unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -1,16 +1,14 @@
-'use strict';
+import chalk from 'chalk';
+import stringUtil from 'ember-cli-string-utils';
+import getPathOption from 'ember-cli-get-component-path-option';
+import normalizeEntityName from 'ember-cli-normalize-entity-name';
+import SilentError from 'silent-error';
+import { generateComponentSignature } from '../-utils.js';
 
-const chalk = require('chalk');
-const stringUtil = require('ember-cli-string-utils');
-const getPathOption = require('ember-cli-get-component-path-option');
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
-const SilentError = require('silent-error');
-const { generateComponentSignature } = require('../-utils');
-
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
 // intentionally avoiding use-edition-detector
-module.exports = {
+export default {
   description: 'Generates a component.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -1,13 +1,11 @@
-'use strict';
+import stringUtil from 'ember-cli-string-utils';
 
-const stringUtil = require('ember-cli-string-utils');
+import path from 'node:path';
 
-const path = require('path');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates a controller unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/controller/index.js
+++ b/blueprints/controller/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   description: 'Generates a controller.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/helper-addon/index.js
+++ b/blueprints/helper-addon/index.js
@@ -1,3 +1,3 @@
-'use strict';
+import addonImport from '../-addon-import.js';
 
-module.exports = require('../-addon-import');
+export default addonImport;

--- a/blueprints/helper-test/index.js
+++ b/blueprints/helper-test/index.js
@@ -1,11 +1,9 @@
-'use strict';
+import semver from 'semver';
 
-const semver = require('semver');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates a helper integration test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/helper/index.js
+++ b/blueprints/helper/index.js
@@ -1,10 +1,8 @@
-'use strict';
+import normalizeEntityName from 'ember-cli-normalize-entity-name';
 
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   description: 'Generates a helper function.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/initializer-addon/index.js
+++ b/blueprints/initializer-addon/index.js
@@ -1,3 +1,3 @@
-'use strict';
+import addonImport from '../-addon-import.js';
 
-module.exports = require('../-addon-import');
+export default addonImport;

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -1,12 +1,10 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const fs = require('fs');
-const path = require('path');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates an initializer unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/initializer/index.js
+++ b/blueprints/initializer/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   description: 'Generates an initializer.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/instance-initializer-addon/index.js
+++ b/blueprints/instance-initializer-addon/index.js
@@ -1,3 +1,3 @@
-'use strict';
+import addonImport from '../-addon-import.js';
 
-module.exports = require('../-addon-import');
+export default addonImport;

--- a/blueprints/instance-initializer-test/index.js
+++ b/blueprints/instance-initializer-test/index.js
@@ -1,12 +1,10 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const fs = require('fs');
-const path = require('path');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates an instance initializer unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/instance-initializer/index.js
+++ b/blueprints/instance-initializer/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   shouldTransformTypeScript: true,
 
   description: 'Generates an instance initializer.',

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import path from 'node:path';
 
-const path = require('path');
-
-module.exports = {
+export default {
   description: 'Generates a mixin unit test.',
 
   fileMapTokens() {

--- a/blueprints/mixin/index.js
+++ b/blueprints/mixin/index.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   description: 'Generates a mixin.',
   normalizeEntityName: function (entityName) {
     return entityName.replace(/\.js$/, ''); //Prevent generation of ".js.js" files

--- a/blueprints/route-addon/index.js
+++ b/blueprints/route-addon/index.js
@@ -1,10 +1,8 @@
-'use strict';
+import path from 'node:path';
+import stringUtil from 'ember-cli-string-utils';
+import inflector from 'inflection';
 
-const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
-const inflector = require('inflection');
-
-module.exports = {
+export default {
   description: 'Generates import wrappers for a route and its template.',
 
   fileMapTokens: function () {

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,12 +1,10 @@
-'use strict';
+import path from 'node:path';
+import stringUtil from 'ember-cli-string-utils';
 
-const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates a route unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/route/index.js
+++ b/blueprints/route/index.js
@@ -1,15 +1,13 @@
-'use strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import stringUtil from 'ember-cli-string-utils';
+import EmberRouterGenerator from 'ember-router-generator';
+import SilentError from 'silent-error';
 
-const fs = require('fs');
-const path = require('path');
-const chalk = require('chalk');
-const stringUtil = require('ember-cli-string-utils');
-const EmberRouterGenerator = require('ember-router-generator');
-const SilentError = require('silent-error');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   description: 'Generates a route and a template, and registers the route with the router.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/service-test/index.js
+++ b/blueprints/service-test/index.js
@@ -1,9 +1,7 @@
-'use strict';
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates a service unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/service/index.js
+++ b/blueprints/service/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   description: 'Generates a service.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/template/index.js
+++ b/blueprints/template/index.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   description: 'Generates a template.',
   normalizeEntityName: function (entityName) {
     return entityName.replace(/\.hbs$/, ''); //Prevent generation of ".hbs.hbs" files

--- a/blueprints/util-test/index.js
+++ b/blueprints/util-test/index.js
@@ -1,11 +1,9 @@
-'use strict';
+import path from 'node:path';
 
-const path = require('path');
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
+import { modulePrefixForProject } from '../-utils.js';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-const { modulePrefixForProject } = require('../-utils');
-
-module.exports = {
+export default {
   description: 'Generates a util unit test.',
 
   shouldTransformTypeScript: true,

--- a/blueprints/util/index.js
+++ b/blueprints/util/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import typescriptBlueprintPolyfill from 'ember-cli-typescript-blueprint-polyfill';
 
-const typescriptBlueprintPolyfill = require('ember-cli-typescript-blueprint-polyfill');
-
-module.exports = {
+export default {
   description: 'Generates a simple utility module/function.',
 
   shouldTransformTypeScript: true,


### PR DESCRIPTION
…tentionally) to take advantage of node's compatibility features to progress towards adding type=module on this package's package.json (which would make all these blueprint files real esm, not cjs pretending to esm)


Requires:
- https://github.com/emberjs/ember.js/pull/21423
  - but that, in turn, requires: https://github.com/emberjs/ember.js/pull/21425
  - this means that ember-source _requires_ ember-cli 7+, and the blueprints provided by ember-source will no longer be compatible with ember-cli < 7 -- I think this is ok, because we don't really formally support mismatched ember-cli/ember-source majors, since we do lockstep _and_, we also require node's require(esm), so... we can do some nice things with that assumption