### PR TITLE
strip ascii tab/newline from urls before protocol check

### DIFF
--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -63,7 +63,11 @@ function findProtocolForURL() {
       let protocol = null;
 
       if (typeof url === 'string') {
-        protocol = nodeURL.parse(url).protocol;
+        // browsers strip ASCII tab/newline/CR from urls before navigating, so
+        // `java\nscript:` runs as `javascript:`. `url.parse` keeps them and reports
+        // a null protocol, slipping past the badProtocols check. Strip them here to
+        // match the WHATWG `URL` parser used on the non-fastboot path.
+        protocol = nodeURL.parse(url.replace(/[\t\n\r]/gu, '')).protocol;
       }
 
       return protocol === null ? ':' : protocol;


### PR DESCRIPTION
On the fastboot path `findProtocolForURL` uses node's `url.parse`, which keeps embedded ASCII tab/newline/CR and reports a null protocol for something like `java\nscript:alert(1)`, so it slips past the badProtocols check and gets serialized into the href untouched. Browsers strip those characters before navigating, so the value runs as `javascript:`. The WHATWG `URL` parser used on the non-fastboot path already drops them, so strip them here too before parsing.