### PR TITLE
compare url attribute names case-insensitively when sanitizing

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -573,6 +573,18 @@ export class AttributesTests extends RenderTest {
     this.assertHTML('<svg viewBox="0 0 100 100" />');
     this.assertStableNodes();
   }
+
+  @test
+  'sanitizes url attributes regardless of attribute name case'() {
+    this.render('<a HREF={{this.foo}}></a>', { foo: 'javascript:foo()' });
+    this.assertHTML('<a href="unsafe:javascript:foo()"></a>');
+
+    this.rerender({ foo: 'http://foo.bar' });
+    this.assertHTML('<a href="http://foo.bar"></a>');
+
+    this.rerender({ foo: 'javascript:foo()' });
+    this.assertHTML('<a href="unsafe:javascript:foo()"></a>');
+  }
 }
 
 jitSuite(AttributesTests);

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -17,12 +17,12 @@ function has(array: Array<string>, item: string): boolean {
 }
 
 function checkURI(tagName: Nullable<string>, attribute: string): boolean {
-  return (tagName === null || has(badTags, tagName)) && has(badAttributes, attribute);
+  return (tagName === null || has(badTags, tagName)) && has(badAttributes, attribute.toLowerCase());
 }
 
 function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
   if (tagName === null) return false;
-  return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, attribute);
+  return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, attribute.toLowerCase());
 }
 
 export function requiresSanitization(tagName: string, attribute: string): boolean {


### PR DESCRIPTION
checkURI and checkDataURI matched attribute names against the lowercase badAttributes lists with a strict comparison, so a mixed-case name such as HREF or SRC bypassed the javascript:/vbscript: protocol check even though requiresSanitization still routed the element through the sanitizer.


--------------------

Supersedes: https://github.com/emberjs/ember.js/pull/21430

Repro: https://limber.glimdown.com/edit?c=MYewdgzgLgBAZiEMC8MDkArAhgNyxYAJwEsAHKALlEhABsBTAOlpAHMAKAIgAtjOBKNAG4AUCIA8UegFtStLFIB8ImDHFYY3QvTjIA3noQgAvscVad4gPRZlq9TAASAJQCiAMX2HEpxS4-WthJWUrLySkA&format=gjs