### PR TITLE
Fix SVG URL sanitization bypass

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -145,6 +145,25 @@ export class AttributesTests extends RenderTest {
   }
 
   @test
+  'svg a[href] is marked as unsafe (sanitization is not namespace-dependent)'() {
+    // SVG-namespaced elements preserve their authored (lowercase) tag name, so
+    // `element.tagName` is `'a'` rather than the `'A'` an HTML anchor reports.
+    // URL sanitization must still apply, otherwise `<svg><a href>` is an XSS
+    // bypass for the same `javascript:` URLs that are blocked on `<a href>`.
+    this.render('<svg><a href="{{this.foo}}"></a></svg>', { foo: 'javascript:foo()' });
+    this.assertHTML('<svg><a href="unsafe:javascript:foo()"></a></svg>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'http://foo.bar' });
+    this.assertHTML('<svg><a href="http://foo.bar"></a></svg>');
+    this.assertStableNodes();
+
+    this.rerender({ foo: 'javascript:foo()' });
+    this.assertHTML('<svg><a href="unsafe:javascript:foo()"></a></svg>');
+    this.assertStableNodes();
+  }
+
+  @test
   'triple curlies in attribute position'() {
     this.render('<div data-bar="bar" data-foo={{{this.rawString}}}>Hello</div>', {
       rawString: 'TRIPLE',

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -26,7 +26,14 @@ function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
 }
 
 export function requiresSanitization(tagName: string, attribute: string): boolean {
-  return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
+  // `badTags`/`badTagsForDataURI` are listed in the uppercase form that HTML
+  // elements report from `tagName`. Elements in other namespaces (e.g. an SVG
+  // `<a href>`) preserve their authored case, so `element.tagName` is `'a'`
+  // rather than `'A'`. Normalize here so the build-time gate matches what
+  // `sanitizeAttributeValue` already does, and the URL sanitization control
+  // can't be bypassed simply by living in the SVG namespace.
+  const upperTagName = tagName.toUpperCase();
+  return checkURI(upperTagName, attribute) || checkDataURI(upperTagName, attribute);
 }
 
 interface NodeUrlParseResult {


### PR DESCRIPTION
Fix a namespace-dependent URL sanitization bypass affecting SVG anchor elements.

`requiresSanitization()` previously compared `tagName` directly against uppercase allow/block lists. While HTML elements report uppercase tag names (e.g. `A`), SVG elements preserve their authored case (e.g. `a`), causing sanitization checks to be skipped for SVG anchors.

This change normalizes tag names to uppercase before evaluating URL sanitization requirements, making the behavior consistent across namespaces and matching the normalization already performed by `sanitizeAttributeValue()`.

## Changes

* Normalize `tagName` to uppercase in `requiresSanitization()`.
* Ensure SVG elements are evaluated against the same URL sanitization rules as their HTML counterparts.
* Add an integration test covering `<svg><a href="{{...}}">` with both unsafe and valid URLs.
* Verify sanitization remains unchanged for existing HTML elements.

## Before

```html
<svg><a href="javascript:foo()"></a></svg>
```

could bypass the URL sanitization gate because the SVG anchor's tag name was reported as `a` instead of `A`.

## After

SVG anchor elements are correctly identified as requiring URL sanitization, and unsafe URLs are rewritten as expected:

```html
<svg><a href="unsafe:javascript:foo()"></a></svg>
```

## Testing

Added an integration test that verifies:

* `javascript:` URLs in SVG anchor `href` attributes are sanitized.
* Valid HTTP URLs continue to work normally.
* Sanitization behavior remains stable across rerenders.
