### PR TITLE
mark data: urls as unsafe on iframe[src] and object[data]

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -89,6 +89,34 @@ export class AttributesTests extends RenderTest {
   }
 
   @test
+  'marks data: urls as unsafe on iframe[src] and object[data]'() {
+    this.render('<iframe src={{this.foo}}></iframe>', {
+      foo: 'data:text/html,<script>alert(1)</script>',
+    });
+    this.assertHTML('<iframe src="unsafe:data:text/html,<script>alert(1)</script>"></iframe>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'https://example.com/page' });
+    this.assertHTML('<iframe src="https://example.com/page"></iframe>');
+    this.assertStableNodes();
+  }
+
+  @test
+  'object[data] marks data: and javascript: urls as unsafe but allows http'() {
+    this.render('<object data={{this.foo}}></object>', {
+      foo: 'data:text/html,<script>alert(1)</script>',
+    });
+    this.assertHTML('<object data="unsafe:data:text/html,<script>alert(1)</script>"></object>');
+
+    this.rerender({ foo: 'javascript:foo()' });
+    this.assertHTML('<object data="unsafe:javascript:foo()"></object>');
+
+    this.rerender({ foo: 'https://example.com/doc.pdf' });
+    this.assertHTML('<object data="https://example.com/doc.pdf"></object>');
+    this.assertStableNodes();
+  }
+
+  @test
   'Quoted disabled is always disabled if a not-null, not-undefined value is given'() {
     this.render('<input disabled="{{this.enabled}}" />', { enabled: true });
     this.assertHTML('<input disabled />');

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -8,9 +8,16 @@ const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM'];
 
 const badTagsForDataURI = ['EMBED'];
 
+// Tags whose URL attribute is loaded as a nested document. A `data:` URL there
+// is rendered and can execute script just like `javascript:`, so it has to be
+// neutralized even though such tags legitimately point at http(s) resources.
+const badTagsForDataProtocol = ['IFRAME', 'OBJECT'];
+
 const badAttributes = ['href', 'src', 'background', 'action'];
 
 const badAttributesForDataURI = ['src'];
+
+const badAttributesForDataProtocol = ['src', 'data'];
 
 function has(array: Array<string>, item: string): boolean {
   return array.indexOf(item) !== -1;
@@ -25,8 +32,17 @@ function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
   return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, attribute);
 }
 
+function checkDataProtocol(tagName: Nullable<string>, attribute: string): boolean {
+  if (tagName === null) return false;
+  return has(badTagsForDataProtocol, tagName) && has(badAttributesForDataProtocol, attribute);
+}
+
 export function requiresSanitization(tagName: string, attribute: string): boolean {
-  return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
+  return (
+    checkURI(tagName, attribute) ||
+    checkDataURI(tagName, attribute) ||
+    checkDataProtocol(tagName, attribute)
+  );
 }
 
 interface NodeUrlParseResult {
@@ -115,6 +131,13 @@ export function sanitizeAttributeValue(
   if (checkURI(tagName, attribute)) {
     let protocol = protocolForUrl(str);
     if (has(badProtocols, protocol)) {
+      return `unsafe:${str}`;
+    }
+  }
+
+  if (checkDataProtocol(tagName, attribute)) {
+    let protocol = protocolForUrl(str);
+    if (protocol === 'data:' || has(badProtocols, protocol)) {
       return `unsafe:${str}`;
     }
   }


### PR DESCRIPTION
The URL sanitizer only neutralizes `data:` URLs on `<embed src>`. `<iframe src>` and `<object data>` also load their URL as a nested document, so `data:text/html,<script>…</script>` is rendered and runs script. For iframe the value reaches `sanitizeAttributeValue` but only `javascript:`/`vbscript:` are rejected; for object `requiresSanitization` returns false and the value is written raw.

The new `checkDataProtocol` path rejects `data:` (and `javascript:`/`vbscript:`) for those two tags while leaving normal http(s) and relative URLs alone, so legitimate iframes and objects keep working. Repro on https://limber.glimdown.com renders the script for an `<object data={{this.url}}>` bound to a `data:text/html` value.