### PR TITLE
sanitize urls: svg/xlink href, formaction, and data: on iframe/object

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -593,6 +593,34 @@ export class AttributesTests extends RenderTest {
     this.rerender({ foo: 'http://foo.bar' });
     this.assert.strictEqual(this.readDOMAttr('xlink:href', anchor), 'http://foo.bar');
   }
+
+  @test
+  'marks data: urls as unsafe on iframe[src] and object[data]'() {
+    this.render('<iframe src={{this.foo}}></iframe>', {
+      foo: 'data:text/html,<script>alert(1)</script>',
+    });
+    this.assertHTML('<iframe src="unsafe:data:text/html,<script>alert(1)</script>"></iframe>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'https://example.com/page' });
+    this.assertHTML('<iframe src="https://example.com/page"></iframe>');
+    this.assertStableNodes();
+  }
+
+  @test
+  'object[data] marks data: and javascript: urls as unsafe but allows http'() {
+    this.render('<object data={{this.foo}}></object>', {
+      foo: 'data:text/html,<script>alert(1)</script>',
+    });
+    this.assertHTML('<object data="unsafe:data:text/html,<script>alert(1)</script>"></object>');
+
+    this.rerender({ foo: 'javascript:foo()' });
+    this.assertHTML('<object data="unsafe:javascript:foo()"></object>');
+
+    this.rerender({ foo: 'https://example.com/doc.pdf' });
+    this.assertHTML('<object data="https://example.com/doc.pdf"></object>');
+    this.assertStableNodes();
+  }
 }
 
 jitSuite(AttributesTests);
@@ -735,6 +763,24 @@ jitSuite(
     static suiteName = 'img[src] attribute';
     protected tag = 'img';
     protected attr = 'src';
+    protected override isEmptyElement = true;
+    protected isSelfClosing = false;
+  }
+);
+
+jitSuite(
+  class extends BoundValuesToSpecialAttributeTests {
+    static suiteName = 'button[formaction] attribute';
+    protected tag = 'button';
+    protected attr = 'formaction';
+  }
+);
+
+jitSuite(
+  class extends BoundValuesToSpecialAttributeTests {
+    static suiteName = 'input[formaction] attribute';
+    protected tag = 'input';
+    protected attr = 'formaction';
     protected override isEmptyElement = true;
     protected isSelfClosing = false;
   }

--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -785,3 +785,12 @@ jitSuite(
     protected isSelfClosing = false;
   }
 );
+
+jitSuite(
+  class extends BoundValuesToSpecialAttributeTests {
+    static suiteName = 'area[href] attribute';
+    protected tag = 'area';
+    protected attr = 'href';
+    protected override isEmptyElement = true;
+  }
+);

--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -573,6 +573,26 @@ export class AttributesTests extends RenderTest {
     this.assertHTML('<svg viewBox="0 0 100 100" />');
     this.assertStableNodes();
   }
+
+  @test
+  'svg a[href] marks javascript: protocol as unsafe'() {
+    this.render('<svg><a href={{this.foo}}></a></svg>', { foo: 'javascript:foo()' });
+    let anchor = (this.element.firstChild as SimpleElement).firstChild as SimpleElement;
+    this.assert.strictEqual(this.readDOMAttr('href', anchor), 'unsafe:javascript:foo()');
+
+    this.rerender({ foo: 'http://foo.bar' });
+    this.assert.strictEqual(this.readDOMAttr('href', anchor), 'http://foo.bar');
+  }
+
+  @test
+  'svg a[xlink:href] marks javascript: protocol as unsafe'() {
+    this.render('<svg><a xlink:href={{this.foo}}></a></svg>', { foo: 'javascript:foo()' });
+    let anchor = (this.element.firstChild as SimpleElement).firstChild as SimpleElement;
+    this.assert.strictEqual(this.readDOMAttr('xlink:href', anchor), 'unsafe:javascript:foo()');
+
+    this.rerender({ foo: 'http://foo.bar' });
+    this.assert.strictEqual(this.readDOMAttr('xlink:href', anchor), 'http://foo.bar');
+  }
 }
 
 jitSuite(AttributesTests);

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -17,19 +17,19 @@ function has(array: Array<string>, item: string): boolean {
 }
 
 function checkURI(tagName: Nullable<string>, attribute: string): boolean {
-  return (tagName === null || has(badTags, tagName)) && has(badAttributes, attribute);
+  // SVG element tagNames are lowercase (e.g. `a`), so they never match the
+  // uppercase `badTags` entries unless we normalize first.
+  let normalizedTag = tagName === null ? tagName : tagName.toUpperCase();
+  return (normalizedTag === null || has(badTags, normalizedTag)) && has(badAttributes, attribute);
 }
 
 function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
   if (tagName === null) return false;
-  return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, attribute);
+  return has(badTagsForDataURI, tagName.toUpperCase()) && has(badAttributesForDataURI, attribute);
 }
 
 export function requiresSanitization(tagName: Nullable<string>, attribute: string): boolean {
-  // SVG element tagNames are lowercase (e.g. `a`), so they never match the
-  // uppercase `badTags` entries unless we normalize first.
-  let normalizedTag = tagName === null ? tagName : tagName.toUpperCase();
-  return checkURI(normalizedTag, attribute) || checkDataURI(normalizedTag, attribute);
+  return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
 }
 
 interface NodeUrlParseResult {
@@ -111,7 +111,7 @@ export function sanitizeAttributeValue(
     return value.toHTML();
   }
 
-  const tagName = element.tagName.toUpperCase();
+  const tagName = element.tagName;
 
   let str = normalizeStringValue(value);
 

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -24,8 +24,9 @@ function has(array: Array<string>, item: string): boolean {
 }
 
 function checkURI(tagName: Nullable<string>, attribute: string): boolean {
-  // SVG element tagNames are lowercase (e.g. `a`), so they never match the
-  // uppercase `badTags` entries unless we normalize first.
+  // SVG tagNames are case-preserved, so the SVG `<a>` element comes through as
+  // lowercase `a` and never matches the uppercase `badTags` entries unless we
+  // normalize first.
   return (tagName === null || has(badTags, tagName.toUpperCase())) && has(badAttributes, attribute);
 }
 

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -8,7 +8,7 @@ const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM'];
 
 const badTagsForDataURI = ['EMBED'];
 
-const badAttributes = ['href', 'src', 'background', 'action'];
+const badAttributes = ['href', 'src', 'background', 'action', 'xlink:href'];
 
 const badAttributesForDataURI = ['src'];
 
@@ -25,8 +25,11 @@ function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
   return has(badTagsForDataURI, tagName) && has(badAttributesForDataURI, attribute);
 }
 
-export function requiresSanitization(tagName: string, attribute: string): boolean {
-  return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
+export function requiresSanitization(tagName: Nullable<string>, attribute: string): boolean {
+  // SVG element tagNames are lowercase (e.g. `a`), so they never match the
+  // uppercase `badTags` entries unless we normalize first.
+  let normalizedTag = tagName === null ? tagName : tagName.toUpperCase();
+  return checkURI(normalizedTag, attribute) || checkDataURI(normalizedTag, attribute);
 }
 
 interface NodeUrlParseResult {

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -4,7 +4,7 @@ import { isSafeString, normalizeStringValue } from '../dom/normalize';
 
 const badProtocols = ['javascript:', 'vbscript:'];
 
-const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM', 'BUTTON', 'INPUT'];
+const badTags = ['A', 'AREA', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM', 'BUTTON', 'INPUT'];
 
 const badTagsForDataURI = ['EMBED'];
 

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -4,13 +4,20 @@ import { isSafeString, normalizeStringValue } from '../dom/normalize';
 
 const badProtocols = ['javascript:', 'vbscript:'];
 
-const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM'];
+const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM', 'BUTTON', 'INPUT'];
 
 const badTagsForDataURI = ['EMBED'];
 
-const badAttributes = ['href', 'src', 'background', 'action', 'xlink:href'];
+// Tags whose URL attribute is loaded as a nested document. A `data:` URL there
+// is rendered and can execute script just like `javascript:`, so it has to be
+// neutralized even though such tags legitimately point at http(s) resources.
+const badTagsForDataProtocol = ['IFRAME', 'OBJECT'];
+
+const badAttributes = ['href', 'src', 'background', 'action', 'formaction', 'xlink:href'];
 
 const badAttributesForDataURI = ['src'];
+
+const badAttributesForDataProtocol = ['src', 'data'];
 
 function has(array: Array<string>, item: string): boolean {
   return array.indexOf(item) !== -1;
@@ -19,8 +26,7 @@ function has(array: Array<string>, item: string): boolean {
 function checkURI(tagName: Nullable<string>, attribute: string): boolean {
   // SVG element tagNames are lowercase (e.g. `a`), so they never match the
   // uppercase `badTags` entries unless we normalize first.
-  let normalizedTag = tagName === null ? tagName : tagName.toUpperCase();
-  return (normalizedTag === null || has(badTags, normalizedTag)) && has(badAttributes, attribute);
+  return (tagName === null || has(badTags, tagName.toUpperCase())) && has(badAttributes, attribute);
 }
 
 function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
@@ -28,8 +34,20 @@ function checkDataURI(tagName: Nullable<string>, attribute: string): boolean {
   return has(badTagsForDataURI, tagName.toUpperCase()) && has(badAttributesForDataURI, attribute);
 }
 
+function checkDataProtocol(tagName: Nullable<string>, attribute: string): boolean {
+  if (tagName === null) return false;
+  return (
+    has(badTagsForDataProtocol, tagName.toUpperCase()) &&
+    has(badAttributesForDataProtocol, attribute)
+  );
+}
+
 export function requiresSanitization(tagName: Nullable<string>, attribute: string): boolean {
-  return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
+  return (
+    checkURI(tagName, attribute) ||
+    checkDataURI(tagName, attribute) ||
+    checkDataProtocol(tagName, attribute)
+  );
 }
 
 interface NodeUrlParseResult {
@@ -66,7 +84,11 @@ function findProtocolForURL() {
       let protocol = null;
 
       if (typeof url === 'string') {
-        protocol = nodeURL.parse(url).protocol;
+        // browsers strip ASCII tab/newline/CR from urls before navigating, so
+        // `java\nscript:` runs as `javascript:`. `url.parse` keeps them and reports
+        // a null protocol, slipping past the badProtocols check. Strip them here to
+        // match the WHATWG `URL` parser used on the non-fastboot path.
+        protocol = nodeURL.parse(url.replace(/[\t\n\r]/gu, '')).protocol;
       }
 
       return protocol === null ? ':' : protocol;
@@ -118,6 +140,13 @@ export function sanitizeAttributeValue(
   if (checkURI(tagName, attribute)) {
     let protocol = protocolForUrl(str);
     if (has(badProtocols, protocol)) {
+      return `unsafe:${str}`;
+    }
+  }
+
+  if (checkDataProtocol(tagName, attribute)) {
+    let protocol = protocolForUrl(str);
+    if (protocol === 'data:' || has(badProtocols, protocol)) {
       return `unsafe:${str}`;
     }
   }


### PR DESCRIPTION
Consolidates the open URL-sanitizer fixes into one PR (per review). Each change closes a way an attacker-controlled value can reach a dangerous protocol that the sanitizer currently misses.

- **SVG anchors (case sensitivity).** `checkURI`/`checkDataURI` matched `element.tagName` against the uppercase `badTags` list, but SVG tagNames come through lowercase (`a`), so `<a href={{value}}>` inside an `<svg>` skipped the `javascript:`/`vbscript:` check. Normalization now happens inside `checkURI`/`checkDataURI` so it is single-sourced. Also added `xlink:href` to the attribute list, since that is the SVG href alias and was not covered at all.
- **formaction (#21438).** `button[formaction]` and `input[formaction]` submit to their URL, so a `javascript:` value there executes. Added `BUTTON`/`INPUT` to `badTags` and `formaction` to the attribute list.
- **data: on iframe[src] and object[data] (#21441).** A `data:` URL in these loads as a nested document and can run script. Added a `data:`-protocol check for `iframe`/`object`.
- **tab/newline stripping (#21433).** Browsers strip ASCII tab/newline/CR from a url before navigating, so `java\nscript:` runs as `javascript:`. The fastboot `url.parse` path kept those chars and reported a null protocol, slipping past the check. Strip them there to match the WHATWG `URL` parser used on the browser path.

Tests added for each case except the tab/newline strip, which only runs on the fastboot `url.parse` path (the browser `URL` parser already strips those chars, so no integration path exercises it).

Reproductions on limber for each case are in the comment below.