### PR TITLE
sanitize javascript: urls in href on area elements

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -719,3 +719,12 @@ jitSuite(
     protected isSelfClosing = false;
   }
 );
+
+jitSuite(
+  class extends BoundValuesToSpecialAttributeTests {
+    static suiteName = 'area[href] attribute';
+    protected tag = 'area';
+    protected attr = 'href';
+    protected override isEmptyElement = true;
+  }
+);

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -4,7 +4,7 @@ import { isSafeString, normalizeStringValue } from '../dom/normalize';
 
 const badProtocols = ['javascript:', 'vbscript:'];
 
-const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM'];
+const badTags = ['A', 'AREA', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM'];
 
 const badTagsForDataURI = ['EMBED'];
 


### PR DESCRIPTION
The URL sanitizer in sanitized-values.ts lists A in badTags but not AREA. An <area> in an image map navigates to its href on click just like an anchor, so <area href={{value}}> with an attacker-controlled value reaches the DOM unsanitized and runs javascript:/vbscript: on click, while the identical <a href> is rewritten to unsafe:. Add AREA so the image-map link is treated like an anchor.