### PR TITLE
Fix URL sanitization bypass through formaction attributes

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -145,6 +145,40 @@ export class AttributesTests extends RenderTest {
   }
 
   @test
+  'button[formaction] is marked as unsafe'() {
+    // `formaction` overrides the owning form's `action` at submit time, so it
+    // is the same submission-URL sink as `<form action>` and must reject
+    // `javascript:` URLs. Otherwise it is a drop-in bypass for the `action`
+    // sanitization.
+    this.render('<form><button formaction="{{this.foo}}"></button></form>', {
+      foo: 'javascript:foo()',
+    });
+    this.assertHTML('<form><button formaction="unsafe:javascript:foo()"></button></form>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'http://foo.bar' });
+    this.assertHTML('<form><button formaction="http://foo.bar"></button></form>');
+    this.assertStableNodes();
+
+    this.rerender({ foo: 'javascript:foo()' });
+    this.assertHTML('<form><button formaction="unsafe:javascript:foo()"></button></form>');
+    this.assertStableNodes();
+  }
+
+  @test
+  'input[formaction] is marked as unsafe'() {
+    this.render('<form><input type="submit" formaction="{{this.foo}}" /></form>', {
+      foo: 'javascript:foo()',
+    });
+    this.assertHTML('<form><input type="submit" formaction="unsafe:javascript:foo()" /></form>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'http://foo.bar' });
+    this.assertHTML('<form><input type="submit" formaction="http://foo.bar" /></form>');
+    this.assertStableNodes();
+  }
+
+  @test
   'triple curlies in attribute position'() {
     this.render('<div data-bar="bar" data-foo={{{this.rawString}}}>Hello</div>', {
       rawString: 'TRIPLE',

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -4,11 +4,19 @@ import { isSafeString, normalizeStringValue } from '../dom/normalize';
 
 const badProtocols = ['javascript:', 'vbscript:'];
 
-const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM'];
+// `BUTTON`/`INPUT` are included because a submit `<button>` or
+// `<input type="submit"|"image">` may carry a `formaction` attribute, which
+// overrides the owning `<form>`'s `action` at submission time. Without them the
+// `action`/`formaction` URL sanitization below would only guard `<form action>`
+// and could be bypassed by moving the same `javascript:` URL onto the submit
+// control's `formaction`.
+const badTags = ['A', 'BODY', 'LINK', 'IMG', 'IFRAME', 'BASE', 'FORM', 'BUTTON', 'INPUT'];
 
 const badTagsForDataURI = ['EMBED'];
 
-const badAttributes = ['href', 'src', 'background', 'action'];
+// `formaction` mirrors `action`: it is the per-submit-control override of a
+// form's submission URL and must be sanitized for the same reason.
+const badAttributes = ['href', 'src', 'background', 'action', 'formaction'];
 
 const badAttributesForDataURI = ['src'];
 


### PR DESCRIPTION
This patch fixes a URL sanitization bypass involving the HTML `formaction` attribute.

The sanitizer currently protects URL-bearing attributes such as `action` from dangerous schemes including `javascript:` and `vbscript:`. However, `formaction` was not included in the protected attribute set.

Because `formaction` overrides a form's `action` during submission, attacker-controlled values could bypass existing URL sanitization and execute script when a submit button is activated.

## Root Cause

The sanitizer denylist covered:

* `action` on `<form>`
* Other protected URL-bearing attributes

but omitted `formaction`, even though it serves the same navigation purpose for submit controls.

As a result, templates such as:

```hbs
<form>
  <button formaction={{this.userInput}}>Submit</button>
</form>
```

could emit dangerous URLs unchanged when `userInput` contained a `javascript:` or `vbscript:` URL.

## Changes

* Add `formaction` to the protected URL attribute list.
* Add `BUTTON` and `INPUT` to the protected element set since they are the only elements that honor `formaction`.
* Document the override semantics with inline comments.
* Add integration tests covering dangerous `formaction` values.

## Security Impact

Before this change, a malicious value supplied to `formaction` could bypass the existing URL sanitization logic and execute script when a submit control was activated.

After this change, dangerous schemes are sanitized using the same mechanism already applied to `action`, ensuring consistent protection across form submission entry points.

## Verification

Verified against the transpiled sanitizer implementation.

### Before

```html
<button formaction="javascript:alert(1)">
```

Dangerous URL emitted unchanged.

### After

```html
<button formaction="unsafe:javascript:alert(1)">
```

Dangerous URL is sanitized and blocked.

Regression testing confirmed no behavioral changes for existing protected attributes and elements, including:

* `<form action>`
* `<a href>`
* `<embed src>` with supported `data:` URLs
* Attributes intentionally outside sanitizer scope

The added integration tests validate the vulnerable path and prevent future regressions.
