### PR TITLE
block prototype traversal in set-path pollution guard

### DIFF
--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -145,7 +145,7 @@ export function _getPath(obj: unknown, path: string | string[], forSet?: boolean
       return undefined;
     }
 
-    if (forSet && (part === '__proto__' || part === 'constructor')) {
+    if (forSet && (part === '__proto__' || part === 'constructor' || part === 'prototype')) {
       return;
     }
 

--- a/packages/@ember/-internals/metal/tests/accessors/set_path_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_path_test.js
@@ -63,6 +63,7 @@ moduleFor(
       class Inner {}
       class Example {
         inner = new Inner();
+        klass = Inner;
       }
       let example = new Example();
 
@@ -85,6 +86,11 @@ moduleFor(
         set(example, 'inner.constructor.ohNo', 'polluted');
       }, /Property set failed: object in path "inner.constructor" could not be found./);
       assert.equal(Inner.ohNo, undefined, 'check for prototype pollution');
+
+      assert.throws(() => {
+        set(example, 'klass.prototype.ohNo', 'polluted');
+      }, /Property set failed: object in path "klass.prototype" could not be found./);
+      assert.equal(Inner.prototype.ohNo, undefined, 'check for prototype pollution');
     }
   }
 );


### PR DESCRIPTION
the set-path pollution guard in `_getPath` refuses `__proto__` and `constructor` but not `prototype`, so `set(obj, 'fn.prototype.key', value)` walks through a function or class held in the path and the final write lands on its shared prototype; spotted while auditing that guard, fixed by adding `prototype` to the same check.