### PR TITLE
[DOC release] `@example` is not handled either by YUIdoc or our api docs site.

### DIFF
--- a/packages/@ember/component/template-only.ts
+++ b/packages/@ember/component/template-only.ts
@@ -14,9 +14,7 @@
 
   Addons may want to use this method directly to ensure that a template-only component is treated consistently in all Ember versions (Ember versions
   before 4.0 have a "template-only-glimmer-components" optional feature that causes a standalone `.hbs` file to be interpreted differently).
-
-  @example
-
+    
   ```js
   import templateOnly from '@ember/component/template-only';
 

--- a/packages/@ember/reactive/collections.ts
+++ b/packages/@ember/reactive/collections.ts
@@ -16,7 +16,6 @@
  *
  * See [MDN for more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
  *
- * @example
  * ```javascript
  * import { trackedArray } from '@ember/reactive/collections';
  * import { on } from '@ember/modifier';
@@ -59,7 +58,6 @@ export { trackedArray } from '@glimmer/validator/lib/collections/array';
  *
  * See [MDN for more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
  *
- * @example
  * ```gjs
  * import { trackedObject } from '@ember/reactive/collections';
  * import { on } from '@ember/modifier';
@@ -102,7 +100,6 @@ export { trackedObject } from '@glimmer/validator/lib/collections/object';
  *
  * See [MDN for more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
  *
- * @example
  * ```gjs
  * import { trackedSet } from '@ember/reactive/collections';
  * import { on } from '@ember/modifier';
@@ -149,7 +146,6 @@ export { trackedSet } from '@glimmer/validator/lib/collections/set';
  *
  * See [MDN for more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet)
  *
- * @example
  * ```gjs
  * import { trackedWeakSet } from '@ember/reactive/collections';
  * import { on } from '@ember/modifier';
@@ -187,7 +183,6 @@ export { trackedWeakSet } from '@glimmer/validator/lib/collections/weak-set';
  *
  * See [MDN for more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
  *
- * @example
  * ```gjs
  * import { trackedMap } from '@ember/reactive/collections';
  * import { on } from '@ember/modifier';
@@ -234,7 +229,6 @@ export { trackedMap } from '@glimmer/validator/lib/collections/map';
  *
  * See [MDN for more information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap)
  *
- * @example
  * ```gjs
  * import { trackedWeakMap } from '@ember/reactive/collections';
  * import { on } from '@ember/modifier';

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -1285,7 +1285,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     the framework will use it.
     If it is not defined, a basic `Controller` instance would be used.
 
-    @example Behavior of a basic Controller
+    Example Behavior of a basic Controller
 
     ```app/routes/post.js
     import Route from '@ember/routing/route';

--- a/packages/@glimmer/runtime/lib/component/template-only.ts
+++ b/packages/@glimmer/runtime/lib/component/template-only.ts
@@ -67,8 +67,6 @@ setInternalComponentManager(
   to use these semantics for its templates but cannot be certain it will only be consumed by applications that have enabled the
   `template-only-glimmer-components` optional feature.
 
-  @example
-
   ```js
   import { templateOnlyComponent } from '@glimmer/runtime';
 


### PR DESCRIPTION
Not sure which, but I have confirmed that removing `@example` allows these examples to display on the API docs site.

You can see the examples missing from `trackedMap` here: 

https://api.emberjs.com/ember/7.0/functions/@ember%2Freactive%2Fcollections/trackedMap

But they are in the code, here:

https://github.com/emberjs/ember.js/blob/v7.0.0-ember-source/packages/%40ember/reactive/collections.ts#L190-L207