### PR TITLE
get route out of hello world

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/mount.ts
@@ -1,5 +1,5 @@
 import type { InternalOwner } from '@ember/-internals/owner';
-import { generateControllerFactory } from '@ember/routing/-internals';
+import { generateControllerFactory } from '@ember/routing/lib/generate_controller';
 import { assert } from '@ember/debug';
 import EngineInstance from '@ember/engine/instance';
 import { associateDestroyableChild } from '@glimmer/destroyable';


### PR DESCRIPTION
importing from `@ember/routing/-internals` is a bad time

this simple change removes `Route` from the hello-world demo

----

NOTE: `sideEffects: false` also achieves the same goal: https://github.com/emberjs/ember.js/pull/21456

but we should ship this PR anyway