### PR TITLE
Annotate pure factory functions/calls with PURE / NO_SIDE_EFFECTS

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
+++ b/packages/@ember/-internals/glimmer/lib/component-managers/curly.ts
@@ -73,7 +73,7 @@ export const DIRTY_TAG = Symbol('DIRTY_TAG');
 export const IS_DISPATCHING_ATTRS = Symbol('IS_DISPATCHING_ATTRS');
 export const BOUNDS = Symbol('BOUNDS');
 
-const EMBER_VIEW_REF = createPrimitiveRef('ember-view');
+const EMBER_VIEW_REF = /* @__PURE__ */ createPrimitiveRef('ember-view');
 
 function aliasIdToElementId(args: VMArguments, props: any) {
   if (args.named.has('id')) {

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -796,7 +796,7 @@ interface Component<S = unknown>
   extends CoreView, TargetActionSupport, ActionSupport, ComponentMethods {}
 
 class Component<S = unknown>
-  extends CoreView.extend(
+  extends /* @__PURE__ */ CoreView.extend(
     TargetActionSupport,
     ActionSupport,
     {

--- a/packages/@ember/-internals/glimmer/lib/helpers/internal-helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/internal-helper.ts
@@ -2,6 +2,7 @@ import type { InternalOwner } from '@ember/-internals/owner';
 import type { Helper, HelperDefinitionState } from '@glimmer/interfaces';
 import { setInternalHelperManager } from '@glimmer/manager/lib/internal/api';
 
+/* @__NO_SIDE_EFFECTS__ */
 export function internalHelper(helper: Helper<InternalOwner>): HelperDefinitionState {
   return setInternalHelperManager(helper, {});
 }

--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.ts
@@ -90,7 +90,7 @@ interface ProxyMixin<T = unknown> {
   setUnknownProperty<V>(key: string, value: V): V;
 }
 
-const ProxyMixin = Mixin.create({
+const ProxyMixin = /* @__PURE__ */ Mixin.create({
   /**
     The object whose properties will be forwarded.
 

--- a/packages/@ember/-internals/runtime/lib/mixins/action_handler.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/action_handler.ts
@@ -21,7 +21,7 @@ interface ActionHandler {
   actions?: Record<string, (...args: any[]) => unknown>;
   send(actionName: string, ...args: unknown[]): void;
 }
-const ActionHandler = Mixin.create({
+const ActionHandler = /* @__PURE__ */ Mixin.create({
   mergedProperties: ['actions'],
 
   /**

--- a/packages/@ember/-internals/runtime/lib/mixins/comparable.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/comparable.ts
@@ -18,7 +18,7 @@ import Mixin from '@ember/object/mixin';
 interface Comparable {
   compare: ((a: unknown, b: unknown) => -1 | 0 | 1) | null;
 }
-const Comparable = Mixin.create({
+const Comparable = /* @__PURE__ */ Mixin.create({
   /**
     __Required.__ You must implement this method to apply this mixin.
 

--- a/packages/@ember/-internals/runtime/lib/mixins/container_proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/container_proxy.ts
@@ -21,7 +21,7 @@ interface ContainerProxyMixin extends ContainerProxy {
   /** @internal */
   __container__: Container;
 }
-const ContainerProxyMixin = Mixin.create({
+const ContainerProxyMixin = /* @__PURE__ */ Mixin.create({
   /**
    The container stores state.
 

--- a/packages/@ember/-internals/runtime/lib/mixins/registry_proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/registry_proxy.ts
@@ -21,7 +21,7 @@ interface RegistryProxyMixin extends RegistryProxy {
   /** @internal */
   __registry__: Registry;
 }
-const RegistryProxyMixin = Mixin.create({
+const RegistryProxyMixin = /* @__PURE__ */ Mixin.create({
   __registry__: null,
 
   resolveRegistration(fullName: string) {

--- a/packages/@ember/-internals/runtime/lib/mixins/target_action_support.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/target_action_support.ts
@@ -31,7 +31,7 @@ interface TargetActionSupport {
   /** @internal */
   _target?: unknown;
 }
-const TargetActionSupport = Mixin.create({
+const TargetActionSupport = /* @__PURE__ */ Mixin.create({
   target: null,
   action: null,
   actionContext: null,

--- a/packages/@ember/-internals/string/index.ts
+++ b/packages/@ember/-internals/string/index.ts
@@ -8,7 +8,7 @@ import Cache from '@ember/-internals/utils/lib/cache';
 
 const STRING_DASHERIZE_REGEXP = /[ _]/g;
 
-const STRING_DASHERIZE_CACHE = new Cache<string, string>(1000, (key) =>
+const STRING_DASHERIZE_CACHE = /* @__PURE__ */ new Cache<string, string>(1000, (key) =>
   decamelize(key).replace(STRING_DASHERIZE_REGEXP, '-')
 );
 
@@ -16,7 +16,7 @@ const STRING_CLASSIFY_REGEXP_1 = /^(-|_)+(.)?/;
 const STRING_CLASSIFY_REGEXP_2 = /(.)(-|_|\.|\s)+(.)?/g;
 const STRING_CLASSIFY_REGEXP_3 = /(^|\/|\.)([a-z])/g;
 
-const CLASSIFY_CACHE = new Cache<string, string>(1000, (str) => {
+const CLASSIFY_CACHE = /* @__PURE__ */ new Cache<string, string>(1000, (str) => {
   let replace1 = (_match: string, _separator: string, chr: string) =>
     chr ? `_${chr.toUpperCase()}` : '';
   let replace2 = (_match: string, initialChar: string, _separator: string, chr: string) =>
@@ -35,7 +35,7 @@ const CLASSIFY_CACHE = new Cache<string, string>(1000, (str) => {
 
 const STRING_DECAMELIZE_REGEXP = /([a-z\d])([A-Z])/g;
 
-const DECAMELIZE_CACHE = new Cache<string, string>(1000, (str) =>
+const DECAMELIZE_CACHE = /* @__PURE__ */ new Cache<string, string>(1000, (str) =>
   str.replace(STRING_DECAMELIZE_REGEXP, '$1_$2').toLowerCase()
 );
 

--- a/packages/@ember/-internals/utils/lib/dictionary.ts
+++ b/packages/@ember/-internals/utils/lib/dictionary.ts
@@ -3,6 +3,7 @@
 // appears worthwhile in some usecases. Please note, these deletes do increase
 // the cost of creation dramatically over a plain Object.create. And as this
 // only makes sense for long-lived dictionaries that aren't instantiated often.
+/* @__NO_SIDE_EFFECTS__ */
 export default function makeDictionary<T>(parent: { [key: string]: T } | null): {
   [key: string]: T;
 } {

--- a/packages/@ember/-internals/utils/lib/guid.ts
+++ b/packages/@ember/-internals/utils/lib/guid.ts
@@ -50,7 +50,7 @@ const NON_OBJECT_GUIDS = new Map();
   @type String
   @final
 */
-export const GUID_KEY = intern(`__ember${Date.now()}`);
+export const GUID_KEY = /* @__PURE__ */ intern(`__ember${Date.now()}`);
 
 /**
   Generates a new guid, optionally saving the guid to the object that you

--- a/packages/@ember/-internals/utils/lib/intern.ts
+++ b/packages/@ember/-internals/utils/lib/intern.ts
@@ -37,6 +37,7 @@
   @private
   @return {String} interned version of the provided string
 */
+/* @__NO_SIDE_EFFECTS__ */
 export default function intern<S extends string>(str: S): S {
   let obj: Record<S, number> = Object.create(null);
   obj[str] = 1;

--- a/packages/@ember/-internals/views/lib/mixins/action_support.ts
+++ b/packages/@ember/-internals/views/lib/mixins/action_support.ts
@@ -14,7 +14,7 @@ import { assert } from '@ember/debug';
 interface ActionSupport {
   send(actionName: string, ...args: unknown[]): void;
 }
-const ActionSupport = Mixin.create({
+const ActionSupport = /* @__PURE__ */ Mixin.create({
   send(actionName: string, ...args: unknown[]) {
     assert(
       `Attempted to call .send() with the action '${actionName}' on the destroyed object '${this}'.`,

--- a/packages/@ember/-internals/views/lib/views/core_view.ts
+++ b/packages/@ember/-internals/views/lib/views/core_view.ts
@@ -24,7 +24,7 @@ import states from './states';
 */
 
 interface CoreView extends Evented, ActionHandler, View {}
-class CoreView extends FrameworkObject.extend(Evented, ActionHandler) {
+class CoreView extends /* @__PURE__ */ FrameworkObject.extend(Evented, ActionHandler) {
   isView = true;
 
   declare _states: typeof states;

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1139,7 +1139,7 @@ interface EmberArray<T> extends Enumerable {
   */
   without(value: T): NativeArray<T>;
 }
-const EmberArray = Mixin.create(Enumerable, {
+const EmberArray = /* @__PURE__ */ Mixin.create(Enumerable, {
   init() {
     this._super(...arguments);
     setEmberArray(this);
@@ -1687,7 +1687,7 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
   */
   addObjects(objects: T[]): this;
 }
-const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
+const MutableArray = /* @__PURE__ */ Mixin.create(EmberArray, MutableEnumerable, {
   clear() {
     let len = this.length;
     if (len === 0) {
@@ -2019,7 +2019,7 @@ interface MutableArrayWithoutNative<T> extends Omit<
 */
 interface NativeArray<T> extends Array<T>, Observable, MutableArrayWithoutNative<T> {}
 
-let NativeArray = Mixin.create(MutableArray, Observable, {
+let NativeArray = /* @__PURE__ */ Mixin.create(MutableArray, Observable, {
   objectAt(idx: number) {
     return this[idx];
   },

--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -233,7 +233,7 @@ interface ControllerMixin<T> extends ActionHandler {
   */
   replaceRoute(...args: RouteArgs): Transition;
 }
-const ControllerMixin = Mixin.create(ActionHandler, {
+const ControllerMixin = /* @__PURE__ */ Mixin.create(ActionHandler, {
   /* ducktype as a controller */
   isController: true,
 
@@ -315,7 +315,7 @@ const ControllerMixin = Mixin.create(ActionHandler, {
   @public
 */
 interface Controller<_T = unknown> extends FrameworkObject, ControllerMixin<_T> {}
-class Controller<_T = unknown> extends FrameworkObject.extend(ControllerMixin) {}
+class Controller<_T = unknown> extends /* @__PURE__ */ FrameworkObject.extend(ControllerMixin) {}
 
 /**
   Creates a property that lazily looks up another controller in the container.

--- a/packages/@ember/engine/index.ts
+++ b/packages/@ember/engine/index.ts
@@ -56,7 +56,7 @@ export interface Initializer<T> {
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface Engine extends RegistryProxyMixin {}
-class Engine extends Namespace.extend(RegistryProxyMixin) {
+class Engine extends /* @__PURE__ */ Namespace.extend(RegistryProxyMixin) {
   static initializers: Record<string, Initializer<Engine>> = Object.create(null);
   static instanceInitializers: Record<string, Initializer<EngineInstance>> = Object.create(null);
 

--- a/packages/@ember/engine/instance.ts
+++ b/packages/@ember/engine/instance.ts
@@ -53,7 +53,9 @@ export interface EngineInstanceOptions {
 // type checking, we have broken part of our public API contract. Medium-term,
 // the goal here is to `EngineInstance` simple be `Owner`.
 interface EngineInstance extends RegistryProxyMixin, ContainerProxyMixin, InternalOwner, Owner {}
-class EngineInstance extends EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin) {
+class EngineInstance
+  extends /* @__PURE__ */ EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin)
+{
   /**
    @private
    @method setupRegistry

--- a/packages/@ember/enumerable/index.ts
+++ b/packages/@ember/enumerable/index.ts
@@ -15,6 +15,6 @@ import Mixin from '@ember/object/mixin';
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface Enumerable {}
-const Enumerable = Mixin.create();
+const Enumerable = /* @__PURE__ */ Mixin.create();
 
 export default Enumerable;

--- a/packages/@ember/enumerable/mutable.ts
+++ b/packages/@ember/enumerable/mutable.ts
@@ -17,6 +17,6 @@ import Mixin from '@ember/object/mixin';
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface MutableEnumerable extends Enumerable {}
-const MutableEnumerable = Mixin.create(Enumerable);
+const MutableEnumerable = /* @__PURE__ */ Mixin.create(Enumerable);
 
 export default MutableEnumerable;

--- a/packages/@ember/object/evented.ts
+++ b/packages/@ember/object/evented.ts
@@ -149,7 +149,7 @@ interface Evented {
    */
   has(name: string): boolean;
 }
-const Evented = Mixin.create({
+const Evented = /* @__PURE__ */ Mixin.create({
   on(name: string, target: object, method?: string | Function) {
     addListener(this, name, target, method);
     return this;

--- a/packages/@ember/object/index.ts
+++ b/packages/@ember/object/index.ts
@@ -36,7 +36,7 @@ export { default as computed } from '@ember/-internals/metal/lib/computed';
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface EmberObject extends Observable {}
-class EmberObject extends CoreObject.extend(Observable) {
+class EmberObject extends /* @__PURE__ */ CoreObject.extend(Observable) {
   get _debugContainerKey() {
     let factory = getFactoryFor(this);
     return factory !== undefined && factory.fullName;

--- a/packages/@ember/object/observable.ts
+++ b/packages/@ember/object/observable.ts
@@ -416,7 +416,7 @@ interface Observable {
   */
   cacheFor<K extends keyof this>(key: K): unknown;
 }
-const Observable = Mixin.create({
+const Observable = /* @__PURE__ */ Mixin.create({
   get(keyName: string) {
     return get(this, keyName);
   },

--- a/packages/@ember/object/promise-proxy-mixin.ts
+++ b/packages/@ember/object/promise-proxy-mixin.ts
@@ -211,7 +211,7 @@ interface PromiseProxyMixin<T> {
   */
   finally: this['promise']['finally'];
 }
-const PromiseProxyMixin = Mixin.create({
+const PromiseProxyMixin = /* @__PURE__ */ Mixin.create({
   reason: null,
 
   isPending: computed('isSettled', function () {

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -256,7 +256,10 @@ interface Route<Model = unknown> extends IRoute<Model>, ActionHandler, Evented {
   error?(error: Error, transition: Transition): boolean | void;
 }
 
-class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) implements IRoute {
+class Route<Model = unknown>
+  extends /* @__PURE__ */ EmberObject.extend(ActionHandler, Evented)
+  implements IRoute
+{
   static isRouteFactory = true;
 
   // These properties will end up appearing in the public interface because we

--- a/packages/@ember/routing/router-service.ts
+++ b/packages/@ember/routing/router-service.ts
@@ -62,7 +62,7 @@ interface RouterService extends Evented {
     callback: (transition: Transition) => void
   ): this;
 }
-class RouterService extends Service.extend(Evented) {
+class RouterService extends /* @__PURE__ */ Service.extend(Evented) {
   [ROUTER]?: EmberRouter;
 
   get _router(): EmberRouter {

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -142,7 +142,7 @@ const { slice } = Array.prototype;
   @uses Evented
   @public
 */
-class EmberRouter extends EmberObject.extend(Evented) implements Evented {
+class EmberRouter extends /* @__PURE__ */ EmberObject.extend(Evented) implements Evented {
   /**
    Represents the URL of the root of the application, often '/'. This prefix is
     assumed on all routes defined on this router.

--- a/packages/@ember/template-compiler/lib/dasherize-component-name.ts
+++ b/packages/@ember/template-compiler/lib/dasherize-component-name.ts
@@ -7,7 +7,7 @@ import Cache from '@ember/-internals/utils/lib/cache';
 const SIMPLE_DASHERIZE_REGEXP = /[A-Z]|::/g;
 const ALPHA = /[A-Za-z0-9]/;
 
-export default new Cache<string, string>(1000, (key) =>
+export default /* @__PURE__ */ new Cache<string, string>(1000, (key) =>
   key.replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
     if (char === '::') {
       return '/';

--- a/packages/@ember/template-compiler/lib/template.ts
+++ b/packages/@ember/template-compiler/lib/template.ts
@@ -233,7 +233,6 @@ export function template<C extends ComponentClass>(
   templateString: string,
   options: ExplicitClassOptions<C> | ImplicitClassOptions<C> | BaseClassTemplateOptions<C>
 ): C;
-/* @__NO_SIDE_EFFECTS__ */
 export function template(
   templateString: string,
   providedOptions?: BaseTemplateOptions | BaseClassTemplateOptions<any>

--- a/packages/@ember/template-compiler/lib/template.ts
+++ b/packages/@ember/template-compiler/lib/template.ts
@@ -233,6 +233,7 @@ export function template<C extends ComponentClass>(
   templateString: string,
   options: ExplicitClassOptions<C> | ImplicitClassOptions<C> | BaseClassTemplateOptions<C>
 ): C;
+/* @__NO_SIDE_EFFECTS__ */
 export function template(
   templateString: string,
   providedOptions?: BaseTemplateOptions | BaseClassTemplateOptions<any>

--- a/packages/@glimmer/opcode-compiler/lib/template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/template.ts
@@ -41,6 +41,7 @@ export interface TemplateWithIdAndReferrer extends TemplateOk {
  * that handles lazy parsing the template and to create per env singletons
  * of the template.
  */
+/* @__NO_SIDE_EFFECTS__ */
 export default function templateFactory({
   id: templateId,
   moduleName,

--- a/packages/@glimmer/program/lib/constants.ts
+++ b/packages/@glimmer/program/lib/constants.ts
@@ -27,8 +27,9 @@ import { InternalComponentCapabilities } from '@glimmer/vm/lib/flags';
 import { DEFAULT_TEMPLATE } from './util/default-template';
 
 const WELL_KNOWN_EMPTY_ARRAY: unknown = Object.freeze([]);
-const STARTER_CONSTANTS = constants(WELL_KNOWN_EMPTY_ARRAY);
-const WELL_KNOWN_EMPTY_ARRAY_POSITION: number = STARTER_CONSTANTS.indexOf(WELL_KNOWN_EMPTY_ARRAY);
+const STARTER_CONSTANTS = /* @__PURE__ */ constants(WELL_KNOWN_EMPTY_ARRAY);
+const WELL_KNOWN_EMPTY_ARRAY_POSITION: number =
+  /* @__PURE__ */ STARTER_CONSTANTS.indexOf(WELL_KNOWN_EMPTY_ARRAY);
 
 export class ConstantsImpl implements ProgramConstants {
   protected reifiedArrs: { [key: number]: unknown[] } = {

--- a/packages/@glimmer/program/lib/util/default-template.ts
+++ b/packages/@glimmer/program/lib/util/default-template.ts
@@ -10,7 +10,7 @@ export const DEFAULT_TEMPLATE: SerializedTemplateWithLazyBlock = {
   // random uuid
   id: '1b32f5c2-7623-43d6-a0ad-9672898920a1',
   moduleName: '__default__.hbs',
-  block: JSON.stringify(DEFAULT_TEMPLATE_BLOCK),
+  block: /* @__PURE__ */ JSON.stringify(DEFAULT_TEMPLATE_BLOCK),
   scope: null,
   isStrictMode: true,
 };

--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -52,6 +52,7 @@ class ReferenceImpl<T = unknown> implements Reference<T> {
   }
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createPrimitiveRef<T extends string | symbol | number | boolean | null | undefined>(
   value: T
 ): Reference<T> {
@@ -72,6 +73,7 @@ export const NULL_REFERENCE = createPrimitiveRef(null);
 export const TRUE_REFERENCE = createPrimitiveRef(true as const);
 export const FALSE_REFERENCE = createPrimitiveRef(false as const);
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createConstRef<T>(value: T, debugLabel: false | string): Reference<T> {
   const ref = new ReferenceImpl<T>(CONSTANT);
 
@@ -85,6 +87,7 @@ export function createConstRef<T>(value: T, debugLabel: false | string): Referen
   return ref;
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createUnboundRef<T>(value: T, debugLabel: false | string): Reference<T> {
   const ref = new ReferenceImpl<T>(UNBOUND);
 
@@ -98,6 +101,7 @@ export function createUnboundRef<T>(value: T, debugLabel: false | string): Refer
   return ref;
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createComputeRef<T = unknown>(
   compute: () => T,
   update: Nullable<(value: T) => void> = null,
@@ -115,6 +119,7 @@ export function createComputeRef<T = unknown>(
   return ref;
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createReadOnlyRef(ref: Reference): Reference {
   if (!isUpdatableRef(ref)) return ref;
 
@@ -125,6 +130,7 @@ export function isInvokableRef(ref: Reference) {
   return ref[REFERENCE] === INVOKABLE;
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function createInvokableRef(inner: Reference): Reference {
   const ref = createComputeRef(
     () => valueForRef(inner),

--- a/packages/@glimmer/runtime/lib/helpers/internal-helper.ts
+++ b/packages/@glimmer/runtime/lib/helpers/internal-helper.ts
@@ -1,6 +1,7 @@
 import type { Helper, HelperDefinitionState } from '@glimmer/interfaces';
 import { setInternalHelperManager } from '@glimmer/manager/lib/internal/api';
 
+/* @__NO_SIDE_EFFECTS__ */
 export function internalHelper(helper: Helper): HelperDefinitionState {
   return setInternalHelperManager(helper, {});
 }

--- a/packages/@glimmer/util/lib/intern.ts
+++ b/packages/@glimmer/util/lib/intern.ts
@@ -37,6 +37,7 @@
   @private
   @return {String} interned version of the provided string
 */
+/* @__NO_SIDE_EFFECTS__ */
 export default function intern(str: string): string {
   let obj: Record<string, number> = {};
   obj[str] = 1;

--- a/packages/ember-testing/lib/adapters/adapter.ts
+++ b/packages/ember-testing/lib/adapters/adapter.ts
@@ -16,7 +16,7 @@ interface Adapter extends EmberObject {
   asyncEnd(): void;
   exception(error: unknown): never;
 }
-const Adapter = EmberObject.extend({
+const Adapter = /* @__PURE__ */ EmberObject.extend({
   /**
     This callback will be called whenever an async operation is about to start.
 

--- a/tests/node-vitest/tree-shakability.test.js
+++ b/tests/node-vitest/tree-shakability.test.js
@@ -47,6 +47,7 @@ it('[dev] has expected tree-shakable entrypoints', async () => {
       "ember-source/@ember/-internals/string/index.js",
       "ember-source/@ember/-internals/utility-types/index.js",
       "ember-source/@ember/-internals/views/lib/compat/attrs.js",
+      "ember-source/@ember/-internals/views/lib/compat/fallback-view-registry.js",
       "ember-source/@ember/array/-internals.js",
       "ember-source/@ember/array/lib/make-array.js",
       "ember-source/@ember/array/make.js",
@@ -121,7 +122,6 @@ it('[dev] has expected tree-shakable entrypoints', async () => {
       "ember-source/@ember/-internals/runtime/lib/mixins/target_action_support.js",
       "ember-source/@ember/-internals/utils/index.js",
       "ember-source/@ember/-internals/views/index.js",
-      "ember-source/@ember/-internals/views/lib/compat/fallback-view-registry.js",
       "ember-source/@ember/-internals/views/lib/mixins/action_support.js",
       "ember-source/@ember/-internals/views/lib/system/event_dispatcher.js",
       "ember-source/@ember/-internals/views/lib/system/utils.js",
@@ -234,6 +234,7 @@ it('[prod] has expected tree-shakable entrypoints', async () => {
   expect(result.shaken).toMatchInlineSnapshot(`
     [
       "ember-source/@ember/-internals/browser-environment/index.js",
+      "ember-source/@ember/-internals/container/index.js",
       "ember-source/@ember/-internals/error-handling/index.js",
       "ember-source/@ember/-internals/meta/index.js",
       "ember-source/@ember/-internals/meta/lib/meta.js",
@@ -241,6 +242,8 @@ it('[prod] has expected tree-shakable entrypoints', async () => {
       "ember-source/@ember/-internals/string/index.js",
       "ember-source/@ember/-internals/utility-types/index.js",
       "ember-source/@ember/-internals/views/lib/compat/attrs.js",
+      "ember-source/@ember/-internals/views/lib/compat/fallback-view-registry.js",
+      "ember-source/@ember/-internals/views/lib/system/utils.js",
       "ember-source/@ember/array/-internals.js",
       "ember-source/@ember/array/lib/make-array.js",
       "ember-source/@ember/array/make.js",
@@ -310,7 +313,6 @@ it('[prod] has expected tree-shakable entrypoints', async () => {
   `);
   expect(result.notShaken).toMatchInlineSnapshot(`
     [
-      "ember-source/@ember/-internals/container/index.js",
       "ember-source/@ember/-internals/deprecations/index.js",
       "ember-source/@ember/-internals/environment/index.js",
       "ember-source/@ember/-internals/glimmer/index.js",
@@ -326,10 +328,8 @@ it('[prod] has expected tree-shakable entrypoints', async () => {
       "ember-source/@ember/-internals/runtime/lib/mixins/target_action_support.js",
       "ember-source/@ember/-internals/utils/index.js",
       "ember-source/@ember/-internals/views/index.js",
-      "ember-source/@ember/-internals/views/lib/compat/fallback-view-registry.js",
       "ember-source/@ember/-internals/views/lib/mixins/action_support.js",
       "ember-source/@ember/-internals/views/lib/system/event_dispatcher.js",
-      "ember-source/@ember/-internals/views/lib/system/utils.js",
       "ember-source/@ember/-internals/views/lib/views/core_view.js",
       "ember-source/@ember/-internals/views/lib/views/states.js",
       "ember-source/@ember/application/index.js",


### PR DESCRIPTION
Adds `/* @__PURE__ */` and `/* @__NO_SIDE_EFFECTS__ */` annotations to ember-source's side-effect-free factory functions and their module-scope call sites.

Rollup/rolldown can't prove these calls pure on their own — the callee almost always lives in another module — so a single module-scope `Mixin.create(...)`, `X.extend(...)`, `createPrimitiveRef(...)`, `new Cache(...)`, etc. is enough to drag the whole module into a consumer's graph. The annotation removes that anchor.

### What's annotated

**`@__NO_SIDE_EFFECTS__` on pure factory definitions**
- `@glimmer/reference`: `createPrimitiveRef` + `createConstRef` / `createUnboundRef` / `createComputeRef` / `createReadOnlyRef` / `createInvokableRef`
- `internalHelper` (glimmer + ember), `intern` (glimmer + ember), `makeDictionary`
- `templateFactory` (`@glimmer/opcode-compiler`), `template` (`@ember/template-compiler`)

**`@__PURE__` on module-scope factory calls**
- `Mixin.create(...)` and `FrameworkObject` / `CoreObject` / `EmberObject` / `Service` / `Namespace`.`extend(...)` across the runtime/views mixins, `@ember/array`, `@ember/controller`, `@ember/engine`, `@ember/enumerable`, `@ember/object`, `@ember/routing`, and `ember-testing`
- `createPrimitiveRef('ember-view')` in the curly component manager
- `intern(...)` for `GUID_KEY`
- the `@ember/-internals/string` and `dasherize-component-name` `Cache`s
- `@glimmer/program`'s `constants()` / `.indexOf()` and `DEFAULT_TEMPLATE`'s `JSON.stringify`

### Safety

These are **inert in ember-source's own builds** — our rollup config keeps all module side effects (`moduleSideEffects: true`), so dist/dev and dist/prod are byte-for-byte equivalent in behavior. They only give *downstream* bundlers (and the side-effect detection in #21449) permission to drop the results when they're unused. Every annotated call is a pure value factory whose result is referenced whenever the module is actually used, so a consumer that keeps the binding keeps the call.

### Effect

- The `tree-shakability` snapshot gains three newly-shakable entrypoints: `@ember/-internals/container`, `@ember/-internals/views/lib/compat/fallback-view-registry`, `@ember/-internals/views/lib/system/utils`.
- Combined with the side-effect detection in #21449, several modules drop off the generated `sideEffects` list (e.g. `curly`, `@ember/-internals/string`, `@glimmer/program`).

### Relationship to other PRs

This **supersedes the manual source annotations** in #21449 and broadens them; #21449 keeps the side-effect-detection plugin and the generated `sideEffects` list. It composes with the renderer/classic-cleanup refactors (#21463 / #21464) — the remaining hello-world weight (classic `Component`, `EmberObject`, `computed`, …) is held in by `reopen()` / manager-registration patterns that those PRs address, not by anything annotations can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)