### PR TITLE
Update some API docs to use template tag where appropriate

### DIFF
--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -116,17 +116,23 @@
   template, an optional block passed to the component should render:
 
   ```app/templates/application.gjs
-  <template>
-  <LabeledTextfield @value={{@model.name}}>
-    First name:
-  </LabeledTextfield>
+  import LabeledTextField from '../components/labeled-textfield';
     
+  <template>
+    <LabeledTextField @value={{@model.name}}>
+      First name:
+    </LabeledTextField>
+  </template>
   ```
 
-  ```app/components/labeled-textfield.hbs
-  <label>
-    {{yield}} <Input @value={{@value}} />
-  </label>
+  ```app/components/labeled-textfield.gjs
+  import { Input } from '@ember/component';
+    
+  <template>
+    <label>
+      {{yield}} <Input @value={{@value}} />
+    </label>
+  </template>
   ```
 
   Result:
@@ -139,19 +145,34 @@
 
   Additionally you can `yield` properties into the context for use by the consumer:
 
-  ```app/templates/application.hbs
-  <LabeledTextfield @value={{@model.validation}} @validator={{this.firstNameValidator}} as |validationError|>
-    {{#if validationError}}
-      <p class="error">{{validationError}}</p>
-    {{/if}}
-    First name:
-  </LabeledTextfield>
+  ```app/templates/application.gjs
+  import Component from '@glimmer/component';
+  import LabeledTextField from '../components/labeled-textfield';
+    
+  export default class Application extends Component {
+    firstNameValidator = (value) => {
+      // validates
+    }
+    
+    <template>
+      <LabeledTextField @value={{@model.validation}} @validator={{this.firstNameValidator}} as |validationError|>
+        {{#if validationError}}
+          <p class="error">{{validationError}}</p>
+        {{/if}}
+        First name:
+      </LabeledTextField>
+    </template>
+  }
   ```
 
-  ```app/components/labeled-textfield.hbs
-  <label>
-    {{yield this.validationError}} <Input @value={{@value}} />
-  </label>
+  ```app/components/labeled-textfield.gjs
+  import { Input } from '@ember/component';
+    
+  <template>
+    <label>
+      {{yield this.validationError}} <Input @value={{@value}} />
+    </label>
+  </template>
   ```
 
   Result:
@@ -165,17 +186,23 @@
 
   `yield` can also be used with the `hash` helper:
 
-  ```app/templates/application.hbs
-  <DateRanges @value={{@model.date}} as |range|>
-    Start date: {{range.start}}
-    End date: {{range.end}}
-  </DateRanges>
+  ```app/templates/application.gjs
+  import DateRanges from '../components/date-ranges';
+    
+  <template>
+    <DateRanges @value={{@model.date}} as |range|>
+      Start date: {{range.start}}
+      End date: {{range.end}}
+    </DateRanges>
+  </template>
   ```
 
-  ```app/components/date-ranges.hbs
-  <div>
-    {{yield (hash start=@value.start end=@value.end)}}
-  </div>
+  ```app/components/date-ranges.gjs
+  <template>
+    <div>
+      {{yield (hash start=@value.start end=@value.end)}}
+    </div>
+  </template>
   ```
 
   Result:
@@ -188,19 +215,25 @@
   ```
 
   Multiple values can be yielded as block params:
-
-  ```app/templates/application.hbs
-  <Banner @value={{@model}} as |title subtitle body|>
-    <h1>{{title}}</h1>
-    <h2>{{subtitle}}</h2>
-    {{body}}
-  </Banner>
+    
+  ```app/templates/application.gjs
+  import Banner from '../components/banner';
+    
+  <template>
+    <Banner @value={{@model}} as |title subtitle body|>
+      <h1>{{title}}</h1>
+      <h2>{{subtitle}}</h2>
+      {{body}}
+    </Banner>
+  </template>
   ```
 
-  ```app/components/banner.hbs
-  <div>
-    {{yield "Hello title" "hello subtitle" "body text"}}
-  </div>
+  ```app/components/banner.gjs
+  <template>
+    <div>
+      {{yield "Hello title" "hello subtitle" "body text"}}
+    </div>
+  </template>
   ```
 
   Result:
@@ -217,15 +250,19 @@
 
   Multiple components can be yielded with the `hash` and `component` helper:
 
-  ```app/templates/application.hbs
-  <Banner @value={{@model}} as |banner|>
-    <banner.Title>Banner title</banner.Title>
-    <banner.Subtitle>Banner subtitle</banner.Subtitle>
-    <banner.Body>A load of body text</banner.Body>
-  </Banner>
+  ```app/templates/application.gjs
+  import Banner from '../components/banner';
+
+  <template>
+    <Banner @value={{@model}} as |banner|>
+      <banner.Title>Banner title</banner.Title>
+      <banner.Subtitle>Banner subtitle</banner.Subtitle>
+      <banner.Body>A load of body text</banner.Body>
+    </Banner>
+  </template>
   ```
 
-  ```app/components/banner.js
+  ```app/components/banner.gjs
   import Title from './banner/title';
   import Subtitle from './banner/subtitle';
   import Body from './banner/body';
@@ -234,17 +271,17 @@
     Title = Title;
     Subtitle = Subtitle;
     Body = Body;
+    
+    <template>
+      <div>
+        {{yield (hash
+          Title=this.Title
+          Subtitle=this.Subtitle
+          Body=(component this.Body defaultArg="some value")
+        )}}
+      </div>
+    </template>
   }
-  ```
-
-  ```app/components/banner.hbs
-  <div>
-    {{yield (hash
-      Title=this.Title
-      Subtitle=this.Subtitle
-      Body=(component this.Body defaultArg="some value")
-    )}}
-  </div>
   ```
 
   Result:
@@ -259,12 +296,16 @@
 
   A benefit of using this pattern is that the user of the component can change the order the components are displayed.
 
-  ```app/templates/application.hbs
-  <Banner @value={{@model}} as |banner|>
-    <banner.Subtitle>Banner subtitle</banner.Subtitle>
-    <banner.Title>Banner title</banner.Title>
-    <banner.Body>A load of body text</banner.Body>
-  </Banner>
+  ```app/templates/application.gjs
+  import Banner from '../components/banner';
+
+  <template>
+    <Banner @value={{@model}} as |banner|>
+      <banner.Subtitle>Banner subtitle</banner.Subtitle>
+      <banner.Title>Banner title</banner.Title>
+      <banner.Body>A load of body text</banner.Body>
+    </Banner>
+  </template>
   ```
 
   Result:
@@ -280,27 +321,33 @@
   Another benefit to using `yield` with the `hash` and `component` helper
   is you can pass attributes and arguments to these components:
 
-  ```app/templates/application.hbs
-  <Banner @value={{@model}} as |banner|>
-    <banner.Subtitle class="mb-1">Banner subtitle</banner.Subtitle>
-    <banner.Title @variant="loud">Banner title</banner.Title>
-    <banner.Body>A load of body text</banner.Body>
-  </Banner>
+  ```app/templates/application.gjs
+  import Banner from '../components/banner';
+
+  <template>
+    <Banner @value={{@model}} as |banner|>
+      <banner.Subtitle class="mb-1">Banner subtitle</banner.Subtitle>
+      <banner.Title @variant="loud">Banner title</banner.Title>
+      <banner.Body>A load of body text</banner.Body>
+    </Banner>
+  </template>
   ```
 
-  ```app/components/banner/subtitle.hbs
+  ```app/components/banner/subtitle.gjs
   {{!-- note the use of ..attributes --}}
   <h2 ...attributes>
     {{yield}}
   </h2>
   ```
 
-  ```app/components/banner/title.hbs
-  {{#if (eq @variant "loud")}}
+  ```app/components/banner/title.gjs
+  <template>
+    {{#if (eq @variant "loud")}}
       <h1 class="loud">{{yield}}</h1>
-  {{else}}
+    {{else}}
       <h1 class="quiet">{{yield}}</h1>
-  {{/if}}
+    {{/if}}
+  </template>
   ```
 
   Result:
@@ -326,36 +373,28 @@
   This component is invoked with a block:
 
   ```handlebars
-  {{#my-component}}
+  <MyComponent>
     Hi Jen!
-  {{/my-component}}
+  </MyComponent>
   ```
 
   This component is invoked without a block:
 
   ```handlebars
-  {{my-component}}
-  ```
-
-  Using angle bracket invocation, this looks like:
-
-  ```html
-  <MyComponent>Hi Jen!</MyComponent> {{! with a block}}
-  ```
-
-  ```html
-  <MyComponent/> {{! without a block}}
+  <MyComponent />
   ```
 
   This is useful when you want to create a component that can optionally take a block
   and then render a default template when it is not invoked with a block.
 
-  ```app/templates/components/my-component.hbs
-  {{#if (has-block)}}
-    Welcome {{yield}}, we are happy you're here!
-  {{else}}
-    Hey you! You're great!
-  {{/if}}
+  ```app/components/my-component.gjs
+  <template>
+    {{#if (has-block)}}
+      Welcome {{yield}}, we are happy you're here!
+    {{else}}
+      Hey you! You're great!
+    {{/if}}
+  </template>
   ```
 
   @method has-block
@@ -369,26 +408,10 @@
   `{{(has-block-params)}}` indicates if the component was invoked with block params.
 
   This component is invoked with block params:
-
+    
   ```handlebars
-  {{#my-component as |favoriteFlavor|}}
-    Hi Jen!
-  {{/my-component}}
-  ```
-
-  This component is invoked without block params:
-
-  ```handlebars
-  {{#my-component}}
-    Hi Jenn!
-  {{/my-component}}
-  ```
-
-  With angle bracket syntax, block params look like this:
-
-    ```handlebars
   <MyComponent as |favoriteFlavor|>
-    Hi Jen!
+  Hi Jen!
   </MyComponent>
   ```
 
@@ -396,21 +419,23 @@
 
   ```handlebars
   <MyComponent>
-    Hi Jen!
+  Hi Jen!
   </MyComponent>
   ```
 
   This is useful when you want to create a component that can render itself
   differently when it is not invoked with block params.
 
-  ```app/templates/components/my-component.hbs
-  {{#if (has-block-params)}}
-    Welcome {{yield this.favoriteFlavor}}, we're happy you're here and hope you
-    enjoy your favorite ice cream flavor.
-  {{else}}
-    Welcome {{yield}}, we're happy you're here, but we're unsure what
-    flavor ice cream you would enjoy.
-  {{/if}}
+  ```app/components/my-component.gjs
+  <template>
+    {{#if (has-block-params)}}
+      Welcome {{yield this.favoriteFlavor}}, we're happy you're here and hope you
+      enjoy your favorite ice cream flavor.
+    {{else}}
+      Welcome {{yield}}, we're happy you're here, but we're unsure what
+      flavor ice cream you would enjoy.
+    {{/if}}
+  </template>
   ```
 
   @method has-block-params

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -1,6 +1,23 @@
 /**
   [Glimmer](https://github.com/tildeio/glimmer) is a templating engine used by Ember.js that is compatible with a subset of the [Handlebars](http://handlebarsjs.com/) syntax.
 
+  Ember ships with two types of JavaScript classes for components:
+
+  1. Glimmer components, imported from `@glimmer/component`, which are the
+  default component's for Ember Octane (3.15) and more recent editions.
+  2. Classic components, imported from `@ember/component`, which were the
+  default for older editions of Ember (pre 3.15) but are still supported.
+
+  Below is the documentation for Classic components. If you are looking for the
+  API documentation for Template-only or Glimmer components, it is [available
+  here](/ember/release/modules/@glimmer%2Fcomponent).
+
+  Note: Prior to Ember 6.8, by default, components were authored in paired `.hbs` and `.js`
+  files. This is still supported, but the default authoring format is now `.gjs` or "template tag".
+  The documentation for `@ember/component` still refers to the older authoring format. To read about
+  the new authoring format, see the
+  [Glimmer Component API documentation](/ember/release/modules/@glimmer%2Fcomponent).
+    
   ### Showing a property
 
   Templates manage the flow of an application's UI, and display state (through
@@ -98,10 +115,12 @@
   When designing components `{{yield}}` is used to denote where, inside the component's
   template, an optional block passed to the component should render:
 
-  ```app/templates/application.hbs
+  ```app/templates/application.gjs
+  <template>
   <LabeledTextfield @value={{@model.name}}>
     First name:
   </LabeledTextfield>
+    
   ```
 
   ```app/components/labeled-textfield.hbs

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -230,6 +230,12 @@ declare const SIGNATURE: unique symbol;
   API documentation for Template-only or Glimmer components, it is [available
   here](/ember/release/modules/@glimmer%2Fcomponent).
 
+  Note: Prior to Ember 6.8, by default, components were authored in paired `.hbs` and `.js`
+  files. This is still supported, but the default authoring format is now `.gjs` or "template tag".
+  The documentation for `@ember/component` still refers to the older authoring format. To read about
+  the new authoring format, see the 
+  [Glimmer Component API documentation](/ember/release/modules/@glimmer%2Fcomponent).
+    
   ## Defining a Classic Component
 
   If you want to customize the component in order to handle events, transform

--- a/packages/@ember/-internals/glimmer/lib/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/component.ts
@@ -262,7 +262,7 @@ declare const SIGNATURE: unique symbol;
 
   And then use it in the component's template:
 
-  ```app/templates/components/person-profile.hbs
+  ```app/components/person-profile.hbs
   <h1>{{this.displayName}}</h1>
   {{yield}}
   ```
@@ -650,7 +650,7 @@ declare const SIGNATURE: unique symbol;
   The `layout` property should be set to the default export of a template
   module, which is the name of a template file without the `.hbs` extension.
 
-  ```app/templates/components/person-profile.hbs
+  ```app/components/person-profile.hbs
   <h1>Person's Title</h1>
   <div class='details'>{{yield}}</div>
   ```

--- a/packages/@ember/-internals/glimmer/lib/components/input.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/input.ts
@@ -67,8 +67,12 @@ if (hasDOM) {
 /**
   The `Input` component lets you create an HTML `<input>` element.
 
-  ```handlebars
-  <Input @value="987" />
+  ```gjs
+  import { Input } from '@ember/component';
+    
+  <template>
+    <Input @value="987" />
+  </template>
   ```
 
   creates an `<input>` element with `type="text"` and value set to 987.

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -50,10 +50,14 @@ function isQueryParams(value: unknown): value is QueryParams {
   supplied model to the route as its `model` context of the route. The block for `LinkTo`
   becomes the contents of the rendered element:
 
-  ```handlebars
-  <LinkTo @route='photoGallery'>
-    Great Hamster Photos
-  </LinkTo>
+  ```gjs
+  import { LinkTo } from '@ember/routing';
+    
+  <template>
+    <LinkTo @route='photoGallery'>
+      Great Hamster Photos
+    </LinkTo>
+  </template>
   ```
 
   This will result in:

--- a/packages/@ember/-internals/glimmer/lib/components/textarea.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/textarea.ts
@@ -15,7 +15,11 @@ import { type OpaqueInternalComponentConstructor, opaquify } from './internal';
   This template:
 
   ```handlebars
-  <Textarea @value="A bunch of text" />
+  import { Textarea } from '@ember/component';
+
+  <template>
+    <Textarea @value="A bunch of text" />
+  </template>
   ```
 
   Would result in the following HTML:
@@ -32,17 +36,17 @@ import { type OpaqueInternalComponentConstructor, opaquify } from './internal';
   In the following example, the `writtenWords` property on the component will be updated as the user
   types 'Lots of text' into the text area of their browser's window.
 
-  ```app/components/word-editor.js
+  ```app/components/word-editor.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 
   export default class WordEditorComponent extends Component {
     @tracked writtenWords = "Lots of text that IS bound";
+    
+    <template>
+      <Textarea @value={{writtenWords}} />
+    </template>
   }
-  ```
-
-  ```handlebars
-  <Textarea @value={{writtenWords}} />
   ```
 
   Would result in the following HTML:

--- a/packages/@ember/-internals/glimmer/lib/glimmer-tracking-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-tracking-docs.ts
@@ -26,17 +26,7 @@
   property changes, any templates that used that property, directly or
   indirectly, will rerender. For instance, consider this component:
 
-  ```handlebars
-  <div>Count: {{this.count}}</div>
-  <div>Times Ten: {{this.timesTen}}</div>
-  <div>
-    <button {{on "click" this.plusOne}}>
-      Plus One
-    </button>
-  </div>
-  ```
-
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
   import { action } from '@ember/object';
@@ -52,6 +42,16 @@
     plusOne() {
       this.count += 1;
     }
+    
+    <template>
+      <div>Count: {{this.count}}</div>
+      <div>Times Ten: {{this.timesTen}}</div>
+      <div>
+        <button {{on "click" this.plusOne}}>
+          Plus One
+        </button>
+      </div>
+    </template>
   }
   ```
 
@@ -61,7 +61,7 @@
   will cause a rerender when updated - this includes through method calls and
   other means:
 
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 

--- a/packages/@ember/-internals/glimmer/lib/helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helper.ts
@@ -58,20 +58,32 @@ declare const SIGNATURE: unique symbol;
   Ember Helpers are functions that can compute values, and are used in templates.
   For example, this code calls a helper named `format-currency`:
 
-  ```app/templates/application.hbs
-  <Cost @cents={{230}} />
+  ```app/templates/application.gjs
+  import Cost from '../components/cost';
+    
+  <template>
+    <Cost @cents={{230}} />
+  </template>
   ```
 
-  ```app/components/cost.hbs
-  <div>{{format-currency @cents currency="$"}}</div>
+  ```app/components/cost.gjs
+  import formatCurrency from '../helpers/format-currency';
+    
+  <template>
+    <div>{{formatCurrency @cents currency="$"}}</div>
+  </template>
   ```
 
   Additionally a helper can be called as a nested helper.
   In this example, we show the formatted currency value if the `showMoney`
   named argument is truthy.
 
-  ```handlebars
-  {{if @showMoney (format-currency @cents currency="$")}}
+  ```gjs
+  import formatCurrency from '../helpers/format-currency';
+
+  <template>
+    {{if @showMoney (formatCurrency @cents currency="$")}}
+  </template>
   ```
 
   Helpers defined using a class must provide a `compute` function. For example:

--- a/packages/@ember/-internals/glimmer/lib/helpers/array.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/array.ts
@@ -15,7 +15,7 @@
    ```
     or
    ```handlebars
-   {{my-component people=(array
+   {{yield people=(array
      'Tom Dale'
      'Yehuda Katz'
      this.myOtherPerson)
@@ -29,6 +29,8 @@
    ```
 
    Where the 3rd item in the array is bound to updates of the `myOtherPerson` property.
+ 
+   The `array` helper is built-in keyword and does not need to be imported as of v7.1.0.
 
    @method array
    @for @ember/helper

--- a/packages/@ember/-internals/glimmer/lib/helpers/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/component.ts
@@ -3,124 +3,85 @@
 */
 
 /**
-  The `{{component}}` helper lets you add instances of `Component` to a
-  template. See [Component](/ember/release/classes/Component) for
+  The `component` helper is used to package a Component with initial arguments.
+  The included arguments can then be merged during the final invocation.
+
+  See [Component](/ember/release/modules/@glimmer%2Fcomponent/) for
   additional information on how a `Component` functions.
+
+  This is similar to the concept of Partial Application.
+    
+  For example, given a `FullName` component:
+  
+  ```app/components/full-name.gjs
+  import MyInputComponent from './my-input-component';
+  
+  <template>
+    {{yield (component MyInputComponent value=@model.name placeholder="Username")}}
+  </template>
+  ```
+  
+  The yielded component can be invoked by the calling component.
+  See the following snippet:
+  
+  ```app/components/person-form.gjs
+  import FullName from './full-name';
+    
+  <template>
+    <FullName @model={{@model}} as |Field|>
+      <Field />
+    </FullName>
+  </template>
+  ```
+  
+  Which will output an input whose value is already bound to `@model.name` and `placeholder`
+  is "Username".
+    
+  Any arguments passed at the invocation site of the component will override those applied via
+  the `component` helper. For example, if the invocation site of the component is:
+
+  ```app/components/person-form.gjs
+  import FullName from './full-name';
+
+  <template>
+    <FullName @model={{@model}} as |Field|>
+      <Field @placeholder="Your name" />
+    </FullName>
+  </template>
+  ```
+
+  The output will be an input whose value is bound to `@model.name` and `placeholder`
+  is "Your name".
     
   The `component` helper is built-in and does not need to be imported. 
     
-  `{{component}}`'s primary use is for cases where you want to dynamically
-  change which type of component is rendered as the state of your application
-  changes. This helper has three modes: inline, block, and nested.
+  Prior to Strict Mode aka "Template Tag" or gjs, the component helper was also used to invoke
+  components dynamically. This is no longer necessary, and they can be directly invoked, as above.
 
-  ### Inline Form
-
-  Given the following component:
+  ### Dynamic Component Invocation
 
   ```app/templates/application.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
   import { component } from '@ember/helper';
+  import LiveUpdatingChart from '../components/live-updating-chart';
+  import MarketCloseSummary from '../components/market-close-summary';
 
   export default class Application extends Component {
-    @tracked isMarketOpen = 'live-updating-chart'
+    @tracked isMarketOpen = false;
 
-    get infographicComponentName() {
-      return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
+    get infographicComponent() {
+      return this.isMarketOpen ? LiveUpdatingChart : MarketCloseSummary;
     }
 
     <template>
+      {{!-- The component can be invoked directly --}}
+      <this.infographicComponent />
+    
+      {{!-- The component helper here is no longer necessary --}}
       {{component this.infographicComponentName}}
     </template>
   }
-  ```
-
-  The `live-updating-chart` component will be appended when `isMarketOpen` is
-  `true`, and the `market-close-summary` component will be appended when
-  `isMarketOpen` is `false`. If the value changes while the app is running,
-  the component will be automatically swapped out accordingly.
-  Note: You should not use this helper when you are consistently rendering the same
-  component. In that case, use standard component syntax, for example:
-
-  ```hbs
-  <LiveUpdatingChart />
-  ```
-
-  ### Block Form
-
-  Using the block form of this helper is similar to using the block form
-  of a component. Given the following application component:
-
-  ```app/templates/application.gjs
-  import Component from '@glimmer/component';
-  import { tracked } from '@glimmer/tracking';
-
-  export default class Application extends Component {
-    @tracked isMarketOpen = 'live-updating-chart'
-
-    get lastUpdateTimestamp() {
-      return new Date();
-    }
-    
-    get infographicComponentName() {
-      return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
-    }
-
-    <template>
-      {{#component this.infographicComponentName}}
-        Last update: {{this.lastUpdateTimestamp}}
-      {{/component}}
-    </template>
-  }
-  ```
-
-  And the following component template:
-
-  ```app/components/live-updating-chart.gjs
-  <template>
-    {{yield}}
-  </template>
-  ```
-
-  The `Last Update: {{this.lastUpdateTimestamp}}` will be rendered in place of the `{{yield}}`.
-
-  ### Nested Usage
-
-  The `component` helper can be used to package a component path with initial attrs.
-  The included attrs can then be merged during the final invocation.
-  For example, given a `PersonForm` component:
-
-  ```app/components/person-form.gjs
-  <template>
-    {{yield (hash
-      nameInput=(component "my-input-component" value=@model.name placeholder="First Name")
-    )}}
-  </template>
-  ```
-
-  When yielding the component via the `hash` helper, the component is invoked directly.
-  See the following snippet:
-
-  ```hbs
-  <PersonForm as |form|>
-    <form.nameInput @placeholder="Username" />
-  </PersonForm>
-  ```
-
-  Which outputs an input whose value is already bound to `model.name` and `placeholder`
-  is "Username".
-
-  When yielding the component without the `hash` helper use the `component` helper.
-  For example, below is a `full-name` component template:
-
-  ```handlebars
-  {{yield (component "my-input-component" value=@model.name placeholder="Name")}}
-  ```
-
-  ```hbs
-  <FullName as |field|>
-    {{component field placeholder="Full name"}}
-  </FullName>
   ```
 
   @method component

--- a/packages/@ember/-internals/glimmer/lib/helpers/component.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/component.ts
@@ -6,30 +6,32 @@
   The `{{component}}` helper lets you add instances of `Component` to a
   template. See [Component](/ember/release/classes/Component) for
   additional information on how a `Component` functions.
+    
+  The `component` helper is built-in and does not need to be imported. 
+    
   `{{component}}`'s primary use is for cases where you want to dynamically
   change which type of component is rendered as the state of your application
   changes. This helper has three modes: inline, block, and nested.
 
   ### Inline Form
 
-  Given the following template:
+  Given the following component:
 
-  ```app/application.hbs
-  {{component this.infographicComponentName}}
-  ```
-
-  And the following application code:
-
-  ```app/controllers/application.js
-  import Controller from '@ember/controller';
+  ```app/templates/application.gjs
+  import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
+  import { component } from '@ember/helper';
 
-  export default class ApplicationController extends Controller {
+  export default class Application extends Component {
     @tracked isMarketOpen = 'live-updating-chart'
 
     get infographicComponentName() {
       return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
     }
+
+    <template>
+      {{component this.infographicComponentName}}
+    </template>
   }
   ```
 
@@ -40,52 +42,44 @@
   Note: You should not use this helper when you are consistently rendering the same
   component. In that case, use standard component syntax, for example:
 
-  ```app/templates/application.hbs
+  ```hbs
   <LiveUpdatingChart />
-  ```
-
-  or
-
-  ```app/templates/application.hbs
-  {{live-updating-chart}}
   ```
 
   ### Block Form
 
   Using the block form of this helper is similar to using the block form
-  of a component. Given the following application template:
+  of a component. Given the following application component:
 
-  ```app/templates/application.hbs
-  {{#component this.infographicComponentName}}
-    Last update: {{this.lastUpdateTimestamp}}
-  {{/component}}
-  ```
-
-  The following controller code:
-
-  ```app/controllers/application.js
-  import Controller from '@ember/controller';
-  import { computed } from '@ember/object';
+  ```app/templates/application.gjs
+  import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 
-  export default class ApplicationController extends Controller {
+  export default class Application extends Component {
     @tracked isMarketOpen = 'live-updating-chart'
 
     get lastUpdateTimestamp() {
       return new Date();
     }
-
+    
     get infographicComponentName() {
       return this.isMarketOpen ? 'live-updating-chart' : 'market-close-summary';
     }
+
+    <template>
+      {{#component this.infographicComponentName}}
+        Last update: {{this.lastUpdateTimestamp}}
+      {{/component}}
+    </template>
   }
   ```
 
   And the following component template:
 
-  ```app/templates/components/live-updating-chart.hbs
-  {{! chart }}
-  {{yield}}
+  ```app/components/live-updating-chart.gjs
+  <template>
+    {{yield}}
+  </template>
   ```
 
   The `Last Update: {{this.lastUpdateTimestamp}}` will be rendered in place of the `{{yield}}`.
@@ -94,28 +88,23 @@
 
   The `component` helper can be used to package a component path with initial attrs.
   The included attrs can then be merged during the final invocation.
-  For example, given a `person-form` component with the following template:
+  For example, given a `PersonForm` component:
 
-  ```app/templates/components/person-form.hbs
-  {{yield (hash
-    nameInput=(component "my-input-component" value=@model.name placeholder="First Name")
-  )}}
+  ```app/components/person-form.gjs
+  <template>
+    {{yield (hash
+      nameInput=(component "my-input-component" value=@model.name placeholder="First Name")
+    )}}
+  </template>
   ```
 
   When yielding the component via the `hash` helper, the component is invoked directly.
   See the following snippet:
 
-  ```
+  ```hbs
   <PersonForm as |form|>
     <form.nameInput @placeholder="Username" />
   </PersonForm>
-  ```
-
-  or
-  ```
-  {{#person-form as |form|}}
-    {{form.nameInput placeholder="Username"}}
-  {{/person-form}}
   ```
 
   Which outputs an input whose value is already bound to `model.name` and `placeholder`
@@ -128,16 +117,10 @@
   {{yield (component "my-input-component" value=@model.name placeholder="Name")}}
   ```
 
-  ```
+  ```hbs
   <FullName as |field|>
     {{component field placeholder="Full name"}}
   </FullName>
-  ```
-  or
-  ```
-  {{#full-name as |field|}}
-    {{component field placeholder="Full name"}}
-  {{/full-name}}
   ```
 
   @method component

--- a/packages/@ember/-internals/glimmer/lib/helpers/concat.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/concat.ts
@@ -7,13 +7,17 @@
 
   Example:
 
-  ```handlebars
-  {{some-component name=(concat firstName " " lastName)}}
+  ```gjs
+  import { concat } from '@ember/helper';
+    
+  <template>
+    {{yield (concat firstName " " lastName)}}
 
-  {{! would pass name="<first name value> <last name value>" to the component}}
+    {{! would yield name="<first name value> <last name value>" to the component}}
+  </template>
   ```
 
-  or for angle bracket invocation, you actually don't need concat at all.
+  For angle bracket invocation of components, you actually don't need concat at all.
 
   ```handlebars
   <SomeComponent @name="{{firstName}} {{lastName}}" />

--- a/packages/@ember/-internals/glimmer/lib/helpers/concat.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/concat.ts
@@ -17,7 +17,7 @@
   </template>
   ```
 
-  For angle bracket invocation of components, you actually don't need concat at all.
+  For invocation of components, you don't need concat at all.
 
   ```handlebars
   <SomeComponent @name="{{firstName}} {{lastName}}" />

--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -126,7 +126,7 @@ import { internalHelper } from './internal-helper';
 
   For example, given this component definition:
 
-  ```app/components/developer-details.js
+  ```app/components/developer-details.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 
@@ -135,21 +135,19 @@ import { internalHelper } from './internal-helper';
       "name": "Shelly Sails",
       "age": 42
     };
+    
+    <template>
+      <ul>
+        {{#each-in this.developer as |key value|}}
+          <li>{{key}}: {{value}}</li>
+        {{/each-in}}
+      </ul>
+    </template>
   }
   ```
 
   This template would display all properties on the `developer`
-  object in a list:
-
-  ```app/components/developer-details.hbs
-  <ul>
-    {{#each-in this.developer as |key value|}}
-      <li>{{key}}: {{value}}</li>
-    {{/each-in}}
-  </ul>
-  ```
-
-  Outputting their name and age:
+  object in a list, outputting their name and age:
 
   ```html
   <ul>

--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -11,7 +11,7 @@ import { consumeTag } from '@glimmer/validator/lib/tracking';
 import { internalHelper } from './internal-helper';
 
 /**
-  The `{{#each}}` helper loops over elements in a collection. It is an extension
+  The `{{#each}}` keyword loops over elements in a collection. It is an extension
   of the base Handlebars `{{#each}}` helper.
 
   The default behavior of `{{#each}}` is to yield its inner block once for every
@@ -55,6 +55,8 @@ import { internalHelper } from './internal-helper';
     {{/each}}
   </ul>
   ```
+    
+  `#each` is a keyword and does not need to be imported. 
 
   ### Specifying Keys
 
@@ -122,7 +124,7 @@ import { internalHelper } from './internal-helper';
  */
 
 /**
-  The `{{each-in}}` helper loops over properties on an object.
+  The `{{#each-in}}` keyword loops over properties on an object.
 
   For example, given this component definition:
 
@@ -155,6 +157,8 @@ import { internalHelper } from './internal-helper';
     <li>age: 42</li>
   </ul>
   ```
+ 
+  `#each-in` is a keyword and does not need to be imported.
 
   @method each-in
   @for Ember.Templates.helpers

--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -98,6 +98,8 @@ function getElementDefinition(tagName: string): ElementComponentDefinition {
   Passing `null`, `undefined`, or non-string values will throw an assertion error.
 
   Changing the tag name will tear down and recreate the element and its contents.
+ 
+  The `element` helper is built-in and does not need to be imported.
 
   @method element
   @for Ember.Templates.helpers

--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -65,6 +65,8 @@
   are bound (via `@action` or other means) before passing into `fn`!
 
   See also [partial application](https://en.wikipedia.org/wiki/Partial_application).
+ 
+  `fn` is built-in and does not need to be imported.
 
   @method fn
   @for @ember/helper

--- a/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/fn.ts
@@ -12,13 +12,15 @@
   to a component invoked within the loop. Here's how you could use the `fn`
   helper to pass both the function and its arguments together:
 
-    ```app/templates/components/items-listing.hbs
-  {{#each @items as |item|}}
-    <DisplayItem @item=item @select={{fn this.handleSelected item}} />
-  {{/each}}
+  ```app/components/items-listing.gjs
+  <template>
+    {{#each @items as |item|}}
+      <DisplayItem @item=item @select={{fn this.handleSelected item}} />
+    {{/each}}
+  </template>
   ```
 
-  ```app/components/items-list.js
+  ```app/components/items-list.gjs
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
@@ -30,7 +32,7 @@
   }
   ```
 
-  In this case the `display-item` component will receive a normal function
+  In this case the `DisplayItem` component will receive a normal function
   that it can invoke. When it invokes the function, the `handleSelected`
   function will receive the `item` and any arguments passed, thanks to the
   `fn` helper.
@@ -47,7 +49,7 @@
   properly bound to the `items-list`, but let's explore what happens if we
   left out `@action`:
 
-  ```app/components/items-list.js
+  ```app/components/items-list.gjs
   import Component from '@glimmer/component';
 
   export default class ItemsList extends Component {

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -71,18 +71,6 @@
   }
   ```
 
-  The `{{get}}` helper can also respect mutable values itself. For example:
-
-  ``hbs
-  <Input @value={{mut (get this.person this.currentFact)}} />
-
-  <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
-  <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
-  ```
-
-  Would allow the user to swap what fact is being displayed, and also edit
-  that fact via a two-way mutable binding.
-
   The `{{get}}` helper can also be used for array element access via index.
   This would display the value of the first element in the array `this.names`:
 

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -48,6 +48,7 @@
   ```app/components/developer-detail.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
+  import { get } from '@ember/object';
 
   export default class extends Component {
     @tracked developer = {

--- a/packages/@ember/-internals/glimmer/lib/helpers/get.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/get.ts
@@ -9,28 +9,33 @@
 
   For example, these two usages are equivalent:
 
-  ```app/components/developer-detail.js
+  ```app/components/developer-detail.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
+  import { get } from '@ember/object';
 
   export default class extends Component {
     @tracked developer = {
       name: "Sandi Metz",
       language: "Ruby"
     }
+    
+    <template>
+      {{this.developer.name}}
+      {{get this.developer "name"}}
+    </template>
   }
   ```
-
-  ```handlebars
-  {{this.developer.name}}
-  {{get this.developer "name"}}
-  ```
-
+    
   If there were several facts about a person, the `{{get}}` helper can dynamically
   pick one:
 
-  ```app/templates/application.hbs
-  <DeveloperDetail @factName="language" />
+  ```app/templates/application.gjs
+  import DeveloperDetail from '../components/developer-detail';
+  
+  <template>
+    <DeveloperDetail @factName="language" />
+  </template
   ```
 
   ```handlebars
@@ -40,7 +45,7 @@
   For a more complex example, this template would allow the user to switch
   between showing the user's name and preferred coding language with a click:
 
-  ```app/components/developer-detail.js
+  ```app/components/developer-detail.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 
@@ -56,19 +61,19 @@
     showFact(fact) {
       this.currentFact = fact;
     }
+    
+    <template>
+      {{get this.developer this.currentFact}}
+
+      <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
+      <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
+    </template>
   }
-  ```
-
-  ```app/components/developer-detail.js
-  {{get this.developer this.currentFact}}
-
-  <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
-  <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
   ```
 
   The `{{get}}` helper can also respect mutable values itself. For example:
 
-  ```app/components/developer-detail.js
+  ``hbs
   <Input @value={{mut (get this.person this.currentFact)}} />
 
   <button {{on 'click' (fn this.showFact "name")}}>Show name</button>

--- a/packages/@ember/-internals/glimmer/lib/helpers/hash.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/hash.ts
@@ -4,7 +4,7 @@
 
 /**
    Use the `{{hash}}` helper to create a hash to pass as an option to your
-   components. This is specially useful for contextual components where you can
+   components. This is especially useful for contextual components where you can
    just yield a hash:
 
    ```handlebars
@@ -32,6 +32,8 @@
      return Object.prototype.toString.apply(obj);
    }
    ```
+ 
+   The `hash` helper is a built-in keyword and does not need to be imported as of v7.1.0.
 
    @method hash
    @for @ember/helper

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -17,26 +17,34 @@
   using the block form to wrap the section of template you want to conditionally render.
   Like so:
 
-  ```app/templates/application.hbs
-  <Weather />
+  ```app/templates/application.gjs
+  import Weather from '../components/weather';
+    
+  <template>
+    <Weather />
+  </template>
   ```
 
-  ```app/components/weather.hbs
-  {{! will not render because greeting is undefined}}
-  {{#if @isRaining}}
-    Yes, grab an umbrella!
-  {{/if}}
+  ```app/components/weather.gjs
+  <template>
+    {{! will not render because greeting is undefined}}
+    {{#if @isRaining}}
+      Yes, grab an umbrella!
+    {{/if}}
+  </template>
   ```
 
   You can also define what to show if the property is falsey by using
   the `else` helper.
 
-  ```app/components/weather.hbs
-  {{#if @isRaining}}
-    Yes, grab an umbrella!
-  {{else}}
-    No, it's lovely outside!
-  {{/if}}
+  ```app/components/weather.gjs
+  <template>
+    {{#if @isRaining}}
+      Yes, grab an umbrella!
+    {{else}}
+      No, it's lovely outside!
+    {{/if}}
+  </template>
   ```
 
   You are also able to combine `else` and `if` helpers to create more complex
@@ -44,20 +52,26 @@
 
   For the following template:
 
-   ```app/components/weather.hbs
-  {{#if @isRaining}}
-    Yes, grab an umbrella!
-  {{else if @isCold}}
-    Grab a coat, it's chilly!
-  {{else}}
-    No, it's lovely outside!
-  {{/if}}
+   ```app/components/weather.gjs
+  <template>
+    {{#if @isRaining}}
+      Yes, grab an umbrella!
+    {{else if @isCold}}
+      Grab a coat, it's chilly!
+    {{else}}
+      No, it's lovely outside!
+    {{/if}}
+  </template>  
   ```
 
   If you call it by saying `isCold` is true:
 
-  ```app/templates/application.hbs
-  <Weather @isCold={{true}} />
+  ```app/templates/application.gjs
+  import Weather from '../components/weather';
+    
+  <template>
+    <Weather @isCold={{true}} />
+  </template>
   ```
 
   Then `Grab a coat, it's chilly!` will be rendered.
@@ -71,12 +85,18 @@
 
   For example, if `useLongGreeting` is truthy, the following:
 
-  ```app/templates/application.hbs
-  <Greeting @useLongGreeting={{true}} />
+  ```app/templates/application.gjs
+  import Greeting from '../components/greeting';
+  
+  <template>
+    <Greeting @useLongGreeting={{true}} />
+  <template>
   ```
 
-  ```app/components/greeting.hbs
-  {{if @useLongGreeting "Hello" "Hi"}} Alex
+  ```app/components/greeting.gjs
+  <template>
+    {{if @useLongGreeting "Hello" "Hi"}} Alex
+  <template>
   ```
 
   Will render:
@@ -108,12 +128,18 @@
 
   For example, if you pass a falsey `useLongGreeting` to the `Greeting` component:
 
-  ```app/templates/application.hbs
-  <Greeting @useLongGreeting={{false}} />
+  ```app/templates/application.gjs
+  import Greeting from '../components/greeting';
+    
+  <template>
+    <Greeting @useLongGreeting={{false}} />
+  </template>
   ```
 
-  ```app/components/greeting.hbs
-  {{unless @useLongGreeting "Hi" "Hello"}} Ben
+  ```app/components/greeting.gjs
+  <template>
+    {{unless @useLongGreeting "Hi" "Hello"}} Ben
+  </template>
   ```
 
   Then it will display:
@@ -128,14 +154,20 @@
 
   The following will not render anything:
 
-  ```app/templates/application.hbs
-  <Greeting />
+  ```app/templates/application.gjs
+  import Greeting from '../components/greeting';
+    
+  <template>
+    <Greeting />
+  </template>
   ```
 
-  ```app/components/greeting.hbs
-  {{#unless @greeting}}
-    No greeting was found. Why not set one?
-  {{/unless}}
+  ```app/components/greeting.gjs
+  <template>
+    {{#unless @greeting}}
+      No greeting was found. Why not set one?
+    {{/unless}}
+  </template>
   ```
 
   You can also use an `else` helper with the `unless` block. The
@@ -143,18 +175,24 @@
 
   If you have the following component:
 
-  ```app/components/logged-in.hbs
-  {{#unless @userData}}
-    Please login.
-  {{else}}
-    Welcome back!
-  {{/unless}}
+  ```app/components/logged-in.gjs
+  <template>
+    {{#unless @userData}}
+      Please login.
+    {{else}}
+      Welcome back!
+    {{/unless}}
+  </template>
   ```
 
   Calling it with a truthy `userData`:
 
-  ```app/templates/application.hbs
-  <LoggedIn @userData={{hash username="Zoey"}} />
+  ```app/templates/application.gjs
+  import LoggedIn from '../components/logged-in';
+    
+  <template>
+    <LoggedIn @userData={{hash username="Zoey"}} />
+  </template>
   ```
 
   Will render:
@@ -165,8 +203,12 @@
 
   and calling it with a falsey `userData`:
 
-  ```app/templates/application.hbs
-  <LoggedIn @userData={{false}} />
+  ```app/templates/application.gjs
+  import LoggedIn from '../components/logged-in';
+
+  <template>
+    <LoggedIn @userData={{false}} />
+  </template>
   ```
 
   Will render:

--- a/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/if-unless.ts
@@ -108,7 +108,9 @@
   One detail to keep in mind is that both branches of the `if` helper will be evaluated,
   so if you have `{{if condition "foo" (expensive-operation "bar")`,
   `expensive-operation` will always calculate.
-
+ 
+  `if` is built-in and does not need to be imported.
+ 
   @method if
   @for Ember.Templates.helpers
   @public
@@ -216,7 +218,9 @@
   ```html
   Please login.
   ```
-
+ 
+  `unless` is built-in and does not need to be imported.
+ 
   @method unless
   @for Ember.Templates.helpers
   @public

--- a/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
@@ -24,7 +24,6 @@ import { internalHelper } from './internal-helper';
   ```app/components/my-child.gjs
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
-  import { on } from '@ember/modifier';
     
   export default class MyChild extends Component {
     @action

--- a/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
@@ -10,6 +10,8 @@ import { internalHelper } from './internal-helper';
   The `mut` helper is a shortcut for updating for args.
     
   However, defining update functions on your backing class is preferable to using `mut`.
+    
+  More directly: Don't use `mut`. 
 
   The `mut` helper, when used with `fn`, will return a function that
   sets the value passed to `mut` to its first argument. As an example, we can create a

--- a/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/mut.ts
@@ -7,72 +7,40 @@ import { createInvokableRef, isUpdatableRef } from '@glimmer/reference/lib/refer
 import { internalHelper } from './internal-helper';
 
 /**
-  The `mut` helper lets you __clearly specify__ that a child `Component` can update the
-  (mutable) value passed to it, which will __change the value of the parent component__.
-
-  To specify that a parameter is mutable, when invoking the child `Component`:
-
-  ```handlebars
-  <MyChild @childClickCount={{fn (mut totalClicks)}} />
-  ```
-
-   or
-
-  ```handlebars
-  {{my-child childClickCount=(mut totalClicks)}}
-  ```
-
-  The child `Component` can then modify the parent's value just by modifying its own
-  property:
-
-  ```javascript
-  // my-child.js
-  export default class MyChild extends Component {
-    click() {
-      this.incrementProperty('childClickCount');
-    }
-  }
-  ```
-
-  Note that for curly components (`{{my-component}}`) the bindings are already mutable,
-  making the `mut` unnecessary.
-
-  Additionally, the `mut` helper can be combined with the `fn` helper to
-  mutate a value. For example:
-
-  ```handlebars
-  <MyChild @childClickCount={{this.totalClicks}} @click-count-change={{fn (mut totalClicks))}} />
-  ```
-
-  or
-
-  ```handlebars
-  {{my-child childClickCount=totalClicks click-count-change=(fn (mut totalClicks))}}
-  ```
-
-  The child `Component` would invoke the function with the new click value:
-
-  ```javascript
-  // my-child.js
-  export default class MyChild extends Component {
-    click() {
-      this.get('click-count-change')(this.get('childClickCount') + 1);
-    }
-  }
-  ```
-
-  The `mut` helper changes the `totalClicks` value to what was provided as the `fn` argument.
+  The `mut` helper is a shortcut for updating for args.
+    
+  However, defining update functions on your backing class is preferable to using `mut`.
 
   The `mut` helper, when used with `fn`, will return a function that
   sets the value passed to `mut` to its first argument. As an example, we can create a
   button that increments a value passing the value directly to the `fn`:
 
   ```handlebars
-  {{! inc helper is not provided by Ember }}
-  <button onclick={{fn (mut count) (inc count)}}>
-    Increment count
-  </button>
+  <MyChild @childClickCount={{this.totalClicks}} @clickCountChange={{fn (mut this.totalClicks)}} />
   ```
+
+  The child `Component` would invoke the function with the new click count:
+
+  ```app/components/my-child.gjs
+  import Component from '@glimmer/component';
+  import { action } from '@ember/object';
+  import { on } from '@ember/modifier';
+    
+  export default class MyChild extends Component {
+    @action
+    update() {
+      this.args.clickCountChange(this.args.childClickCount + 1);
+    }
+    
+    <template>
+      <button {{on "click" this.update}}>
+        Click me!
+      </button>
+    </template>
+  }
+  ```
+
+  The `mut` helper changes the `totalClicks` value to what was provided as the `fn` argument.
 
   @method mut
   @param {Object} [attr] the "two-way" attribute that can be modified.

--- a/packages/@ember/-internals/glimmer/lib/helpers/page-title.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/page-title.ts
@@ -7,8 +7,12 @@
   append additional titles for each route. For complete documentation, see
   https://github.com/ember-cli/ember-page-title.
 
-  ```handlebars
-  {{page-title "My Page Title" }}
+  ```gjs
+  import pageTitle from 'ember-page-title/helpers/page-title';
+  
+  <template>
+    {{pageTitle "My Page Title" }}
+  </template>
   ```
 
   @method page-title

--- a/packages/@ember/-internals/glimmer/lib/helpers/readonly.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/readonly.ts
@@ -9,6 +9,10 @@ import { internalHelper } from './internal-helper';
 /**
   The `readonly` helper let's you specify that a binding is one-way only,
   instead of two-way.
+  
+  This is a vestigial helper from the days of `@ember/component` and does not apply to
+  components extending from `@glimmer/component`.
+    
   When you pass a `readonly` binding from an outer context (e.g. parent component),
   to to an inner context (e.g. child component), you are saying that changing that
   property in the inner context does not change the value in the outer context.
@@ -19,14 +23,6 @@ import { internalHelper } from './internal-helper';
   export default class MyParent extends Component {
     totalClicks = 3;
   }
-  ```
-
-  ```app/templates/components/my-parent.hbs
-  {{log totalClicks}} // -> 3
-  <MyChild @childClickCount={{readonly totalClicks}} />
-  ```
-  ```
-  {{my-child childClickCount=(readonly totalClicks)}}
   ```
 
   Now, when you update `childClickCount`:

--- a/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
@@ -10,20 +10,20 @@
   For example, if you'd like to run a function on your component when a `<button>`
   in the components template is clicked you might do something like:
 
-  ```app/components/like-post.hbs
-  <button {{on 'click' this.saveLike}}>Like this post!</button>
-  ```
-
   ```app/components/like-post.js
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
-  export default class LikePostComponent extends Component {
+  export default class LikePost extends Component {
     @action
     saveLike() {
       // someone likes your post!
       // better send a request off to your server...
     }
+    
+    <template>
+      <button {{on 'click' this.saveLike}}>Like this post!</button>
+    </template>
   }
   ```
 
@@ -58,7 +58,7 @@
   For example, in our example case above if you'd like to pass in the post that
   was being liked when the button is clicked you could do something like:
 
-  ```app/components/like-post.hbs
+  ```hbs
   <button {{on 'click' (fn this.saveLike @post)}}>Like this post!</button>
   ```
 
@@ -68,13 +68,13 @@
   ### Function Context
 
   In the example above, we used `@action` to ensure that `likePost` is
-  properly bound to the `items-list`, but let's explore what happens if we
+  properly bound to the `LikePost` Component, but let's explore what happens if we
   left out `@action`:
 
   ```app/components/like-post.js
   import Component from '@glimmer/component';
 
-  export default class LikePostComponent extends Component {
+  export default class LikePost extends Component {
     saveLike() {
       // ...snip...
     }

--- a/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
+++ b/packages/@ember/-internals/glimmer/lib/modifiers/on.ts
@@ -10,7 +10,7 @@
   For example, if you'd like to run a function on your component when a `<button>`
   in the components template is clicked you might do something like:
 
-  ```app/components/like-post.js
+  ```app/components/like-post.gjs
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
@@ -71,7 +71,7 @@
   properly bound to the `LikePost` Component, but let's explore what happens if we
   left out `@action`:
 
-  ```app/components/like-post.js
+  ```app/components/like-post.gjs
   import Component from '@glimmer/component';
 
   export default class LikePost extends Component {

--- a/packages/@ember/-internals/glimmer/lib/syntax/in-element.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/in-element.ts
@@ -39,6 +39,8 @@
      {{/in-element}}
      ```
 
+ `in-element` is built-in and does not need to be imported.
+ 
  @method in-element
  @for Ember.Templates.helpers
  @public

--- a/packages/@ember/-internals/glimmer/lib/syntax/let.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/let.ts
@@ -33,6 +33,8 @@
     {{/let}}
   ```
 
+ `let` is built-in and does not need to be imported.
+ 
   @method let
   @for Ember.Templates.helpers
   @public

--- a/packages/@ember/-internals/glimmer/lib/syntax/let.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/let.ts
@@ -32,20 +32,6 @@
       <MyPost @title={{title}} @content={{content}} @options={{options}} />
     {{/let}}
   ```
- or
-  ```handlebars
-    {{#let
-        (concat post.title ' | The Ember.js Blog')
-        post.content
-        (hash
-          theme="high-contrast"
-          enableComments=true
-        )
-        as |title content options|
-    }}
-      {{my-post title=title content=content options=options}}
-    {{/let}}
-  ```
 
   @method let
   @for Ember.Templates.helpers

--- a/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
@@ -48,6 +48,8 @@ import { internalHelper } from '../helpers/internal-helper';
     </div>
   </template>
   ```
+ 
+ `mount` is built-in and does not need to be imported.
 
   @method mount
   @param {String} name Name of the engine to mount.

--- a/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
@@ -21,15 +21,14 @@ import { internalHelper } from '../helpers/internal-helper';
 
   For example, the following template mounts the `ember-chat` engine:
 
-  ```handlebars
-  {{! application.hbs }}
+  ```app/templates/application.gjs
   {{mount "ember-chat"}}
   ```
 
   Additionally, you can also pass in a `model` argument that will be
   set as the engines model. This can be an existing object:
 
-  ```
+  ```hbs
   <div>
     {{mount 'admin' model=userSettings}}
   </div>
@@ -37,7 +36,7 @@ import { internalHelper } from '../helpers/internal-helper';
 
   Or an inline `hash`, and you can even pass components:
 
-  ```
+  ```hbs
   <div>
     <h1>Application template!</h1>
     {{mount 'admin' model=(hash

--- a/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/mount.ts
@@ -36,14 +36,17 @@ import { internalHelper } from '../helpers/internal-helper';
 
   Or an inline `hash`, and you can even pass components:
 
-  ```hbs
-  <div>
-    <h1>Application template!</h1>
-    {{mount 'admin' model=(hash
-        title='Secret Admin'
-        signInButton=(component 'sign-in-button')
-    )}}
-  </div>
+  ```gjs
+  import SignInButton from '../components/sign-in-button';
+  <template>
+    <div>
+      <h1>Application template!</h1>
+      {{mount 'admin' model=(hash
+          title='Secret Admin'
+          signInButton=SignInButton
+      )}}
+    </div>
+  </template>
   ```
 
   @method mount

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -28,17 +28,22 @@ import type { OutletState } from '../utils/outlet';
 /**
   The `{{outlet}}` helper lets you specify where a child route will render in
   your template. An important use of the `{{outlet}}` helper is in your
-  application's `application.hbs` file:
+  application's `application.gjs` file:
 
-  ```app/templates/application.hbs
-  <MyHeader />
-
-  <div class="my-dynamic-content">
-    <!-- this content will change based on the current route, which depends on the current URL -->
-    {{outlet}}
-  </div>
-
-  <MyFooter />
+  ```app/templates/application.gjs
+  import MyHeader from '../components/my-header';
+  import MyFooter from '../components/my-footer';
+    
+  <template>
+    <MyHeader />
+  
+    <div class="my-dynamic-content">
+      <!-- this content will change based on the current route, which depends on the current URL -->
+      {{outlet}}
+    </div>
+  
+    <MyFooter />
+  </template>
   ```
 
   See the [routing guide](https://guides.emberjs.com/release/routing/rendering-a-template/) for more

--- a/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
+++ b/packages/@ember/-internals/glimmer/lib/syntax/outlet.ts
@@ -50,6 +50,8 @@ import type { OutletState } from '../utils/outlet';
   information on how your `route` interacts with the `{{outlet}}` helper.
   Note: Your content __will not render__ if there isn't an `{{outlet}}` for it.
 
+  `outlet` is built-in and does not need to be imported. 
+ 
   @method outlet
   @for Ember.Templates.helpers
   @public

--- a/packages/@ember/-internals/runtime/lib/mixins/target_action_support.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/target_action_support.ts
@@ -11,7 +11,7 @@ import { DEBUG } from '@glimmer/env';
 
 /**
 `TargetActionSupport` is a mixin that can be included in a class
-to add a `triggerAction` method with semantics similar to the Handlebars
+to add a `triggerAction` method with semantics similar to the
 `{{action}}` helper. In normal Ember usage, the `{{action}}` helper is
 usually the best choice. This mixin is most often useful when you are
 doing more complex event handling in Components.

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1810,6 +1810,10 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
 /**
   Creates an `NativeArray` from an Array-like object.
   Does not modify the original object's contents.
+    
+  This exists primarily for historic reasons and should not be used
+  in new code. Prefer native [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+  or [trackedArray](https://api.emberjs.com/ember/release/functions/@ember%2Freactive%2Fcollections/trackedArray).
 
   Example
 

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -1813,7 +1813,7 @@ const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
     
   This exists primarily for historic reasons and should not be used
   in new code. Prefer native [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-  or [trackedArray](https://api.emberjs.com/ember/release/functions/@ember%2Freactive%2Fcollections/trackedArray).
+  or [trackedArray](/ember/release/functions/@ember%2Freactive%2Fcollections/trackedArray).
 
   Example
 

--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -39,7 +39,7 @@ interface ControllerMixin<T> extends ActionHandler {
   /**
     The object to which actions from the view should be sent.
 
-    For example, when a Handlebars template uses the `{{action}}` helper,
+    For example, when a template uses the `{{action}}` helper,
     it will attempt to send the action to the view's controller's `target`.
 
     By default, the value of the target property is set to the router, and

--- a/packages/@ember/helper/index.ts
+++ b/packages/@ember/helper/index.ts
@@ -348,18 +348,12 @@ export const invokeHelper = glimmerInvokeHelper;
  * as an argument to your components.
  *
  * ```
- * import { hash } from '@ember/helper';
- *
  * <template>
  *   {{#each-in (hash givenName='Jen' familyName='Weber') as |key value|}}
  *     <p>{{key}}: {{value}}</p>
  *   {{/each-in}}
  * </template>
  * ```
- *
- * **NOTE:** this example uses the experimental `<template>` feature, which is
- * the only place you need to import `hash` to use it (it is a built-in when
- * writing standalone `.hbs` files).
  */
 export const hash = glimmerHash as HashHelper;
 export interface HashHelper extends Opaque<'helper:hash'> {}
@@ -369,7 +363,6 @@ export interface HashHelper extends Opaque<'helper:hash'> {}
  * as an argument to your components.
  *
  * ```js
- * import { array } from '@ember/helper';
  *
  * <template>
  *   <ul>
@@ -378,10 +371,6 @@ export interface HashHelper extends Opaque<'helper:hash'> {}
  *   {{/each}}
  *   </ul>
  * </template>
- *
- * **NOTE:** this example uses the experimental `<template>` feature, which is
- * the only place you need to import `array` to use it (it is a built-in when
- * writing standalone `.hbs` files).
  * ```
  */
 export const array = glimmerArray as ArrayHelper;
@@ -404,10 +393,6 @@ export interface ArrayHelper extends Opaque<'helper:array'> {}
  *
  * This will display the result of `@foo.item1` when `index` is `1`, and
  * `this.foo.item2` when `index` is `2`, etc.
- *
- * **NOTE:** this example uses the experimental `<template>` feature, which is
- * the only place you need to import `concat` to use it (it is a built-in when
- * writing standalone `.hbs` files).
  */
 export const concat = glimmerConcat as ConcatHelper;
 export interface ConcatHelper extends Opaque<'helper:concat'> {}
@@ -449,10 +434,6 @@ export interface ConcatHelper extends Opaque<'helper:concat'> {}
  *
  * This will display the result of `@foo.item1` when `index` is `1`, and
  * `this.foo.item2` when `index` is `2`, etc.
- *
- * **NOTE:** this example uses the experimental `<template>` feature, which is
- * the only place you need to import `concat` to use it (it is a built-in when
- * writing standalone `.hbs` files).
  */
 export const get = glimmerGet as GetHelper;
 export interface GetHelper extends Opaque<'helper:get'> {}

--- a/packages/@ember/object/index.ts
+++ b/packages/@ember/object/index.ts
@@ -49,8 +49,8 @@ export default EmberObject;
   Decorator that turns the target function into an Action which can be accessed
   directly by reference.
 
-  ```js
-  import Component from '@ember/component';
+  ```gjs
+  import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
   import { action } from '@ember/object';
 
@@ -61,24 +61,24 @@ export default EmberObject;
     toggleShowing() {
       this.isShowing = !this.isShowing;
     }
+    
+    <template>
+      <button {{on "click" this.toggleShowing}}>Show tooltip</button>
+    
+      {{#if isShowing}}
+        <div class="tooltip">
+          I'm a tooltip!
+        </div>
+      {{/if}}
+    </template>
   }
-  ```
-  ```hbs
-  <!-- template.hbs -->
-  <button {{on "click" this.toggleShowing}}>Show tooltip</button>
-
-  {{#if isShowing}}
-    <div class="tooltip">
-      I'm a tooltip!
-    </div>
-  {{/if}}
   ```
 
   It also binds the function directly to the instance, so it can be used in any
   context and will correctly refer to the class it came from:
 
-  ```js
-  import Component from '@ember/component';
+  ```gjs
+  import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
   import { action } from '@ember/object';
 
@@ -97,6 +97,10 @@ export default EmberObject;
     toggleShowing() {
       this.isShowing = !this.isShowing;
     }
+    
+    <template>
+      {{!-- ...--}}
+    </template>
   }
   ```
 
@@ -248,9 +252,10 @@ type ObserverDefinition<T extends AnyFn> = {
   });
   ```
 
-  Also available as `Function.prototype.observes` if prototype extensions are
-  enabled.
-
+  While observers are still supported, there are [plans to deprecate them](https://github.com/emberjs/rfcs/pull/1115)
+  See the [in-progress deprecation guide](https://github.com/ember-learn/deprecation-app/pull/1407) 
+  for guidance on how to avoid using observers.
+ 
   @method observer
   @for @ember/object
   @param {String} propertyNames*

--- a/packages/@ember/object/observable.ts
+++ b/packages/@ember/object/observable.ts
@@ -322,6 +322,10 @@ interface Observable {
     only a sender and key value as parameters or, if you aren't interested in
     any of these values, to write an observer that has no parameters at all.
 
+    While observers are still supported, there are [plans to deprecate them](https://github.com/emberjs/rfcs/pull/1115)
+    See the [in-progress deprecation guide](https://github.com/ember-learn/deprecation-app/pull/1407)
+    for guidance on how to avoid using observers.
+
     @method addObserver
     @param {String} key The key to observe
     @param {Object} target The target object to invoke

--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -1117,7 +1117,7 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
 
     Note that for routes with dynamic segments, this hook is not always
     executed. If the route is entered through a transition (e.g. when
-    using the `link-to` Handlebars helper or the `transitionTo` method
+    using the `link-to` helper or the `transitionTo` method
     of routes), and a model context is already provided this hook
     is not called.
 

--- a/packages/@ember/routing/router-service.ts
+++ b/packages/@ember/routing/router-service.ts
@@ -194,11 +194,15 @@ class RouterService extends Service.extend(Evented) {
     In this example, the URL for the `author.books` route for a given author
     is copied to the clipboard.
 
-    ```app/templates/application.hbs
-    <CopyLink @author={{hash id="tomster" name="Tomster"}} />
+    ```app/templates/application.gjs
+    import CopyLink from '../components/copy-link';
+      
+    <template>
+      <CopyLink @author={{hash id="tomster" name="Tomster"}} />
+    </template>
     ```
 
-    ```app/components/copy-link.js
+    ```app/components/copy-link.gjs
     import Component from '@glimmer/component';
     import { service } from '@ember/service';
     import { action } from '@ember/object';
@@ -221,11 +225,15 @@ class RouterService extends Service.extend(Evented) {
     Just like with `transitionTo` and `replaceWith`, `urlFor` can also handle
     query parameters.
 
-    ```app/templates/application.hbs
-    <CopyLink @author={{hash id="tomster" name="Tomster"}} />
+    ```app/templates/application.gjs
+    import CopyLink from '../components/copy-link';
+
+    <template>
+      <CopyLink @author={{hash id="tomster" name="Tomster"}} />
+    </template>
     ```
 
-    ```app/components/copy-link.js
+    ```app/components/copy-link.gjs
     import Component from '@glimmer/component';
     import { service } from '@ember/service';
     import { action } from '@ember/object';
@@ -270,7 +278,7 @@ class RouterService extends Service.extend(Evented) {
 
      In the following example, `isActive` will return `true` if the current route is `/posts`.
 
-     ```app/components/posts.js
+     ```app/components/posts.gjs
      import Component from '@glimmer/component';
      import { service } from '@ember/service';
 
@@ -286,7 +294,7 @@ class RouterService extends Service.extend(Evented) {
      The next example includes a dynamic segment, and will return `true` if the current route is `/posts/1`,
      assuming the post has an id of 1:
 
-     ```app/components/posts.js
+     ```app/components/posts.gjs
      import Component from '@glimmer/component';
      import { service } from '@ember/service';
 
@@ -378,7 +386,7 @@ class RouterService extends Service.extend(Evented) {
      In the following example `recognize` is used to verify if a path belongs to our
      application before transitioning to it.
 
-     ```
+     ```js
      import Component from '@ember/component';
      import { service } from '@ember/service';
 

--- a/packages/@ember/routing/router-service.ts
+++ b/packages/@ember/routing/router-service.ts
@@ -35,7 +35,7 @@ function cleanURL(url: string, rootURL: string) {
    In this example, the Router service is injected into a component to initiate a transition
    to a dedicated route:
 
-   ```app/components/example.js
+   ```app/components/example.gjs
    import Component from '@glimmer/component';
    import { action } from '@ember/object';
    import { service } from '@ember/service';
@@ -99,7 +99,7 @@ class RouterService extends Service.extend(Evented) {
      specific model from a Component in the first action, and in the second we trigger
      a query-params only transition.
 
-     ```app/components/example.js
+     ```app/components/example.gjs
      import Component from '@glimmer/component';
      import { action } from '@ember/object';
      import { service } from '@ember/service';
@@ -741,7 +741,7 @@ class RouterService extends Service.extend(Evented) {
     and doesn't change the active route).
 
     Usage example:
-    ```app/components/header.js
+    ```app/components/header.gjs
       import Component from '@glimmer/component';
       import { service } from '@ember/service';
       import { notEmpty } from '@ember/object/computed';

--- a/packages/@glimmer/component/src/index.ts
+++ b/packages/@glimmer/component/src/index.ts
@@ -5,10 +5,10 @@ import _GlimmerComponent, { type Args } from './-private/component';
 import { setOwner, type default as Owner } from '@ember/owner';
 
 /**
-  A component is a reusable UI element that consists of a `.hbs` template and an
+  A component is a reusable UI element that consists of a template and an
   optional JavaScript class that defines its behavior. For example, someone
   might make a `button` in the template and handle the click behavior in the
-  JavaScript file that shares the same name as the template.
+  JavaScript.
 
   Components are broken down into two categories:
 
@@ -27,41 +27,41 @@ import { setOwner, type default as Owner } from '@ember/owner';
   Below is the documentation for Template-only and Glimmer components. If you
   are looking for the API documentation for Classic components, it is
   [available here](/ember/release/classes/Component). The source code for
-  Glimmer components can be found in [`@glimmer/component`](https://github.com/glimmerjs/glimmer.js/tree/master/packages/%40glimmer/component).
+  Glimmer components can be found in [`@glimmer/component`](https://github.com/emberjs/ember.js/tree/main/packages/%40glimmer/component).
 
+  Note: Prior to Ember 6.8, by default, components were authored in paired `.hbs` and `.js` 
+  files. This is still supported, but the default authoring format is now `.gjs` or "template tag".
+  To read more about how components were previously authored, see the 
+  [6.7 version of this API documentation](https://api.emberjs.com/ember/6.7/modules/@glimmer%2Fcomponent).
+    
   ## Defining a Template-only Component
 
-  The simplest way to create a component is to create a template file in
-  `app/templates/components`. For example, if you name a template
-  `app/templates/components/person-profile.hbs`:
+  The simplest way to create a component is to create a `gjs` file in
+  `app/components` with a `<template>` tag wrapper:
 
-  ```app/templates/components/person-profile.hbs
-  <h1>{{@person.name}}</h1>
-  <img src={{@person.avatar}}>
-  <p class='signature'>{{@person.signature}}</p>
+  ```app/components/person-profile.gjs
+  <template>
+    <h1>{{@person.name}}</h1>
+    <img src={{@person.avatar}}>
+    <p class='signature'>{{@person.signature}}</p>
+  </template>
   ```
 
   You will be able to use `<PersonProfile />` to invoke this component elsewhere
   in your application:
 
-  ```app/templates/application.hbs
-  <PersonProfile @person={{this.currentUser}} />
+  ```app/templates/application.gjs
+  import PersonProfile from '../components/person-profile';
+    
+  <template>
+    <PersonProfile @person={{@model.currentUser}} />
+  </template>
   ```
 
   Note that component names are capitalized here in order to distinguish them
-  from regular HTML elements, but they are dasherized in the file system.
+  from regular HTML elements.
 
-  While the angle bracket invocation form is generally preferred, it is also
-  possible to invoke the same component with the `{{person-profile}}` syntax:
-
-  ```app/templates/application.hbs
-  {{person-profile person=this.currentUser}}
-  ```
-
-  Note that with this syntax, you use dashes in the component name and
-  arguments are passed without the `@` sign.
-
-  In both cases, Ember will render the content of the component template we
+  Ember will render the content of the component template we
   created above. The end result will be something like this:
 
   ```html
@@ -72,20 +72,24 @@ import { setOwner, type default as Owner } from '@ember/owner';
 
   ## File System Nesting
 
-  Components can be nested inside sub-folders for logical groupping. For
-  example, if we placed our template in
-  `app/templates/components/person/short-profile.hbs`, we can invoke it as
-  `<Person::ShortProfile />`:
+  In Ember templates, “invokables” are things you can invoke in a template. These include components, 
+  helpers, and modifiers. In the template tag format, these invokables need to be imported before 
+  they can be used. This makes it easier to understand where values come from and what they do, as 
+  well as unlocks build optimizations.
 
-  ```app/templates/application.hbs
-  <Person::ShortProfile @person={{this.currentUser}} />
-  ```
+  When making use of the `PersonProfile` component as defined before in a different component file, 
+  it first needs to be imported. This is done using the import statement, just like you would import 
+  any other JavaScript module -- from your local project or from an external package.
 
-  Or equivalently, `{{person/short-profile}}`:
-
-  ```app/templates/application.hbs
-  {{person/short-profile person=this.currentUser}}
-  ```
+  Since they are imported, Components can be placed anywhere in your project on the filesystem, but 
+  they are conventionally placed within `app/components` for reusable components and within 
+  `app/templates` for Route components. 
+    
+  Route components must be named after the route they are associated with -- and placed in the 
+  `app/templates` directory. For example, a `Person` route would have a corresponding `Person` 
+  component defined in `app/templates/person.gjs`. This component would then be rendered whenever 
+  the user visits the `/person` route. For more information, see the 
+  [Routing](https://guides.emberjs.com/release/routing/) section of the guides.
 
   ## Using Blocks
 
@@ -93,27 +97,25 @@ import { setOwner, type default as Owner } from '@ember/owner';
   attached to the component. For instance, if we added a `{{yield}}` to our
   component like so:
 
-  ```app/templates/components/person-profile.hbs
-  <h1>{{@person.name}}</h1>
-  {{yield}}
+  ```app/components/person-profile.gjs
+  <template>
+    <h1>{{@person.name}}</h1>
+    {{yield}}
+  </template>
   ```
 
   We could then invoke it like this:
 
-  ```handlebars
-  <PersonProfile @person={{this.currentUser}}>
-    <p>Admin mode</p>
-  </PersonProfile>
+  ```gjs
+  import PersonProfile from '../components/person-profile';
+    
+  <template>
+    <PersonProfile @person={{@model.currentUser}}>
+      <p>Admin mode</p>
+    </PersonProfile>
+  </template>
   ```
-
-  or with curly syntax like this:
-
-  ```handlebars
-  {{#person-profile person=this.currentUser}}
-    <p>Admin mode</p>
-  {{/person-profile}}
-  ```
-
+    
   And the content passed in between the brackets of the component would be
   rendered in the same place as the `{{yield}}` within it, replacing it.
 
@@ -125,17 +127,23 @@ import { setOwner, type default as Owner } from '@ember/owner';
   You can also pass positional parameters to `{{yield}}`, which are then made
   available in the block:
 
-  ```app/templates/components/person-profile.hbs
-  <h1>{{@person.name}}</h1>
-  {{yield @person.signature}}
+  ```app/components/person-profile.gjs
+  <template>
+    <h1>{{@person.name}}</h1>
+    {{yield @person.signature}}
+  </template>
   ```
 
   We can then use this value in the block like so:
 
-  ```handlebars
-  <PersonProfile @person={{this.currentUser}} as |signature|>
-    {{signature}}
-  </PersonProfile>
+  ```gjs
+  import PersonProfile from '../components/person-profile';
+    
+  <template>
+    <PersonProfile @person={{@model.currentUser}} as |signature|>
+      {{signature}}
+    </PersonProfile>
+  </template>
   ```
 
   ### Passing multiple blocks
@@ -145,18 +153,24 @@ import { setOwner, type default as Owner } from '@ember/owner';
   we wanted to add a way for users to customize the title of our
   `<PersonProfile>` component, we could add a named block inside of the header:
 
-  ```app/templates/components/person-profile.hbs
-  <h1>{{yield to="title"}}</h1>
-  {{yield}}
+  ```app/components/person-profile.gjs
+  <template>
+    <h1>{{yield to="title"}}</h1>
+    {{yield}}
+  </template>
   ```
 
   This component could then be invoked like so:
 
-  ```handlebars
-  <PersonProfile @person={{this.currentUser}}>
-    <:title>{{this.currentUser.name}}</:title>
-    <:default>{{this.currentUser.signature}}</:default>
-  </PersonProfile>
+  ```gjs
+  import PersonProfile from '../components/person-profile';
+
+  <template>
+    <PersonProfile @person={{@model.currentUser}}>
+      <:title>{{@model.currentUser.name}}</:title>
+      <:default>{{@model.currentUser.signature}}</:default>
+    </PersonProfile>
+  </template>
   ```
 
   When passing named blocks, you must name every block, including the `default`
@@ -168,18 +182,24 @@ import { setOwner, type default as Owner } from '@ember/owner';
 
   You can also pass parameters to named blocks:
 
-  ```app/templates/components/person-profile.hbs
-  <h1>{{yield @person.name to="title"}}</h1>
-  {{yield @person.signature}}
+  ```app/components/person-profile.gjs
+  <template>
+    <h1>{{yield @person.name to="title"}}</h1>
+    {{yield @person.signature}}
+  </template>
   ```
 
   These parameters can then be used like so:
 
-  ```handlebars
-  <PersonProfile @person={{this.currentUser}}>
-    <:title as |name|>{{name}}</:title>
-    <:default as |signature|>{{signature}}</:default>
-  </PersonProfile>
+  ```gjs
+  import PersonProfile from '../components/person-profile';
+
+  <template>
+    <PersonProfile @person={{@model.currentUser}}>
+      <:title as |name|>{{name}}</:title>
+      <:default as |signature|>{{signature}}</:default>
+    </PersonProfile>
+  </template>
   ```
 
   ### Checking to see if a block exists
@@ -187,44 +207,50 @@ import { setOwner, type default as Owner } from '@ember/owner';
   You can also check to see if a block exists using the `(has-block)` keyword,
   and conditionally use it, or provide a default template instead.
 
-  ```app/templates/components/person-profile.hbs
-  <h1>
-    {{#if (has-block "title")}}
-      {{yield @person.name to="title"}}
+  ```app/components/person-profile.gjs
+  <template>
+    <h1>
+      {{#if (has-block "title")}}
+        {{yield @person.name to="title"}}
+      {{else}}
+        {{@person.name}}
+      {{/if}}
+    </h1>
+  
+    {{#if (has-block)}}
+      {{yield @person.signature}}
     {{else}}
-      {{@person.name}}
+      {{@person.signature}}
     {{/if}}
-  </h1>
-
-  {{#if (has-block)}}
-    {{yield @person.signature}}
-  {{else}}
-    {{@person.signature}}
-  {{/if}}
+  </template>
   ```
 
   With this template, we can then optionally pass in one block, both blocks, or
   none at all:
 
-  ```handlebars
-  {{! passing both blocks }}
-  <PersonProfile @person={{this.currentUser}}>
-    <:title as |name|>{{name}}</:title>
-    <:default as |signature|>{{signature}}</:default>
-  </PersonProfile>
+  ```gjs
+  import PersonProfile from '../components/person-profile';
 
-  {{! passing just the title block }}
-  <PersonProfile @person={{this.currentUser}}>
-    <:title as |name|>{{name}}</:title>
-  </PersonProfile>
-
-  {{! passing just the default block }}
-  <PersonProfile @person={{this.currentUser}} as |signature|>
-    {{signature}}
-  </PersonProfile>
-
-  {{! not passing any blocks }}
-  <PersonProfile @person={{this.currentUser}}/>
+  <template>
+    {{! passing both blocks }}
+    <PersonProfile @person={{@model.currentUser}}>
+      <:title as |name|>{{name}}</:title>
+      <:default as |signature|>{{signature}}</:default>
+    </PersonProfile>
+  
+    {{! passing just the title block }}
+    <PersonProfile @person={{@model.currentUser}}>
+      <:title as |name|>{{name}}</:title>
+    </PersonProfile>
+  
+    {{! passing just the default block }}
+    <PersonProfile @person={{@model.currentUser}} as |signature|>
+      {{signature}}
+    </PersonProfile>
+  
+    {{! not passing any blocks }}
+    <PersonProfile @person={{@model.currentUser}}/>
+  </template>
   ```
 
   ### Checking to see if a block has parameters
@@ -232,27 +258,26 @@ import { setOwner, type default as Owner } from '@ember/owner';
   We can also check if a block receives parameters using the `(has-block-params)`
   keyword, and conditionally yield different values if so.
 
-  ```app/templates/components/person-profile.hbs
-  {{#if (has-block-params)}}
-    {{yield @person.signature}}
-  {{else}}
-    {{yield}}
-  {{/if}}
+  ```app/components/person-profile.gjs
+  <template>
+    {{#if (has-block-params)}}
+      {{yield @person.signature}}
+    {{else}}
+      {{yield}}
+    {{/if}}
+  </template>
   ```
 
   ## Customizing Components With JavaScript
 
-  To add JavaScript to a component, create a JavaScript file in the same
-  location as the template file, with the same name, and export a subclass
-  of `Component` as the default value. For example, to add Javascript to the
-  `PersonProfile` component which we defined above, we would create
-  `app/components/person-profile.js` and export our class as the default, like
-  so:
+  To add JavaScript to a component, add a class extending from `@glimmer/component` to the `gjs` 
+  file, wrapping your `<template>` tag.
+  For example, to add JavaScript to the `PersonProfile` component which we defined above:
 
-  ```app/components/person-profile.js
+  ```app/components/person-profile.gjs
   import Component from '@glimmer/component';
 
-  export default class PersonProfileComponent extends Component {
+  export default class PersonProfile extends Component {
     get displayName() {
       let { title, firstName, lastName } = this.args.person;
 
@@ -262,19 +287,19 @@ import { setOwner, type default as Owner } from '@ember/owner';
         return `${firstName} ${lastName}`;
       }
     })
+    
+    <template>
+      <h1>{{this.displayName}}</h1>
+      {{yield}}
+    </template>
   }
   ```
 
   You can add your own properties, methods, and lifecycle hooks to this
   subclass to customize its behavior, and you can reference the instance of the
-  class in your template using `{{this}}`. For instance, we could access the
+  class in your template using `{{this}}`. In the example above, we access the
   `displayName` property of our `PersonProfile` component instance in the
-  template like this:
-
-  ```app/templates/components/person-profile.hbs
-  <h1>{{this.displayName}}</h1>
-  {{yield}}
-  ```
+  template.
 
   ## `constructor`
 
@@ -284,7 +309,7 @@ import { setOwner, type default as Owner } from '@ember/owner';
   constructor is run whenever a new instance of the component is created, and
   can be used to setup the initial state of the component.
 
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
 
   export default class SomeComponent extends Component {
@@ -300,7 +325,7 @@ import { setOwner, type default as Owner } from '@ember/owner';
 
   Service injections and arguments are available in the constructor.
 
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { service } from '@ember/service';
 
@@ -322,8 +347,11 @@ import { setOwner, type default as Owner } from '@ember/owner';
   `willDestroy` is called after the component has been removed from the DOM, but
   before the component is fully destroyed. This lifecycle hook can be used to
   cleanup the component and any related state.
+    
+  You may prefer the [@ember/destroyable](/ember/release/modules//@ember%2Fdestroyable) APIs for
+  this purpose.
 
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { service } from '@ember/service';
 
@@ -344,8 +372,10 @@ import { setOwner, type default as Owner } from '@ember/owner';
   _arguments_ that are passed to the component. For instance, the
   following component usage:
 
-  ```handlebars
-  <SomeComponent @fadeIn={{true}} />
+  ```gjs
+  <template>
+    <SomeComponent @fadeIn={{true}} />
+  </template>
   ```
 
   Would result in the following `args` object to be passed to the component:
@@ -356,26 +386,22 @@ import { setOwner, type default as Owner } from '@ember/owner';
 
   `args` can be accessed at any point in the component lifecycle, including
   `constructor` and `willDestroy`. They are also automatically marked as tracked
-  properties, and they can be depended on as computed property dependencies:
+  properties, and they can be depended on to update as any other tracked property:
 
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { computed } from '@ember/object';
 
   export default class SomeComponent extends Component {
-
-    @computed('args.someValue')
-    get computedGetter() {
-      // updates whenever args.someValue updates
-      return this.args.someValue;
-    }
-
     get standardGetter() {
-      // updates whenever args.anotherValue updates (Ember 3.13+)
+      // updates whenever args.anotherValue updates
       return this.args.anotherValue;
     }
   }
   ```
+    
+  A components arguments are accessible in the template using the `@` prefix - for example, 
+  `this.args.fadeIn` from the example above can be accessed in the template as `@fadeIn`.
 
   ## `isDestroying`
 

--- a/packages/@glimmer/runtime/lib/helpers/array.ts
+++ b/packages/@glimmer/runtime/lib/helpers/array.ts
@@ -18,7 +18,7 @@ import { internalHelper } from './internal-helper';
    ```
     or
    ```handlebars
-   {{my-component people=(array
+   {{yield people=(array
      'Tom Dale'
      'Yehuda Katz'
      this.myOtherPerson)

--- a/packages/@glimmer/runtime/lib/helpers/concat.ts
+++ b/packages/@glimmer/runtime/lib/helpers/concat.ts
@@ -20,10 +20,15 @@ const normalizeTextValue = (value: unknown): string => {
 
   Example:
 
-  ```handlebars
-  {{some-component name=(concat firstName " " lastName)}}
 
-  {{! would pass name="<first name value> <last name value>" to the component}}
+  ```gjs
+  import { concat } from '@ember/helper';
+
+  <template>
+  {{yield (concat firstName " " lastName)}}
+
+  {{! would yield name="<first name value> <last name value>" to the component}}
+  </template>
   ```
 
   or for angle bracket invocation, you actually don't need concat at all.

--- a/packages/@glimmer/runtime/lib/helpers/fn.ts
+++ b/packages/@glimmer/runtime/lib/helpers/fn.ts
@@ -80,6 +80,8 @@ const context = buildUntouchableThis('`fn` helper');
 
   See also [partial application](https://en.wikipedia.org/wiki/Partial_application).
 
+  `fn` is built-in and does not require any additional imports.
+ 
   @method fn
   @public
 */

--- a/packages/@glimmer/runtime/lib/helpers/fn.ts
+++ b/packages/@glimmer/runtime/lib/helpers/fn.ts
@@ -25,13 +25,17 @@ const context = buildUntouchableThis('`fn` helper');
   to a component invoked within the loop. Here's how you could use the `fn`
   helper to pass both the function and its arguments together:
 
-    ```app/templates/components/items-listing.hbs
-  {{#each @items as |item|}}
-    <DisplayItem @item=item @select={{fn this.handleSelected item}} />
-  {{/each}}
+  ```app/components/items-listing.gjs
+  import DisplayItem from './display-item';
+    
+  <template>
+    {{#each @items as |item|}}
+      <DisplayItem @item=item @select={{fn this.handleSelected item}} />
+    {{/each}}
+  </template>
   ```
 
-  ```app/components/items-list.js
+  ```app/components/items-list.gjs
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
@@ -42,7 +46,7 @@ const context = buildUntouchableThis('`fn` helper');
   }
   ```
 
-  In this case the `display-item` component will receive a normal function
+  In this case the `DisplayItem` component will receive a normal function
   that it can invoke. When it invokes the function, the `handleSelected`
   function will receive the `item` and any arguments passed, thanks to the
   `fn` helper.
@@ -59,7 +63,7 @@ const context = buildUntouchableThis('`fn` helper');
   `handleSelected` is properly bound to the `items-list`, but let's explore what
   happens if we left out the arrow function:
 
-  ```app/components/items-list.js
+  ```app/components/items-list.gjs
   import Component from '@glimmer/component';
 
   export default class ItemsList extends Component {

--- a/packages/@glimmer/runtime/lib/helpers/get.ts
+++ b/packages/@glimmer/runtime/lib/helpers/get.ts
@@ -15,28 +15,31 @@ import { internalHelper } from './internal-helper';
 
   For example, these two usages are equivalent:
 
-  ```app/components/developer-detail.js
+  ```app/components/developer-detail.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
+  import { get } from '@ember/object';
 
   export default class extends Component {
     @tracked developer = {
       name: "Sandi Metz",
       language: "Ruby"
     }
+    
+    <template>
+      {{this.developer.name}}
+      {{get this.developer "name"}}
+    </template>
   }
-  ```
-
-  ```handlebars
-  {{this.developer.name}}
-  {{get this.developer "name"}}
   ```
 
   If there were several facts about a person, the `{{get}}` helper can dynamically
   pick one:
 
-  ```app/templates/application.hbs
-  <DeveloperDetail @factName="language" />
+  ```app/templates/application.gjs
+  <template>
+    <DeveloperDetail @factName="language" />
+  </template>
   ```
 
   ```handlebars
@@ -46,10 +49,11 @@ import { internalHelper } from './internal-helper';
   For a more complex example, this template would allow the user to switch
   between showing the user's height and weight with a click:
 
-  ```app/components/developer-detail.js
+  ```app/components/developer-detail.gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
-
+  import { get } from '@ember/object';
+    
   export default class extends Component {
     @tracked developer = {
       name: "Sandi Metz",
@@ -61,27 +65,15 @@ import { internalHelper } from './internal-helper';
     showFact = (fact) => {
       this.currentFact = fact;
     }
+    
+    <template>
+      {{get this.developer this.currentFact}}
+
+      <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
+      <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
+    </template>
   }
   ```
-
-  ```app/components/developer-detail.js
-  {{get this.developer this.currentFact}}
-
-  <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
-  <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
-  ```
-
-  The `{{get}}` helper can also respect mutable values itself. For example:
-
-  ```app/components/developer-detail.js
-  <Input @value={{mut (get this.person this.currentFact)}} />
-
-  <button {{on 'click' (fn this.showFact "name")}}>Show name</button>
-  <button {{on 'click' (fn this.showFact "language")}}>Show language</button>
-  ```
-
-  Would allow the user to swap what fact is being displayed, and also edit
-  that fact via a two-way mutable binding.
 
   @public
   @method get

--- a/packages/@glimmer/runtime/lib/helpers/hash.ts
+++ b/packages/@glimmer/runtime/lib/helpers/hash.ts
@@ -7,7 +7,7 @@ import { internalHelper } from './internal-helper';
 
 /**
    Use the `{{hash}}` helper to create a hash to pass as an option to your
-   components. This is specially useful for contextual components where you can
+   components. This is especially useful for contextual components where you can
    just yield a hash:
 
    ```handlebars

--- a/packages/@glimmer/runtime/lib/modifiers/on.ts
+++ b/packages/@glimmer/runtime/lib/modifiers/on.ts
@@ -254,11 +254,7 @@ function addEventListener(
   For example, if you'd like to run a function on your component when a `<button>`
   in the components template is clicked you might do something like:
 
-  ```app/components/like-post.hbs
-  <button {{on 'click' this.saveLike}}>Like this post!</button>
-  ```
-
-  ```app/components/like-post.js
+  ```app/components/like-post.gjs
   import Component from '@glimmer/component';
   import { action } from '@ember/object';
 
@@ -267,6 +263,10 @@ function addEventListener(
       // someone likes your post!
       // better send a request off to your server...
     }
+    
+    <template>
+      <button {{on 'click' this.saveLike}}>Like this post!</button>
+    </template>
   }
   ```
 
@@ -314,7 +314,7 @@ function addEventListener(
   properly bound to the `items-list`, but let's explore what happens if we
   left out the arrow function:
 
-  ```app/components/like-post.js
+  ```app/components/like-post.gjs
   import Component from '@glimmer/component';
 
   export default class LikePostComponent extends Component {

--- a/packages/@glimmer/syntax/lib/get-template-locals.ts
+++ b/packages/@glimmer/syntax/lib/get-template-locals.ts
@@ -82,7 +82,7 @@ function addTokens(
 }
 
 /**
- * Parses and traverses a given handlebars html template to extract all template locals
+ * Parses and traverses a given template to extract all template locals
  * referenced that could possible come from the parent scope. Can exclude known keywords
  * optionally.
  */

--- a/packages/@glimmer/tracking/index.ts
+++ b/packages/@glimmer/tracking/index.ts
@@ -21,17 +21,7 @@ export { cached } from '@ember/-internals/metal/lib/cached';
   property changes, any templates that used that property, directly or
   indirectly, will rerender. For instance, consider this component:
 
-  ```handlebars
-  <div>Count: {{this.count}}</div>
-  <div>Times Ten: {{this.timesTen}}</div>
-  <div>
-    <button {{on "click" this.plusOne}}>
-      Plus One
-    </button>
-  </div>
-  ```
-
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
   import { action } from '@ember/object';
@@ -47,6 +37,16 @@ export { cached } from '@ember/-internals/metal/lib/cached';
     plusOne() {
       this.count += 1;
     }
+    
+    <template>
+      <div>Count: {{this.count}}</div>
+      <div>Times Ten: {{this.timesTen}}</div>
+      <div>
+        <button {{on "click" this.plusOne}}>
+          Plus One
+        </button>
+      </div>
+    </template>
   }
   ```
 
@@ -56,7 +56,7 @@ export { cached } from '@ember/-internals/metal/lib/cached';
   will cause a rerender when updated - this includes through method calls and
   other means:
 
-  ```javascript
+  ```gjs
   import Component from '@glimmer/component';
   import { tracked } from '@glimmer/tracking';
 


### PR DESCRIPTION
Using ```handlebars is still appropriate for snippets of template. 

Rewrote the `mut` docs because they were wrong? They are probably less wrong now. 

Also added some notes about built-ins. 

fixes #21455 

## TODO

- [x] Check if full URLs work https://github.com/emberjs/ember.js/pull/21468/files#diff-04b88f0bc62813f021c712d7b84fcb3bb79e17e3d3949049ca1404008152aa9aR237 and if so, fix others too