### PR TITLE
cleanup COMPUTE_SYMBOL is never read

### DIFF
--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -43,7 +43,6 @@ const CONSTANT_TAG_ID: ICONSTANT_TAG_ID = 3;
 //////////
 
 export const COMPUTE: TagComputeSymbol = Symbol('TAG_COMPUTE') as TagComputeSymbol;
-Reflect.set(globalThis, 'COMPUTE_SYMBOL', COMPUTE);
 
 //////////
 


### PR DESCRIPTION
small, but Reflect.set is a side-effect, and since it's meaningless, let's just delete it