### PR TITLE
[FEATURE] Add `renderToString` for server-side rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
     "@octokit/rest": "^22.0.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@simple-dom/document": "^1.4.0",
+    "@simple-dom/serializer": "^1.4.0",
+    "@simple-dom/void-map": "^1.4.0",
     "@swc-node/register": "^1.6.8",
     "@swc/core": "^1.3.100",
     "@tsconfig/ember": "3.0.8",

--- a/packages/@ember/-internals/glimmer/index.ts
+++ b/packages/@ember/-internals/glimmer/index.ts
@@ -516,6 +516,7 @@ export {
   _resetRenderers,
   renderSettled,
   renderComponent,
+  renderToString,
   type View,
 } from './lib/renderer';
 export {

--- a/packages/@ember/-internals/glimmer/lib/base-renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/base-renderer.ts
@@ -23,9 +23,18 @@ import type {
 import { artifacts } from '@glimmer/program/lib/helpers';
 import { RuntimeOpImpl } from '@glimmer/program/lib/opcode';
 import { clientBuilder } from '@glimmer/runtime/lib/vm/element-builder';
+import { serializeBuilder } from '@glimmer/node/lib/serialize-builder';
+import NodeDOMTreeConstruction from '@glimmer/node/lib/node-dom-helper';
+import { DOMChangesImpl } from '@glimmer/runtime/lib/dom/helper';
 import { inTransaction, runtimeOptions } from '@glimmer/runtime/lib/environment';
-import { renderComponent as glimmerRenderComponent } from '@glimmer/runtime/lib/render';
+import {
+  renderComponent as glimmerRenderComponent,
+  renderSync as glimmerRenderSync,
+} from '@glimmer/runtime/lib/render';
 import { CURRENT_TAG, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
+import createHTMLDocument from '@simple-dom/document';
+import Serializer from '@simple-dom/serializer';
+import voidMap from '@simple-dom/void-map';
 import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import { hasDOM } from '../../browser-environment';
 import { EmberEnvironmentDelegate } from './environment';
@@ -579,6 +588,131 @@ export function renderComponent(
 
 const RENDER_CACHE = new WeakMap<IntoTarget, RenderCacheEntry>();
 const RENDERER_CACHE = new WeakMap<object, BaseRenderer>();
+
+/**
+ * Render a component to an HTML string, without needing a live DOM.
+ *
+ * This is the server-side-rendering (SSR) / `renderToString` counterpart to
+ * {@link renderComponent}. Instead of rendering into a DOM `Element`, it builds
+ * the component tree against an in-memory [SimpleDOM](https://github.com/ember-fastboot/simple-dom)
+ * document and serializes the result to a string. That makes it usable in
+ * Node.js (or any environment without a global `document`), which is exactly
+ * what a server needs in order to produce HTML for the initial page load.
+ *
+ * ```js
+ * import { renderToString } from '@ember/renderer';
+ *
+ * let html = renderToString(MyComponent, { args: { name: 'Zoey' } });
+ * // => "<h1>Hello, Zoey!</h1>"
+ * ```
+ *
+ * Because there is no live document to update, rendering is a synchronous,
+ * one-shot operation: there is no re-rendering and no reactivity. Rendering is
+ * non-interactive by default (modifiers do not run), matching the constraints
+ * of a server environment. Pass `env: { rehydratable: true }` to include
+ * Glimmer's rehydration markers in the output so a subsequent client render can
+ * re-use (rehydrate) the server-rendered markup rather than throwing it away.
+ *
+ * @method renderToString
+ * @static
+ * @for @ember/renderer
+ * @param {Object} component The component to render.
+ * @param {Object} [options]
+ * @param {Object} [options.owner] Optionally specify the owner to use. This will be used for injections, and overall cleanup.
+ * @param {Object} [options.args] Optionally pass args in to the component.
+ * @param {Object} [options.env] Optional renderer configuration. `isInteractive` (default `false`) controls whether modifiers run; `rehydratable` (default `false`) controls whether rehydration markers are emitted.
+ * @returns {String} the serialized HTML for the rendered component
+ * @public
+ */
+export function renderToString(
+  /**
+   * The component definition to render. Any component that has had its manager
+   * registered is valid, same as {@link renderComponent}.
+   */
+  component: object,
+  {
+    owner = {},
+    args,
+    env,
+  }: {
+    /**
+     * Optional owner. Defaults to `{}`, can be any object, but will need to
+     * implement the [Owner](https://api.emberjs.com/ember/release/classes/Owner)
+     * API for components within this render tree to access services.
+     */
+    owner?: object;
+    /**
+     * These args get passed to the rendered component.
+     */
+    args?: Record<string, unknown>;
+    /**
+     * Optionally configure the rendering environment.
+     */
+    env?: {
+      /**
+       * When true, modifiers will run. Defaults to `false`, since server
+       * rendering is typically non-interactive.
+       */
+      isInteractive?: boolean;
+      /**
+       * When true, the emitted HTML includes Glimmer's rehydration markers so
+       * the output can be re-used (rehydrated) by a subsequent client-side
+       * render. Defaults to `false`, which produces clean HTML with no
+       * framework-specific comments.
+       */
+      rehydratable?: boolean;
+      /**
+       * All other options are forwarded to the underlying renderer (private API).
+       */
+      [rendererOption: string]: unknown;
+    };
+  } = {}
+): string {
+  let document = createHTMLDocument();
+  // A throwaway wrapper we render into and then serialize the children of, so
+  // the returned string is just the component's markup with no wrapper element.
+  let element = document.createElement('div');
+
+  let isInteractive = env?.isInteractive ?? false;
+  let rehydratable = Boolean(env?.rehydratable);
+
+  // SSR has no live document to mutate, so we build against a fresh SimpleDOM
+  // document. `NodeDOMTreeConstruction` knows how to append raw HTML (e.g.
+  // `{{{html}}}`) into a SimpleDOM tree, and `DOMChangesImpl` satisfies the
+  // tree builder's requirement for update operations, even though we never
+  // re-render.
+  let appendOperations = new NodeDOMTreeConstruction(document);
+  let updateOperations = new DOMChangesImpl(document);
+
+  let sharedArtifacts = artifacts();
+  let delegate = new EmberEnvironmentDelegate(owner as InternalOwner, isInteractive);
+  let options = runtimeOptions(
+    { appendOperations, updateOperations },
+    delegate,
+    sharedArtifacts,
+    new ResolverImpl()
+  );
+  let context = new EvaluationContextImpl(
+    sharedArtifacts,
+    (heap) => new RuntimeOpImpl(heap),
+    options
+  );
+
+  // `serializeBuilder` emits rehydration markers; `clientBuilder` emits clean
+  // markup.
+  let builder = rehydratable ? serializeBuilder : clientBuilder;
+  let tree = builder(context.env, { element, nextSibling: null });
+
+  let iterator = glimmerRenderComponent(context, tree, owner, component, args ?? {});
+  let result = glimmerRenderSync(context.env, iterator);
+
+  let html = new Serializer(voidMap).serializeChildren(element);
+
+  // One-shot render: tear down synchronously so any component destructors run.
+  _backburner.run(() => destroy(result));
+
+  return html;
+}
 
 export class BaseRenderer {
   static strict(

--- a/packages/@ember/-internals/glimmer/lib/renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/renderer.ts
@@ -53,6 +53,7 @@ export {
   ComponentRootState,
   errorLoopTransaction,
   renderComponent,
+  renderToString,
   renderSettled,
   _resetRenderers,
 } from './base-renderer';

--- a/packages/@ember/-internals/glimmer/tests/integration/components/render-to-string-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/render-to-string-test.ts
@@ -1,0 +1,105 @@
+import { AbstractTestCase, buildOwner, moduleFor, runDestroy } from 'internal-test-helpers';
+
+import { template } from '@ember/template-compiler';
+import { precompileTemplate } from '@ember/template-compilation';
+import { setComponentTemplate } from '@glimmer/manager';
+import templateOnly from '@ember/component/template-only';
+import { on } from '@glimmer/runtime';
+import GlimmerishComponent from '../../utils/glimmerish-component';
+import { renderToString } from '../../../lib/renderer';
+import type Owner from '@ember/owner';
+
+class RenderToStringTestCase extends AbstractTestCase {
+  owner: Owner;
+
+  constructor(assert: QUnit['assert']) {
+    super(assert);
+    this.owner = buildOwner({});
+  }
+
+  teardown() {
+    runDestroy(this.owner);
+  }
+}
+
+moduleFor(
+  'Server-side rendering - renderToString',
+  class extends RenderToStringTestCase {
+    ['@test it renders a template-only component to a string']() {
+      let Hello = template('<h1>Hello, world!</h1>');
+
+      this.assert.strictEqual(
+        renderToString(Hello, { owner: this.owner }),
+        '<h1>Hello, world!</h1>'
+      );
+    }
+
+    ['@test it renders args into the string']() {
+      let Greeting = template('<p>Hello, {{@name}}!</p>');
+
+      this.assert.strictEqual(
+        renderToString(Greeting, { owner: this.owner, args: { name: 'Zoey' } }),
+        '<p>Hello, Zoey!</p>'
+      );
+    }
+
+    ['@test it renders `{{{tripleStache}}}` raw HTML without a live DOM']() {
+      let Component = template('<div>{{{@html}}}</div>');
+
+      this.assert.strictEqual(
+        renderToString(Component, { owner: this.owner, args: { html: '<b>bold</b>' } }),
+        '<div><b>bold</b></div>'
+      );
+    }
+
+    ['@test it renders a glimmer component with state']() {
+      class State extends GlimmerishComponent {
+        get shout() {
+          return String((this.args as { message: unknown }).message).toUpperCase();
+        }
+      }
+      let Component = setComponentTemplate(
+        precompileTemplate('<span>{{this.shout}}</span>'),
+        State
+      );
+
+      this.assert.strictEqual(
+        renderToString(Component, { owner: this.owner, args: { message: 'hi' } }),
+        '<span>HI</span>'
+      );
+    }
+
+    ['@test by default it is non-interactive, so modifiers do not run']() {
+      let ran = false;
+      let noop = () => (ran = true);
+      let Component = template('<button {{on "click" noop}}>ok</button>', {
+        scope: () => ({ on, noop }),
+      });
+
+      let html = renderToString(Component, { owner: this.owner });
+
+      this.assert.strictEqual(html, '<button>ok</button>');
+      this.assert.false(ran, 'the modifier did not install during non-interactive SSR');
+    }
+
+    ['@test it can emit rehydration markers']() {
+      let Hello = template('<h1>Hello!</h1>');
+
+      let html = renderToString(Hello, { owner: this.owner, env: { rehydratable: true } });
+
+      this.assert.ok(
+        html.includes('<!--%+b:0%-->'),
+        `rehydratable output contains open-block markers: ${html}`
+      );
+      this.assert.ok(html.includes('<h1>Hello!</h1>'), 'the rendered content is still present');
+    }
+
+    ['@test it does not require a real DOM element to render into']() {
+      // `renderToString` builds its own in-memory document, so it works even
+      // when nothing is passed for `into` (unlike `renderComponent`).
+      let Component = setComponentTemplate(precompileTemplate('<em>ok</em>'), templateOnly());
+
+      this.assert.strictEqual(renderToString(Component, { owner: this.owner }), '<em>ok</em>');
+    }
+  }
+);

--- a/packages/@ember/renderer/index.ts
+++ b/packages/@ember/renderer/index.ts
@@ -80,3 +80,38 @@ export { renderSettled } from '@ember/-internals/glimmer/lib/base-renderer';
  * @public
  */
 export { renderComponent } from '@ember/-internals/glimmer/lib/base-renderer';
+
+/**
+ * Render a component to an HTML string, without needing a live DOM.
+ *
+ * This is the server-side-rendering (SSR) / `renderToString` counterpart to
+ * `renderComponent`. Instead of rendering into a DOM `Element`, it builds the
+ * component tree against an in-memory
+ * [SimpleDOM](https://github.com/ember-fastboot/simple-dom) document and
+ * serializes the result to a string, so it works in Node.js (or any
+ * environment without a global `document`).
+ *
+ * ```js
+ * import { renderToString } from '@ember/renderer';
+ *
+ * let html = renderToString(MyComponent, { args: { name: 'Zoey' } });
+ * // => "<h1>Hello, Zoey!</h1>"
+ * ```
+ *
+ * Rendering is a synchronous, one-shot operation with no reactivity, and is
+ * non-interactive by default (modifiers do not run). Pass
+ * `env: { rehydratable: true }` to include Glimmer's rehydration markers in the
+ * output so a subsequent client render can rehydrate the markup.
+ *
+ * @method renderToString
+ * @static
+ * @for @ember/renderer
+ * @param {Object} component The component to render.
+ * @param {Object} [options]
+ * @param {Object} [options.owner] Optionally specify the owner to use. This will be used for injections, and overall cleanup.
+ * @param {Object} [options.args] Optionally pass args in to the component.
+ * @param {Object} [options.env] Optional renderer configuration (`isInteractive`, `rehydratable`).
+ * @returns {String} the serialized HTML for the rendered component
+ * @public
+ */
+export { renderToString } from '@ember/-internals/glimmer/lib/base-renderer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,12 @@ importers:
       '@simple-dom/document':
         specifier: ^1.4.0
         version: 1.4.0
+      '@simple-dom/serializer':
+        specifier: ^1.4.0
+        version: 1.4.0
+      '@simple-dom/void-map':
+        specifier: ^1.4.0
+        version: 1.4.0
       '@swc-node/register':
         specifier: ^1.6.8
         version: 1.11.1(@swc/core@1.15.40)(@swc/types@0.1.26)(typescript@5.9.3)

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,14 +15,7 @@ const packageCache = PackageCache.shared('ember-source', projectRoot);
 const buildDebugMacroPlugin = require('./broccoli/build-debug-macro-plugin.cjs');
 const canaryFeatures = require('./broccoli/canary-features.cjs');
 
-const testDependencies = [
-  'qunit',
-  'vite',
-  'js-reporters',
-  '@simple-dom/serializer',
-  '@simple-dom/void-map',
-  'expect-type',
-];
+const testDependencies = ['qunit', 'vite', 'js-reporters', 'expect-type'];
 
 let configs = [
   esmConfig(),
@@ -299,7 +292,10 @@ export function hiddenDependencies() {
     ).path,
     rsvp: resolve(findFromProject('rsvp').root, 'dist/es6/rsvp.es.js'),
     '@handlebars/parser': resolve(packageCache.appRoot, 'packages/@handlebars/parser/lib/index.js'),
-    ...walkGlimmerDeps(['@glimmer/compiler']),
+    // `@simple-dom/serializer` (and its void-map) power `renderToString` from
+    // `@ember/renderer`, which serializes a server-rendered SimpleDOM tree to a
+    // string. They are inlined rather than exposed to consumers.
+    ...walkGlimmerDeps(['@glimmer/compiler', '@simple-dom/serializer', '@simple-dom/void-map']),
     'decorator-transforms/runtime': resolve(
       findFromProject('decorator-transforms').root,
       'dist/runtime.js'

--- a/tests/docs/expected.cjs
+++ b/tests/docs/expected.cjs
@@ -414,6 +414,7 @@ module.exports = {
     'removeObserver',
     'renderComponent',
     'renderSettled',
+    'renderToString',
     'reopen',
     'reopenClass',
     'replace',


### PR DESCRIPTION
## What / Why

An experiment to give `@ember/renderer` a server-side-rendering (SSR) story: a `renderToString` companion to [`renderComponent`](https://github.com/emberjs/rfcs/blob/main/text/1099-renderComponent.md).

`renderComponent` requires a live DOM `Element` to render into. `renderToString` instead builds the component tree against an in-memory [SimpleDOM](https://github.com/ember-fastboot/simple-dom) document and serializes the result to an HTML string, so it works in Node.js — or anywhere there is no global `document` — which is exactly what a server needs to produce HTML for the initial page load.

This directly follows the `SAFETY` note left in `base-renderer.ts`:

> we should figure out what we need out of a `document` and narrow the API. this exercise should also end up beginning to define what we need for CLI rendering (or to other outputs)

## Usage

```js
import { renderToString } from '@ember/renderer';

let html = renderToString(MyComponent, { args: { name: 'Zoey' } });
// => "<h1>Hello, Zoey!</h1>"
```

Options mirror `renderComponent` (`owner`, `args`, `env`), minus `into` (there is no element to render into):

- Rendering is a **synchronous, one-shot** operation — no reactivity, no re-render, nothing registered on the run loop.
- **Non-interactive by default** (`env.isInteractive` defaults to `false`), so modifiers do not run — matching a server environment.
- `env: { rehydratable: true }` emits Glimmer's rehydration markers so a subsequent client render can **rehydrate** the server markup instead of throwing it away. The default produces clean HTML with no framework comments.

## How it works

- Renders via the low-level glimmer `renderComponent` + `renderSync` against a fresh SimpleDOM document, so it never touches (or needs) a real DOM and does not register a reactive renderer.
- Uses `NodeDOMTreeConstruction` so `{{{tripleStache}}}` raw HTML works without a live DOM, and `DOMChangesImpl` to satisfy the tree builder (which requires update operations even though we never re-render).
- `@simple-dom/serializer` + `@simple-dom/void-map` (previously test-only deps) are inlined into the build to serialize the SimpleDOM tree to a string.

## Open questions

- Is bundling `@simple-dom/serializer` into the published build acceptable, or should the string-serialization live behind a separate entrypoint / be provided by the caller?
- Should `renderToString` be `async` to leave room for future streaming / `renderToStream`?
- Naming: `renderToString` vs. something that signals "SSR".

## Tests

Added `render-to-string-test.ts` covering template-only + glimmer components, args, `{{{tripleStache}}}` raw HTML, non-interactive modifier behavior, and rehydration markers. Verified end-to-end in Node (no DOM globals): both clean and rehydratable output render correctly.

---

Marking as **draft** to start the conversation. cc @NullVoxPopuli for review.