### PR TITLE
block prototype pollution via final set-path segment

### DIFF
--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -145,7 +145,7 @@ export function _getPath(obj: unknown, path: string | string[], forSet?: boolean
       return undefined;
     }
 
-    if (forSet && (part === '__proto__' || part === 'constructor')) {
+    if (forSet && (part === '__proto__' || part === 'constructor' || part === 'prototype')) {
       return;
     }
 

--- a/packages/@ember/-internals/metal/lib/property_set.ts
+++ b/packages/@ember/-internals/metal/lib/property_set.ts
@@ -114,6 +114,15 @@ function _setPath(root: object, path: string, value: any, tolerant?: boolean): a
   let newRoot = getPath(root, parts, true);
 
   if (newRoot !== null && newRoot !== undefined) {
+    if (keyName === '__proto__' || keyName === 'constructor' || keyName === 'prototype') {
+      // `getPath` screens these keys while walking the intermediate segments, but
+      // the final segment is popped off before that walk, so guard it here too.
+      // Otherwise `set(obj, 'a.__proto__', ...)` reassigns `obj.a`'s prototype.
+      if (tolerant) {
+        return;
+      }
+      throw new Error(`Property set failed: '${keyName}' is a prohibited path segment.`);
+    }
     return set(newRoot, keyName, value);
   } else if (!tolerant) {
     throw new Error(`Property set failed: object in path "${parts.join('.')}" could not be found.`);

--- a/packages/@ember/-internals/metal/tests/accessors/set_path_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/set_path_test.js
@@ -86,6 +86,39 @@ moduleFor(
       }, /Property set failed: object in path "inner.constructor" could not be found./);
       assert.equal(Inner.ohNo, undefined, 'check for prototype pollution');
     }
+
+    ['@test ignores a dangerous property as the final path segment'](assert) {
+      class Inner {}
+      class Example {
+        inner = new Inner();
+      }
+      let example = new Example();
+
+      assert.throws(() => {
+        set(example, 'inner.__proto__', { ohNo: 'polluted' });
+      }, /Property set failed: '__proto__' is a prohibited path segment./);
+      assert.equal(example.inner.ohNo, undefined, 'check for prototype pollution');
+      assert.equal(Inner.prototype.ohNo, undefined, 'check for prototype pollution');
+
+      assert.throws(() => {
+        set(example, 'inner.constructor', 'polluted');
+      }, /Property set failed: 'constructor' is a prohibited path segment./);
+    }
+
+    ['@test ignores attempts to traverse or set through prototype'](assert) {
+      class Klass {}
+      let holder = { klass: Klass };
+
+      assert.throws(() => {
+        set(holder, 'klass.prototype.ohNo', 'polluted');
+      }, /Property set failed: object in path "klass.prototype" could not be found./);
+      assert.equal(new Klass().ohNo, undefined, 'check for prototype pollution');
+
+      assert.throws(() => {
+        set(holder, 'klass.prototype', { ohNo: 'polluted' });
+      }, /Property set failed: 'prototype' is a prohibited path segment./);
+      assert.equal(new Klass().ohNo, undefined, 'check for prototype pollution');
+    }
   }
 );
 


### PR DESCRIPTION
The prototype-pollution guard added in #21178 only screens the intermediate segments of a set path, because `_setPath` pops the final key off before handing the rest to `_getPath`. So `set(obj, 'a.__proto__', value)` still reassigns `obj.a`'s prototype, and a `prototype` segment was never in the blocklist, letting `set(obj, 'fn.prototype.x', value)` pollute every instance of `fn`. This screens the popped key in `_setPath` and adds `prototype` alongside `__proto__`/`constructor` in the `_getPath` check, with the missing final-segment cases added to the existing set-path test.