### PR TITLE
[FEATURE] Debug render tree: helper nodes and reactivity introspection

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/internal-helper.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/internal-helper.ts
@@ -1,7 +1,10 @@
 import type { InternalOwner } from '@ember/-internals/owner';
 import type { Helper, HelperDefinitionState } from '@glimmer/interfaces';
-import { setInternalHelperManager } from '@glimmer/manager/lib/internal/api';
+import { internalHelper as glimmerInternalHelper } from '@glimmer/runtime/lib/helpers/internal-helper';
 
 export function internalHelper(helper: Helper<InternalOwner>): HelperDefinitionState {
-  return setInternalHelperManager(helper, {});
+  // Registering through the VM's own `internalHelper` marks the helper as an
+  // implementation detail, keeping it out of debug tooling like the debug
+  // render tree (the same treatment `fn`, `hash`, etc. get).
+  return glimmerInternalHelper(helper as Helper);
 }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -5,6 +5,7 @@ import { Component, setComponentManager } from '@ember/-internals/glimmer';
 import type { InternalOwner } from '@ember/-internals/owner';
 import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
+import { helper } from '@ember/component/helper';
 import { assert, captureRenderTree } from '@ember/debug';
 import Engine from '@ember/engine';
 import type { EngineInstanceOptions } from '@ember/engine/instance';
@@ -40,10 +41,64 @@ interface ExpectedRenderNode {
   children: Expected<CapturedRenderNode['children']> | ExpectedRenderNode[];
 }
 
+function collectByType(
+  nodes: CapturedRenderNode[],
+  type: CapturedRenderNode['type']
+): CapturedRenderNode[] {
+  let result: CapturedRenderNode[] = [];
+
+  for (let node of nodes) {
+    if (node.type === type) {
+      result.push(node);
+    }
+    result.push(...collectByType(node.children, type));
+  }
+
+  return result;
+}
+
 if (ENV._DEBUG_RENDER_TREE) {
   moduleFor(
     'Application test: debug render tree',
     class extends ApplicationTestCase {
+      async '@test helpers'() {
+        this.add(
+          'helper:up-case',
+          helper(([value]: [unknown]) => String(value).toUpperCase())
+        );
+        this.add(
+          'template:index',
+          precompileTemplate('{{up-case "hello"}} {{array "a" "b"}}', {
+            moduleName: 'my-app/templates/index.hbs',
+          })
+        );
+
+        await this.visit('/');
+
+        let helperNodes = collectByType(captureRenderTree(this.owner), 'helper');
+
+        this.assert.strictEqual(
+          helperNodes.length,
+          1,
+          'user helpers are captured; internal helpers ({{array}}, the outlet machinery) are not'
+        );
+
+        let [node] = helperNodes;
+        assert('expected node', node);
+
+        this.assert.strictEqual(node.bounds, null, 'helper nodes have no bounds');
+        this.assert.deepEqual(
+          node.args,
+          { positional: ['hello'], named: {} },
+          'helper args are captured'
+        );
+        this.assert.strictEqual(
+          node.reactivity.updateCount,
+          0,
+          'no re-renders after initial render'
+        );
+      }
+
       async '@test routes'() {
         this.add(
           'template:index',

--- a/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/debug-render-tree-test.ts
@@ -19,6 +19,7 @@ import {
   BaseEnv,
   createTemplate,
   defComponent,
+  defineSimpleHelper,
   defineSimpleModifier,
   GlimmerishComponent,
   JitRenderDelegate,
@@ -106,6 +107,83 @@ class DebugRenderTreeTest extends RenderTest {
         ],
       },
     ]);
+  }
+
+  @test({ skip: !DEBUG }) 'helpers are captured in the render tree'() {
+    const state = trackedObj({ value: 'first' });
+
+    const upcase = defineSimpleHelper((value: string) => value.toUpperCase());
+    const Root = defComponent(`<p>{{upcase state.value}}</p>`, {
+      scope: { upcase, state },
+    });
+
+    this.renderComponent(Root);
+
+    let rootChildren = this.delegate.getCapturedRenderTree()[0]?.children ?? [];
+    let helperNode = rootChildren.find((n: CapturedRenderNode) => n.type === 'helper');
+
+    this.assert.ok(helperNode, 'found a helper node');
+    this.assert.strictEqual(helperNode?.bounds, null, 'helper nodes have no bounds');
+    this.assert.strictEqual(helperNode?.instance, null, 'helper nodes have no instance');
+    this.assert.deepEqual(
+      helperNode?.args,
+      { positional: ['first'], named: {} },
+      'helper args are captured'
+    );
+    this.assert.strictEqual(
+      helperNode?.reactivity.updateCount,
+      0,
+      'no updates after the initial render'
+    );
+
+    state['value'] = 'second';
+    this.rerender();
+
+    rootChildren = this.delegate.getCapturedRenderTree()[0]?.children ?? [];
+    helperNode = rootChildren.find((n: CapturedRenderNode) => n.type === 'helper');
+
+    this.assert.deepEqual(
+      helperNode?.args,
+      { positional: ['second'], named: {} },
+      'helper args are captured after update'
+    );
+    this.assert.strictEqual(helperNode?.reactivity.updateCount, 1, 'one update');
+    this.assert.true(
+      helperNode?.reactivity.args.positional[0]?.changed,
+      'the changed argument is flagged as the cause of the update'
+    );
+  }
+
+  @test({ skip: !DEBUG }) 'reactivity introspection on component nodes'() {
+    const state = trackedObj({ value: 'first' });
+
+    const HelloWorld = defComponent('{{@arg}}');
+    const Root = defComponent(`<HelloWorld @arg={{state.value}}/>`, {
+      scope: { HelloWorld, state },
+    });
+
+    this.renderComponent(Root);
+
+    let child = this.delegate.getCapturedRenderTree()[0]?.children[0];
+
+    this.assert.strictEqual(child?.reactivity.updateCount, 0, 'no updates yet');
+    this.assert.strictEqual(child?.reactivity.previousRevision, null, 'no previous render yet');
+    this.assert.false(child?.reactivity.args.named['arg']?.changed, '@arg has not changed');
+
+    state['value'] = 'second';
+    this.rerender();
+
+    child = this.delegate.getCapturedRenderTree()[0]?.children[0];
+
+    this.assert.strictEqual(child?.reactivity.updateCount, 1, 'one update');
+    this.assert.true(
+      typeof child?.reactivity.previousRevision === 'number',
+      'previous render revision is recorded'
+    );
+    this.assert.true(
+      child?.reactivity.args.named['arg']?.changed,
+      '@arg is flagged as the cause of the update'
+    );
   }
 
   @test 'strict-mode components preserve names from scope'() {

--- a/packages/@glimmer/interfaces/lib/references.d.ts
+++ b/packages/@glimmer/interfaces/lib/references.d.ts
@@ -24,6 +24,11 @@ export type ReferenceSymbol = typeof REFERENCE;
 export interface Reference<T = unknown> {
   [REFERENCE]: ReferenceType;
   debugLabel?: string | false | undefined;
+  /**
+   * The untransformed name the reference was created with (e.g. the helper
+   * name for compute references). Debug builds only.
+   */
+  debugName?: string | undefined;
   compute: Nullable<() => T>;
   children: null | Map<string | Reference, Reference>;
 }

--- a/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/debug-render-tree.d.ts
@@ -1,6 +1,8 @@
 import type { SimpleElement, SimpleNode } from '@simple-dom/interface';
 
+import type { Nullable } from '../core.js';
 import type { Bounds } from '../dom/bounds.js';
+import type { Revision } from '../tags.js';
 import type { Arguments, CapturedArguments } from './arguments.js';
 
 export type RenderNodeType =
@@ -9,13 +11,44 @@ export type RenderNodeType =
   | 'route-template'
   | 'component'
   | 'modifier'
-  | 'keyword';
+  | 'keyword'
+  | 'helper';
 
 export interface RenderNode {
   type: RenderNodeType;
   name: string;
   args: CapturedArguments;
   instance: unknown;
+}
+
+/**
+ * Reactivity introspection for a single argument of a render node: the
+ * revision of its most recently computed value, and whether that value
+ * was invalidated since the node's previous render (i.e. whether this
+ * argument caused the node's most recent re-render).
+ */
+export interface CapturedRenderNodeArgReactivity {
+  debugLabel: string | undefined;
+  revision: Revision;
+  changed: boolean;
+}
+
+/**
+ * Reactivity introspection for a render node, so debug tooling (e.g. the
+ * Ember Inspector) can answer "how often did this re-render, and what
+ * caused the most recent re-render?" without patching the VM.
+ */
+export interface CapturedRenderNodeReactivity {
+  /** Number of times the node re-rendered after its initial render. */
+  updateCount: number;
+  /** The global revision when the node last (re-)rendered. */
+  revision: Revision;
+  /** The global revision of the render before that, if it re-rendered. */
+  previousRevision: Nullable<Revision>;
+  args: {
+    positional: CapturedRenderNodeArgReactivity[];
+    named: Record<string, CapturedRenderNodeArgReactivity>;
+  };
 }
 
 export interface CapturedRenderNode {
@@ -29,6 +62,7 @@ export interface CapturedRenderNode {
     firstNode: SimpleNode;
     lastNode: SimpleNode;
   };
+  reactivity: CapturedRenderNodeReactivity;
   children: CapturedRenderNode[];
 }
 
@@ -39,7 +73,7 @@ export interface DebugRenderTree<Bucket extends object = object> {
 
   update(state: Bucket): void;
 
-  didRender(state: Bucket, bounds: Bounds): void;
+  didRender(state: Bucket, bounds: Nullable<Bounds>): void;
 
   willDestroy(state: Bucket): void;
 

--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -46,10 +46,19 @@ class ReferenceImpl<T = unknown> implements Reference<T> {
   public update: Nullable<(val: T) => void> = null;
 
   public debugLabel?: string;
+  public debugName?: string;
 
   constructor(type: ReferenceType) {
     this[REFERENCE] = type;
   }
+}
+
+/**
+ * Debug-only introspection used by the debug render tree: the revision of
+ * the reference's most recently computed value.
+ */
+export function lastRevisionForRef(ref: Reference): Revision {
+  return (ref as ReferenceImpl).lastRevision;
 }
 
 export function createPrimitiveRef<T extends string | symbol | number | boolean | null | undefined>(
@@ -80,6 +89,9 @@ export function createConstRef<T>(value: T, debugLabel: false | string): Referen
 
   if (DEBUG) {
     ref.debugLabel = debugLabel as string;
+    if (debugLabel) {
+      ref.debugName = debugLabel;
+    }
   }
 
   return ref;
@@ -110,6 +122,9 @@ export function createComputeRef<T = unknown>(
 
   if (DEBUG) {
     ref.debugLabel = `(result of a \`${debugLabel}\` helper)`;
+    if (debugLabel) {
+      ref.debugName = debugLabel;
+    }
   }
 
   return ref;

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/component.ts
@@ -102,6 +102,7 @@ import {
   CheckInvocation,
   CheckReference,
 } from './-debug-strip';
+import { DebugRenderTreeDidRenderOpcode, DebugRenderTreeUpdateOpcode } from './debug-render-tree';
 import { UpdateDynamicAttributeOpcode } from './dom';
 
 /**
@@ -949,24 +950,5 @@ export class DidUpdateLayoutOpcode implements UpdatingOpcode {
     manager.didUpdateLayout(state, bounds);
 
     vm.env.didUpdate(component);
-  }
-}
-
-class DebugRenderTreeUpdateOpcode implements UpdatingOpcode {
-  constructor(private bucket: object) {}
-
-  evaluate(vm: UpdatingVM) {
-    vm.env.debugRenderTree?.update(this.bucket);
-  }
-}
-
-class DebugRenderTreeDidRenderOpcode implements UpdatingOpcode {
-  constructor(
-    private bucket: object,
-    private bounds: Bounds
-  ) {}
-
-  evaluate(vm: UpdatingVM) {
-    vm.env.debugRenderTree?.didRender(this.bucket, this.bounds);
   }
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/debug-render-tree.ts
@@ -1,0 +1,20 @@
+import type { Bounds, Nullable, UpdatingOpcode, UpdatingVM } from '@glimmer/interfaces';
+
+export class DebugRenderTreeUpdateOpcode implements UpdatingOpcode {
+  constructor(private bucket: object) {}
+
+  evaluate(vm: UpdatingVM) {
+    vm.env.debugRenderTree?.update(this.bucket);
+  }
+}
+
+export class DebugRenderTreeDidRenderOpcode implements UpdatingOpcode {
+  constructor(
+    private bucket: object,
+    private bounds: Nullable<Bounds>
+  ) {}
+
+  evaluate(vm: UpdatingVM) {
+    vm.env.debugRenderTree?.didRender(this.bucket, this.bounds);
+  }
+}

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/expressions.ts
@@ -39,13 +39,19 @@ import {
 } from '@glimmer/debug/lib/stack-check';
 import debugToString from '@glimmer/debug-util/lib/debug-to-string';
 import assert from '@glimmer/debug-util/lib/assert';
-import { _hasDestroyableChildren, associateDestroyableChild, destroy } from '@glimmer/destroyable';
+import {
+  _hasDestroyableChildren,
+  associateDestroyableChild,
+  destroy,
+  registerDestructor,
+} from '@glimmer/destroyable';
 import { debugAssert, toBool } from '@glimmer/global-context';
 import { getInternalHelperManager } from '@glimmer/manager/lib/internal/api';
 import {
   childRefFor,
   createComputeRef,
   FALSE_REFERENCE,
+  NULL_REFERENCE,
   TRUE_REFERENCE,
   UNDEFINED_REFERENCE,
   valueForRef,
@@ -55,6 +61,7 @@ import { isIndexable } from '@glimmer/util/lib/collections';
 import { $v0 } from '@glimmer/vm/lib/registers';
 
 import { isCurriedType, resolveCurriedValue } from '../../curried-value';
+import { isInternalHelper } from '../../helpers/internal-helper';
 import { APPEND_OPCODES } from '../../opcodes';
 import createCurryRef from '../../references/curry-value';
 import { reifyPositional } from '../../vm/arguments';
@@ -69,6 +76,7 @@ import {
   CheckScopeBlock,
   CheckUndefinedReference,
 } from './-debug-strip';
+import { DebugRenderTreeDidRenderOpcode, DebugRenderTreeUpdateOpcode } from './debug-render-tree';
 
 APPEND_OPCODES.add(VM_CURRY_OP, (vm, { op1: type, op2: _isStrict }) => {
   let stack = vm.stack;
@@ -143,6 +151,30 @@ APPEND_OPCODES.add(VM_DYNAMIC_HELPER_OP, (vm) => {
   });
 
   vm.associateDestroyable(helperInstanceRef);
+
+  let debugRenderTree = vm.env.debugRenderTree;
+
+  if (
+    DEBUG &&
+    debugRenderTree !== undefined &&
+    typeof ref.debugLabel === 'string' &&
+    ref.debugLabel &&
+    ref.debugLabel !== 'unknown'
+  ) {
+    debugRenderTree.create(helperInstanceRef, {
+      type: 'helper',
+      name: ref.debugLabel,
+      args,
+      instance: null,
+    });
+    debugRenderTree.didRender(helperInstanceRef, null);
+
+    registerDestructor(helperInstanceRef, () => debugRenderTree.willDestroy(helperInstanceRef));
+
+    vm.updateWith(new DebugRenderTreeUpdateOpcode(helperInstanceRef));
+    vm.updateWith(new DebugRenderTreeDidRenderOpcode(helperInstanceRef, null));
+  }
+
   vm.loadValue($v0, helperValueRef);
 });
 
@@ -176,14 +208,58 @@ APPEND_OPCODES.add(VM_HELPER_OP, (vm, { op1: handle }) => {
   let stack = vm.stack;
   let helper = check(vm.constants.getValue(handle), CheckHelper);
   let args = check(stack.pop(), CheckArguments);
-  let value = helper(args.capture(), vm.getOwner(), vm.dynamicScope());
+  let capturedArgs = args.capture();
+  let value = helper(capturedArgs, vm.getOwner(), vm.dynamicScope());
 
-  if (_hasDestroyableChildren(value)) {
+  let debugRenderTree = vm.env.debugRenderTree;
+
+  if (
+    DEBUG &&
+    debugRenderTree !== undefined &&
+    !isInternalHelper(helper) &&
+    isCapturableHelperRef(value)
+  ) {
+    debugRenderTree.create(value, {
+      type: 'helper',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked in isCapturableHelperRef
+      name: value.debugName!,
+      args: capturedArgs,
+      instance: null,
+    });
+    debugRenderTree.didRender(value, null);
+
+    vm.associateDestroyable(value);
+    registerDestructor(value, () => debugRenderTree.willDestroy(value));
+
+    vm.updateWith(new DebugRenderTreeUpdateOpcode(value));
+    vm.updateWith(new DebugRenderTreeDidRenderOpcode(value, null));
+  } else if (_hasDestroyableChildren(value)) {
     vm.associateDestroyable(value);
   }
 
   vm.loadValue($v0, value);
 });
+
+/**
+ * Helper invocations only show up in the debug render tree when we can
+ * present them meaningfully:
+ *
+ * - shared singleton references cannot serve as tree buckets, because the
+ *   tree keys nodes and destructors on the reference's identity, and
+ * - references without a real debug name are implementation-detail refs
+ *   (e.g. the internal helpers behind `{{outlet}}` and `{{mount}}`), not
+ *   user-observable helper invocations.
+ */
+function isCapturableHelperRef(ref: Reference): boolean {
+  return (
+    ref !== UNDEFINED_REFERENCE &&
+    ref !== NULL_REFERENCE &&
+    ref !== TRUE_REFERENCE &&
+    ref !== FALSE_REFERENCE &&
+    typeof ref.debugName === 'string' &&
+    ref.debugName !== 'unknown'
+  );
+}
 
 APPEND_OPCODES.add(VM_GET_VARIABLE_OP, (vm, { op1: symbol }) => {
   let expr = vm.referenceForSymbol(symbol);

--- a/packages/@glimmer/runtime/lib/debug-render-tree.ts
+++ b/packages/@glimmer/runtime/lib/debug-render-tree.ts
@@ -1,21 +1,35 @@
 import { DEBUG } from '@glimmer/env';
 import type {
   Bounds,
+  CapturedArguments,
   CapturedRenderNode,
+  CapturedRenderNodeArgReactivity,
+  CapturedRenderNodeReactivity,
   ComponentDefinition,
   DebugRenderTree,
   Nullable,
+  Reference,
   RenderNode,
+  Revision,
 } from '@glimmer/interfaces';
 import { expect } from '@glimmer/debug-util/lib/platform-utils';
+import { lastRevisionForRef } from '@glimmer/reference/lib/reference';
 import { assign } from '@glimmer/util/lib/object-utils';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
+import { CURRENT_TAG, valueForTag } from '@glimmer/validator/lib/validators';
 
 import { reifyArgsDebug } from './vm/arguments';
+
+interface RenderNodeUpdates {
+  count: number;
+  revision: Revision;
+  previousRevision: Nullable<Revision>;
+}
 
 interface InternalRenderNode<T extends object> extends RenderNode {
   bounds: Nullable<Bounds>;
   refs: Set<Ref<T>>;
+  updates: RenderNodeUpdates;
   parent?: InternalRenderNode<T>;
 }
 
@@ -74,6 +88,11 @@ export default class DebugRenderTreeImpl<
     let internalNode: InternalRenderNode<TBucket> = assign({}, node, {
       bounds: null,
       refs: new Set<Ref<TBucket>>(),
+      updates: {
+        count: 0,
+        revision: valueForTag(CURRENT_TAG),
+        previousRevision: null,
+      },
     });
     this.nodes.set(state, internalNode);
     this.appendChild(internalNode, state);
@@ -81,10 +100,15 @@ export default class DebugRenderTreeImpl<
   }
 
   update(state: TBucket): void {
+    let updates = this.nodeFor(state).updates;
+    updates.previousRevision = updates.revision;
+    updates.revision = valueForTag(CURRENT_TAG);
+    updates.count++;
+
     this.enter(state);
   }
 
-  didRender(state: TBucket, bounds: Bounds): void {
+  didRender(state: TBucket, bounds: Nullable<Bounds>): void {
     if (DEBUG && this.stack.current !== state) {
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       throw new Error(`BUG: expecting ${this.stack.current}, got ${state}`);
@@ -184,18 +208,64 @@ export default class DebugRenderTreeImpl<
   private captureNode(id: string, state: TBucket): CapturedRenderNode {
     let node = this.nodeFor(state);
     let { type, name, args, instance, refs } = node;
+    // Reify before capturing reactivity so the argument references carry
+    // their current revisions.
+    let reifiedArgs = reifyArgsDebug(args);
+    let reactivity = captureReactivity(node.updates, args);
     let bounds = this.captureBounds(node);
     let children = this.captureRefs(refs);
-    return { id, type, name, args: reifyArgsDebug(args), instance, bounds, children };
+    return { id, type, name, args: reifiedArgs, instance, bounds, reactivity, children };
   }
 
   private captureBounds(node: InternalRenderNode<TBucket>): CapturedRenderNode['bounds'] {
+    // Helper nodes are not rendered into the DOM and legitimately have no
+    // bounds; everything else must have rendered by capture time.
+    if (node.type === 'helper' && node.bounds === null) {
+      return null;
+    }
+
     let bounds = expect(node.bounds, 'BUG: missing bounds');
     let parentElement = bounds.parentElement();
     let firstNode = bounds.firstNode();
     let lastNode = bounds.lastNode();
     return { parentElement, firstNode, lastNode };
   }
+}
+
+function captureArgReactivity(
+  ref: Reference,
+  previousRevision: Nullable<Revision>
+): CapturedRenderNodeArgReactivity {
+  let revision = lastRevisionForRef(ref);
+
+  return {
+    debugLabel: typeof ref.debugLabel === 'string' ? ref.debugLabel : undefined,
+    revision,
+    // Arguments whose value was invalidated after the node's previous
+    // render are what caused its most recent re-render.
+    changed: previousRevision !== null && revision > previousRevision,
+  };
+}
+
+function captureReactivity(
+  updates: RenderNodeUpdates,
+  args: CapturedArguments
+): CapturedRenderNodeReactivity {
+  let { count, revision, previousRevision } = updates;
+
+  let positional = args.positional.map((ref) => captureArgReactivity(ref, previousRevision));
+
+  let named: Record<string, CapturedRenderNodeArgReactivity> = {};
+  for (let [key, ref] of Object.entries(args.named)) {
+    named[key] = captureArgReactivity(ref, previousRevision);
+  }
+
+  return {
+    updateCount: count,
+    revision,
+    previousRevision,
+    args: { positional, named },
+  };
 }
 
 export function getDebugName(

--- a/packages/@glimmer/runtime/lib/helpers/internal-helper.ts
+++ b/packages/@glimmer/runtime/lib/helpers/internal-helper.ts
@@ -1,6 +1,18 @@
 import type { Helper, HelperDefinitionState } from '@glimmer/interfaces';
 import { setInternalHelperManager } from '@glimmer/manager/lib/internal/api';
 
+const INTERNAL_HELPERS = new WeakSet<object>();
+
 export function internalHelper(helper: Helper): HelperDefinitionState {
+  INTERNAL_HELPERS.add(helper);
   return setInternalHelperManager(helper, {});
+}
+
+/**
+ * VM-internal helpers (`fn`, `hash`, `array`, …) are implementation details
+ * of the templating language rather than user-observable invocations, so
+ * debug tooling (e.g. the debug render tree) leaves them out.
+ */
+export function isInternalHelper(helper: object): boolean {
+  return INTERNAL_HELPERS.has(helper);
 }


### PR DESCRIPTION
## Motivation

Debug tooling — most concretely the Ember Inspector — currently has to answer two questions by monkeypatching VM internals from the outside, which is fragile and increasingly impossible (module namespaces are read-only in modern builds):

1. **What did this template invoke?** Helpers never appear in the debug render tree, so a derived value's producer is invisible; its reactive inputs can only be *attributed* to the enclosing component.
2. **Why did this re-render?** There is no first-class way to learn how often a render node re-rendered, or which of its arguments was invalidated since the previous render.

emberjs/ember-inspector#2776 ships "why did this render?" introspection built on instance-level patches of the debug render tree (`create`/`update`/`captureNode`). This PR moves those capabilities where they belong — into the VM — so the inspector (and any other tooling) can consume plain captured data instead of patching. It also closes the helper gap, which was impossible to patch in from the outside.

All new work is DEBUG-gated and only active when the debug render tree exists (`_DEBUG_RENDER_TREE`), same as the existing component/modifier bookkeeping.

## Helper nodes (`type: 'helper'`)

Template helper invocations now register debug render tree nodes, in both invocation paths:

- **Resolved helpers** (`VM_HELPER_OP`): the produced reference is the node bucket; nodes get `create`/`didRender` at append, `DebugRenderTreeUpdateOpcode`/`DidRenderOpcode` for re-renders, and a destructor tied to the surrounding block.
- **Dynamic/curried helpers** (`VM_DYNAMIC_HELPER_OP`): same lifecycle keyed on the helper instance reference, named from the callee reference's `debugLabel` (the lexical name in strict-mode templates).

Two deliberate exclusions keep the tree meaningful:

- **VM-internal helpers** (`fn`, `hash`, `array`, …) are excluded via a new `isInternalHelper` marker in `internalHelper`. Ember's own internal helpers (the machinery behind `{{outlet}}` etc.) now register through the same function, so they get the same treatment — they're implementation details, not user-observable invocations. (This is also load-bearing: capturing the anonymous outlet-machinery reference as a tree bucket breaks outlet rendering.)
- **Unnamed references**: a helper whose reference has no real debug name can't be presented meaningfully and is treated as an implementation detail. To support this, references now carry an untransformed `debugName` alongside the display-oriented `debugLabel` (`(result of a \`x\` helper)`).

Helper nodes have **no DOM bounds** — `didRender` and `captureBounds` accept `null` bounds for them; `CapturedRenderNode.bounds` was already nullable.

## Reactivity introspection (`CapturedRenderNode.reactivity`)

Every captured node now reports:

```ts
interface CapturedRenderNodeReactivity {
  updateCount: number;                 // re-renders after the initial render
  revision: Revision;                  // global revision at the last (re-)render
  previousRevision: Nullable<Revision>;
  args: {
    positional: CapturedRenderNodeArgReactivity[];
    named: Record<string, CapturedRenderNodeArgReactivity>;
  };
}

interface CapturedRenderNodeArgReactivity {
  debugLabel: string | undefined;      // e.g. "this.user.name" (debug builds)
  revision: Revision;                  // revision of the arg's last computed value
  changed: boolean;                    // invalidated since the node's previous render
}
```

- `create`/`update` record the revision bookkeeping (`valueForTag(CURRENT_TAG)` reads — no tag consumption).
- `captureNode` walks the node's argument references *after* the existing `reifyArgsDebug` pass, so revisions are current; `changed` is pure revision arithmetic: an argument caused the most recent re-render iff its revision is greater than the node's previous render revision.

This applies to components, modifiers, keywords, and the new helper nodes uniformly — e.g. a helper's captured node directly shows which of its inputs invalidated it.

## Implementation notes

- `DebugRenderTreeUpdateOpcode`/`DebugRenderTreeDidRenderOpcode` moved out of `component.ts` into `compiled/opcodes/debug-render-tree.ts` so the helper opcodes can share them (no behavior change).
- New reference helpers: `lastRevisionForRef(ref)` (revision accessor for the debug render tree) and the `debugName` field described above.
- Existing captured-node consumers are unaffected structurally: `reactivity` is a new field, and the existing per-field test matchers pass unchanged.

## Relationship to other work

- **#21483** (tree-shakeable debug render tree) is complementary: it changes *how the tree is instantiated/enabled*; this PR changes *what the tree records*. They touch different seams (`EnvironmentDelegate` vs. `DebugRenderTreeImpl` + opcodes) and should merge independently.
- **emberjs/ember-inspector#2776** is the intended consumer; with this PR it can drop its `create`/`update`/`captureNode` instance patches and read `reactivity` straight off captured nodes. Helper nodes additionally unlock helper-level display in the inspector, which is impossible today.

## Testing

- New tests in `@glimmer-workspace/integration-tests` (`debug render tree` suite): helper node capture (args, null bounds, update count, changed-argument flagging across a re-render) and reactivity introspection on component nodes.
- New tests in the Ember-side `Application test: debug render tree`: user helpers captured in loose-mode templates while `{{array}}` and the outlet machinery are not.
- Full suite: 9399 tests, 0 failures (`vite build` + `testem ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
