### PR TITLE
Remove ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "backburner.js": "^2.8.0",
     "broccoli-file-creator": "^2.1.1",
     "chalk": "^4.0.0",
-    "ember-cli-babel": "^8.3.1",
     "ember-cli-get-component-path-option": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-path-utils": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
-      ember-cli-babel:
-        specifier: ^8.3.1
-        version: 8.3.1(@babel/core@7.29.7)
       ember-cli-get-component-path-option:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
ember-source is a v2 addon. this is not needed