### PR TITLE
escape rootURL and baseURL before regexp in getURL

### DIFF
--- a/packages/@ember/routing/history-location.ts
+++ b/packages/@ember/routing/history-location.ts
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { assert } from '@ember/debug';
 import type { default as EmberLocation, UpdateCallback } from '@ember/routing/location';
-import { getHash } from './lib/location-utils';
+import { escapeRegExp, getHash } from './lib/location-utils';
 
 /**
 @module @ember/routing/history-location
@@ -134,8 +134,8 @@ export default class HistoryLocation extends EmberObject implements EmberLocatio
 
     // remove baseURL and rootURL from start of path
     let url = path
-      .replace(new RegExp(`^${baseURL}(?=/|$)`), '')
-      .replace(new RegExp(`^${rootURL}(?=/|$)`), '')
+      .replace(new RegExp(`^${escapeRegExp(baseURL)}(?=/|$)`), '')
+      .replace(new RegExp(`^${escapeRegExp(rootURL)}(?=/|$)`), '')
       .replace(/\/\//g, '/'); // remove extra slashes
 
     let search = location.search || '';

--- a/packages/@ember/routing/lib/location-utils.ts
+++ b/packages/@ember/routing/lib/location-utils.ts
@@ -1,6 +1,16 @@
 /**
   @private
 
+  Escapes any regular-expression metacharacters in `str` so it can be safely
+  interpolated into a `RegExp` and matched as a literal.
+*/
+export function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+  @private
+
   Returns the current `location.pathname`, ensuring it has a leading slash.
 */
 export function getPath(location: Location): string {

--- a/packages/@ember/routing/lib/location-utils.ts
+++ b/packages/@ember/routing/lib/location-utils.ts
@@ -3,6 +3,9 @@
 
   Escapes any regular-expression metacharacters in `str` so it can be safely
   interpolated into a `RegExp` and matched as a literal.
+
+  TODO: delete this in favor of `RegExp.escape` once our minimum supported
+  browsers all include it (https://caniuse.com/mdn-javascript_builtins_regexp_escape).
 */
 export function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/@ember/routing/none-location.ts
+++ b/packages/@ember/routing/none-location.ts
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { assert } from '@ember/debug';
 import type { default as EmberLocation, UpdateCallback } from '@ember/routing/location';
+import { escapeRegExp } from './lib/location-utils';
 
 /**
 @module @ember/routing/none-location
@@ -63,7 +64,7 @@ export default class NoneLocation extends EmberObject implements EmberLocation {
     rootURL = rootURL.replace(/\/$/, '');
 
     // remove rootURL from url
-    return path.replace(new RegExp(`^${rootURL}(?=/|$)`), '');
+    return path.replace(new RegExp(`^${escapeRegExp(rootURL)}(?=/|$)`), '');
   }
 
   /**

--- a/packages/@ember/routing/tests/location/history_location_test.js
+++ b/packages/@ember/routing/tests/location/history_location_test.js
@@ -319,6 +319,23 @@ moduleFor(
       assert.equal(location.getURL(), '/admin/profile/');
     }
 
+    ['@test HistoryLocation.getURL() treats regex metacharacters in rootURL and baseURL literally'](
+      assert
+    ) {
+      HistoryTestLocation.reopen({
+        init() {
+          this._super(...arguments);
+          set(this, 'location', mockBrowserLocation('/axc/secret'));
+          set(this, 'rootURL', '/a.c/');
+          set(this, 'baseURL', '/a.c/');
+        },
+      });
+
+      createLocation();
+
+      assert.equal(location.getURL(), '/axc/secret');
+    }
+
     ['@test Existing state is preserved on init'](assert) {
       let existingState = {
         path: '/route/path',

--- a/packages/@ember/routing/tests/location/none_location_test.js
+++ b/packages/@ember/routing/tests/location/none_location_test.js
@@ -98,5 +98,19 @@ moduleFor(
 
       assert.equal(location.getURL(), '/axc/secret');
     }
+
+    ['@test NoneLocation.getURL() strips the rootURL when it has an extra trailing slash'](assert) {
+      NoneTestLocation.reopen({
+        init() {
+          this._super(...arguments);
+          set(this, 'rootURL', '/foo//');
+          set(this, 'path', '/foo//bar');
+        },
+      });
+
+      createLocation();
+
+      assert.equal(location.getURL(), '/bar');
+    }
   }
 );

--- a/packages/@ember/routing/tests/location/none_location_test.js
+++ b/packages/@ember/routing/tests/location/none_location_test.js
@@ -84,5 +84,19 @@ moduleFor(
 
       assert.equal(location.getURL(), '/bars/baz');
     }
+
+    ['@test NoneLocation.getURL() treats regex metacharacters in rootURL literally'](assert) {
+      NoneTestLocation.reopen({
+        init() {
+          this._super(...arguments);
+          set(this, 'rootURL', '/a.c/');
+          set(this, 'path', '/axc/secret');
+        },
+      });
+
+      createLocation();
+
+      assert.equal(location.getURL(), '/axc/secret');
+    }
   }
 );


### PR DESCRIPTION
getURL in HistoryLocation and NoneLocation strips the configured rootURL and baseURL off location.pathname by dropping them straight into `new RegExp(`^${rootURL}(?=/|$)`)`, so any regex metacharacter in those values is matched as a pattern against the browser-controlled pathname instead of a literal. a prefix like `/a.c/` then strips `/axc/secret` down to `/secret` and hands the router the wrong route, an unbalanced `(` throws a SyntaxError on every navigation, and a nested-quantifier prefix backtracks exponentially on a short path. this routes both values through a small escapeRegExp helper in location-utils so the prefixes only ever match literally, with tests covering the metacharacter case in both location classes.