### PR TITLE
Update sideEffects property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "7.3.0-alpha.1",
   "description": "A JavaScript framework for creating ambitious web applications",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/*/packages/ember-testing/index.js"
+  ],
   "keywords": [
     "ember-addon"
   ],


### PR DESCRIPTION
Followup to https://github.com/emberjs/ember.js/pull/21456

This should resolve the issue that the ecosystem-ci nightly run found https://github.com/NullVoxPopuli/ember-ecosystem-ci/actions/runs/28985574086/job/86013935001

```bash
  Error: Attempted to use test utilities, but `ember-testing` was not included
                at testingNotAvailableMessage (webpack://__ember_auto_import__/../node_modules/.pnpm/ember-source@file+..+..+..+ember-source-main.tgz_@glimmer+component@2.1.1/node_modules/ember-source/dist/dev/packages/@ember/test/index.js?:8:93)
                at Object.<anonymous> (http://localhost:7357/assets/tests.js:457:32)
```

(affected ember-qunit, and @ember/test-waiters only )


> [!NOTE]
> In our app blueprint, we import ember-testing directly, so this is normally a non-issue. https://github.com/ember-cli/ember-app-blueprint/blob/feddd39c5f4e0de2b8cf3afb6003d00b353eccf8/files/tests/index.html#L33


