### PR TITLE
[CLEANUP] Support typescript@latest (7.x) in nightly type checks

### DIFF
--- a/packages/@ember/runloop/type-tests/bind.test.ts
+++ b/packages/@ember/runloop/type-tests/bind.test.ts
@@ -112,14 +112,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<() => number | void>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number): number {
+  return 1;
+};
 // @ts-expect-error Invalid args
-bind(
-  foo,
-  function (this: Foo, _foo: number): number {
-    return 1;
-  },
-  'string'
-);
+bind(foo, invalidArgsMethod, 'string');
 
 // With function string reference
 expectTypeOf(bind(foo, 'test')).toEqualTypeOf<

--- a/packages/@ember/runloop/type-tests/debounce.test.ts
+++ b/packages/@ember/runloop/type-tests/debounce.test.ts
@@ -127,17 +127,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-debounce(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true,
-  1
-);
+debounce(foo, invalidArgsMethod, 1, 'string', true, 1);
 
 // With function string reference
 expectTypeOf(debounce(foo, 'test', 1, true, 'string', 1)).toEqualTypeOf<Timer>();

--- a/packages/@ember/runloop/type-tests/join.test.ts
+++ b/packages/@ember/runloop/type-tests/join.test.ts
@@ -61,15 +61,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<number | void>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-join(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string'
-);
+join(foo, invalidArgsMethod, 1, 'string');
 
 // With function string reference
 expectTypeOf(join(foo, 'test', 1, true)).toEqualTypeOf<number | void>();

--- a/packages/@ember/runloop/type-tests/later.test.ts
+++ b/packages/@ember/runloop/type-tests/later.test.ts
@@ -68,17 +68,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-later(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true,
-  1
-);
+later(foo, invalidArgsMethod, 1, 'string', true, 1);
 
 // With function string reference
 expectTypeOf(later(foo, 'test', 1, true, 'string', 1)).toEqualTypeOf<Timer>();

--- a/packages/@ember/runloop/type-tests/next.test.ts
+++ b/packages/@ember/runloop/type-tests/next.test.ts
@@ -63,16 +63,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-next(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true
-);
+next(foo, invalidArgsMethod, 1, 'string', true);
 
 // With function string reference
 expectTypeOf(next(foo, 'test', 1, true, 'string')).toEqualTypeOf<Timer>();

--- a/packages/@ember/runloop/type-tests/once.test.ts
+++ b/packages/@ember/runloop/type-tests/once.test.ts
@@ -63,16 +63,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-once(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true
-);
+once(foo, invalidArgsMethod, 1, 'string', true);
 
 // With function string reference
 expectTypeOf(once(foo, 'test', 1, true, 'string')).toEqualTypeOf<Timer>();

--- a/packages/@ember/runloop/type-tests/run.test.ts
+++ b/packages/@ember/runloop/type-tests/run.test.ts
@@ -62,16 +62,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<number>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-run(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true
-);
+run(foo, invalidArgsMethod, 1, 'string', true);
 
 // With function string reference
 expectTypeOf(run(foo, 'test', 1, true, 'string')).toEqualTypeOf<number>();

--- a/packages/@ember/runloop/type-tests/schedule-once.test.ts
+++ b/packages/@ember/runloop/type-tests/schedule-once.test.ts
@@ -71,17 +71,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-scheduleOnce(
-  'my-queue',
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true
-);
+scheduleOnce('my-queue', foo, invalidArgsMethod, 1, 'string', true);
 
 // With function string reference
 expectTypeOf(scheduleOnce('my-queue', foo, 'test', 1, true, 'string')).toEqualTypeOf<Timer>();

--- a/packages/@ember/runloop/type-tests/schedule.test.ts
+++ b/packages/@ember/runloop/type-tests/schedule.test.ts
@@ -71,17 +71,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-schedule(
-  'my-queue',
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true
-);
+schedule('my-queue', foo, invalidArgsMethod, 1, 'string', true);
 
 // With function string reference
 expectTypeOf(schedule('my-queue', foo, 'test', 1, true, 'string')).toEqualTypeOf<Timer>();

--- a/packages/@ember/runloop/type-tests/throttle.test.ts
+++ b/packages/@ember/runloop/type-tests/throttle.test.ts
@@ -127,17 +127,11 @@ expectTypeOf(
   )
 ).toEqualTypeOf<Timer>();
 
+const invalidArgsMethod = function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
+  return 1;
+};
 // @ts-expect-error invalid args
-throttle(
-  foo,
-  function (this: Foo, _foo: number, _bar: boolean, _baz?: string): number {
-    return 1;
-  },
-  1,
-  'string',
-  true,
-  1
-);
+throttle(foo, invalidArgsMethod, 1, 'string', true, 1);
 
 // With function string reference
 expectTypeOf(throttle(foo, 'test', 1, true, 'string', 1)).toEqualTypeOf<Timer>();

--- a/packages/@glimmer/debug/lib/stack-check.ts
+++ b/packages/@glimmer/debug/lib/stack-check.ts
@@ -24,7 +24,7 @@ export interface Checker<T> {
 
 class NoopChecker<T> implements Checker<T> {
   declare type: T;
-  validate(value: unknown): value is T {
+  validate(_value: unknown): _value is T {
     return true;
   }
   expected(): string {

--- a/packages/@handlebars/parser/tsconfig.json
+++ b/packages/@handlebars/parser/tsconfig.json
@@ -12,7 +12,6 @@
     // Enhance Strictness
     "strict": true,
     "skipLibCheck": true,
-    "suppressImplicitAnyIndexErrors": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
Fixes the nightly `typescript@latest` run, which now installs 7.0.2 (the Go-native compiler).

- TS 7 anchors TS2769 at the failing argument instead of the call, breaking `@ts-expect-error` above multi-line calls — extracted the callbacks in the runloop type-tests so the call is one line and the directive covers both anchor positions
- TS 7 doesn't exempt unused params of local-class methods used only in a type predicate — renamed to `_value` in `stack-check.ts`
- TS 7 removed `suppressImplicitAnyIndexErrors` — dropped it from `@handlebars/parser`'s tsconfig (it was set to its default)

All changes are version-agnostic: full `pnpm type-check` is green on both 5.9.3 and 7.0.2, and the published types are untouched, so the 5.2–5.9 matrix is unaffected.

Note: `broccoli/features.cjs` uses the old synchronous compiler API, which typescript@7 doesn't ship — fine for the nightly (build runs before the TS swap) but will block bumping the pinned version past 6.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)