### PR TITLE
Widen TS matrix

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -48,7 +48,8 @@ jobs:
     needs: ["types"]
     strategy:
       matrix:
-        ts-version: ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"]
+        ts-version:
+          ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9", "6.0", "7.0"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Prereq for https://github.com/emberjs/ember.js/pull/21495
^ which turns out to not be needed, and the nightly failure on 7 was a fluke / fixed by a patch
