### PR TITLE
[BUGFIX] keep origin as authority in replacePath

### DIFF
--- a/packages/@ember/routing/lib/location-utils.ts
+++ b/packages/@ember/routing/lib/location-utils.ts
@@ -45,5 +45,14 @@ export function getFullPath(location: Location): string {
   @private
 */
 export function replacePath(location: Location, path: string): void {
+  // `path` is joined straight onto the origin, so a value that does not begin
+  // with a slash (e.g. `@evil.com`) would be reparsed as part of the authority:
+  // `http://app.com` + `@evil.com` becomes `http://app.com@evil.com`, where the
+  // origin's host turns into userinfo and `evil.com` becomes the host. Force a
+  // leading slash so the origin always stays the authority.
+  if (path.charAt(0) !== '/') {
+    path = `/${path}`;
+  }
+
   location.replace(location.origin + path);
 }

--- a/packages/@ember/routing/tests/location/util_test.js
+++ b/packages/@ember/routing/tests/location/util_test.js
@@ -20,7 +20,7 @@ moduleFor(
   'Location Utilities',
   class extends AbstractTestCase {
     ['@test replacePath cannot be used to redirect to a different origin'](assert) {
-      assert.expect(1);
+      assert.expect(2);
 
       let expectedURL;
 
@@ -34,6 +34,11 @@ moduleFor(
 
       expectedURL = 'http://emberjs.com:1337//google.com';
       replacePath(location, '//google.com');
+
+      // A path without a leading slash would otherwise be reparsed into the
+      // authority (`http://emberjs.com:1337@google.com` navigates to google.com).
+      expectedURL = 'http://emberjs.com:1337/@google.com';
+      replacePath(location, '@google.com');
     }
 
     ['@test getPath() should normalize location.pathname, making sure it always returns a leading slash'](


### PR DESCRIPTION
replacepath in @ember/routing lib documents that it prepends location.origin to prevent redirecting to a different origin, and util_test asserts exactly that, but it joins path onto the origin with no separator. a path that does not start with a slash gets reparsed into the authority: origin `http://app.com` plus `@evil.com` becomes `http://app.com@evil.com`, so the app's own host turns into userinfo and evil.com becomes the host. the existing test only exercises `//google.com`, which stays same-origin and hides this. forcing a leading slash before the concat keeps the origin as the authority for every input, and the test now covers the `@` case too.