### PR TITLE
reject invalid tag names in the element helper

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/element.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/element.ts
@@ -13,6 +13,15 @@ import { internalHelper } from './internal-helper';
 // Renders content wrapped in the specified HTML element, or just renders
 // content without a wrapper for empty string.
 
+// The tag name flows straight into `document.createElement` and, when the app
+// is rendered on the server, into the serialized HTML. A browser rejects a name
+// containing characters like a space or `>` (InvalidCharacterError), but the
+// server-side DOM does not, so an unvalidated name such as
+// `img src=x onerror=...` would be written verbatim into the rendered markup.
+// Restrict the name to characters that are legal in a tag so both environments
+// agree.
+const VALID_TAG_NAME = /^[a-zA-Z][a-zA-Z0-9._:-]*$/;
+
 const ELEMENT_CAPABILITIES = {
   createInstance: true,
   wrapped: true,
@@ -96,6 +105,7 @@ function getElementDefinition(tagName: string): ElementComponentDefinition {
   a wrapping element.
 
   Passing `null`, `undefined`, or non-string values will throw an assertion error.
+  Passing a string that is not a valid tag name will throw an error.
 
   Changing the tag name will tear down and recreate the element and its contents.
  
@@ -127,6 +137,10 @@ export default internalHelper(({ positional, named }: CapturedArguments) => {
           }`,
           typeof tagName === 'string'
         );
+      }
+
+      if (typeof tagName === 'string' && tagName !== '' && !VALID_TAG_NAME.test(tagName)) {
+        throw new Error(`The \`element\` helper was passed an invalid tag name \`${tagName}\`.`);
       }
 
       return getElementDefinition(tagName as string);

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -190,6 +190,19 @@ moduleFor(
       }, /The argument passed to the `element` helper must be a string \(you passed `false`\)/);
     }
 
+    '@test it throws when passed a tag name with invalid characters'() {
+      // A tag name is written into the DOM verbatim. The browser rejects names
+      // like this, but the server-side DOM used for SSR does not, so an
+      // unvalidated name would be serialized straight into the rendered HTML.
+      let tag = 'img src=x onerror=alert(document.cookie)';
+      this.assert.throws(() => {
+        let AComponent = template(`{{#let (element tag) as |Tag|}}<Tag>hello</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, tag }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
+      }, /The `element` helper was passed an invalid tag name/);
+    }
+
     ['@test it throws when passed an object']() {
       if (!DEBUG) {
         this.assert.expect(0);


### PR DESCRIPTION
the `element` helper hands its argument to getElementDefinition and on into dom.createElement without checking it. a browser rejects a name like `img src=x onerror=...` with InvalidCharacterError, but the server-side dom used for ssr serializes whatever it's given, so a tag name bound from data ends up written verbatim into the rendered html and the onerror fires once the client parses it. validate the name against a tag-name pattern in the helper and throw for anything that isn't well formed so the ssr and browser paths agree; the empty string still renders without a wrapper. the added test fails before the change (the browser throws a different error) and passes after.