### PR TITLE
collapse leading double slash in HashLocation.getURL

### DIFF
--- a/packages/@ember/routing/hash-location.ts
+++ b/packages/@ember/routing/hash-location.ts
@@ -85,7 +85,10 @@ export default class HashLocation extends EmberObject implements EmberLocation {
       }
     }
 
-    return outPath;
+    // Collapse a leading run of slashes so an attacker-influenced hash such as
+    // `#//example.com` is not surfaced as a protocol-relative URL through
+    // `router.currentURL`. HistoryLocation.getURL already normalizes slashes.
+    return outPath.replace(/^\/\/+/, '/');
   }
 
   /**

--- a/packages/@ember/routing/tests/location/hash_location_test.js
+++ b/packages/@ember/routing/tests/location/hash_location_test.js
@@ -82,6 +82,17 @@ moduleFor(
       assert.equal(location.getURL(), '/foo#bar#car');
     }
 
+    ['@test HashLocation.getURL() collapses a leading double slash'](assert) {
+      createLocation(
+        {
+          _location: mockBrowserLocation('/#//example.com/x'),
+        },
+        assert
+      );
+
+      assert.equal(location.getURL(), '/example.com/x');
+    }
+
     ['@test HashLocation.getURL() assumes location.hash without #/ prefix is not a route path'](
       assert
     ) {


### PR DESCRIPTION
HashLocation.getURL returns the hash path unchanged once it starts with a slash, so a hash like `#//example.com` comes back as the protocol-relative URL `//example.com` and rides along in `router.currentURL`. HistoryLocation.getURL already collapses duplicate slashes (it has a dedicated test for it), so only hash-location apps end up reflecting an off-origin authority when that value reaches an href or redirect. This collapses a leading run of slashes to one in getURL, matching HistoryLocation, and leaves ordinary paths untouched.