### PR TITLE
give query param meta maps a null prototype

### DIFF
--- a/packages/@ember/routing/route.ts
+++ b/packages/@ember/routing/route.ts
@@ -1632,7 +1632,9 @@ class Route<Model = unknown> extends EmberObject.extend(ActionHandler, Evented) 
     }
 
     let qps: QueryParam[] = [];
-    let map: Record<string, QueryParam> = {};
+    // Looked up by query param names that come from the URL, so it must not
+    // inherit from Object.prototype.
+    let map: Record<string, QueryParam> = Object.create(null);
     let propertyNames: string[] = [];
 
     for (let propName in combinedQueryParameterConfiguration) {

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -1156,9 +1156,11 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     }
 
     let shouldCache = true;
-    let map: QueryParamMeta['map'] = {};
+    // Both of these are looked up by names that come from the URL (or from a
+    // route's `as:` config), so they must not inherit from Object.prototype.
+    let map: QueryParamMeta['map'] = Object.create(null);
     let qps = [];
-    let qpsByUrlKey: Record<string, QueryParam> | null = DEBUG ? {} : null;
+    let qpsByUrlKey: Record<string, QueryParam> | null = DEBUG ? Object.create(null) : null;
     let qpMeta;
     let urlKey;
     let qpOther;

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1237,6 +1237,17 @@ moduleFor(
       });
     }
 
+    ['@test Query params named after Object.prototype properties are left alone'](assert) {
+      assert.expect(2);
+
+      this.setSingleQPController('index', 'foo', 'bar');
+
+      return this.visit('/?toString=1&foo=baz').then(() => {
+        assert.equal(this.currentURL, '/?toString=1&foo=baz');
+        assert.equal(this.getController('index').get('foo'), 'baz');
+      });
+    }
+
     ['@test Query param without value are empty string'](assert) {
       assert.expect(1);
 


### PR DESCRIPTION
forEachQueryParam and Route.queryParamsDidChange look up query param names taken from the url against the plain objects built in _queryParamsFor and _qp, so /?toString=1 finds Object.prototype.toString, treats it as query param metadata, and the transition dies in qp.route.deserializeQueryParam. any app is affected, including one that declares no query params at all. forEachQueryParam already guards the queryParams side of that loop with hasOwnProperty and only misses the map side, so giving both maps a null prototype fixes it at the source and matches _qpCache and _engineInstances a few lines up. test covers /?toString=1 arriving alongside a real qp.