### PR TITLE
[BUGFIX] Invoke argument-less helpers in attribute position in strict mode

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
@@ -1512,6 +1512,65 @@ class AttributeStrictModeTest extends RenderTest {
   }
 
   @test
+  'Component definitions in attribute position are used as values'() {
+    const Foo = defineComponent({}, 'Hello, world!');
+    const Bar = defineComponent({ Foo }, '<div data-foo={{Foo}}></div>');
+
+    this.renderComponent(Bar);
+    this.assertHTML('<div data-foo="@glimmer/component/template-only"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Paths on lexical variables in attribute position are used as values'() {
+    const styles = { works: 'works' };
+    const Foo = defineComponent(
+      { styles },
+      '<div data-foo={{styles.works}} class="it {{styles.works}}"></div>'
+    );
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div data-foo="works" class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can call a helper in attribute position (with args)'() {
+    const echo = defineSimpleHelper((value: string) => value);
+    const Foo = defineComponent(
+      { echo },
+      '<div data-foo={{echo "works"}} class="it {{echo "works"}}"></div>'
+    );
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div data-foo="works" class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can call a helper in attribute position as a subexpression (without args)'() {
+    const works = defineSimpleHelper(() => 'works');
+    const Foo = defineComponent(
+      { works },
+      '<div data-foo={{(works)}} class="it {{(works)}}"></div>'
+    );
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div data-foo="works" class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use a helper in trusting attribute position (without args)'() {
+    const works = defineSimpleHelper(() => 'works');
+    const Foo = defineComponent({ works }, '<div data-foo={{{works}}}></div>');
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div data-foo="works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
   'Helpers in argument position (without parens) are passed by value'(assert: Assert) {
     const works = defineSimpleHelper(() => 'works');
     const Foo = defineComponent({}, '{{this.receivedFunction}}', {

--- a/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
@@ -1440,7 +1440,102 @@ class BuiltInsStrictModeTest extends RenderTest {
   }
 }
 
+class AttributeStrictModeTest extends RenderTest {
+  static suiteName = 'strict mode: attribute position';
+
+  @test
+  'Can use a helper in attribute position (without args)'() {
+    const works = defineSimpleHelper(() => 'works');
+    const Foo = defineComponent({ works }, '<div class={{works}}></div>');
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div class="works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use a helper in attribute interpolation (without args)'() {
+    const works = defineSimpleHelper(() => 'works');
+    const Foo = defineComponent({ works }, '<div class="it {{works}}"></div>');
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use a plain function in attribute position (without args)'() {
+    const works = () => 'works';
+    const Foo = defineComponent({ works }, '<div class="it {{works}}"></div>');
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Can use a helper in attribute position on a component (without args)'() {
+    const works = defineSimpleHelper(() => 'works');
+    const Foo = defineComponent({}, '<div ...attributes></div>');
+    const Bar = defineComponent({ works, Foo }, '<Foo class="it {{works}}"/>');
+
+    this.renderComponent(Bar);
+    this.assertHTML('<div class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Helpers in attribute position update when their dependencies change'() {
+    const obj = trackedObj({ value: 'red' });
+    const color = defineSimpleHelper(() => obj['value']);
+    const Foo = defineComponent({ color }, '<div class="it {{color}}"></div>');
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div class="it red"></div>');
+    this.assertStableRerender();
+
+    obj['value'] = 'blue';
+
+    this.rerender();
+    this.assertHTML('<div class="it blue"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Non-helper values in attribute position are used directly'() {
+    const value = 'works';
+    const Foo = defineComponent({ value }, '<div data-foo={{value}} class="it {{value}}"></div>');
+
+    this.renderComponent(Foo);
+    this.assertHTML('<div data-foo="works" class="it works"></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'Helpers in argument position (without parens) are passed by value'(assert: Assert) {
+    const works = defineSimpleHelper(() => 'works');
+    const Foo = defineComponent({}, '{{this.receivedFunction}}', {
+      definition: class extends GlimmerishComponent {
+        get receivedFunction() {
+          assert.strictEqual(
+            (this.args as { value: unknown })['value'],
+            works,
+            'the helper itself was passed as the argument'
+          );
+          return String(typeof this.args['value'] === 'function');
+        }
+      },
+    });
+    const Bar = defineComponent({ works, Foo }, '<Foo @value={{works}}/>');
+
+    this.renderComponent(Bar);
+    this.assertHTML('true');
+    this.assertStableRerender();
+  }
+}
+
 jitSuite(GeneralStrictModeTest);
 jitSuite(StaticStrictModeTest);
 jitSuite(DynamicStrictModeTest);
 jitSuite(BuiltInsStrictModeTest);
+jitSuite(AttributeStrictModeTest);

--- a/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/strict-mode-test.ts
@@ -1511,14 +1511,14 @@ class AttributeStrictModeTest extends RenderTest {
     this.assertStableRerender();
   }
 
-  @test
-  'Component definitions in attribute position are used as values'() {
+  @test({ skip: !DEBUG })
+  'Component definitions in attribute position are an error'() {
     const Foo = defineComponent({}, 'Hello, world!');
     const Bar = defineComponent({ Foo }, '<div data-foo={{Foo}}></div>');
 
-    this.renderComponent(Bar);
-    this.assertHTML('<div data-foo="@glimmer/component/template-only"></div>');
-    this.assertStableRerender();
+    this.assert.throws(() => {
+      this.renderComponent(Bar);
+    }, /Attempted to use a component as the value of an attribute, but only values and helpers are valid in attribute position./u);
   }
 
   @test
@@ -1576,6 +1576,11 @@ class AttributeStrictModeTest extends RenderTest {
     const Foo = defineComponent({}, '{{this.receivedFunction}}', {
       definition: class extends GlimmerishComponent {
         get receivedFunction() {
+          assert.strictEqual(
+            typeof this.args['value'],
+            'function',
+            'the argument is a function, not an invoked result'
+          );
           assert.strictEqual(
             (this.args as { value: unknown })['value'],
             works,

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
@@ -3,6 +3,7 @@ import { encodeImmediate, isSmallInt } from '@glimmer/constants/lib/immediate';
 import {
   VM_BIND_DYNAMIC_SCOPE_OP,
   VM_CAPTURE_ARGS_OP,
+  VM_CONSTANT_REFERENCE_OP,
   VM_CURRY_OP,
   VM_DUP_OP,
   VM_DYNAMIC_HELPER_OP,
@@ -16,9 +17,11 @@ import {
 } from '@glimmer/constants/lib/syscall-ops';
 import { VM_POP_FRAME_OP, VM_PUSH_FRAME_OP } from '@glimmer/constants/lib/vm-ops';
 import { $fp, $v0 } from '@glimmer/vm/lib/registers';
+import { opcodes as SexpOpcodes } from '@glimmer/wire-format/lib/opcodes';
 
 import type { PushExpressionOp, PushStatementOp } from '../../syntax/compilers';
 
+import { HighLevelResolutionOpcodes } from '../opcodes';
 import { isStrictMode, nonSmallIntOperand } from '../operands';
 import { expr } from './expr';
 import { SimpleArgs } from './shared';
@@ -102,6 +105,43 @@ export function CallDynamic(
     op(VM_POP_FRAME_OP);
     op(VM_POP_OP, 1);
     op(VM_FETCH_OP, $v0);
+  }
+}
+
+/**
+ * Compile an expression in attribute-value position (either an entire dynamic
+ * attribute value, or one part of an attribute interpolation).
+ *
+ * In strict mode, a bare curly referencing an in-scope (lexical) binding —
+ * e.g. `class={{foo}}` or `class="prefix {{foo}}"` — is invoked as a
+ * zero-argument helper if its value has an associated helper manager (which
+ * includes plain functions, per RFC 0756). Otherwise the value itself is
+ * used. This matches loose mode, where an attribute curly that resolves to a
+ * helper is always invoked.
+ */
+export function DynamicAttrValue(op: PushExpressionOp, expression: WireFormat.Expression): void {
+  if (
+    Array.isArray(expression) &&
+    expression[0] === SexpOpcodes.GetLexicalSymbol &&
+    expression.length === 2
+  ) {
+    op(HighLevelResolutionOpcodes.OptionalComponentOrHelper, expression, {
+      // A component definition is not invokable in attribute position; use
+      // the value itself, like any other non-helper value.
+      ifComponent: () => {
+        expr(op, expression);
+      },
+
+      ifHelper: (handle: number) => {
+        Call(op, handle, null, null);
+      },
+
+      ifValue: (handle: number) => {
+        op(VM_CONSTANT_REFERENCE_OP, handle);
+      },
+    });
+  } else {
+    expr(op, expression);
   }
 }
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/vm.ts
@@ -1,4 +1,5 @@
 import type { CurriedType, NonSmallIntOperand, Nullable, WireFormat } from '@glimmer/interfaces';
+import { DEBUG } from '@glimmer/env';
 import { encodeImmediate, isSmallInt } from '@glimmer/constants/lib/immediate';
 import {
   VM_BIND_DYNAMIC_SCOPE_OP,
@@ -126,10 +127,14 @@ export function DynamicAttrValue(op: PushExpressionOp, expression: WireFormat.Ex
     expression.length === 2
   ) {
     op(HighLevelResolutionOpcodes.OptionalComponentOrHelper, expression, {
-      // A component definition is not invokable in attribute position; use
-      // the value itself, like any other non-helper value.
       ifComponent: () => {
-        expr(op, expression);
+        if (DEBUG) {
+          throw new Error(
+            'Attempted to use a component as the value of an attribute, but only values and helpers are valid in attribute position.'
+          );
+        }
+
+        PushPrimitiveReference(op, undefined);
       },
 
       ifHelper: (handle: number) => {

--- a/packages/@glimmer/opcode-compiler/lib/syntax/expressions.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/expressions.ts
@@ -23,7 +23,13 @@ import type { PushExpressionOp } from './compilers';
 import { expr } from '../opcode-builder/helpers/expr';
 import { isGetFreeHelper } from '../opcode-builder/helpers/resolution';
 import { SimpleArgs } from '../opcode-builder/helpers/shared';
-import { Call, CallDynamic, Curry, PushPrimitiveReference } from '../opcode-builder/helpers/vm';
+import {
+  Call,
+  CallDynamic,
+  Curry,
+  DynamicAttrValue,
+  PushPrimitiveReference,
+} from '../opcode-builder/helpers/vm';
 import { HighLevelResolutionOpcodes } from '../opcode-builder/opcodes';
 import { Compilers } from './compilers';
 
@@ -31,7 +37,7 @@ export const EXPRESSIONS = new Compilers<PushExpressionOp, ExpressionSexpOpcode>
 
 EXPRESSIONS.add(SexpOpcodes.Concat, (op, [, parts]) => {
   for (let part of parts) {
-    expr(op, part);
+    DynamicAttrValue(op, part);
   }
 
   op(VM_CONCAT_OP, parts.length);

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -67,6 +67,7 @@ import { CompilePositional, SimpleArgs } from '../opcode-builder/helpers/shared'
 import {
   Call,
   CallDynamic,
+  DynamicAttrValue,
   DynamicScope,
   PushPrimitiveReference,
 } from '../opcode-builder/helpers/vm';
@@ -123,22 +124,22 @@ STATEMENTS.add(SexpOpcodes.StaticComponentAttr, (op, [, name, value, namespace])
 });
 
 STATEMENTS.add(SexpOpcodes.DynamicAttr, (op, [, name, value, namespace]) => {
-  expr(op, value);
+  DynamicAttrValue(op, value);
   op(VM_DYNAMIC_ATTR_OP, inflateAttrName(name), false, namespace ?? null);
 });
 
 STATEMENTS.add(SexpOpcodes.TrustingDynamicAttr, (op, [, name, value, namespace]) => {
-  expr(op, value);
+  DynamicAttrValue(op, value);
   op(VM_DYNAMIC_ATTR_OP, inflateAttrName(name), true, namespace ?? null);
 });
 
 STATEMENTS.add(SexpOpcodes.ComponentAttr, (op, [, name, value, namespace]) => {
-  expr(op, value);
+  DynamicAttrValue(op, value);
   op(VM_COMPONENT_ATTR_OP, inflateAttrName(name), false, namespace ?? null);
 });
 
 STATEMENTS.add(SexpOpcodes.TrustingComponentAttr, (op, [, name, value, namespace]) => {
-  expr(op, value);
+  DynamicAttrValue(op, value);
   op(VM_COMPONENT_ATTR_OP, inflateAttrName(name), true, namespace ?? null);
 });
 


### PR DESCRIPTION
Fixes #21040

## The bug

In loose mode, a bare curly in attribute position that resolves to a helper is invoked:

```hbs
{{!-- works in standalone hbs --}}
<div class="it {{works}}" />
```

In strict mode (gjs/gts), the same template renders `Function.prototype.toString` output instead, because a lexical variable in attribute position compiles to a plain constant reference that the attribute (or interpolation) stringifies:

```gjs
function works() {
  return "works";
}

<template>
  {{!-- renders class="it function works() {...}" before this fix --}}
  <div class="it {{works}}" />
</template>
```

The [strict mode RFC only intended to remove implicit invocation for *arguments*, not attributes](https://github.com/emberjs/rfcs/blob/508ac9b95bf2a4b397bf72b8e51d981c14c42535/text/0496-handlebars-strict-mode.md#3-no-implicit-invocation-of-argument-less-helpers), so this was an unintended inconsistency between the two modes and a hazard when migrating templates to strict mode. Reproduction (from #21040): https://share.glimdown.com/v5IaYaF4Ttmsngzuntoaqg

## The fix

A template's lexical scope values are static, so helper-ness can be decided at compile time — the same way append position already handles bare lexical curlies (which is why `{{works}}` in *content* position already invokes in strict mode).

No new opcodes: the fix reuses the existing `OptionalComponentOrHelper` high-level resolution (compile-time only; no wire-format or VM changes). When a bare lexical variable appears as a dynamic attribute value or as part of an attribute interpolation:

- if its value has an associated helper manager (including plain functions, per RFC 0756), it is invoked as a zero-argument helper — matching loose mode;
- if it is a plain value (string, number, etc.), the value is used directly, as before;
- if it is a component definition, it is an error (DEBUG): only values and helpers are valid in attribute position.

Scope notes:

- Bare argument curlies (`@arg={{works}}`) are unaffected and continue to pass the function by value, per the RFC.
- Path expressions (`{{this.works}}`, `{{works.foo}}`), block params, and explicit calls (`{{works arg}}`, `{{(works)}}`) are unaffected — these already behave consistently between the modes.
- Applies to plain-element attrs, component attrs (`ComponentAttr`), and their trusting variants.

## Testing

New `strict mode: attribute position` suite in `strict-mode-test.ts` (12 tests) covers every branch of the new `DynamicAttrValue` compile path: helper in attr position and in interpolation, plain function invocation, component attrs with `...attributes`, reactive updates when the helper's tracked dependencies change, the trusting variant (`{{{works}}}`), non-helper values passing through unchanged, component definitions erroring, paths on lexical variables (`{{styles.works}}`), helpers called with args, parenthesized subexpressions, and `@arg={{helper}}` still passing by value. The 5 invocation tests fail on `main` and pass with this change; the guard tests pass on both.

Locally green: `strict mode` (467), `attribute` (902), `updating` (176), `compil` (438), `lexical scope` filters, plus `tsc --noEmit` and eslint/prettier on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

