### PR TITLE
skip __proto__ keys when creating an object

### DIFF
--- a/packages/@ember/object/core.ts
+++ b/packages/@ember/object/core.ts
@@ -87,6 +87,14 @@ function initialize(obj: CoreObject, properties?: unknown) {
     let keyNames = Object.keys(properties);
 
     for (let keyName of keyNames) {
+      // `JSON.parse` produces `__proto__` as an own enumerable key, so it
+      // survives `Object.keys` and reaches the assignment below, where it hits
+      // the `Object.prototype.__proto__` setter and re-parents the instance
+      // instead of setting a property on it.
+      if (keyName === '__proto__') {
+        continue;
+      }
+
       // SAFETY: this cast as a Record is safe because all object types can be
       // indexed in JS, and we explicitly type it as returning `unknown`, so the
       // result *must* be checked below.
@@ -1068,6 +1076,9 @@ function flattenProps(this: typeof CoreObject, ...props: Array<Record<string, un
 
     for (let j = 0, k = keyNames.length; j < k; j++) {
       let keyName = keyNames[j]!;
+      if (keyName === '__proto__') {
+        continue;
+      }
       let value = properties[keyName];
       initProperties[keyName] = value;
     }

--- a/packages/@ember/object/tests/create_test.js
+++ b/packages/@ember/object/tests/create_test.js
@@ -282,5 +282,37 @@ moduleFor(
       assert.equal(getOwner(instance), container.owner, 'owner was defined on the instance');
       assert.ok(getFactoryFor(instance), 'factory was defined on the instance');
     }
+
+    ['@test a __proto__ key in the passed properties does not re-parent the instance'](assert) {
+      class Greeter extends EmberObject {
+        greet() {
+          return 'hi';
+        }
+      }
+
+      let payload = JSON.parse('{"__proto__": {"isAdmin": true}, "name": "zoey"}');
+      let obj = Greeter.create(payload);
+
+      assert.ok(obj instanceof Greeter, 'prototype chain is intact');
+      assert.equal(obj.greet(), 'hi', 'class methods are still reachable');
+      assert.equal(obj.isAdmin, undefined, 'nothing was inherited from the payload');
+      assert.equal(obj.get('name'), 'zoey', 'the remaining properties are still set');
+    }
+
+    ['@test a __proto__ key does not leak into the hash passed to init'](assert) {
+      let seen;
+
+      class Recorder extends EmberObject {
+        init(props) {
+          super.init(...arguments);
+          seen = props.isAdmin;
+        }
+      }
+
+      let obj = Recorder.create({ name: 'zoey' }, JSON.parse('{"__proto__": {"isAdmin": true}}'));
+
+      assert.equal(seen, undefined, 'init did not read an inherited value off the merged hash');
+      assert.equal(obj.get('name'), 'zoey', 'the remaining properties are still set');
+    }
   }
 );


### PR DESCRIPTION
`JSON.parse` gives you `__proto__` as an own enumerable key, so it survives the `Object.keys` loop in `initialize` and lands on `obj[keyName] = value`, which runs the `Object.prototype.__proto__` setter and re-parents the instance instead of setting a property. The `setUnknownProperty` branch just above can't catch it either, since `'__proto__' in obj` is always true. Concretely, `SomeClass.create(JSON.parse('{"__proto__": {"isAdmin": true}}'))` on a payload straight from a server currently throws `obj.init is not a function` because the instance no longer has a prototype, and the payload's keys are inherited where `Object.keys` can't see them. The same key also re-parents the merged hash in `flattenProps`, which then gets handed to the app's own `init(props)`.

I put the skip in both loops rather than at the call sites since `create` is the entry point everyone reaches this through, and it matches the guard `_getPath` already has for the set path. Two tests in `create_test.js` cover it; both fail on main.