### PR TITLE
refuse script and style as a dynamic tag name

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/curly-components-test.js
@@ -336,6 +336,24 @@ moduleFor(
       });
     }
 
+    ['@test tagName can not be a raw text element']() {
+      window.__curlyTagNameScriptRan = false;
+
+      this.owner.register(
+        'component:foo-bar',
+        setComponentTemplate(
+          precompileTemplate('window.__curlyTagNameScriptRan = true;'),
+          class extends Component {}
+        )
+      );
+
+      this.assert.throws(() => {
+        this.render('{{foo-bar tagName="script"}}');
+      }, /Cannot create a <script> element from a dynamic tag name/);
+
+      this.assert.strictEqual(window.__curlyTagNameScriptRan, false);
+    }
+
     ['@test tagName can not be a computed property']() {
       let FooBarComponent = class extends Component {
         @computed

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/element-test.js
@@ -65,6 +65,31 @@ moduleFor(
       });
     }
 
+    ['@test it throws when passed "script" instead of running the block as code']() {
+      window.__elementHelperScriptRan = false;
+
+      let tag = 'script';
+      let code = 'window.__elementHelperScriptRan = true;';
+      this.assert.throws(() => {
+        let AComponent = template(`{{#let (element tag) as |Tag|}}<Tag>{{code}}</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, tag, code }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
+      }, /Cannot create a <script> element from a dynamic tag name/);
+
+      this.assert.strictEqual(window.__elementHelperScriptRan, false);
+    }
+
+    ['@test it throws when passed a raw text tag name in any casing']() {
+      let tag = 'STYLE';
+      this.assert.throws(() => {
+        let AComponent = template(`{{#let (element tag) as |Tag|}}<Tag>a{b:c}</Tag>{{/let}}`, {
+          scope: () => ({ element: elementHelper, tag }),
+        });
+        this.renderComponent(AComponent, { expect: '' });
+      }, /Cannot create a <STYLE> element from a dynamic tag name/);
+    }
+
     '@test it can be rendered multiple times'() {
       let AComponent = template(
         `{{#let (element "h1") as |Tag|}}<Tag id="content-1">hello</Tag><Tag id="content-2">world</Tag><Tag id="content-3">!!!!!</Tag>{{/let}}`,

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -67,8 +67,21 @@ APPEND_OPCODES.add(VM_OPEN_ELEMENT_OP, (vm, { op1: tag }) => {
   vm.tree().openElement(vm.constants.getValue(tag));
 });
 
+// The children of a raw text element are not markup, so the escaping applied to
+// `{{...}}` output means nothing there: whatever the layout renders inside a
+// `<script>` runs as JavaScript, and inside a `<style>` it applies as CSS. A tag
+// name that arrives as a runtime value must therefore never open one, otherwise
+// data flowing into `(element ...)` or a curly component's `tagName` turns the
+// surrounding escaped content into code.
+const RAW_TEXT_TAGS = ['script', 'style'];
+
 APPEND_OPCODES.add(VM_OPEN_DYNAMIC_ELEMENT_OP, (vm) => {
   let tagName = check(valueForRef(check(vm.stack.pop(), CheckReference)), CheckString);
+
+  if (RAW_TEXT_TAGS.indexOf(tagName.toLowerCase()) !== -1) {
+    throw new Error(`Cannot create a <${tagName}> element from a dynamic tag name`);
+  }
+
   vm.tree().openElement(tagName);
 });
 


### PR DESCRIPTION
A tag name that arrives as a runtime value goes straight to `createElement`, and `script` and `style` are well formed names, so nothing rejects them the way the platform rejects a malformed one. `flushElement` inserts the opened element into the document before appending its children, so an already connected `<script>` re-prepares and runs whatever the layout renders inside it, and the escaping on `{{...}}` counts for nothing because the children of a raw text element are not markup.

Repro, with both values coming from an API response:

```gjs
<template>
  {{#let (element @tag) as |Tag|}}
    <Tag>{{@text}}</Tag>
  {{/let}}
</template>
```

`@tag="script"` and `@text="alert(document.cookie)"` executes on render today; `@tag="style"` is the same story for CSS. The curly `tagName=` form (`{{foo-bar tagName=this.model.wrapper}}`) is the other way in, and since both compile down to the same dynamic tag opcode the check sits there rather than in each helper. A `<script>` written literally in a template goes through the static opcode and is untouched.
