### PR TITLE
[SPIKE / not for merge] Push-invalidation: tags queue their consumers, no revalidation walk

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/base-renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/base-renderer.ts
@@ -197,10 +197,28 @@ function resolveRenderPromise() {
   }
 }
 
+/**
+ * SPIKE: revalidation deferred to an animation frame is *expected* to
+ * leave the renderer invalid at runloop end -- the frame will handle
+ * it. Without this, loopEnd spins NO_OP runloops (recursing via join)
+ * until the loop guard throws.
+ */
+let framePending = false;
+
+export function setFramePending(value: boolean) {
+  framePending = value;
+}
+
 let loops = 0;
 function loopEnd() {
   for (let renderer of renderers) {
     if (!renderer.isValid()) {
+      if (framePending) {
+        // the scheduled frame will revalidate; its own runloop will
+        // re-enter loopEnd and resolve the render promise
+        return;
+      }
+
       if (loops > ENV._RERENDER_LOOP_LIMIT) {
         loops = 0;
         // TODO: do something better
@@ -368,8 +386,31 @@ export class RendererState {
     }
   }
 
+  #frameScheduled = false;
+
+  /**
+   * SPIKE: coalesce revalidation to at most once per animation frame.
+   *
+   * Invalidation bursts (sockets, workers) otherwise trigger a full
+   * revalidation per runloop flush -- many times per painted frame.
+   * Only frames that will actually paint need the DOM updated.
+   */
   scheduleRevalidate(renderer: BaseRenderer): void {
-    _backburner.scheduleOnce('render', this, this.revalidate, renderer);
+    if (typeof requestAnimationFrame === 'function') {
+      if (this.#frameScheduled) {
+        return;
+      }
+
+      this.#frameScheduled = true;
+      setFramePending(true);
+      requestAnimationFrame(() => {
+        this.#frameScheduled = false;
+        setFramePending(false);
+        _backburner.join(() => this.revalidate(renderer));
+      });
+    } else {
+      _backburner.scheduleOnce('render', this, this.revalidate, renderer);
+    }
   }
 
   isValid(): boolean {

--- a/packages/@ember/-internals/glimmer/lib/base-renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/base-renderer.ts
@@ -24,8 +24,9 @@ import { artifacts } from '@glimmer/program/lib/helpers';
 import { RuntimeOpImpl } from '@glimmer/program/lib/opcode';
 import { clientBuilder } from '@glimmer/runtime/lib/vm/element-builder';
 import { inTransaction, runtimeOptions } from '@glimmer/runtime/lib/environment';
+import { drainInvalidationQueue, hasQueuedInvalidations } from '@glimmer/runtime/lib/vm/update';
 import { renderComponent as glimmerRenderComponent } from '@glimmer/runtime/lib/render';
-import { CURRENT_TAG, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
+import { consumeUnsubscribedDirt, CURRENT_TAG, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import { hasDOM } from '../../browser-environment';
 import { EmberEnvironmentDelegate } from './environment';
@@ -386,31 +387,8 @@ export class RendererState {
     }
   }
 
-  #frameScheduled = false;
-
-  /**
-   * SPIKE: coalesce revalidation to at most once per animation frame.
-   *
-   * Invalidation bursts (sockets, workers) otherwise trigger a full
-   * revalidation per runloop flush -- many times per painted frame.
-   * Only frames that will actually paint need the DOM updated.
-   */
   scheduleRevalidate(renderer: BaseRenderer): void {
-    if (typeof requestAnimationFrame === 'function') {
-      if (this.#frameScheduled) {
-        return;
-      }
-
-      this.#frameScheduled = true;
-      setFramePending(true);
-      requestAnimationFrame(() => {
-        this.#frameScheduled = false;
-        setFramePending(false);
-        _backburner.join(() => this.revalidate(renderer));
-      });
-    } else {
-      _backburner.scheduleOnce('render', this, this.revalidate, renderer);
-    }
+    _backburner.scheduleOnce('render', this, this.revalidate, renderer);
   }
 
   isValid(): boolean {
@@ -423,7 +401,30 @@ export class RendererState {
     if (this.isValid()) {
       return;
     }
+
+    // SPIKE push-invalidation: when every piece of dirt since the last
+    // flush reached a subscribed opcode, process exactly those opcodes
+    // instead of walking the tree.
+    const stats = ((globalThis as any).__pushStats ??= { push: 0, walk: 0, dirtBlocked: 0 });
+    const unsub = consumeUnsubscribedDirt();
+    if (unsub) stats.dirtBlocked++;
+    if (!unsub && hasQueuedInvalidations()) {
+      stats.push++;
+      inTransaction(this.context.env, () => drainInvalidationQueue(this.context.env));
+
+      this.#lastRevision = valueForTag(CURRENT_TAG);
+      // dirt produced while draining was handled by the drain
+      consumeUnsubscribedDirt();
+
+      if (this.isValid()) {
+        return;
+      }
+    }
+
+    stats.walk++;
     this.#renderRootsTransaction(renderer);
+    // dirt produced during the walk was handled by the walk
+    consumeUnsubscribedDirt();
   }
 
   clearAllRoots(renderer: BaseRenderer): void {

--- a/packages/@ember/-internals/glimmer/lib/base-renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/base-renderer.ts
@@ -24,9 +24,11 @@ import { artifacts } from '@glimmer/program/lib/helpers';
 import { RuntimeOpImpl } from '@glimmer/program/lib/opcode';
 import { clientBuilder } from '@glimmer/runtime/lib/vm/element-builder';
 import { inTransaction, runtimeOptions } from '@glimmer/runtime/lib/environment';
-import { drainInvalidationQueue, hasQueuedInvalidations } from '@glimmer/runtime/lib/vm/update';
+import { drainInvalidationQueue } from '@glimmer/runtime/lib/vm/update';
+import { beginTrackFrame, endTrackFrame } from '@glimmer/validator/lib/tracking';
+import type { Tag } from '@glimmer/interfaces';
 import { renderComponent as glimmerRenderComponent } from '@glimmer/runtime/lib/render';
-import { consumeUnsubscribedDirt, CURRENT_TAG, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
+import { consumeUnsubscribedDirt, CURRENT_TAG, subscribeToTag, unsubscribeFromTags, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import { hasDOM } from '../../browser-environment';
 import { EmberEnvironmentDelegate } from './environment';
@@ -134,6 +136,13 @@ export class ComponentRootState implements RendererRoot {
     return this.#result;
   }
 }
+
+/** SPIKE push-invalidation: roots whose own deps changed. */
+const queuedRoots = new Set<RendererRoot>();
+const rootSubscriptions = new WeakMap<
+  RendererRoot,
+  { leaves: Tag[]; enqueue: () => void }
+>();
 
 const renderers: BaseRenderer[] = [];
 
@@ -367,7 +376,7 @@ export class RendererState {
             continue;
           }
 
-          root.render();
+          this.#renderRootSubscribed(root);
         }
 
         this.#lastRevision = valueForTag(CURRENT_TAG);
@@ -387,8 +396,25 @@ export class RendererState {
     }
   }
 
+  #frameScheduled = false;
+
+  /** SPIKE: coalesce all invalidation delivery to one drain per frame. */
   scheduleRevalidate(renderer: BaseRenderer): void {
-    _backburner.scheduleOnce('render', this, this.revalidate, renderer);
+    if (typeof requestAnimationFrame === 'function') {
+      if (this.#frameScheduled) {
+        return;
+      }
+
+      this.#frameScheduled = true;
+      setFramePending(true);
+      requestAnimationFrame(() => {
+        this.#frameScheduled = false;
+        setFramePending(false);
+        _backburner.join(() => this.revalidate(renderer));
+      });
+    } else {
+      _backburner.scheduleOnce('render', this, this.revalidate, renderer);
+    }
   }
 
   isValid(): boolean {
@@ -397,34 +423,66 @@ export class RendererState {
     );
   }
 
+  /**
+   * SPIKE push-invalidation v5, walk-free: subscription coverage is
+   * complete (roots + blocks + items), so unsubscribed dirt affects
+   * nothing rendered and is deliberately ignored. The only "walk" is
+   * re-rendering a root whose own (non-delegated) deps changed --
+   * which is the minimal correct response, not a fallback.
+   */
   revalidate(renderer: BaseRenderer): void {
     if (this.isValid()) {
       return;
     }
 
-    // SPIKE push-invalidation: when every piece of dirt since the last
-    // flush reached a subscribed opcode, process exactly those opcodes
-    // instead of walking the tree.
-    const stats = ((globalThis as any).__pushStats ??= { push: 0, walk: 0, dirtBlocked: 0 });
-    const unsub = consumeUnsubscribedDirt();
-    if (unsub) stats.dirtBlocked++;
-    if (!unsub && hasQueuedInvalidations()) {
-      stats.push++;
-      inTransaction(this.context.env, () => drainInvalidationQueue(this.context.env));
+    const stats = ((globalThis as any).__pushStats ??= { drains: 0, rootRenders: 0 });
 
-      this.#lastRevision = valueForTag(CURRENT_TAG);
-      // dirt produced while draining was handled by the drain
-      consumeUnsubscribedDirt();
-
-      if (this.isValid()) {
-        return;
-      }
-    }
-
-    stats.walk++;
-    this.#renderRootsTransaction(renderer);
-    // dirt produced during the walk was handled by the walk
+    stats.drains++;
     consumeUnsubscribedDirt();
+
+    inTransaction(this.context.env, () => {
+      if (queuedRoots.size > 0) {
+        const roots = [...queuedRoots];
+
+        queuedRoots.clear();
+
+        for (const root of roots) {
+          if (root.destroyed) continue;
+
+          stats.rootRenders++;
+          this.#renderRootSubscribed(root);
+        }
+      }
+
+      drainInvalidationQueue(this.context.env);
+    });
+
+    this.#lastRevision = valueForTag(CURRENT_TAG);
+    consumeUnsubscribedDirt();
+  }
+
+  /**
+   * Render one root inside a tracking frame and keep its subscription
+   * pointed at what it actually read. Items and blocks do not
+   * propagate their deps upward, so this collects only the root's own
+   * non-delegated dependencies.
+   */
+  #renderRootSubscribed(root: RendererRoot): void {
+    beginTrackFrame();
+
+    try {
+      root.render();
+    } finally {
+      const tag = endTrackFrame();
+      const previous = rootSubscriptions.get(root);
+      const enqueue = previous?.enqueue ?? (() => queuedRoots.add(root));
+
+      if (previous !== undefined) {
+        unsubscribeFromTags(previous.leaves, previous.enqueue);
+      }
+
+      rootSubscriptions.set(root, { leaves: subscribeToTag(tag, enqueue), enqueue });
+    }
   }
 
   clearAllRoots(renderer: BaseRenderer): void {

--- a/packages/@ember/-internals/metal/lib/property_get.ts
+++ b/packages/@ember/-internals/metal/lib/property_get.ts
@@ -111,24 +111,13 @@ export function _getProp(obj: unknown, keyName: string) {
       value = (obj as any)[keyName];
     }
 
-    if (
-      value === undefined &&
-      typeof obj === 'object' &&
-      !(keyName in obj) &&
-      hasUnknownProperty(obj)
-    ) {
-      value = obj.unknownProperty(keyName);
-    }
-
-    if (isTracking()) {
-      consumeTag(tagFor(obj, keyName));
-
-      if (Array.isArray(value) || isEmberArray(value)) {
-        // Add the tag of the returned value if it is an array, since arrays
-        // should always cause updates if they are consumed and then changed
-        consumeTag(tagFor(value, '[]'));
-      }
-    }
+    // SPIKE: deleted legacy read-path support:
+    // - unknownProperty (ObjectProxy / EmberObject)
+    // - per-(object, key) tag consumption on arbitrary objects, which
+    //   existed so Ember.set() on POJOs invalidates renders
+    // - the '[]' EmberArray tag consume for array-valued reads
+    // Modern semantics: plain-data reads don't entangle; reactivity
+    // comes from @tracked, tracked collections, and value replacement.
   } else {
     // SAFETY: It should be ok to access properties on any non-nullish value
     value = (obj as any)[keyName];

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -19,6 +19,12 @@ export interface IterationItem<T, U> {
 export interface AbstractIterator<T, U, V extends IterationItem<T, U>> {
   isEmpty(): boolean;
   next(): Nullable<V>;
+  /**
+   * SPIKE: allocation-free iteration -- writes into `target` and returns
+   * it, instead of allocating a fresh item per step. Optional; callers
+   * must not retain the returned object across steps.
+   */
+  nextInto?(target: V): Nullable<V>;
 }
 
 export type OpaqueIterationItem = IterationItem<unknown, unknown>;
@@ -262,5 +268,25 @@ class ArrayIterator implements OpaqueIterator {
     let memo = this.pos;
 
     return { key, value, memo };
+  }
+
+  nextInto(target: IterationItem<unknown, number>): Nullable<IterationItem<unknown, number>> {
+    let value: unknown;
+
+    let current = this.current;
+    if (current.kind === 'first') {
+      this.current = { kind: 'progress' };
+      value = current.value;
+    } else if (this.pos >= this.iterator.length - 1) {
+      return null;
+    } else {
+      value = this.iterator[++this.pos];
+    }
+
+    target.key = this.keyFor(value, this.pos);
+    target.value = value;
+    target.memo = this.pos;
+
+    return target;
   }
 }

--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -180,6 +180,11 @@ export function valueForRef<T>(_ref: Reference<T>): T {
   return lastValue as T;
 }
 
+/** SPIKE push-invalidation: the tag a ref last computed with, if any. */
+export function tagOfRef(_ref: Reference): Tag | null {
+  return (_ref as ReferenceImpl).tag;
+}
+
 export function updateRef(_ref: Reference, value: unknown) {
   const ref = _ref as ReferenceImpl;
 

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -293,9 +293,9 @@ export class ListItemOpcode extends TryOpcode {
       !vm.alwaysRevalidate &&
       validateTag(subtreeTag, this.subtreeRevision)
     ) {
-      // propagate this item's dependencies to any enclosing tracking
-      // frame, exactly as executing the children would have
-      consumeTag(subtreeTag);
+      // push-invalidation owns delivery: do NOT propagate item deps
+      // upward, or enclosing subscriptions (the root's) would fire on
+      // every item change and re-walk everything
       return;
     }
 
@@ -308,7 +308,6 @@ export class ListItemOpcode extends TryOpcode {
 
       this.subtreeTag = tag;
       this.subtreeRevision = valueForTag(tag);
-      consumeTag(tag);
 
       // keep the push-invalidation subscription pointing at the leaves
       // this subtree actually read
@@ -330,6 +329,11 @@ export class ListItemOpcode extends TryOpcode {
     }
 
     super.handleException();
+  }
+
+  /** push bootstrap: items that never collected must be walked once */
+  get needsCollection(): boolean {
+    return this.subtreeTag === null;
   }
 
   shouldRemove(): boolean {
@@ -443,6 +447,13 @@ export class ListBlockOpcode extends BlockOpcode {
       // array proxy read during next()), so the subscription must come
       // from what the sync actually read, not just the iterable ref
       this.resubscribeTo(endTrackFrame());
+      this.enqueueUncollectedItems();
+    }
+  }
+
+  private enqueueUncollectedItems() {
+    for (const item of this.children) {
+      if (item.needsCollection) queuedItems.add(item);
     }
   }
 
@@ -453,6 +464,7 @@ export class ListBlockOpcode extends BlockOpcode {
       this.evaluateSync(vm);
     } finally {
       this.resubscribeTo(endTrackFrame());
+      this.enqueueUncollectedItems();
     }
 
     // Run now-updated updating opcodes

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -18,13 +18,13 @@ import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib
 import type { Reference } from '@glimmer/reference/lib/reference';
 import type { Revision, Tag } from '@glimmer/interfaces';
 import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
-import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/destroyable';
+import { associateDestroyableChild, destroy, destroyChildren, isDestroyed, isDestroying, registerDestructor } from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
-import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
+import { tagOfRef, updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
 import { debug } from '@glimmer/validator/lib/debug';
 import { beginTrackFrame, consumeTag, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
-import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
+import { CONSTANT_TAG, INITIAL, markUnsubscribedDirt, subscribeToTag, unsubscribeFromTags, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
 import type { AppendingBlockList } from './element-builder';
@@ -132,6 +132,49 @@ export class UpdatingVM implements IUpdatingVM {
 
 const EMPTY_OPS: UpdatingOpcode[] = [];
 
+/**
+ * SPIKE push-invalidation: opcodes queued directly by tag dirtying.
+ * The render flush drains this instead of walking the whole tree,
+ * falling back to a full walk when unsubscribed dirt was seen.
+ */
+const queuedBlocks = new Set<ListBlockOpcode>();
+const queuedItems = new Set<ListItemOpcode>();
+
+export function hasQueuedInvalidations(): boolean {
+  return queuedBlocks.size > 0 || queuedItems.size > 0;
+}
+
+const NOOP_HANDLER: ExceptionHandler = {
+  handleException() {},
+};
+
+export function drainInvalidationQueue(env: Environment): void {
+  // blocks first: membership syncs may destroy queued items
+  while (queuedBlocks.size > 0 || queuedItems.size > 0) {
+    if (queuedBlocks.size > 0) {
+      const blocks = [...queuedBlocks];
+
+      queuedBlocks.clear();
+
+      for (const block of blocks) {
+        if (isDestroyed(block) || isDestroying(block)) continue;
+
+        block.pushEvaluate(env);
+      }
+    } else {
+      const items = [...queuedItems];
+
+      queuedItems.clear();
+
+      for (const item of items) {
+        if (isDestroyed(item) || isDestroying(item)) continue;
+
+        new UpdatingVM(env, {}).execute([item], item);
+      }
+    }
+  }
+}
+
 export interface VMState {
   readonly pc: number;
   readonly scope: Scope;
@@ -214,7 +257,11 @@ export class ListItemOpcode extends TryOpcode {
    */
   private subtreeTag: Nullable<Tag> = null;
   private subtreeRevision: Revision = INITIAL;
-  private isTrivial: boolean | null = null;
+  /** SPIKE push-invalidation */
+  private subscribedLeaves: Nullable<Tag[]> = null;
+  private enqueue = () => {
+    queuedItems.add(this);
+  };
 
   constructor(
     state: Closure,
@@ -225,20 +272,20 @@ export class ListItemOpcode extends TryOpcode {
     public value: Reference
   ) {
     super(state, context, bounds, []);
+
+    registerDestructor(this, () => {
+      if (this.subscribedLeaves !== null) {
+        unsubscribeFromTags(this.subscribedLeaves, this.enqueue);
+        this.subscribedLeaves = null;
+      }
+      queuedItems.delete(this);
+    });
   }
 
   override evaluate(vm: UpdatingVM) {
-    // Trivial items (a text node or two) can't win: validating their
-    // combined tag costs as much as just updating them, so collection
-    // would be pure overhead. Skipping only pays off for items with a
-    // real subtree -- more than a couple of opcodes, or any nested
-    // block (a nested block child means an arbitrarily large subtree
-    // hides behind a small top-level count).
-    if (this.isTrivial ?? (this.isTrivial = computeIsTrivial(this.children))) {
-      vm.try(this.children, this);
-      return;
-    }
-
+    // SPIKE push-invalidation: every item collects and subscribes (the
+    // triviality gate is incompatible with push -- unsubscribed items
+    // would silently go stale).
     let { subtreeTag } = this;
 
     if (
@@ -262,14 +309,26 @@ export class ListItemOpcode extends TryOpcode {
       this.subtreeTag = tag;
       this.subtreeRevision = valueForTag(tag);
       consumeTag(tag);
+
+      // keep the push-invalidation subscription pointing at the leaves
+      // this subtree actually read
+      if (this.subscribedLeaves !== null) {
+        unsubscribeFromTags(this.subscribedLeaves, this.enqueue);
+      }
+      this.subscribedLeaves = subscribeToTag(tag, this.enqueue);
     });
   }
 
   override handleException() {
-    // children are about to be rebuilt; the collected tag and triviality
-    // no longer describe them
+    // children are about to be rebuilt; the collected tag and
+    // subscriptions no longer describe them
     this.subtreeTag = null;
-    this.isTrivial = null;
+
+    if (this.subscribedLeaves !== null) {
+      unsubscribeFromTags(this.subscribedLeaves, this.enqueue);
+      this.subscribedLeaves = null;
+    }
+
     super.handleException();
   }
 
@@ -282,16 +341,6 @@ export class ListItemOpcode extends TryOpcode {
   }
 }
 
-function computeIsTrivial(children: UpdatingOpcode[]): boolean {
-  if (children.length > 2) return false;
-
-  for (const child of children) {
-    if (child instanceof BlockOpcode) return false;
-  }
-
-  return true;
-}
-
 export class ListBlockOpcode extends BlockOpcode {
   public type = 'list-block';
   declare public children: ListItemOpcode[];
@@ -299,6 +348,12 @@ export class ListBlockOpcode extends BlockOpcode {
   private opcodeMap = new Map<unknown, ListItemOpcode>();
   private marker: SimpleComment | null = null;
   private lastIterator: OpaqueIterator;
+
+  /** SPIKE push-invalidation */
+  private subscribedLeaves: Nullable<Tag[]> = null;
+  private enqueueBlock = () => {
+    queuedBlocks.add(this);
+  };
 
   declare protected readonly bounds: AppendingBlockList;
 
@@ -311,6 +366,28 @@ export class ListBlockOpcode extends BlockOpcode {
   ) {
     super(state, context, bounds, children);
     this.lastIterator = valueForRef(iterableRef);
+    this.resubscribeTo(CONSTANT_TAG);
+
+    registerDestructor(this, () => {
+      if (this.subscribedLeaves !== null) {
+        unsubscribeFromTags(this.subscribedLeaves, this.enqueueBlock);
+        this.subscribedLeaves = null;
+      }
+      queuedBlocks.delete(this);
+    });
+  }
+
+  private resubscribeTo(syncTag: Tag) {
+    if (this.subscribedLeaves !== null) {
+      unsubscribeFromTags(this.subscribedLeaves, this.enqueueBlock);
+    }
+
+    let leaves = subscribeToTag(syncTag, this.enqueueBlock);
+    let refTag = tagOfRef(this.iterableRef);
+
+    if (refTag !== null) subscribeToTag(refTag, this.enqueueBlock, leaves);
+
+    this.subscribedLeaves = leaves;
   }
 
   initializeChild(opcode: ListItemOpcode) {
@@ -318,7 +395,71 @@ export class ListBlockOpcode extends BlockOpcode {
     this.opcodeMap.set(opcode.key, opcode);
   }
 
+  /**
+   * SPIKE push-invalidation: membership sync only -- children are NOT
+   * walked; changed items enqueue themselves via their own
+   * subscriptions and are processed by the drain. Falls back to a full
+   * walk (via the unsubscribed-dirt flag) when the list transitions
+   * between empty and non-empty, because the surrounding Enter/Assert
+   * opcodes this path skips are what rebuild that region.
+   */
+  pushEvaluate(env: Environment) {
+    let wasEmpty = this.children.length === 0;
+
+    beginTrackFrame();
+
+    try {
+      let iterator = valueForRef(this.iterableRef);
+
+      if (this.lastIterator !== iterator) {
+        if (wasEmpty !== iterator.isEmpty()) {
+          markUnsubscribedDirt();
+          return;
+        }
+
+        let buffered = this.tryFastSync(iterator);
+
+        if (buffered !== null) {
+          let { bounds } = this;
+          let dom = env.getDOM();
+
+          let marker = (this.marker = dom.createComment(''));
+          dom.insertAfter(
+            bounds.parentElement(),
+            marker,
+            expect(bounds.lastNode(), "can't insert after an empty bounds")
+          );
+
+          this.sync(new PrefixedIterator(buffered, iterator));
+
+          this.parentElement().removeChild(marker);
+          this.marker = null;
+        }
+
+        this.lastIterator = iterator;
+      }
+    } finally {
+      // iteration consumes collection cell tags lazily (e.g. a tracked
+      // array proxy read during next()), so the subscription must come
+      // from what the sync actually read, not just the iterable ref
+      this.resubscribeTo(endTrackFrame());
+    }
+  }
+
   override evaluate(vm: UpdatingVM) {
+    beginTrackFrame();
+
+    try {
+      this.evaluateSync(vm);
+    } finally {
+      this.resubscribeTo(endTrackFrame());
+    }
+
+    // Run now-updated updating opcodes
+    super.evaluate(vm);
+  }
+
+  private evaluateSync(vm: UpdatingVM) {
     let iterator = valueForRef(this.iterableRef);
 
     if (this.lastIterator !== iterator) {
@@ -348,9 +489,6 @@ export class ListBlockOpcode extends BlockOpcode {
 
       this.lastIterator = iterator;
     }
-
-    // Run now-updated updating opcodes
-    super.evaluate(vm);
   }
 
   /**

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -22,7 +22,6 @@ import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/de
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
-import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
 import { beginTrackFrame, consumeTag, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
 import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
@@ -38,7 +37,15 @@ export class UpdatingVM implements IUpdatingVM {
   public dom: GlimmerTreeChanges;
   public alwaysRevalidate: boolean;
 
-  private frameStack: Stack<UpdatingVMFrame> = new Stack<UpdatingVMFrame>();
+  /**
+   * SPIKE: a flat frame stack (parallel arrays indexed by depth)
+   * instead of allocating an UpdatingVMFrame per block per render.
+   */
+  #ops: UpdatingOpcode[][] = [];
+  #current: number[] = [];
+  #handlers: Nullable<ExceptionHandler>[] = [];
+  #finalizers: (((didError: boolean) => void) | undefined)[] = [];
+  #depth = -1;
 
   constructor(env: Environment, { alwaysRevalidate = false }) {
     this.env = env;
@@ -71,39 +78,59 @@ export class UpdatingVM implements IUpdatingVM {
   }
 
   private _execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler) {
-    let { frameStack } = this;
-
     this.try(opcodes, handler);
 
-    while (!frameStack.isEmpty()) {
-      let opcode = this.frame.nextStatement();
+    while (this.#depth >= 0) {
+      let depth = this.#depth;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depth checked
+      let ops = this.#ops[depth]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depth checked
+      let index = this.#current[depth]!;
 
-      if (opcode === undefined) {
-        frameStack.pop()?.finalize(false);
+      if (index >= ops.length) {
+        this.#pop(false);
         continue;
       }
 
-      opcode.evaluate(this);
+      this.#current[depth] = index + 1;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      ops[index]!.evaluate(this);
     }
   }
 
-  private get frame() {
-    return expect(this.frameStack.current, 'bug: expected a frame');
+  #pop(didError: boolean) {
+    let depth = this.#depth;
+    let finalizer = this.#finalizers[depth];
+
+    // release references so retained arrays don't leak between renders
+    this.#ops[depth] = EMPTY_OPS;
+    this.#handlers[depth] = null;
+    this.#finalizers[depth] = undefined;
+    this.#depth = depth - 1;
+
+    finalizer?.(didError);
   }
 
   goto(index: number) {
-    this.frame.goto(index);
+    this.#current[this.#depth] = index;
   }
 
   try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>, finalizer?: (didError: boolean) => void) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler, finalizer));
+    let depth = ++this.#depth;
+
+    this.#ops[depth] = ops;
+    this.#current[depth] = 0;
+    this.#handlers[depth] = handler;
+    this.#finalizers[depth] = finalizer;
   }
 
   throw() {
-    this.frame.handleException();
-    this.frameStack.pop()?.finalize(true);
+    this.#handlers[this.#depth]?.handleException();
+    this.#pop(true);
   }
 }
+
+const EMPTY_OPS: UpdatingOpcode[] = [];
 
 export interface VMState {
   readonly pc: number;
@@ -327,42 +354,69 @@ export class ListBlockOpcode extends BlockOpcode {
   }
 
   /**
-   * Streaming compare of the new iteration against existing children.
-   * Returns null when everything matched in order (refs updated in
-   * place); otherwise returns the already-consumed items so the full
+   * Streaming compare of the new iteration against existing children,
+   * applied as it matches: allocation-free on the happy path (a shared
+   * scratch item via nextInto). Returns null when everything matched in
+   * order; otherwise reconstructs the already-applied prefix (reading
+   * the just-updated refs back) plus the mismatched item, so the full
    * sync can replay them.
    */
   private tryFastSync(iterator: OpaqueIterator): Nullable<OpaqueIterationItem[]> {
     let { children } = this;
-    let buffered: OpaqueIterationItem[] = [];
+    let matched = 0;
 
     while (true) {
-      let item = iterator.next();
+      let item =
+        iterator.nextInto !== undefined ? iterator.nextInto(SCRATCH_ITEM) : iterator.next();
 
       if (item === null) {
-        if (buffered.length !== children.length) return buffered;
+        if (matched === children.length) return null;
 
-        for (let i = 0; i < buffered.length; i++) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
-          let opcode = children[i]!;
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
-          let next = buffered[i]!;
-
-          updateRef(opcode.memo, next.memo);
-          updateRef(opcode.value, next.value);
-        }
-
-        return null;
+        // the list shrank; replay the matched prefix through full sync
+        return this.reconstructPrefix(matched, null);
       }
 
-      let opcode = children[buffered.length];
-
-      buffered.push(item);
+      let opcode = children[matched];
 
       if (opcode === undefined || opcode.key !== item.key) {
-        return buffered;
+        return this.reconstructPrefix(matched, {
+          key: item.key,
+          value: item.value,
+          memo: item.memo,
+        });
       }
+
+      updateRef(opcode.memo, item.memo);
+      updateRef(opcode.value, item.value);
+      matched++;
     }
+  }
+
+  /**
+   * The matched prefix was already applied to the item refs, so its
+   * items can be reconstructed from the opcodes themselves.
+   */
+  private reconstructPrefix(
+    matched: number,
+    mismatch: Nullable<OpaqueIterationItem>
+  ): OpaqueIterationItem[] {
+    let { children } = this;
+    let prefix: OpaqueIterationItem[] = [];
+
+    for (let i = 0; i < matched; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      let opcode = children[i]!;
+
+      prefix.push({
+        key: opcode.key,
+        value: valueForRef(opcode.value),
+        memo: valueForRef(opcode.memo),
+      });
+    }
+
+    if (mismatch !== null) prefix.push(mismatch);
+
+    return prefix;
   }
 
   private sync(iterator: OpaqueIterator) {
@@ -539,6 +593,9 @@ export class ListBlockOpcode extends BlockOpcode {
   }
 }
 
+/** Shared scratch for allocation-free fast-path iteration. */
+const SCRATCH_ITEM: OpaqueIterationItem = { key: null, value: null, memo: null };
+
 /** Replays already-consumed items before draining the rest. */
 class PrefixedIterator implements OpaqueIterator {
   private index = 0;
@@ -562,30 +619,3 @@ class PrefixedIterator implements OpaqueIterator {
   }
 }
 
-class UpdatingVMFrame {
-  private current = 0;
-
-  constructor(
-    private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>,
-    private finalizer?: (didError: boolean) => void
-  ) {}
-
-  goto(index: number) {
-    this.current = index;
-  }
-
-  nextStatement(): UpdatingOpcode | undefined {
-    return this.ops[this.current++];
-  }
-
-  finalize(didError: boolean) {
-    this.finalizer?.(didError);
-  }
-
-  handleException() {
-    if (this.exceptionHandler) {
-      this.exceptionHandler.handleException();
-    }
-  }
-}

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -16,6 +16,7 @@ import type {
 } from '@glimmer/interfaces';
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
 import type { Reference } from '@glimmer/reference/lib/reference';
+import type { Revision, Tag } from '@glimmer/interfaces';
 import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
@@ -23,7 +24,8 @@ import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
-import { resetTracking } from '@glimmer/validator/lib/tracking';
+import { beginTrackFrame, consumeTag, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
+import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
 import type { AppendingBlockList } from './element-builder';
@@ -77,7 +79,7 @@ export class UpdatingVM implements IUpdatingVM {
       let opcode = this.frame.nextStatement();
 
       if (opcode === undefined) {
-        frameStack.pop();
+        frameStack.pop()?.finalize(false);
         continue;
       }
 
@@ -93,13 +95,13 @@ export class UpdatingVM implements IUpdatingVM {
     this.frame.goto(index);
   }
 
-  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler));
+  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>, finalizer?: (didError: boolean) => void) {
+    this.frameStack.push(new UpdatingVMFrame(ops, handler, finalizer));
   }
 
   throw() {
     this.frame.handleException();
-    this.frameStack.pop();
+    this.frameStack.pop()?.finalize(true);
   }
 }
 
@@ -178,6 +180,15 @@ export class ListItemOpcode extends TryOpcode {
   public retained = false;
   public index = -1;
 
+  /**
+   * Everything this item's subtree consumed during its last update,
+   * combined. When still valid, the whole subtree is skipped -- one tag
+   * validation instead of walking every opcode in the item.
+   */
+  private subtreeTag: Nullable<Tag> = null;
+  private subtreeRevision: Revision = INITIAL;
+  private isTrivial: boolean | null = null;
+
   constructor(
     state: Closure,
     context: EvaluationContext,
@@ -189,6 +200,52 @@ export class ListItemOpcode extends TryOpcode {
     super(state, context, bounds, []);
   }
 
+  override evaluate(vm: UpdatingVM) {
+    // Trivial items (a text node or two) can't win: validating their
+    // combined tag costs as much as just updating them, so collection
+    // would be pure overhead. Skipping only pays off for items with a
+    // real subtree -- more than a couple of opcodes, or any nested
+    // block (a nested block child means an arbitrarily large subtree
+    // hides behind a small top-level count).
+    if (this.isTrivial ?? (this.isTrivial = computeIsTrivial(this.children))) {
+      vm.try(this.children, this);
+      return;
+    }
+
+    let { subtreeTag } = this;
+
+    if (
+      subtreeTag !== null &&
+      !vm.alwaysRevalidate &&
+      validateTag(subtreeTag, this.subtreeRevision)
+    ) {
+      // propagate this item's dependencies to any enclosing tracking
+      // frame, exactly as executing the children would have
+      consumeTag(subtreeTag);
+      return;
+    }
+
+    beginTrackFrame();
+    vm.try(this.children, this, (didError) => {
+      // always balance beginTrackFrame, even when unwinding
+      let tag = endTrackFrame();
+
+      if (didError) return;
+
+      this.subtreeTag = tag;
+      this.subtreeRevision = valueForTag(tag);
+      consumeTag(tag);
+    });
+  }
+
+  override handleException() {
+    // children are about to be rebuilt; the collected tag and triviality
+    // no longer describe them
+    this.subtreeTag = null;
+    this.isTrivial = null;
+    super.handleException();
+  }
+
   shouldRemove(): boolean {
     return !this.retained;
   }
@@ -196,6 +253,16 @@ export class ListItemOpcode extends TryOpcode {
   reset() {
     this.retained = false;
   }
+}
+
+function computeIsTrivial(children: UpdatingOpcode[]): boolean {
+  if (children.length > 2) return false;
+
+  for (const child of children) {
+    if (child instanceof BlockOpcode) return false;
+  }
+
+  return true;
 }
 
 export class ListBlockOpcode extends BlockOpcode {
@@ -428,7 +495,8 @@ class UpdatingVMFrame {
 
   constructor(
     private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>
+    private exceptionHandler: Nullable<ExceptionHandler>,
+    private finalizer?: (didError: boolean) => void
   ) {}
 
   goto(index: number) {
@@ -437,6 +505,10 @@ class UpdatingVMFrame {
 
   nextStatement(): UpdatingOpcode | undefined {
     return this.ops[this.current++];
+  }
+
+  finalize(didError: boolean) {
+    this.finalizer?.(didError);
   }
 
   handleException() {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -295,25 +295,74 @@ export class ListBlockOpcode extends BlockOpcode {
     let iterator = valueForRef(this.iterableRef);
 
     if (this.lastIterator !== iterator) {
-      let { bounds } = this;
-      let { dom } = vm;
+      // SPIKE: deriving a fresh array from tracked state is the idiomatic
+      // pattern, so iterator identity changes every render even when the
+      // list's keys did not. When items match the existing children in
+      // order and count, just update the item refs -- no diff
+      // bookkeeping, no marker DOM, no children rebuild.
+      let buffered = this.tryFastSync(iterator);
 
-      let marker = (this.marker = dom.createComment(''));
-      dom.insertAfter(
-        bounds.parentElement(),
-        marker,
-        expect(bounds.lastNode(), "can't insert after an empty bounds")
-      );
+      if (buffered !== null) {
+        let { bounds } = this;
+        let { dom } = vm;
 
-      this.sync(iterator);
+        let marker = (this.marker = dom.createComment(''));
+        dom.insertAfter(
+          bounds.parentElement(),
+          marker,
+          expect(bounds.lastNode(), "can't insert after an empty bounds")
+        );
 
-      this.parentElement().removeChild(marker);
-      this.marker = null;
+        this.sync(new PrefixedIterator(buffered, iterator));
+
+        this.parentElement().removeChild(marker);
+        this.marker = null;
+      }
+
       this.lastIterator = iterator;
     }
 
     // Run now-updated updating opcodes
     super.evaluate(vm);
+  }
+
+  /**
+   * Streaming compare of the new iteration against existing children.
+   * Returns null when everything matched in order (refs updated in
+   * place); otherwise returns the already-consumed items so the full
+   * sync can replay them.
+   */
+  private tryFastSync(iterator: OpaqueIterator): Nullable<OpaqueIterationItem[]> {
+    let { children } = this;
+    let buffered: OpaqueIterationItem[] = [];
+
+    while (true) {
+      let item = iterator.next();
+
+      if (item === null) {
+        if (buffered.length !== children.length) return buffered;
+
+        for (let i = 0; i < buffered.length; i++) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+          let opcode = children[i]!;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+          let next = buffered[i]!;
+
+          updateRef(opcode.memo, next.memo);
+          updateRef(opcode.value, next.value);
+        }
+
+        return null;
+      }
+
+      let opcode = children[buffered.length];
+
+      buffered.push(item);
+
+      if (opcode === undefined || opcode.key !== item.key) {
+        return buffered;
+      }
+    }
   }
 
   private sync(iterator: OpaqueIterator) {
@@ -487,6 +536,29 @@ export class ListBlockOpcode extends BlockOpcode {
     destroy(opcode);
     clear(opcode);
     this.opcodeMap.delete(opcode.key);
+  }
+}
+
+/** Replays already-consumed items before draining the rest. */
+class PrefixedIterator implements OpaqueIterator {
+  private index = 0;
+
+  constructor(
+    private prefix: OpaqueIterationItem[],
+    private inner: OpaqueIterator
+  ) {}
+
+  isEmpty(): boolean {
+    return this.index >= this.prefix.length && this.inner.isEmpty();
+  }
+
+  next(): Nullable<OpaqueIterationItem> {
+    if (this.index < this.prefix.length) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      return this.prefix[this.index++]!;
+    }
+
+    return this.inner.next();
   }
 }
 

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -99,8 +99,37 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
       case 1:
         return tags[0] as Tag;
       default: {
+        // SPIKE: flatten nested combinators (and drop constants) so
+        // validating a combined tag is one flat loop instead of a
+        // pointer-chasing tree walk. Capped so pathological frames
+        // don't build giant arrays.
+        let flattened: Tag[] = [];
+        let budget = 64;
+
+        for (const t of tags) {
+          const impl = t as MonomorphicTagImpl;
+
+          if (impl === CONSTANT_TAG) continue;
+
+          if (
+            impl[TYPE] === COMBINATOR_TAG_ID &&
+            Array.isArray(impl.subtag) &&
+            impl.subtag.length <= budget
+          ) {
+            for (const sub of impl.subtag) {
+              if (sub !== CONSTANT_TAG) flattened.push(sub);
+            }
+            budget -= impl.subtag.length;
+          } else {
+            flattened.push(t);
+          }
+        }
+
+        if (flattened.length === 0) return CONSTANT_TAG;
+        if (flattened.length === 1) return flattened[0] as Tag;
+
         let tag: MonomorphicTagImpl = new MonomorphicTagImpl(COMBINATOR_TAG_ID);
-        tag.subtag = tags;
+        tag.subtag = flattened;
         return tag;
       }
     }

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -76,6 +76,10 @@ export function validateTag(tag: Tag, snapshot: Revision): boolean {
 
 const TYPE: TagTypeSymbol = Symbol('TAG_TYPE') as TagTypeSymbol;
 
+// SPIKE push-invalidation (declared early: the module warm-up below
+// dirties tags during evaluation)
+let sawUnsubscribedDirt = false;
+
 // this is basically a const
 export let ALLOW_CYCLES: WeakMap<Tag, boolean> | undefined;
 
@@ -138,6 +142,9 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
   private revision = INITIAL;
   private lastChecked = INITIAL;
   private lastValue = INITIAL;
+
+  /** SPIKE push-invalidation: callbacks to run when this tag dirties. */
+  subscribers: Set<() => void> | null = null;
 
   private isUpdating = false;
   public subtag: Tag | Tag[] | null = null;
@@ -252,6 +259,18 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
 
     (tag as MonomorphicTagImpl).revision = ++$REVISION;
 
+    // SPIKE push-invalidation: notify subscribers right here; dirt on
+    // an unsubscribed tag means the next flush cannot use the push
+    // path and must fall back to a full revalidation walk.
+    let subscribers = (tag as MonomorphicTagImpl).subscribers;
+
+    if (subscribers !== null && subscribers.size > 0) {
+      for (const callback of subscribers) callback();
+    } else {
+      sawUnsubscribedDirt = true;
+      (globalThis as any).__dirtHook?.();
+    }
+
     scheduleRevalidate();
   }
 }
@@ -326,3 +345,61 @@ UPDATE_TAG(tag1, tag3);
 valueForTag(tag1);
 DIRTY_TAG(tag3);
 valueForTag(tag1);
+
+//////////
+// SPIKE push-invalidation
+
+export function markUnsubscribedDirt(): void {
+  sawUnsubscribedDirt = true;
+}
+
+export function consumeUnsubscribedDirt(): boolean {
+  let saw = sawUnsubscribedDirt;
+  sawUnsubscribedDirt = false;
+  return saw;
+}
+
+/**
+ * Attach `callback` to every dirtyable leaf reachable from `tag`.
+ * Combinators are walked; constants are skipped. Returns the leaves so
+ * the caller can unsubscribe the same set later (a combined tag is an
+ * immutable snapshot, so the set is stable).
+ */
+export function subscribeToTag(tag: Tag, callback: () => void, leaves: Tag[] = []): Tag[] {
+  const impl = tag as MonomorphicTagImpl;
+
+  if (impl === (CONSTANT_TAG as unknown as MonomorphicTagImpl)) return leaves;
+
+  const type = impl[TYPE];
+
+  if (type === COMBINATOR_TAG_ID) {
+    const subtag = impl.subtag;
+
+    if (Array.isArray(subtag)) {
+      for (const sub of subtag as Tag[]) subscribeToTag(sub, callback, leaves);
+    } else if (subtag !== null) {
+      subscribeToTag(subtag, callback, leaves);
+    }
+
+    return leaves;
+  }
+
+  if (type === DIRYTABLE_TAG_ID || type === UPDATABLE_TAG_ID) {
+    (impl.subscribers ??= new Set()).add(callback);
+    leaves.push(tag);
+
+    // updatable tags can be re-pointed at another tag (UPDATE_TAG);
+    // walk the current target too so its leaves notify as well
+    if (type === UPDATABLE_TAG_ID && impl.subtag !== null && !Array.isArray(impl.subtag)) {
+      subscribeToTag(impl.subtag, callback, leaves);
+    }
+  }
+
+  return leaves;
+}
+
+export function unsubscribeFromTags(leaves: Tag[], callback: () => void): void {
+  for (const leaf of leaves) {
+    (leaf as MonomorphicTagImpl).subscribers?.delete(callback);
+  }
+}


### PR DESCRIPTION
**Documentation PR — explored and declined.** This is the "what if there is no revalidation?" experiment referenced from #21513 (rounds 4-5), given its own diff so the design and its costs are reviewable. It is stacked on #21513 but **replaces** that branch's revalidation design rather than adding to it — the two are mutually exclusive.

## The design (final form)

- tags gain `subscribers`; `dirtyTag` notifies them synchronously
- `{{#each}}` items subscribe to their collected subtree-tag leaves; list blocks collect *sync-consumed* tags in a tracking frame (iteration reads collection cells lazily — subscribing to the iterable ref alone misses `trackedArray.shift`)
- render **roots** render inside a tracking frame and subscribe to what they read; items/blocks do NOT propagate deps upward, so a root re-render fires only when the root's own non-delegated deps change
- no full walk exists: with complete coverage, unsubscribed dirt provably affects nothing rendered and is ignored; item bootstrap flows through the queue (blocks enqueue never-collected children)
- drains coalesce to one `requestAnimationFrame`

## Why declined

Same-batch dbmon at 8x CPU throttle (svelte anchors stable):

| configuration | fps | vs svelte |
|---|---|---|
| stock 7.3.0-alpha.5 | 7.2 | 22% |
| #21512 subtree-skip | 13.7 | 42% |
| **#21513 coalesced-walk stack** | **27.1** | **82%** |
| this branch (walk-free push) | 22.3 | 68% |

The theoretical O(changed) win is eaten by per-flush subscription churn (unsubscribe/resubscribe per processed opcode), root bookkeeping, and high run-to-run variance. Two design findings worth keeping regardless:

1. **Partial subscription coverage is silently incoherent** — un-subscribed regions go stale and can be masked by unrelated fallback renders. Push is all-or-nothing.
2. **rAF deferral breaks render-latency-coupled patterns** — a set→effect→advance loop went 0.4s → 33.6s (every iteration waits a frame). This caveat applies equally to #21513's coalescing lever and needs a sync-flush escape hatch in any landable frame-aligned design.

Conclusion: the walk was never the enemy — per-message flushing and legacy read tracking were. See #21513 for the direction worth landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)