### PR TITLE
[BUGFIX] Treat nullish LinkTo @query as an empty query object

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -469,7 +469,7 @@ class _LinkTo extends InternalComponent {
     if ('query' in this.args.named) {
       let query = this.named('query');
 
-      if (query == null) {
+      if (query === null) {
         return EMPTY_QUERY_PARAMS;
       }
 

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -469,7 +469,7 @@ class _LinkTo extends InternalComponent {
     if ('query' in this.args.named) {
       let query = this.named('query');
 
-      if (query === null) {
+      if (query === null || query === undefined) {
         return EMPTY_QUERY_PARAMS;
       }
 

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -469,9 +469,13 @@ class _LinkTo extends InternalComponent {
     if ('query' in this.args.named) {
       let query = this.named('query');
 
+      if (query == null) {
+        return EMPTY_QUERY_PARAMS;
+      }
+
       assert(
         'The `@query` argument to the <LinkTo> component must be an object.',
-        query !== null && typeof query === 'object'
+        typeof query === 'object'
       );
 
       return { ...query };

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -72,6 +72,48 @@ moduleFor(
         content: 'Index',
       });
     }
+
+    async ['@test it treats a nullish @query value as an empty query object']() {
+      this.add(
+        'controller:index',
+        class extends Controller {
+          queryParams = ['foo'];
+          foo = '123';
+          maybeQuery = undefined;
+        }
+      );
+
+      this.add(
+        'template:index',
+        precompileTemplate(`<LinkTo @route='index' @query={{this.maybeQuery}}>Index</LinkTo>`)
+      );
+
+      await this.visit('/');
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/', class: classMatcher('ember-view active') },
+        content: 'Index',
+      });
+
+      let indexController = this.controllerFor('index');
+
+      runTask(() => indexController.set('maybeQuery', null));
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/', class: classMatcher('ember-view active') },
+        content: 'Index',
+      });
+
+      runTask(() => indexController.set('maybeQuery', { foo: '456' }));
+
+      this.assertComponentElement(this.firstChild, {
+        tagName: 'a',
+        attrs: { href: '/?foo=456' },
+        content: 'Index',
+      });
+    }
   }
 );
 


### PR DESCRIPTION
Conditional bindings like `@query={{this.maybeParams}}` often evaluate to null or undefined. Those values previously failed the object assertion even though they mean "no query params". Treat nullish @query the same as an omitted argument so the link still renders.

Closes #20462