### PR TITLE
[BUGFIX] Reset sticky query params with an explicit empty query hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ember Changelog
 
+## Unreleased
+
+- [BUGFIX] An explicitly empty `{ queryParams: {} }` (and LinkTo `@query={{(hash)}}`) now resets sticky query params to their defaults for that transition. Omitting `queryParams` / `@query` still preserves sticky values. Apps that used an empty object as a no-op placeholder may observe a behavior change. See #20211.
+
 ## v7.2.0-beta.1 (June 22, 2026)
 
 - [#21303](https://github.com/emberjs/ember.js/pull/21303) [FEATURE] Build in a default Strict Resolver, an opt-in replacement for `ember-resolver` per [RFC #1132](https://rfcs.emberjs.com/id/1132-default-strict-resolver).

--- a/packages/@ember/-internals/glimmer/lib/components/link-to.ts
+++ b/packages/@ember/-internals/glimmer/lib/components/link-to.ts
@@ -252,6 +252,20 @@ function isQueryParams(value: unknown): value is QueryParams {
   </a>
   ```
 
+  Query parameters are sticky by default: omitting `@query` keeps previously used
+  values for that route. To reset sticky values back to their defaults for the
+  destination route, pass an explicitly empty hash:
+
+  ```handlebars
+  <LinkTo @route='photoGallery' @query={{(hash)}}>
+    Great Hamster Photos
+  </LinkTo>
+  ```
+
+  An explicitly empty `@query` resets defaults for that link/transition only; it
+  does not clear sticky values cached for other routes. Apps that previously
+  passed a dynamic empty hash as a no-op may observe a behavior change.
+
   @for Ember.Templates.components
   @method LinkTo
   @public
@@ -352,7 +366,9 @@ class _LinkTo extends InternalComponent {
 
     if (DEBUG) {
       try {
-        return routing.generateURL(route, models, query);
+        return routing.generateURL(route, models, query, {
+          queryParamsProvided: this.hasExplicitQuery,
+        });
       } catch (e) {
         let details = e instanceof Error ? e.message : inspect(e);
         let message = `While generating link to route "${route}": ${details}`;
@@ -364,7 +380,9 @@ class _LinkTo extends InternalComponent {
         }
       }
     } else {
-      return routing.generateURL(route, models, query);
+      return routing.generateURL(route, models, query, {
+        queryParamsProvided: this.hasExplicitQuery,
+      });
     }
   }
 
@@ -416,7 +434,9 @@ class _LinkTo extends InternalComponent {
     flaggedInstrument('interaction.link-to', payload, () => {
       assert('[BUG] route can only be missing if isLoading is true', isPresent(route));
 
-      payload.transition = routing.transitionTo(route, models, query, replace);
+      payload.transition = routing.transitionTo(route, models, query, replace, {
+        queryParamsProvided: this.hasExplicitQuery,
+      });
     });
   }
 
@@ -465,8 +485,12 @@ class _LinkTo extends InternalComponent {
     }
   }
 
+  private get hasExplicitQuery(): boolean {
+    return 'query' in this.args.named;
+  }
+
   private get query(): Record<string, unknown> {
-    if ('query' in this.args.named) {
+    if (this.hasExplicitQuery) {
       let query = this.named('query');
 
       assert(
@@ -572,7 +596,9 @@ class _LinkTo extends InternalComponent {
 
       assert('[BUG] route can only be missing if isLoading is true', isPresent(route));
 
-      return routing.isActiveForRoute(models, query, route, state);
+      return routing.isActiveForRoute(models, query, route, state, {
+        queryParamsProvided: this.hasExplicitQuery,
+      });
     }
   }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-angle-test.js
@@ -151,7 +151,7 @@ moduleFor(
       );
     }
 
-    async [`@test it doesn't update controller QP properties on current route when invoked (empty query-params obj)`](
+    async [`@test an explicit empty @query object resets sticky query params on the current route`](
       assert
     ) {
       this.add(
@@ -159,20 +159,27 @@ moduleFor(
         precompileTemplate(`<LinkTo id='the-link' @route='index' @query={{(hash)}}>Index</LinkTo>`)
       );
 
-      await this.visit('/');
-
-      await this.click('#the-link');
+      await this.visit('/?foo=456&bar=YES');
 
       let indexController = this.getController('index');
 
       assert.deepEqual(
         indexController.getProperties('foo', 'bar'),
-        this.indexProperties,
-        'controller QP properties do not update'
+        { foo: '456', bar: 'YES' },
+        'starts with sticky non-default QP values'
       );
+
+      await this.click('#the-link');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'explicit empty @query resets sticky QP values to defaults'
+      );
+      assert.equal(this.appRouter.get('location.path'), '/', 'URL drops non-default QPs');
     }
 
-    async [`@test it doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)`](
+    async [`@test an explicit empty @query object resets sticky query params (inferred route)`](
       assert
     ) {
       this.add(
@@ -180,7 +187,7 @@ moduleFor(
         precompileTemplate(`<LinkTo id='the-link' @query={{(hash)}}>Index</LinkTo>`)
       );
 
-      await this.visit('/');
+      await this.visit('/?foo=456&bar=YES');
 
       await this.click('#the-link');
 
@@ -189,8 +196,87 @@ moduleFor(
       assert.deepEqual(
         indexController.getProperties('foo', 'bar'),
         this.indexProperties,
-        'controller QP properties do not update'
+        'explicit empty @query resets sticky QP values to defaults'
       );
+    }
+
+    async [`@test omitting @query preserves sticky query params on the current route`](assert) {
+      this.add(
+        'template:index',
+        precompileTemplate(
+          `<LinkTo id='preserve-link' @route='index'>Index</LinkTo>
+           <LinkTo id='reset-link' @route='index' @query={{(hash)}}>Reset</LinkTo>`
+        )
+      );
+
+      await this.visit('/?foo=456&bar=YES');
+
+      assert.equal(
+        this.$('#preserve-link').attr('href'),
+        '/?bar=YES&foo=456',
+        'paramless LinkTo href keeps sticky QPs'
+      );
+      assert.equal(this.$('#reset-link').attr('href'), '/', 'empty @query href resets sticky QPs');
+
+      await this.click('#preserve-link');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'YES' },
+        'omitting @query keeps sticky QP values'
+      );
+    }
+
+    async [`@test an explicit empty @query resets sticky query params when transitioning to another route`](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('about');
+      });
+
+      this.add(
+        'template:about',
+        precompileTemplate(
+          `<LinkTo id='reset-link' @route='index' @query={{(hash)}}>Index</LinkTo>`
+        )
+      );
+
+      await this.visit('/?foo=456&bar=YES');
+      await this.visit('/about');
+
+      assert.equal(this.$('#reset-link').attr('href'), '/', 'href targets defaults, not sticky QPs');
+
+      await this.click('#reset-link');
+
+      let indexController = this.getController('index');
+
+      assert.equal(this.appRouter.get('location.path'), '/');
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        this.indexProperties,
+        'empty @query clears sticky values when entering the route'
+      );
+    }
+
+    async [`@test an explicit empty @query is inactive while sticky non-default query params are present`](
+      assert
+    ) {
+      this.add(
+        'template:index',
+        precompileTemplate(
+          `<LinkTo id='reset-link' @route='index' @query={{(hash)}}>Reset</LinkTo>`
+        )
+      );
+
+      await this.visit('/?foo=456&bar=YES');
+
+      this.shouldNotBeActive(assert, '#reset-link');
+
+      await this.click('#reset-link');
+
+      this.shouldBeActive(assert, '#reset-link');
     }
 
     async ['@test it updates controller QP properties on current route when invoked'](assert) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/query-params-curly-test.js
@@ -151,7 +151,7 @@ moduleFor(
       );
     }
 
-    async [`@test doesn't update controller QP properties on current route when invoked (empty query-params obj)`](
+    async [`@test an explicit empty query hash resets sticky query params on the current route`](
       assert
     ) {
       this.add(
@@ -161,20 +161,58 @@ moduleFor(
         )
       );
 
-      await this.visit('/');
-
-      await this.click('#the-link > a');
+      await this.visit('/?foo=456&bar=YES');
 
       let indexController = this.getController('index');
 
       assert.deepEqual(
         indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'YES' },
+        'starts with sticky non-default QP values'
+      );
+
+      await this.click('#the-link > a');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
         this.indexProperties,
-        'controller QP properties do not update'
+        'explicit empty query hash resets sticky QP values to defaults'
       );
     }
 
-    async [`@test it doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)`](
+    async [`@test omitting query preserves sticky query params on the current route`](assert) {
+      this.add(
+        'template:index',
+        precompileTemplate(
+          `<div id='preserve-link'>{{#link-to route='index'}}Index{{/link-to}}</div>
+           <div id='reset-link'>{{#link-to route='index' query=(hash)}}Reset{{/link-to}}</div>`
+        )
+      );
+
+      await this.visit('/?foo=456&bar=YES');
+
+      assert.ok(
+        this.$('#preserve-link > a').attr('href').includes('foo=456'),
+        'paramless link-to href keeps sticky QPs'
+      );
+      assert.equal(
+        this.$('#reset-link > a').attr('href'),
+        '/',
+        'empty query href resets sticky QPs'
+      );
+
+      await this.click('#preserve-link > a');
+
+      let indexController = this.getController('index');
+
+      assert.deepEqual(
+        indexController.getProperties('foo', 'bar'),
+        { foo: '456', bar: 'YES' },
+        'omitting query keeps sticky QP values'
+      );
+    }
+
+    async [`@test an explicit empty query hash resets sticky query params (inferred route)`](
       assert
     ) {
       this.add(
@@ -182,7 +220,7 @@ moduleFor(
         precompileTemplate(`<div id='the-link'>{{#link-to query=(hash)}}Index{{/link-to}}</div>`)
       );
 
-      await this.visit('/');
+      await this.visit('/?foo=456&bar=YES');
 
       await this.click('#the-link > a');
 
@@ -191,7 +229,7 @@ moduleFor(
       assert.deepEqual(
         indexController.getProperties('foo', 'bar'),
         this.indexProperties,
-        'controller QP properties do not update'
+        'explicit empty query hash resets sticky QP values to defaults'
       );
     }
 

--- a/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/link-to/routing-angle-test.js
@@ -1784,12 +1784,24 @@ moduleFor(
 
       this.add(
         'template:index',
-        precompileTemplate(`<LinkTo id='the-link' @route='index' @query={{(hash)}}>Index</LinkTo>`)
+        precompileTemplate(
+          `<LinkTo id='sticky-link' @route='index'>Sticky</LinkTo>
+           <LinkTo id='reset-link' @route='index' @query={{(hash)}}>Reset</LinkTo>`
+        )
       );
 
-      await this.visit('/');
+      await this.visit('/?foo=456');
 
-      assert.equal(this.$('#the-link').attr('href'), '/', 'link has right href');
+      assert.equal(
+        this.$('#sticky-link').attr('href'),
+        '/?foo=456',
+        'omitting @query keeps sticky href'
+      );
+      assert.equal(
+        this.$('#reset-link').attr('href'),
+        '/',
+        'empty @query href resets sticky query params'
+      );
     }
 
     async [`@test it updates when route changes with only query-params and a block`](assert) {

--- a/packages/@ember/routing/lib/router_state.ts
+++ b/packages/@ember/routing/lib/router_state.ts
@@ -1,6 +1,6 @@
 import type { ModelFor, TransitionState } from 'router_js';
 import type Router from 'router_js';
-import { shallowEqual } from './utils';
+import { shallowEqual, shouldResetStickyQueryParams } from './utils';
 import type Route from '@ember/routing/route';
 import type EmberRouter from '@ember/routing/router';
 
@@ -21,17 +21,24 @@ export default class RouterState {
   isActiveIntent(
     routeName: string,
     models: ModelFor<Route>[],
-    queryParams?: Record<string, unknown>
+    queryParams?: Record<string, unknown>,
+    { queryParamsProvided = false }: { queryParamsProvided?: boolean } = {}
   ): boolean {
     let state = this.routerJsState;
     if (!this.router.isActiveIntent(routeName, models, undefined, state)) {
       return false;
     }
 
-    if (queryParams !== undefined && Object.keys(queryParams).length > 0) {
+    let resetSticky =
+      queryParams !== undefined &&
+      shouldResetStickyQueryParams(queryParams, queryParamsProvided);
+
+    if (queryParams !== undefined && (Object.keys(queryParams).length > 0 || resetSticky)) {
       let visibleQueryParams = Object.assign({}, queryParams);
 
-      this.emberRouter._prepareQueryParams(routeName, models, visibleQueryParams);
+      this.emberRouter._prepareQueryParams(routeName, models, visibleQueryParams, {
+        resetStickyQueryParams: resetSticky,
+      });
       return shallowEqual(visibleQueryParams, state.queryParams);
     }
 

--- a/packages/@ember/routing/lib/routing-service.ts
+++ b/packages/@ember/routing/lib/routing-service.ts
@@ -11,6 +11,11 @@ import type Route from '@ember/routing/route';
 import EmberRouter from '@ember/routing/router';
 import type RouterState from './router_state';
 import { ROUTER } from '@ember/routing/router-service';
+import { shouldResetStickyQueryParams } from './utils';
+
+export type RoutingQueryParamsOptions = {
+  queryParamsProvided?: boolean;
+};
 
 /**
   The Routing service is used by LinkTo, and provides facilities for
@@ -55,9 +60,12 @@ export default class RoutingService<R extends Route> extends Service {
     routeName: string,
     models: ModelFor<R>[],
     queryParams: Record<string, unknown>,
-    shouldReplace: boolean
+    shouldReplace: boolean,
+    { queryParamsProvided = false }: RoutingQueryParamsOptions = {}
   ) {
-    let transition = this.router._doTransition(routeName, models, queryParams);
+    let transition = this.router._doTransition(routeName, models, queryParams, {
+      queryParamsProvided,
+    });
 
     if (shouldReplace) {
       transition.method('replace');
@@ -69,16 +77,24 @@ export default class RoutingService<R extends Route> extends Service {
   normalizeQueryParams(
     routeName: string,
     models: ModelFor<R>[],
-    queryParams: Record<string, unknown>
+    queryParams: Record<string, unknown>,
+    { queryParamsProvided = false }: RoutingQueryParamsOptions = {}
   ) {
-    this.router._prepareQueryParams(routeName, models, queryParams);
+    this.router._prepareQueryParams(routeName, models, queryParams, {
+      resetStickyQueryParams: shouldResetStickyQueryParams(queryParams, queryParamsProvided),
+    });
   }
 
-  _generateURL(routeName: string, models: ModelFor<R>[], queryParams: Record<string, unknown>) {
+  _generateURL(
+    routeName: string,
+    models: ModelFor<R>[],
+    queryParams: Record<string, unknown>,
+    options: RoutingQueryParamsOptions = {}
+  ) {
     let visibleQueryParams = {};
     if (queryParams) {
       Object.assign(visibleQueryParams, queryParams);
-      this.normalizeQueryParams(routeName, models, visibleQueryParams);
+      this.normalizeQueryParams(routeName, models, visibleQueryParams, options);
     }
 
     return this.router.generate(routeName, ...models, {
@@ -86,14 +102,19 @@ export default class RoutingService<R extends Route> extends Service {
     });
   }
 
-  generateURL(routeName: string, models: ModelFor<R>[], queryParams: Record<string, unknown>) {
+  generateURL(
+    routeName: string,
+    models: ModelFor<R>[],
+    queryParams: Record<string, unknown>,
+    options: RoutingQueryParamsOptions = {}
+  ) {
     if (this.router._initialTransitionStarted) {
-      return this._generateURL(routeName, models, queryParams);
+      return this._generateURL(routeName, models, queryParams, options);
     } else {
       // Swallow error when transition has not started.
       // When rendering in tests without visit(), we cannot infer the route context which <LinkTo/> needs be aware of
       try {
-        return this._generateURL(routeName, models, queryParams);
+        return this._generateURL(routeName, models, queryParams, options);
       } catch (_e) {
         return;
       }
@@ -104,7 +125,8 @@ export default class RoutingService<R extends Route> extends Service {
     contexts: ModelFor<R>[],
     queryParams: Record<string, unknown> | undefined,
     routeName: string,
-    routerState: RouterState
+    routerState: RouterState,
+    { queryParamsProvided = false }: RoutingQueryParamsOptions = {}
   ): boolean {
     let handlers = this.router._routerMicrolib.recognizer.handlersFor(routeName);
     let leafName = handlers[handlers.length - 1].handler;
@@ -124,7 +146,9 @@ export default class RoutingService<R extends Route> extends Service {
       routeName = leafName;
     }
 
-    return routerState.isActiveIntent(routeName, contexts, queryParams);
+    return routerState.isActiveIntent(routeName, contexts, queryParams, {
+      queryParamsProvided,
+    });
   }
 }
 

--- a/packages/@ember/routing/lib/utils.ts
+++ b/packages/@ember/routing/lib/utils.ts
@@ -33,9 +33,29 @@ type ExtractedArgs = {
   routeName: string | undefined;
   models: unknown[];
   queryParams: Record<string, unknown>;
+  /**
+    True when the caller passed an options hash with a `queryParams` key.
+    An explicitly empty `{ queryParams: {} }` resets sticky query params
+    instead of restoring cached values.
+   */
+  queryParamsProvided: boolean;
 };
 
 export type RouteOptions = { queryParams: Record<string, unknown> };
+
+export type QueryParamsTransitionOptions = {
+  fromRouterService?: boolean;
+  queryParamsProvided?: boolean;
+};
+
+export type PrepareQueryParamsOptions = {
+  fromRouterService?: boolean;
+  /**
+    When true, unsupplied query params are set to their defaults instead of
+    restoring sticky (cached) values.
+   */
+  resetStickyQueryParams?: boolean;
+};
 
 export function extractRouteArgs(args: RouteArgs): ExtractedArgs {
   // SAFETY: This should just be the same thing
@@ -44,9 +64,11 @@ export function extractRouteArgs(args: RouteArgs): ExtractedArgs {
   let possibleOptions = args[args.length - 1];
 
   let queryParams: Record<string, unknown>;
+  let queryParamsProvided = false;
   if (isRouteOptions(possibleOptions)) {
     args.pop(); // Remove options
     queryParams = possibleOptions.queryParams;
+    queryParamsProvided = true;
   } else {
     queryParams = {};
   }
@@ -62,7 +84,18 @@ export function extractRouteArgs(args: RouteArgs): ExtractedArgs {
   // SAFTEY: We removed the name and options if they existed, only models left.
   let models = args;
 
-  return { routeName, models, queryParams };
+  return { routeName, models, queryParams, queryParamsProvided };
+}
+
+/**
+  An explicitly empty query-params object means "do not restore sticky values";
+  omitted query params keep existing sticky hydration behavior.
+ */
+export function shouldResetStickyQueryParams(
+  queryParams: Record<string, unknown>,
+  queryParamsProvided: boolean | undefined
+): boolean {
+  return Boolean(queryParamsProvided) && Object.keys(queryParams).length === 0;
 }
 
 export function getActiveTargetName(router: Router<Route>): string {

--- a/packages/@ember/routing/router-service.ts
+++ b/packages/@ember/routing/router-service.ts
@@ -13,7 +13,7 @@ import type Route from '@ember/routing/route';
 import EmberRouter from '@ember/routing/router';
 import type { RouteInfo, RouteInfoWithAttributes } from './lib/route-info';
 import type { RouteArgs, RouteOptions } from './lib/utils';
-import { extractRouteArgs, resemblesURL, shallowEqual } from './lib/utils';
+import { extractRouteArgs, resemblesURL, shallowEqual, shouldResetStickyQueryParams } from './lib/utils';
 
 export const ROUTER = Symbol('ROUTER');
 
@@ -127,7 +127,12 @@ class RouterService extends Service.extend(Evented) {
        transitioning to the route.
      @param {Object} [options] optional hash with a queryParams property
        containing a mapping of query parameters. May be supplied as the only
-      parameter to trigger a query-parameter-only transition.
+       parameter to trigger a query-parameter-only transition.
+       Passing `{ queryParams: {} }` resets sticky query params for the
+       destination route to their defaults for that transition (without
+       clearing the sticky cache for other routes). Omitting `queryParams`
+       preserves sticky values. Apps that used `{}` as a no-op placeholder
+       may see a behavior change.
      @return {Transition} the transition object associated with this
        attempted transition
      @public
@@ -139,9 +144,12 @@ class RouterService extends Service.extend(Evented) {
       return this._router._doURLTransition('transitionTo', args[0]);
     }
 
-    let { routeName, models, queryParams } = extractRouteArgs(args);
+    let { routeName, models, queryParams, queryParamsProvided } = extractRouteArgs(args);
 
-    let transition = this._router._doTransition(routeName, models, queryParams, true);
+    let transition = this._router._doTransition(routeName, models, queryParams, {
+      fromRouterService: true,
+      queryParamsProvided,
+    });
 
     return transition;
   }
@@ -178,7 +186,9 @@ class RouterService extends Service.extend(Evented) {
      @param {...Object} models the model(s) or identifier(s) to be used while
        transitioning to the route i.e. an object of params to pass to the destination route
      @param {Object} [options] optional hash with a queryParams property
-       containing a mapping of query parameters
+       containing a mapping of query parameters. Passing `{ queryParams: {} }`
+       resets sticky query params for the destination route to their defaults;
+       omitting `queryParams` preserves sticky values.
      @return {Transition} the transition object associated with this
        attempted transition
      @public
@@ -314,12 +324,14 @@ class RouterService extends Service.extend(Evented) {
      @param {String} routeName the name of the route
      @param {...Object} models the model(s) or identifier(s) to be used when determining the active route.
      @param {Object} [options] optional hash with a queryParams property
-       containing a mapping of query parameters
+       containing a mapping of query parameters. An explicitly empty
+       `{ queryParams: {} }` is compared against default values (not sticky
+       cached values).
      @return {boolean} true if the provided routeName/models/queryParams are active
      @public
    */
   isActive(...args: RouteArgs) {
-    let { routeName, models, queryParams } = extractRouteArgs(args);
+    let { routeName, models, queryParams, queryParamsProvided } = extractRouteArgs(args);
     this._router.setupRouter();
     let routerMicrolib = this._router._routerMicrolib;
 
@@ -343,7 +355,8 @@ class RouterService extends Service.extend(Evented) {
     if (!routerMicrolib.isActiveIntent(routeName as string, models)) {
       return false;
     }
-    let hasQueryParams = Object.keys(queryParams).length > 0;
+    let resetSticky = shouldResetStickyQueryParams(queryParams, queryParamsProvided);
+    let hasQueryParams = Object.keys(queryParams).length > 0 || resetSticky;
 
     if (hasQueryParams) {
       // UNSAFE: casting `routeName as string` here encodes the existing
@@ -355,20 +368,15 @@ class RouterService extends Service.extend(Evented) {
       let targetRouteName = routeName as string;
 
       queryParams = Object.assign({}, queryParams);
-      this._router._prepareQueryParams(
-        targetRouteName,
-        models,
-        queryParams,
-        true /* fromRouterService */
-      );
+      this._router._prepareQueryParams(targetRouteName, models, queryParams, {
+        fromRouterService: true,
+        resetStickyQueryParams: resetSticky,
+      });
 
       let currentQueryParams = Object.assign({}, routerMicrolib.state!.queryParams);
-      this._router._prepareQueryParams(
-        targetRouteName,
-        models,
-        currentQueryParams,
-        true /* fromRouterService */
-      );
+      this._router._prepareQueryParams(targetRouteName, models, currentQueryParams, {
+        fromRouterService: true,
+      });
 
       return shallowEqual(queryParams, currentQueryParams);
     }

--- a/packages/@ember/routing/router.ts
+++ b/packages/@ember/routing/router.ts
@@ -19,8 +19,14 @@ import {
   extractRouteArgs,
   getActiveTargetName,
   resemblesURL,
+  shouldResetStickyQueryParams,
 } from './lib/utils';
-import type { RouteArgs, RouteOptions } from './lib/utils';
+import type {
+  PrepareQueryParamsOptions,
+  QueryParamsTransitionOptions,
+  RouteArgs,
+  RouteOptions,
+} from './lib/utils';
 import type {
   default as EmberLocation,
   Registry as LocationRegistry,
@@ -702,12 +708,23 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     Transition the application into another route. The route may
     be either a single route or route path:
 
+    Passing `{ queryParams: {} }` (an explicitly empty object) resets sticky
+    query param values for the destination route back to their defaults for
+    that transition. Omitting `queryParams` preserves sticky values.
+
+    Resetting fills unsupplied keys with each query param's default for the
+    destination; it does not clear the global sticky query-param cache used
+    by other routes or models.
+
     @method transitionTo
     @param {String} [name] the name of the route or a URL
     @param {...Object} models the model(s) or identifier(s) to be used while
       transitioning to the route.
     @param {Object} [options] optional hash with a queryParams property
-      containing a mapping of query parameters
+      containing a mapping of query parameters. An empty `queryParams: {}`
+      resets sticky query params for this transition; omitting `queryParams`
+      keeps them sticky. Apps that used `{}` as a no-op placeholder may see
+      a behavior change.
     @return {Transition} the transition object associated with this
       attempted transition
     @public
@@ -720,12 +737,12 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
       );
       return this._doURLTransition('transitionTo', args[0]);
     }
-    let { routeName, models, queryParams } = extractRouteArgs(args);
+    let { routeName, models, queryParams, queryParamsProvided } = extractRouteArgs(args);
     assert(
       `A transition was attempted from '${this.currentRouteName}' to '${routeName}' but the application instance has already been destroyed.`,
       !this.isDestroying && !this.isDestroyed
     );
-    return this._doTransition(routeName, models, queryParams);
+    return this._doTransition(routeName, models, queryParams, { queryParamsProvided });
   }
 
   intermediateTransitionTo(name: string, ...args: any[]) {
@@ -755,7 +772,8 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @param {...Object} models the model(s) or identifier(s) to be used while
       transitioning to the route.
     @param {Object} [options] optional hash with a queryParams property
-      containing a mapping of query parameters
+      containing a mapping of query parameters. An empty `queryParams: {}`
+      resets sticky query params; omitting `queryParams` keeps them sticky.
     @return {Transition} the transition object associated with this
       attempted transition
     @public
@@ -1042,8 +1060,9 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     _targetRouteName: string | undefined,
     models: ModelFor<Route>[],
     _queryParams: Record<string, unknown>,
-    _fromRouterService?: boolean
+    options: QueryParamsTransitionOptions = {}
   ): Transition {
+    let { fromRouterService = false, queryParamsProvided = false } = options;
     let targetRouteName = _targetRouteName || getActiveTargetName(this._routerMicrolib);
     assert(
       `The route ${targetRouteName} was not found`,
@@ -1052,13 +1071,19 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
 
     this._initialTransitionStarted = true;
 
+    let resetSticky = shouldResetStickyQueryParams(_queryParams, queryParamsProvided);
     let queryParams: Record<string, unknown> = {};
 
-    this._processActiveTransitionQueryParams(targetRouteName, models, queryParams, _queryParams);
+    if (!resetSticky) {
+      this._processActiveTransitionQueryParams(targetRouteName, models, queryParams, _queryParams);
+    }
 
     Object.assign(queryParams, _queryParams);
 
-    this._prepareQueryParams(targetRouteName, models, queryParams, Boolean(_fromRouterService));
+    this._prepareQueryParams(targetRouteName, models, queryParams, {
+      fromRouterService,
+      resetStickyQueryParams: resetSticky,
+    });
 
     let transition = this._routerMicrolib.transitionTo(targetRouteName, ...models, { queryParams });
 
@@ -1106,20 +1131,24 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     @param {String} targetRouteName
     @param {Array<Object>} models
     @param {Object} queryParams
-    @param {boolean} keepDefaultQueryParamValues
+    @param {Object} [options]
     @return {Void}
   */
   _prepareQueryParams(
     targetRouteName: string,
     models: ModelFor<Route>[],
     queryParams: Record<string, unknown>,
-    _fromRouterService?: boolean
+    options: PrepareQueryParamsOptions = {}
   ) {
+    let { fromRouterService = false, resetStickyQueryParams = false } = options;
     let state = calculatePostTransitionState(this, targetRouteName, models);
-    this._hydrateUnsuppliedQueryParams(state, queryParams, Boolean(_fromRouterService));
+    this._hydrateUnsuppliedQueryParams(state, queryParams, {
+      fromRouterService,
+      resetStickyQueryParams,
+    });
     this._serializeQueryParams(state.routeInfos, queryParams);
 
-    if (!_fromRouterService) {
+    if (!fromRouterService) {
       this._pruneDefaultQueryParamValues(state.routeInfos, queryParams);
     }
   }
@@ -1247,16 +1276,24 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
     the given queryParams hash. This is what allows query params to be "sticky"
     and restore their last known values for their scope.
 
+    When `resetStickyQueryParams` is true, unsupplied keys are filled with each
+    QP's default instead of the sticky cache (used for explicitly empty
+    `queryParams: {}` / LinkTo `@query={{(hash)}}`).
+
     @private
     @method _hydrateUnsuppliedQueryParams
     @param {TransitionState} state
     @param {Object} queryParams
+    @param {Object} [options]
     @return {Void}
   */
   _hydrateUnsuppliedQueryParams(
     state: TransitionState<Route>,
     queryParams: QueryParams,
-    _fromRouterService: boolean
+    {
+      fromRouterService: _fromRouterService = false,
+      resetStickyQueryParams = false,
+    }: PrepareQueryParamsOptions = {}
   ): void {
     let routeInfos = state.routeInfos;
     let appCache = this._bucketCache;
@@ -1304,6 +1341,8 @@ class EmberRouter extends EmberObject.extend(Evented) implements Evented {
             queryParams[qp.scopedPropertyName] = queryParams[presentProp];
             delete queryParams[presentProp];
           }
+        } else if (resetStickyQueryParams) {
+          queryParams[qp.scopedPropertyName] = qp.defaultValue;
         } else {
           let cacheKey = calculateCacheKey(qp.route.fullRouteName, qp.parts, state.params);
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1820,5 +1820,135 @@ moduleFor(
       assert.equal(parentController.bar, 'NEW_BAR');
       this.assertCurrentPath('/grandparent/1/parent/child?bar=NEW_BAR&foo=NEW_FOO');
     }
+
+    async [`@test EmberRouter#transitionTo omits queryParams to keep sticky values and uses {} to reset defaults`](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('parent', function () {
+          this.route('child');
+        });
+      });
+
+      this.add(
+        'controller:parent.child',
+        class extends Controller {
+          queryParams = ['sort'];
+          sort = 'ASC';
+        }
+      );
+
+      await this.visit('/parent/child?sort=DESC');
+      assert.equal(this.getController('parent.child').get('sort'), 'DESC');
+
+      await this.transitionTo('parent.child');
+      this.assertCurrentPath('/parent/child?sort=DESC', 'omitting queryParams keeps sticky values');
+      assert.equal(this.getController('parent.child').get('sort'), 'DESC');
+
+      await this.transitionTo('parent.child', { queryParams: {} });
+      this.assertCurrentPath('/parent/child', 'explicit empty queryParams resets to defaults');
+      assert.equal(this.getController('parent.child').get('sort'), 'ASC');
+    }
+
+    async [`@test EmberRouter#transitionTo sticky semantics with multiple typed query params`](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('filters');
+      });
+
+      this.add(
+        'controller:filters',
+        class extends Controller {
+          queryParams = ['label', 'enabled', 'page'];
+          label = 'all';
+          enabled = false;
+          page = 1;
+        }
+      );
+
+      await this.visit('/filters?label=photos&enabled=true&page=4');
+      let controller = this.getController('filters');
+
+      assert.strictEqual(controller.get('label'), 'photos');
+      // Boolean QPs deserialize from the URL as booleans when the default is a boolean
+      // (see "A default boolean value deserializes QPs as booleans rather than strings").
+      assert.strictEqual(controller.get('enabled'), true);
+      assert.strictEqual(controller.get('page'), 4);
+
+      let assertPathHasQuery = (path, expected, message) => {
+        let query = path.split('?')[1] || '';
+        let actual = Object.fromEntries(new URLSearchParams(query).entries());
+        // URL serialization layer is always strings.
+        assert.deepEqual(actual, expected, message);
+      };
+
+      await this.transitionTo('filters');
+      assertPathHasQuery(
+        this.appRouter.get('location.path'),
+        { label: 'photos', enabled: 'true', page: '4' },
+        'omitting queryParams keeps all sticky values'
+      );
+
+      await this.transitionTo('filters', { queryParams: { page: 2 } });
+      assertPathHasQuery(
+        this.appRouter.get('location.path'),
+        { label: 'photos', enabled: 'true', page: '2' },
+        'partial queryParams updates only the supplied key'
+      );
+      assert.strictEqual(controller.get('label'), 'photos', 'unsupplied string QP stays sticky');
+      assert.strictEqual(controller.get('enabled'), true, 'unsupplied boolean QP stays sticky');
+      assert.strictEqual(controller.get('page'), 2, 'supplied number QP updates');
+
+      await this.transitionTo('filters', { queryParams: {} });
+      this.assertCurrentPath('/filters', 'empty queryParams resets every QP to defaults');
+      assert.deepEqual(
+        controller.getProperties('label', 'enabled', 'page'),
+        { label: 'all', enabled: false, page: 1 },
+        'string/boolean/number defaults are restored without sticky leftovers'
+      );
+    }
+
+    async [`@test EmberRouter#transitionTo empty queryParams reset does not clear sticky cache for other routes`](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('parent', function () {
+          this.route('child');
+          this.route('sibling');
+        });
+      });
+
+      this.add(
+        'controller:parent.child',
+        class extends Controller {
+          queryParams = ['sort'];
+          sort = 'ASC';
+        }
+      );
+
+      this.add(
+        'controller:parent.sibling',
+        class extends Controller {
+          queryParams = ['filter'];
+          filter = 'ALL';
+        }
+      );
+
+      await this.visit('/parent/child?sort=DESC');
+      await this.transitionTo('parent.sibling', { queryParams: { filter: 'MINE' } });
+      this.assertCurrentPath('/parent/sibling?filter=MINE');
+
+      await this.transitionTo('parent.child', { queryParams: {} });
+      this.assertCurrentPath('/parent/child', 'child sticky values reset to defaults');
+      assert.equal(this.getController('parent.child').get('sort'), 'ASC');
+
+      await this.transitionTo('parent.sibling');
+      this.assertCurrentPath(
+        '/parent/sibling?filter=MINE',
+        'sibling sticky cache is intact after resetting a different route'
+      );
+      assert.equal(this.getController('parent.sibling').get('filter'), 'MINE');
+    }
   }
 );

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -277,6 +277,135 @@ moduleFor(
         });
     }
 
+    ['@test RouterService#transitionTo with an explicit empty queryParams object resets sticky query params'](
+      assert
+    ) {
+      assert.expect(3);
+
+      this.add(
+        'controller:parent.child',
+        Controller.extend({
+          queryParams: ['sort'],
+          sort: 'ASC',
+        })
+      );
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo(
+            'parent.child',
+            this.buildQueryParams({ sort: 'DESC' })
+          );
+        })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child?sort=DESC');
+          assert.equal(get(this.controllerFor('parent.child'), 'sort'), 'DESC');
+        })
+        .then(() => {
+          return this.routerService.transitionTo('parent.child', this.buildQueryParams({}));
+        })
+        .then(() => {
+          assert.equal(
+            this.routerService.get('currentURL'),
+            '/child',
+            'explicit empty queryParams resets sticky values to defaults'
+          );
+        });
+    }
+
+    ['@test RouterService#transitionTo without queryParams preserves sticky query params'](
+      assert
+    ) {
+      assert.expect(2);
+
+      this.add(
+        'controller:parent.child',
+        Controller.extend({
+          queryParams: ['sort'],
+          sort: 'ASC',
+        })
+      );
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo(
+            'parent.child',
+            this.buildQueryParams({ sort: 'DESC' })
+          );
+        })
+        .then(() => {
+          return this.routerService.transitionTo('parent.child');
+        })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child?sort=DESC');
+          assert.equal(get(this.controllerFor('parent.child'), 'sort'), 'DESC');
+        });
+    }
+
+    ['@test RouterService#replaceWith with an explicit empty queryParams object resets sticky query params'](
+      assert
+    ) {
+      assert.expect(2);
+
+      this.add(
+        'controller:parent.child',
+        Controller.extend({
+          queryParams: ['sort'],
+          sort: 'ASC',
+        })
+      );
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo(
+            'parent.child',
+            this.buildQueryParams({ sort: 'DESC' })
+          );
+        })
+        .then(() => {
+          return this.routerService.replaceWith('parent.child', this.buildQueryParams({}));
+        })
+        .then(() => {
+          assert.equal(this.routerService.get('currentURL'), '/child');
+          assert.equal(get(this.controllerFor('parent.child'), 'sort'), 'ASC');
+        });
+    }
+
+    ['@test RouterService#isActive treats explicit empty queryParams as defaults'](assert) {
+      assert.expect(2);
+
+      this.add(
+        'controller:parent.child',
+        Controller.extend({
+          queryParams: ['sort'],
+          sort: 'ASC',
+        })
+      );
+
+      return this.visit('/')
+        .then(() => {
+          return this.routerService.transitionTo(
+            'parent.child',
+            this.buildQueryParams({ sort: 'DESC' })
+          );
+        })
+        .then(() => {
+          assert.false(
+            this.routerService.isActive('parent.child', this.buildQueryParams({})),
+            'empty queryParams is not active while sticky non-defaults are present'
+          );
+        })
+        .then(() => {
+          return this.routerService.transitionTo('parent.child', this.buildQueryParams({}));
+        })
+        .then(() => {
+          assert.true(
+            this.routerService.isActive('parent.child', this.buildQueryParams({})),
+            'empty queryParams is active at defaults'
+          );
+        });
+    }
+
     ['@test RouterService#transitionTo passing only queryParams works'](assert) {
       assert.expect(2);
 


### PR DESCRIPTION
## Summary

Sticky query params are preserved when `@query` / `queryParams` is omitted. There was previously no clean way to reset them without knowing every QP key.

An **explicitly empty** query object now resets to defaults for that transition:

- `<LinkTo @route="photos" @query={{(hash)}}>` → defaults
- `router.transitionTo('photos', { queryParams: {} })` → defaults
- Omitting `@query` / `queryParams` → sticky unchanged
- A partial `{ queryParams: { page: 1 } }` updates only supplied keys (not a full reset)

Reset hydrates defaults for the destination transition; it does not clear the sticky cache for other routes.

**Compatibility:** apps that used `{ queryParams: {} }` / an empty `@query` hash as a no-op placeholder may observe a behavior change, because empty now means reset to defaults.

Closes #20211