### PR TITLE
[BUGFIX] Allow CoreObject#init to be called with no arguments

### DIFF
--- a/packages/@ember/object/core.ts
+++ b/packages/@ember/object/core.ts
@@ -346,7 +346,7 @@ class CoreObject {
     @method init
     @public
   */
-  init(_properties: object | undefined) {}
+  init(_properties?: object) {}
 
   /**
     Defines the properties that will be concatenated from the superclass

--- a/type-tests/@ember/component-test/component.ts
+++ b/type-tests/@ember/component-test/component.ts
@@ -17,12 +17,14 @@ const component1 = Component.extend({
   },
 });
 
-class AnotherComponent extends Component {
-  name = '';
-
-  init() {
+class ClassicComponent extends Component {
+  override init(): void {
     super.init();
   }
+}
+
+class AnotherComponent extends Component {
+  name = '';
 
   hello(name: string) {
     this.set('name', name);

--- a/type-tests/ember/core-object.ts
+++ b/type-tests/ember/core-object.ts
@@ -9,6 +9,13 @@ expectTypeOf(co1.isDestroying).toBeBoolean();
 expectTypeOf(co1.destroy()).toEqualTypeOf<CoreObject>();
 expectTypeOf(co1.toString()).toBeString();
 
+/** Subclasses may override init and call super.init() without arguments. */
+class CoreObjectWithInit extends CoreObject {
+  override init(): void {
+    super.init();
+  }
+}
+
 /** .create tests */
 const co2 = CoreObject.create();
 expectTypeOf(co2.isDestroyed).toBeBoolean();


### PR DESCRIPTION
Component.init was fixed in #20492, but Controller, Route, Service, and other EmberObject subclasses still required an argument via CoreObject because a parameter typed `T | undefined` is still required. Make it optional so `super.init()` type-checks again.

Closes #20483