### PR TITLE
Failing test for #19287

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1802,3 +1802,46 @@ if (DEBUG) {
     }
   );
 }
+
+moduleFor(
+  'Dynamic content tests: disabling a focused element',
+  class extends RenderingTestCase {
+    async '@todo a {{on "blur"}} listener may update rendered state when the element becomes disabled (GH#19287)'(
+      assert
+    ) {
+      let error;
+
+      this.render(
+        '<span>{{this.isFocused}}</span><textarea disabled={{this.isDisabled}} {{on "focus" this.onFocus}} {{on "blur" this.onBlur}}></textarea>',
+        {
+          isDisabled: false,
+          isFocused: false,
+          onFocus: () => set(this.context, 'isFocused', true),
+          onBlur: () => {
+            try {
+              set(this.context, 'isFocused', false);
+            } catch (e) {
+              error = e;
+            }
+          },
+        }
+      );
+
+      let textarea = this.element.querySelector('textarea');
+
+      runTask(() => textarea.focus());
+      assert.strictEqual(this.context.isFocused, true, 'precond - focus listener ran');
+
+      runTask(() => set(this.context, 'isDisabled', true));
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      assert.strictEqual(
+        error,
+        undefined,
+        'no backtracking assertion was thrown from the blur listener'
+      );
+      assert.strictEqual(this.context.isFocused, false, 'blur listener updated the state');
+    }
+  }
+);

--- a/packages/internal-test-helpers/lib/module-for.ts
+++ b/packages/internal-test-helpers/lib/module-for.ts
@@ -163,6 +163,10 @@ export function setupTestClass<T extends TestCase, G extends Generator>(
       QUnit.skip(name.slice(5), function (this: TestContext<T>, assert) {
         return (this.instance![name] as any)(assert);
       });
+    } else if (name.indexOf('@todo ') === 0) {
+      QUnit.todo(name.slice(5), function (this: TestContext<T>, assert) {
+        return (this.instance![name] as any)(assert);
+      });
     } else {
       let match = /^@feature\(([A-Z_a-z-! ,]+)\) /.exec(name);
 


### PR DESCRIPTION
Adds a failing test for #19287: disabling a focused element fires `blur` during render, and a `{{on "blur"}}` listener that updates rendered state hits the backtracking assertion.

The test is a QUnit `todo`: CI stays green while the bug exists, and fails once it is fixed (then flip `@todo` to `@test`). Adds `@todo` to `moduleFor`, mapping to native `QUnit.todo` like `@skip`.

Prototype fix: [johanrd#36](https://github.com/johanrd/ember.js/pull/36) — defers dynamic attribute updates to transaction commit, so DOM writes that dispatch events synchronously (like `disabled` → `blur`) run after the render transaction has closed, the same way modifier install/update is already scheduled. With it, this PR's `@todo` test flips to a passing `@test`.

A first iteration ([johanrd#37](https://github.com/johanrd/ember.js/pull/37)) special-cased only `disabled`, but the attribute layer already has too many per-name special cases (see #21344), and the generic deferral fixes the whole class — any attribute write that can dispatch a synchronous event — instead of one name. It also moves DOM writes out of the tracked computation. Cost: one closure per changed attribute per rerender.
