### PR TITLE
Failing test for #19344

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1802,3 +1802,46 @@ if (DEBUG) {
     }
   );
 }
+
+moduleFor(
+  'Dynamic content tests: disabling a focused element',
+  class extends RenderingTestCase {
+    async '@todo a {{on "blur"}} listener may update rendered state when the element becomes disabled (GH#19287)'(
+      assert
+    ) {
+      let error;
+
+      this.render(
+        '<span>{{this.isFocused}}</span><textarea disabled={{this.isDisabled}} {{on "focus" this.onFocus}} {{on "blur" this.onBlur}}></textarea>',
+        {
+          isDisabled: false,
+          isFocused: false,
+          onFocus: () => set(this.context, 'isFocused', true),
+          onBlur: () => {
+            try {
+              set(this.context, 'isFocused', false);
+            } catch (e) {
+              error = e;
+            }
+          },
+        }
+      );
+
+      let textarea = this.element.querySelector('textarea');
+
+      runTask(() => textarea.focus());
+      assert.strictEqual(this.context.isFocused, true, 'precond - focus listener ran');
+
+      runTask(() => set(this.context, 'isDisabled', true));
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      assert.strictEqual(
+        error,
+        undefined,
+        'no backtracking assertion was thrown from the blur listener'
+      );
+      assert.strictEqual(this.context.isFocused, false, 'blur listener updated the state');
+    }
+  }
+);

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1803,45 +1803,49 @@ if (DEBUG) {
   );
 }
 
-moduleFor(
-  'Dynamic content tests: disabling a focused element',
-  class extends RenderingTestCase {
-    async '@todo a {{on "blur"}} listener may update rendered state when the element becomes disabled (GH#19287)'(
-      assert
-    ) {
-      let error;
+// The bug this documents is the backtracking assertion, which only exists in
+// debug builds; in production the listener succeeds and the todo would pass.
+if (DEBUG) {
+  moduleFor(
+    'Dynamic content tests: disabling a focused element',
+    class extends RenderingTestCase {
+      async '@todo a {{on "blur"}} listener may update rendered state when the element becomes disabled (GH#19287)'(
+        assert
+      ) {
+        let error;
 
-      this.render(
-        '<span>{{this.isFocused}}</span><textarea disabled={{this.isDisabled}} {{on "focus" this.onFocus}} {{on "blur" this.onBlur}}></textarea>',
-        {
-          isDisabled: false,
-          isFocused: false,
-          onFocus: () => set(this.context, 'isFocused', true),
-          onBlur: () => {
-            try {
-              set(this.context, 'isFocused', false);
-            } catch (e) {
-              error = e;
-            }
-          },
-        }
-      );
+        this.render(
+          '<span>{{this.isFocused}}</span><textarea disabled={{this.isDisabled}} {{on "focus" this.onFocus}} {{on "blur" this.onBlur}}></textarea>',
+          {
+            isDisabled: false,
+            isFocused: false,
+            onFocus: () => set(this.context, 'isFocused', true),
+            onBlur: () => {
+              try {
+                set(this.context, 'isFocused', false);
+              } catch (e) {
+                error = e;
+              }
+            },
+          }
+        );
 
-      let textarea = this.element.querySelector('textarea');
+        let textarea = this.element.querySelector('textarea');
 
-      runTask(() => textarea.focus());
-      assert.strictEqual(this.context.isFocused, true, 'precond - focus listener ran');
+        runTask(() => textarea.focus());
+        assert.strictEqual(this.context.isFocused, true, 'precond - focus listener ran');
 
-      runTask(() => set(this.context, 'isDisabled', true));
+        runTask(() => set(this.context, 'isDisabled', true));
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+        await new Promise((resolve) => setTimeout(resolve, 50));
 
-      assert.strictEqual(
-        error,
-        undefined,
-        'no backtracking assertion was thrown from the blur listener'
-      );
-      assert.strictEqual(this.context.isFocused, false, 'blur listener updated the state');
+        assert.strictEqual(
+          error,
+          undefined,
+          'no backtracking assertion was thrown from the blur listener'
+        );
+        assert.strictEqual(this.context.isFocused, false, 'blur listener updated the state');
+      }
     }
-  }
-);
+  );
+}

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -1,4 +1,5 @@
 import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
+import { setTesting } from '@ember/debug';
 import { getInternalModifierManager, setComponentTemplate } from '@glimmer/manager';
 import { on } from '@glimmer/runtime';
 import { precompileTemplate } from '@ember/template-compilation';
@@ -295,6 +296,53 @@ moduleFor(
 
       this.assertStableRerender();
       this.assertCounts({ adds: 2, removes: 0 });
+    }
+
+    async '@todo all listeners for an event run even when an earlier one removes the element (GH#19344)'(
+      assert
+    ) {
+      let sequence = [];
+
+      this.render(
+        '{{#if this.showBox}}<div id="scrollbox" style="overflow: scroll; height: 50px; width: 50px;" {{on "scroll" this.first}} {{on "scroll" this.second}}><div style="height: 500px;"></div></div>{{/if}}',
+        {
+          showBox: true,
+          first: () => {
+            sequence.push('first');
+            this.context.set('showBox', false);
+          },
+          second: () => sequence.push('second'),
+        }
+      );
+
+      let box = this.element.querySelector('#scrollbox');
+
+      // Testing mode disables the autorun that makes this reproducible in
+      // apps: with autorun enabled, the flush is scheduled as a microtask,
+      // and browser-dispatched events (unlike synthetic el.click()) run a
+      // microtask checkpoint between listener callbacks. The flush tears
+      // down the element's modifiers mid-dispatch, and the removed second
+      // listener is never invoked.
+      setTesting(false);
+      try {
+        box.scrollTop = 30;
+
+        await new Promise((resolve) => {
+          let attempts = 0;
+          (function check() {
+            if (sequence.length >= 2 || ++attempts > 50) {
+              resolve();
+            } else {
+              setTimeout(check, 10);
+            }
+          })();
+        });
+      } finally {
+        setTesting(true);
+      }
+
+      assert.strictEqual(this.element.querySelector('#scrollbox'), null, 'the element was removed');
+      assert.deepEqual(sequence, ['first', 'second'], 'both listeners ran, in order');
     }
   }
 );

--- a/packages/internal-test-helpers/lib/module-for.ts
+++ b/packages/internal-test-helpers/lib/module-for.ts
@@ -163,6 +163,10 @@ export function setupTestClass<T extends TestCase, G extends Generator>(
       QUnit.skip(name.slice(5), function (this: TestContext<T>, assert) {
         return (this.instance![name] as any)(assert);
       });
+    } else if (name.indexOf('@todo ') === 0) {
+      QUnit.todo(name.slice(5), function (this: TestContext<T>, assert) {
+        return (this.instance![name] as any)(assert);
+      });
     } else {
       let match = /^@feature\(([A-Z_a-z-! ,]+)\) /.exec(name);
 


### PR DESCRIPTION
Adds a failing test for #19344: with autorun enabled (as in apps), a state change in the first `{{on}}` listener schedules the render flush as a microtask, and browser-dispatched events run a microtask checkpoint between listener callbacks — the flush tears down the element's modifiers mid-dispatch and the removed second listener is never invoked. Test-mode clicks mask this (runloop-wrapped, autorun disabled), which is why it went uncaught; the test uses `setTesting(false)` and a browser-task `scroll` dispatch to reproduce the real path.

The test is a QUnit `todo`: CI stays green while the bug exists, and fails once it is fixed (then flip `@todo` to `@test`).

**Mechanism** (verified on `main`): each `{{on}}` registers its own native listener ([on.ts#L220](https://github.com/emberjs/ember.js/blob/115d89be47f2/packages/@glimmer/runtime/lib/modifiers/on.ts#L220)). A state change in the first listener schedules the render flush as a microtask (backburner autorun). For browser-dispatched events the JS stack empties between listener callbacks, so a microtask checkpoint runs *between the two listeners* — the flush tears down the element's modifiers, teardown calls `removeEventListener` ([on.ts#L47-L53](https://github.com/emberjs/ember.js/blob/115d89be47f2/packages/@glimmer/runtime/lib/modifiers/on.ts#L47-L53)) on the not-yet-invoked second listener, and a listener removed mid-dispatch is never invoked.

**Why tests never caught it** (@marcin-wicha's false positive): test mode masks it twice — `click()` is runloop-wrapped *and* autorun is disabled — and even with autorun enabled, synthetic `el.click()` dispatches inside the calling JS stack, so no checkpoint runs between listeners. Only browser-task dispatch reproduces it. #21530 adds a failing (`todo`) test using `setTesting(false)` plus a browser-dispatched `scroll`.

**Fix prototype:** [johanrd#38](https://github.com/johanrd/ember.js/pull/38) — all `{{on}}` handlers for the same (element, event, capture/passive bucket) share one native listener that dispatches to a snapshot of the handler list, so sibling handlers run in a single callback frame and no checkpoint can fall between them. Full suite green (9437 tests, 0 failures); the failing test flips to passing. Scope note: this covers the reported same-element case. A cross-element variant exists (a handler's flush destroying an *ancestor's* `{{on}}` before the event bubbles up to it) — fixing that requires deferring teardown past the dispatch, i.e. deciding whether handlers may fire after their component is destroyed, which needs maintainer input.

**Precedent** — every mainstream framework funnels its handlers through a single native callback per dispatch; the surfaces that don't are exactly where this bug class lives:

| | architecture | source |
|---|---|---|
| React | one native listener per event at the root, synthesized propagation, post-dispatch flush | [DOMPluginEventSystem.js#L432-L435](https://github.com/facebook/react/blob/dcd4ec28a132/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js#L432-L435) |
| Vue 3 | per-element invoker (`el[veiKey]`), handler swaps mutate `invoker.value`, stale-event guard via `e._vts <= invoker.attached` | [events.ts#L43-L61](https://github.com/vuejs/core/blob/b5f8518379b7/packages/runtime-dom/src/modules/events.ts#L43-L61), [#L112-L116](https://github.com/vuejs/core/blob/b5f8518379b7/packages/runtime-dom/src/modules/events.ts#L112-L116) |
| Solid | document delegation, handlers as `node[$$event]` props | [client.js#L90-L96](https://github.com/ryansolid/dom-expressions/blob/062d23cc2973/packages/dom-expressions/src/client.js#L90-L96) |
| Svelte 5 | root delegation — and the same bug class, open, at the native/delegated boundary: sveltejs/svelte#18070 | [events.js#L173-L177](https://github.com/sveltejs/svelte/blob/44a781373057/packages/svelte/src/internal/client/dom/elements/events.js#L173-L177) |
| Angular | per-listener change detection by default; opt-in rAF event coalescing exists precisely for multi-handler events | [ng_zone.ts#L310-L328](https://github.com/angular/angular/blob/5ad823139758/packages/core/src/zone/ng_zone.ts#L310-L328) |

Cowritten by Claude