### PR TITLE
Passing test for #11288

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -265,6 +265,28 @@ moduleFor(
       this.assertCurrentPath('/?fun-times=woot');
     }
 
+    async ['@test Routes can override serializeQueryParam to customize serialization (GH#11288)'](
+      assert
+    ) {
+      assert.expect(2);
+
+      this.add(
+        'route:index',
+        class extends Route {
+          serializeQueryParam(value) {
+            return 'v' + value;
+          }
+        }
+      );
+
+      this.setSingleQPController('index', 'foo', 1);
+
+      await this.visitAndAssert('/');
+
+      await this.setAndFlush(this.getController('index'), 'foo', 5);
+      this.assertCurrentPath('/?foo=v5');
+    }
+
     async ['@test Can override inherited QP behavior by specifying queryParams as a computed property'](
       assert
     ) {


### PR DESCRIPTION
Closes #11288

Note: a constant-return override (as in the issue's example) interacts with default-QP omission — when the serialized current value equals the serialized default, the QP is omitted from the URL entirely. The test uses a value-dependent override to isolate the reported question (is the override invoked and used): it is.