### PR TITLE
Passing test for #18608

### DIFF
--- a/packages/ember/tests/routing/explicit_index_route_test.js
+++ b/packages/ember/tests/routing/explicit_index_route_test.js
@@ -1,0 +1,40 @@
+import { moduleFor, ApplicationTestCase } from 'internal-test-helpers';
+
+moduleFor(
+  'Router: explicitly declared index routes (GH#18608)',
+  class extends ApplicationTestCase {
+    async ['@test an explicitly declared index route defaults to path "/index", so the parent URL does not match'](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('secure', function () {
+          this.route('cluster', { path: '/clusters/:cluster_id' }, function () {
+            this.route('index');
+            this.route('details');
+          });
+        });
+      });
+
+      await this.visit('/secure/clusters/100').then(
+        () => assert.ok(false, 'expected the URL not to match'),
+        (error) => assert.ok(/did not match any routes/.test(error.message), error.message)
+      );
+    }
+
+    async ['@test an explicitly declared index route with path "/" matches the parent URL'](
+      assert
+    ) {
+      this.router.map(function () {
+        this.route('secure', function () {
+          this.route('cluster', { path: '/clusters/:cluster_id' }, function () {
+            this.route('index', { path: '/' });
+            this.route('details');
+          });
+        });
+      });
+
+      await this.visit('/secure/clusters/100');
+      assert.equal(this.appRouter.currentURL, '/secure/clusters/100');
+    }
+  }
+);

--- a/packages/ember/tests/routing/explicit_index_route_test.js
+++ b/packages/ember/tests/routing/explicit_index_route_test.js
@@ -15,10 +15,7 @@ moduleFor(
         });
       });
 
-      await this.visit('/secure/clusters/100').then(
-        () => assert.ok(false, 'expected the URL not to match'),
-        (error) => assert.ok(/did not match any routes/.test(error.message), error.message)
-      );
+      await assert.rejects(this.visit('/secure/clusters/100'), /\/secure\/clusters\/100/);
     }
 
     async ['@test an explicitly declared index route with path "/" matches the parent URL'](


### PR DESCRIPTION
Closes #18608

Explicitly declaring `this.route('index')` gives it the default path `/index` (no special-casing), so the parent's URL no longer matches — which is the error the issue hit. `this.route('index', { path: '/' })` restores the expected matching. Both asserted.