### PR TITLE
Passing test for #21031

### DIFF
--- a/packages/ember-template-compiler/tests/system/compile_options_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_options_test.js
@@ -78,3 +78,15 @@ moduleFor(
     }
   }
 );
+
+moduleFor(
+  'ember-template-compiler: syntax error locations (GH#21031)',
+  class extends AbstractTestCase {
+    ['@test compile errors include the module name and source location'](assert) {
+      assert.throws(
+        () => compile('<div><span></div>', { moduleName: 'my-app/components/foo.hbs' }),
+        /error occurred in 'my-app\/components\/foo\.hbs' @ line 1 : column \d+/
+      );
+    }
+  }
+);


### PR DESCRIPTION
Closes #21031

Covers template syntax errors (unclosed element etc.), which now include the module name and line/column. Raw Handlebars parse errors still omit the module name; if those are considered in scope, the fix there is a follow-up.