### PR TITLE
[DOC] Document the `key` option for `{{#each-in}}`

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
+++ b/packages/@ember/-internals/glimmer/lib/helpers/each-in.ts
@@ -100,8 +100,8 @@ import { internalHelper } from './internal-helper';
 
   There are two special values for `key`:
 
+    * `@identity` - The item in the array itself. This is the default.
     * `@index` - The index of the item in the array.
-    * `@identity` - The item in the array itself.
 
   ### {{else}} condition
 
@@ -159,6 +159,30 @@ import { internalHelper } from './internal-helper';
   ```
  
   `#each-in` is a keyword and does not need to be imported.
+
+  ### Specifying Keys
+
+  Like `{{#each}}`, `{{#each-in}}` accepts a `key` option to decide which DOM
+  elements can be reused between renders. Since `{{#each-in}}` yields two block
+  params, the special values pick which one is used:
+
+    * `@identity` - The second block param: the property's value. This is the
+      default. Changing a value replaces that entry's DOM instead of updating it
+      in place.
+    * `@key` - The first block param: the property name, or for a `Map`, its key.
+
+  Any other string is a path, looked up on the value: `key="id"` keys each entry
+  by its `value.id`.
+
+  For example, `@key` keeps each entry's DOM as its score changes, so anything
+  stateful inside it — focus, a running transition, a component instance — survives
+  the update:
+
+  ```handlebars
+  {{#each-in this.scores key="@key" as |player score|}}
+    <PlayerScore @name={{player}} @score={{score}} />
+  {{/each-in}}
+  ```
 
   @method each-in
   @for Ember.Templates.helpers

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -701,6 +701,128 @@ moduleFor(
   }
 );
 
+moduleFor(
+  'Syntax test: {{#each-in}} with the key option',
+  class extends RenderingTestCase {
+    items() {
+      let items = Array.from(this.element.querySelectorAll('li'));
+      this.assert.strictEqual(items.length, 2, 'both entries rendered');
+      return items;
+    }
+
+    [`@test by default the entry's value is the key, so changing a value replaces its DOM`]() {
+      this.render(
+        `<ul>{{#each-in this.hash as |name value|}}<li>{{name}}: {{value}}</li>{{/each-in}}</ul>`,
+        { hash: { a: 1, b: 2 } }
+      );
+      this.assertText('a: 1b: 2');
+
+      let before = this.items();
+
+      runTask(() => set(this.context, 'hash', { a: 1, b: 3 }));
+      this.assertText('a: 1b: 3');
+
+      let after = this.items();
+      this.assert.strictEqual(after[0], before[0], 'unchanged entry keeps its node');
+      this.assert.notStrictEqual(after[1], before[1], 'changed entry gets a new node');
+    }
+
+    [`@test key="@key" uses the property name, so a changed value updates in place`]() {
+      this.render(
+        `<ul>{{#each-in this.hash key="@key" as |name value|}}<li>{{name}}: {{value}}</li>{{/each-in}}</ul>`,
+        { hash: { a: 1, b: 2 } }
+      );
+      this.assertText('a: 1b: 2');
+
+      let before = this.items();
+
+      runTask(() => set(this.context, 'hash', { a: 1, b: 3 }));
+      this.assertText('a: 1b: 3');
+
+      let after = this.items();
+      this.assert.strictEqual(after[0], before[0], 'unchanged entry keeps its node');
+      this.assert.strictEqual(after[1], before[1], 'changed entry keeps its node');
+    }
+
+    // `@index` is accepted here and #16719 calls it public API, though docs omit it and
+    // rfc #321 was never accepted. These two record what it resolves to, ensuring a
+    // future change is deliberate.
+    [`@test key="@index" keys on the property name, not the position or the value`]() {
+      this.render(
+        `<ul>{{#each-in this.hash key="@index" as |name value|}}<li>{{name}}: {{value}}</li>{{/each-in}}</ul>`,
+        { hash: { a: 1, b: 2 } }
+      );
+      this.assertText('a: 1b: 2');
+
+      let before = this.items();
+
+      // reordering while changing a value: keying by name moves both nodes, a
+      // position would keep them put, and the value would replace the changed one
+      runTask(() => set(this.context, 'hash', { b: 2, a: 9 }));
+      this.assertText('b: 2a: 9');
+
+      let after = this.items();
+      this.assert.strictEqual(after[0], before[1], `b's node moves with its name`);
+      this.assert.strictEqual(after[1], before[0], `a's node moves and survives its new value`);
+    }
+
+    [`@test a path key is looked up on the entry's value`]() {
+      this.render(
+        `<ul>{{#each-in this.hash key="id" as |name value|}}<li>{{name}}: {{value.id}}</li>{{/each-in}}</ul>`,
+        { hash: { a: { id: 1 }, b: { id: 2 } } }
+      );
+      this.assertText('a: 1b: 2');
+
+      let before = this.items();
+
+      runTask(() => set(this.context, 'hash', { a: { id: 9 }, b: { id: 2 } }));
+      this.assertText('a: 9b: 2');
+
+      let after = this.items();
+      this.assert.notStrictEqual(after[0], before[0], 'a changed value.id gets a new node');
+      this.assert.strictEqual(after[1], before[1], 'an unchanged value.id keeps its node');
+    }
+
+    [`@test key="@index" collides when a Map is keyed by objects`]() {
+      let a = { name: 'a' };
+      let b = { name: 'b' };
+
+      this.render(
+        `<ul>{{#each-in this.map key="@index" as |name value|}}<li>{{name.name}}: {{value}}</li>{{/each-in}}</ul>`,
+        {
+          map: new Map([
+            [a, 1],
+            [b, 2],
+          ]),
+        }
+      );
+      this.assertText('a: 1b: 2');
+
+      let before = this.items();
+
+      runTask(() =>
+        set(
+          this.context,
+          'map',
+          new Map([
+            [b, 2],
+            [a, 1],
+          ])
+        )
+      );
+      this.assertText('b: 2a: 1');
+
+      let after = this.items();
+      this.assert.strictEqual(
+        after[0],
+        before[0],
+        'every object key stringifies alike, so nodes are reused by position rather than moved'
+      );
+      this.assert.strictEqual(after[1], before[1], 'likewise for the second entry');
+    }
+  }
+);
+
 // Utils
 function makeIterator(ary) {
   let index = 0;


### PR DESCRIPTION
Closes #16719

`{{#each-in}}` accepts `key=`, but only `{{#each}}`'s special values were documented — and over entries they mean something different:

| `key=` | keys on |
|---|---|
| `@key` | the property name, or a `Map`'s key |
| omitted / `@identity` | the entry's value, so a changed value replaces that entry's DOM |
| any other string | a path resolved against the value |

`@key` was called public API for `{{#each-in}}` in emberjs/ember.js#16719 but was documented nowhere.

`@index` is deliberately left out: it also resolves to the property name, so it duplicates `@key` on a plain object and is worse on a `Map` keyed by objects, where every key coerces alike. Added two tests to record its behavior anyway, since #16719 calls it public API while RFC #321 (never accepted) marks it N/A.

Five tests added, each asserting DOM node identity across an update. `{{#each-in}}` previously had no coverage for `@key`, `@index` or path keys, and `@identity` appeared only incidentally in tests asserting rendered text.

Cowritten by Claude