### PR TITLE
Overload cached for non-class use

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/glimmer-tracking-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-tracking-docs.ts
@@ -307,7 +307,7 @@
 
   ### Standalone usage
 
-  Calling `cached` with a function creates a standalone memoized reactive
+  Calling `cached` with a function creates a standalone cached reactive
   value, usable outside of classes:
 
   ```js
@@ -316,7 +316,7 @@
   const count = tracked(0);
   const doubled = cached(() => count.value * 2);
 
-  doubled.value; // read the memoized value, entangling with any tracking context
+  doubled.value; // read the cached value, entangling with any tracking context
   doubled.get(); // function shorthand for reading
   ```
 
@@ -324,19 +324,11 @@
   changed; reading `value` in a template (or in a getter used by a template)
   will rerender just like a `@cached` getter.
 
-  This form accepts an options object containing an `equals` function and a
-  `description` used for debugging. When a re-computation produces a value
-  that `equals` deems equal to the previous one (it defaults to `Object.is`),
-  the previous value -- and its identity -- is retained, so downstream
-  consumers do not update:
+  This form accepts an options object containing a `description` used for
+  debugging:
 
   ```js
-  const letters = tracked(['b', 'a']);
-  const sorted = cached(() => letters.value.slice().sort(), {
-    equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-  });
-
-  letters.value = ['a', 'b']; // recomputes, but `sorted.value` keeps its identity
+  const doubled = cached(() => count.value * 2, { description: 'doubled' });
   ```
 
   @method cached

--- a/packages/@ember/-internals/glimmer/lib/glimmer-tracking-docs.ts
+++ b/packages/@ember/-internals/glimmer/lib/glimmer-tracking-docs.ts
@@ -305,6 +305,40 @@
   or as the result of a user action. Setting tracked data during render
   (such as in a getter), is not supported.
 
+  ### Standalone usage
+
+  Calling `cached` with a function creates a standalone memoized reactive
+  value, usable outside of classes:
+
+  ```js
+  import { tracked, cached } from '@glimmer/tracking';
+
+  const count = tracked(0);
+  const doubled = cached(() => count.value * 2);
+
+  doubled.value; // read the memoized value, entangling with any tracking context
+  doubled.get(); // function shorthand for reading
+  ```
+
+  The function is only re-invoked when tracked state it previously read has
+  changed; reading `value` in a template (or in a getter used by a template)
+  will rerender just like a `@cached` getter.
+
+  This form accepts an options object containing an `equals` function and a
+  `description` used for debugging. When a re-computation produces a value
+  that `equals` deems equal to the previous one (it defaults to `Object.is`),
+  the previous value -- and its identity -- is retained, so downstream
+  consumers do not update:
+
+  ```js
+  const letters = tracked(['b', 'a']);
+  const sorted = cached(() => letters.value.slice().sort(), {
+    equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+  });
+
+  letters.value = ['a', 'b']; // recomputes, but `sorted.value` keeps its identity
+  ```
+
   @method cached
   @static
   @for @glimmer/tracking

--- a/packages/@ember/-internals/glimmer/tests/integration/components/cached-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/cached-test.js
@@ -1,0 +1,70 @@
+import { cached, tracked } from '@ember/-internals/metal';
+import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
+import { Component } from '../../utils/helpers';
+import { precompileTemplate } from '@ember/template-compilation';
+import { setComponentTemplate } from '@glimmer/manager';
+
+moduleFor(
+  'Component Standalone Cached Values',
+  class extends RenderingTestCase {
+    '@test standalone cached values rerender when their inputs update'() {
+      class CountComponent extends Component {
+        count = tracked(0);
+        doubled = cached(() => this.count.value * 2);
+
+        increment = () => {
+          this.count.value++;
+        };
+      }
+
+      this.owner.register(
+        'component:counter',
+        setComponentTemplate(
+          precompileTemplate(
+            '<button {{on "click" this.increment}}>{{this.doubled.value}}</button>'
+          ),
+          CountComponent
+        )
+      );
+
+      this.render('<Counter />');
+
+      this.assertText('0');
+
+      runTask(() => this.$('button').click());
+
+      this.assertText('2');
+    }
+
+    '@test standalone cached values in module scope rerender when their inputs update'(assert) {
+      let count = tracked(0);
+      let computations = 0;
+      let doubled = cached(() => {
+        computations++;
+        return count.value * 2;
+      });
+
+      class CountComponent extends Component {
+        doubled = doubled;
+      }
+
+      this.owner.register(
+        'component:counter',
+        setComponentTemplate(
+          precompileTemplate('{{this.doubled.value}} and {{this.doubled.value}}'),
+          CountComponent
+        )
+      );
+
+      this.render('<Counter />');
+
+      this.assertText('0 and 0');
+      assert.strictEqual(computations, 1, 'computed once for two reads');
+
+      runTask(() => count.set(1));
+
+      this.assertText('2 and 2');
+      assert.strictEqual(computations, 2, 'computed once after the input changed');
+    }
+  }
+);

--- a/packages/@ember/-internals/metal/lib/cached.ts
+++ b/packages/@ember/-internals/metal/lib/cached.ts
@@ -1,7 +1,9 @@
 // NOTE: copied from: https://github.com/glimmerjs/glimmer.js/pull/358
 // Both glimmerjs/glimmer.js and emberjs/ember.js have the exact same implementation
 // of @cached, so any changes made to one should also be made to the other
+import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
+import { type CachedValue, cachedValue } from '@glimmer/validator/lib/cached-value';
 import { createCache, getValue } from '@glimmer/validator/lib/tracking';
 
 /**
@@ -84,20 +86,119 @@ import { createCache, getValue } from '@glimmer/validator/lib/tracking';
   the subsequent cache invalidations of the `@cached` properties who were
   using this `trackedProp`.
 
-  Remember that setting tracked data should only be done during initialization, 
+  Remember that setting tracked data should only be done during initialization,
   or as the result of a user action. Setting tracked data during render
   (such as in a getter), is not supported.
+
+  ### Standalone usage
+
+  Calling `cached` with a function creates a standalone memoized reactive
+  value, usable outside of classes:
+
+  ```js
+  import { tracked, cached } from '@glimmer/tracking';
+
+  const count = tracked(0);
+  const doubled = cached(() => count.value * 2);
+
+  doubled.value; // read the memoized value, entangling with any tracking context
+  doubled.get(); // function shorthand for reading
+  ```
+
+  The function is only re-invoked when tracked state it previously read has
+  changed; reading `value` in a template (or in a getter used by a template)
+  will rerender just like a `@cached` getter.
+
+  This form accepts an options object containing an `equals` function and a
+  `description` used for debugging. When a re-computation produces a value
+  that `equals` deems equal to the previous one (it defaults to `Object.is`),
+  the previous value -- and its identity -- is retained, so downstream
+  consumers do not update:
+
+  ```js
+  const letters = tracked(['b', 'a']);
+  const sorted = cached(() => letters.value.slice().sort(), {
+    equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+  });
+
+  letters.value = ['a', 'b']; // recomputes, but `sorted.value` keeps its identity
+  ```
 
   @method cached
   @static
   @for @glimmer/tracking
   @public
  */
-export const cached: MethodDecorator = (...args: any[]) => {
+/**
+ * Reactivity options for the standalone `cached(fn, options)` form.
+ *
+ * - `equals` decides whether a re-computed value counts as a new value; when it
+ *   returns `true`, the previous value (and its identity) is retained. It
+ *   defaults to `Object.is`.
+ * - `description` is used in development for debugging.
+ */
+interface CachedValueOptions<Value> {
+  equals?: (a: Value, b: Value) => boolean;
+  description?: string;
+}
+
+/**
+ * `cached` as a decorator: `@cached get fullName() { … }`.
+ */
+export function cached<T>(
+  target: object,
+  key: string | symbol,
+  descriptor: TypedPropertyDescriptor<T>
+): void;
+/**
+ * `cached` as a standalone memoized reactive value, usable outside of classes:
+ * `const doubled = cached(() => count.value * 2)`.
+ */
+export function cached<Value>(
+  fn: () => Value,
+  options?: CachedValueOptions<Value>
+): CachedValue<Value>;
+export function cached(...args: any[]): CachedValue<unknown> | void {
   const [target, key, descriptor] = args;
 
   // Error on `@cached()`, `@cached(...args)`, and `@cached propName = value;`
   if (DEBUG && target === undefined) throwCachedExtraneousParens();
+
+  if (typeof target === 'function' && args.length <= 2) {
+    /*
+      Standalone form. Returns a read-only `CachedValue` usable outside of
+      classes. A legacy decorator invocation always receives three arguments,
+      so it can never land in this branch.
+
+      ```js
+      const doubled = cached(() => count.value * 2);
+
+      doubled.value; // read (consumes what the function read)
+      doubled.get(); // function shorthand for reading
+      ```
+    */
+    const options = key as CachedValueOptions<unknown> | undefined;
+
+    assert(
+      `cached() may only receive an options object containing 'equals' or 'description' as its second argument, received ${options}`,
+      options === undefined || (typeof options === 'object' && options !== null)
+    );
+
+    if (DEBUG && options) {
+      assert(
+        `The 'equals' option passed to cached must be a function. Received ${options.equals}`,
+        !('equals' in options) || typeof options.equals === 'function'
+      );
+
+      assert(
+        `The 'description' option passed to cached must be a string. Received ${options.description}`,
+        !('description' in options) || typeof options.description === 'string'
+      );
+    }
+
+    return cachedValue(target as () => unknown, options);
+  }
+
   if (
     DEBUG &&
     (typeof target !== 'object' ||
@@ -121,7 +222,7 @@ export const cached: MethodDecorator = (...args: any[]) => {
 
     return getValue(caches.get(this));
   };
-};
+}
 
 function throwCachedExtraneousParens(): never {
   throw new Error(

--- a/packages/@ember/-internals/metal/lib/cached.ts
+++ b/packages/@ember/-internals/metal/lib/cached.ts
@@ -3,7 +3,8 @@
 // of @cached, so any changes made to one should also be made to the other
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
-import { type CachedValue, cachedValue } from '@glimmer/validator/lib/cached-value';
+import { cachedValue } from '@glimmer/validator/lib/cached-value';
+import type { ReadOnlyReactive } from '@glimmer/validator/lib/tracked-value';
 import { createCache, getValue } from '@glimmer/validator/lib/tracking';
 
 /**
@@ -142,8 +143,11 @@ export function cached<T>(
  * `cached` as a standalone cached reactive value, usable outside of classes:
  * `const doubled = cached(() => count.value * 2)`.
  */
-export function cached<Value>(fn: () => Value, options?: CachedValueOptions): CachedValue<Value>;
-export function cached(...args: any[]): CachedValue<unknown> | void {
+export function cached<Value>(
+  fn: () => Value,
+  options?: CachedValueOptions
+): ReadOnlyReactive<Value>;
+export function cached(...args: any[]): ReadOnlyReactive<unknown> | void {
   const [target, key, descriptor] = args;
 
   // Error on `@cached()`, `@cached(...args)`, and `@cached propName = value;`
@@ -151,7 +155,7 @@ export function cached(...args: any[]): CachedValue<unknown> | void {
 
   if (typeof target === 'function' && args.length <= 2) {
     /*
-      Standalone form. Returns a read-only `CachedValue` usable outside of
+      Standalone form. Returns a `ReadOnlyReactive` usable outside of
       classes. A legacy decorator invocation always receives three arguments,
       so it can never land in this branch.
 

--- a/packages/@ember/-internals/metal/lib/cached.ts
+++ b/packages/@ember/-internals/metal/lib/cached.ts
@@ -92,7 +92,7 @@ import { createCache, getValue } from '@glimmer/validator/lib/tracking';
 
   ### Standalone usage
 
-  Calling `cached` with a function creates a standalone memoized reactive
+  Calling `cached` with a function creates a standalone cached reactive
   value, usable outside of classes:
 
   ```js
@@ -101,7 +101,7 @@ import { createCache, getValue } from '@glimmer/validator/lib/tracking';
   const count = tracked(0);
   const doubled = cached(() => count.value * 2);
 
-  doubled.value; // read the memoized value, entangling with any tracking context
+  doubled.value; // read the cached value, entangling with any tracking context
   doubled.get(); // function shorthand for reading
   ```
 
@@ -109,19 +109,11 @@ import { createCache, getValue } from '@glimmer/validator/lib/tracking';
   changed; reading `value` in a template (or in a getter used by a template)
   will rerender just like a `@cached` getter.
 
-  This form accepts an options object containing an `equals` function and a
-  `description` used for debugging. When a re-computation produces a value
-  that `equals` deems equal to the previous one (it defaults to `Object.is`),
-  the previous value -- and its identity -- is retained, so downstream
-  consumers do not update:
+  This form accepts an options object containing a `description` used for
+  debugging:
 
   ```js
-  const letters = tracked(['b', 'a']);
-  const sorted = cached(() => letters.value.slice().sort(), {
-    equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-  });
-
-  letters.value = ['a', 'b']; // recomputes, but `sorted.value` keeps its identity
+  const doubled = cached(() => count.value * 2, { description: 'doubled' });
   ```
 
   @method cached
@@ -130,15 +122,11 @@ import { createCache, getValue } from '@glimmer/validator/lib/tracking';
   @public
  */
 /**
- * Reactivity options for the standalone `cached(fn, options)` form.
+ * Options for the standalone `cached(fn, options)` form.
  *
- * - `equals` decides whether a re-computed value counts as a new value; when it
- *   returns `true`, the previous value (and its identity) is retained. It
- *   defaults to `Object.is`.
  * - `description` is used in development for debugging.
  */
-interface CachedValueOptions<Value> {
-  equals?: (a: Value, b: Value) => boolean;
+interface CachedValueOptions {
   description?: string;
 }
 
@@ -151,13 +139,10 @@ export function cached<T>(
   descriptor: TypedPropertyDescriptor<T>
 ): void;
 /**
- * `cached` as a standalone memoized reactive value, usable outside of classes:
+ * `cached` as a standalone cached reactive value, usable outside of classes:
  * `const doubled = cached(() => count.value * 2)`.
  */
-export function cached<Value>(
-  fn: () => Value,
-  options?: CachedValueOptions<Value>
-): CachedValue<Value>;
+export function cached<Value>(fn: () => Value, options?: CachedValueOptions): CachedValue<Value>;
 export function cached(...args: any[]): CachedValue<unknown> | void {
   const [target, key, descriptor] = args;
 
@@ -177,19 +162,14 @@ export function cached(...args: any[]): CachedValue<unknown> | void {
       doubled.get(); // function shorthand for reading
       ```
     */
-    const options = key as CachedValueOptions<unknown> | undefined;
+    const options = key as CachedValueOptions | undefined;
 
     assert(
-      `cached() may only receive an options object containing 'equals' or 'description' as its second argument, received ${options}`,
+      `cached() may only receive an options object containing 'description' as its second argument, received ${options}`,
       options === undefined || (typeof options === 'object' && options !== null)
     );
 
     if (DEBUG && options) {
-      assert(
-        `The 'equals' option passed to cached must be a function. Received ${options.equals}`,
-        !('equals' in options) || typeof options.equals === 'function'
-      );
-
       assert(
         `The 'description' option passed to cached must be a string. Received ${options.description}`,
         !('description' in options) || typeof options.description === 'string'

--- a/packages/@ember/-internals/metal/tests/cached/standalone_test.js
+++ b/packages/@ember/-internals/metal/tests/cached/standalone_test.js
@@ -1,0 +1,76 @@
+import { AbstractTestCase, moduleFor } from 'internal-test-helpers';
+import { cached, tracked } from '../..';
+
+import { track, valueForTag, validateTag } from '@glimmer/validator';
+
+moduleFor(
+  'cached() - standalone usage',
+  class extends AbstractTestCase {
+    ['@test creates a memoized derived value'](assert) {
+      let count = tracked(1);
+
+      let computations = 0;
+      let doubled = cached(() => {
+        computations++;
+        return count.value * 2;
+      });
+
+      assert.strictEqual(doubled.value, 2, 'value is readable via .value');
+      assert.strictEqual(doubled.get(), 2, 'value is readable via .get()');
+      assert.strictEqual(computations, 1, 'repeated reads do not recompute');
+
+      count.value = 2;
+
+      assert.strictEqual(doubled.value, 4, 'a changed input recomputes');
+      assert.strictEqual(computations, 2);
+    }
+
+    ['@test reading entangles with the state the function reads'](assert) {
+      let count = tracked(0);
+      let doubled = cached(() => count.value * 2);
+
+      let tag = track(() => doubled.value);
+      let snapshot = valueForTag(tag);
+
+      assert.true(validateTag(tag, snapshot), 'tag is valid before a change');
+
+      count.value = 1;
+      assert.false(validateTag(tag, snapshot), 'tag is invalidated by a change to an input');
+    }
+
+    ['@test equals option retains the previous value and its identity'](assert) {
+      let letters = tracked(['b', 'a']);
+      let sorted = cached(() => letters.value.slice().sort(), {
+        equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+      });
+
+      let first = sorted.value;
+      assert.deepEqual(first, ['a', 'b']);
+
+      letters.value = ['a', 'b'];
+      assert.strictEqual(sorted.value, first, 'an equal recomputation retains the previous array');
+
+      letters.value = ['c', 'a'];
+      assert.notStrictEqual(sorted.value, first, 'an unequal recomputation is a new array');
+      assert.deepEqual(sorted.value, ['a', 'c']);
+    }
+
+    ['@test errors when the second argument is not an options object']() {
+      expectAssertion(() => {
+        cached(() => 1, null);
+      }, "cached() may only receive an options object containing 'equals' or 'description' as its second argument, received null");
+    }
+
+    ['@test errors when equals is not a function']() {
+      expectAssertion(() => {
+        cached(() => 1, { equals: true });
+      }, "The 'equals' option passed to cached must be a function. Received true");
+    }
+
+    ['@test errors when description is not a string']() {
+      expectAssertion(() => {
+        cached(() => 1, { description: 123 });
+      }, "The 'description' option passed to cached must be a string. Received 123");
+    }
+  }
+);

--- a/packages/@ember/-internals/metal/tests/cached/standalone_test.js
+++ b/packages/@ember/-internals/metal/tests/cached/standalone_test.js
@@ -6,7 +6,7 @@ import { track, valueForTag, validateTag } from '@glimmer/validator';
 moduleFor(
   'cached() - standalone usage',
   class extends AbstractTestCase {
-    ['@test creates a memoized derived value'](assert) {
+    ['@test creates a cached computation'](assert) {
       let count = tracked(1);
 
       let computations = 0;
@@ -38,33 +38,10 @@ moduleFor(
       assert.false(validateTag(tag, snapshot), 'tag is invalidated by a change to an input');
     }
 
-    ['@test equals option retains the previous value and its identity'](assert) {
-      let letters = tracked(['b', 'a']);
-      let sorted = cached(() => letters.value.slice().sort(), {
-        equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-      });
-
-      let first = sorted.value;
-      assert.deepEqual(first, ['a', 'b']);
-
-      letters.value = ['a', 'b'];
-      assert.strictEqual(sorted.value, first, 'an equal recomputation retains the previous array');
-
-      letters.value = ['c', 'a'];
-      assert.notStrictEqual(sorted.value, first, 'an unequal recomputation is a new array');
-      assert.deepEqual(sorted.value, ['a', 'c']);
-    }
-
     ['@test errors when the second argument is not an options object']() {
       expectAssertion(() => {
         cached(() => 1, null);
-      }, "cached() may only receive an options object containing 'equals' or 'description' as its second argument, received null");
-    }
-
-    ['@test errors when equals is not a function']() {
-      expectAssertion(() => {
-        cached(() => 1, { equals: true });
-      }, "The 'equals' option passed to cached must be a function. Received true");
+      }, "cached() may only receive an options object containing 'description' as its second argument, received null");
     }
 
     ['@test errors when description is not a string']() {

--- a/packages/@glimmer-workspace/integration-tests/test/cached-value-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/cached-value-test.ts
@@ -23,7 +23,7 @@ class CachedValueTest extends RenderTest {
   }
 
   @test
-  'memoizes across repeated reads in a render'(assert: Assert) {
+  'caches across repeated reads in a render'(assert: Assert) {
     const count = trackedValue(1);
     const doubled = cachedValue(() => {
       assert.step(`computed:${count.value}`);
@@ -43,33 +43,6 @@ class CachedValueTest extends RenderTest {
     this.assertHTML('4 and 4');
     this.assertStableRerender();
     assert.verifySteps(['computed:2'], 'computed once after the input changed');
-  }
-
-  @test
-  'options.equals prevents downstream updates for equivalent recomputations'(assert: Assert) {
-    const letters = trackedValue(['b', 'a']);
-    const sorted = cachedValue(() => letters.value.slice().sort(), {
-      equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-    });
-    const step = () => {
-      const value = sorted.value.join('');
-      assert.step(value);
-      return value;
-    };
-
-    const List = defineComponent({ step }, '{{ (step) }}');
-
-    this.renderComponent(List);
-
-    this.assertHTML('ab');
-    assert.verifySteps(['ab']);
-
-    letters.set(['a', 'b']);
-    this.rerender();
-
-    this.assertHTML('ab');
-    this.assertStableRerender();
-    assert.verifySteps(['ab'], 'the step reran, receiving the retained value');
   }
 }
 

--- a/packages/@glimmer-workspace/integration-tests/test/cached-value-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/cached-value-test.ts
@@ -1,0 +1,76 @@
+import { cachedValue, trackedValue } from '@glimmer/validator';
+import { defineComponent, jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+class CachedValueTest extends RenderTest {
+  static suiteName = `cachedValue() (rendering)`;
+
+  @test
+  'renders and updates when an input changes'() {
+    const count = trackedValue(0);
+    const doubled = cachedValue(() => count.value * 2);
+
+    const Counter = defineComponent({ doubled }, '{{doubled.value}}');
+
+    this.renderComponent(Counter);
+
+    this.assertHTML('0');
+
+    count.set(1);
+    this.rerender();
+
+    this.assertHTML('2');
+    this.assertStableRerender();
+  }
+
+  @test
+  'memoizes across repeated reads in a render'(assert: Assert) {
+    const count = trackedValue(1);
+    const doubled = cachedValue(() => {
+      assert.step(`computed:${count.value}`);
+      return count.value * 2;
+    });
+
+    const Counter = defineComponent({ doubled }, '{{doubled.value}} and {{doubled.value}}');
+
+    this.renderComponent(Counter);
+
+    this.assertHTML('2 and 2');
+    assert.verifySteps(['computed:1'], 'computed once for two reads');
+
+    count.set(2);
+    this.rerender();
+
+    this.assertHTML('4 and 4');
+    this.assertStableRerender();
+    assert.verifySteps(['computed:2'], 'computed once after the input changed');
+  }
+
+  @test
+  'options.equals prevents downstream updates for equivalent recomputations'(assert: Assert) {
+    const letters = trackedValue(['b', 'a']);
+    const sorted = cachedValue(() => letters.value.slice().sort(), {
+      equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+    });
+    const step = () => {
+      const value = sorted.value.join('');
+      assert.step(value);
+      return value;
+    };
+
+    const List = defineComponent({ step }, '{{ (step) }}');
+
+    this.renderComponent(List);
+
+    this.assertHTML('ab');
+    assert.verifySteps(['ab']);
+
+    letters.set(['a', 'b']);
+    this.rerender();
+
+    this.assertHTML('ab');
+    this.assertStableRerender();
+    assert.verifySteps(['ab'], 'the step reran, receiving the retained value');
+  }
+}
+
+jitSuite(CachedValueTest);

--- a/packages/@glimmer/tracking/index.ts
+++ b/packages/@glimmer/tracking/index.ts
@@ -6,6 +6,7 @@ export type {
   ReadOnlyReactive,
   TrackedValue,
 } from '@glimmer/validator/lib/tracked-value';
+export type { CachedValue } from '@glimmer/validator/lib/cached-value';
 
 /**
   In order to tell Ember a value might change, we need to mark it as trackable.
@@ -271,6 +272,40 @@ export type {
   your app. Many getters and tracked properties are only accessed once, rendered,
   and then never rerendered, so adding `@cached` when it is unnecessary can
   negatively impact performance.
+
+  ### Standalone usage
+
+  Calling `cached` with a function creates a standalone memoized reactive
+  value, usable outside of classes:
+
+  ```js
+  import { tracked, cached } from '@glimmer/tracking';
+
+  const count = tracked(0);
+  const doubled = cached(() => count.value * 2);
+
+  doubled.value; // read the memoized value, entangling with any tracking context
+  doubled.get(); // function shorthand for reading
+  ```
+
+  The function is only re-invoked when tracked state it previously read has
+  changed; reading `value` in a template (or in a getter used by a template)
+  will rerender just like a `@cached` getter.
+
+  This form accepts an options object containing an `equals` function and a
+  `description` used for debugging. When a re-computation produces a value
+  that `equals` deems equal to the previous one (it defaults to `Object.is`),
+  the previous value -- and its identity -- is retained, so downstream
+  consumers do not update:
+
+  ```js
+  const letters = tracked(['b', 'a']);
+  const sorted = cached(() => letters.value.slice().sort(), {
+    equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+  });
+
+  letters.value = ['a', 'b']; // recomputes, but `sorted.value` keeps its identity
+  ```
 
   @method cached
   @static

--- a/packages/@glimmer/tracking/index.ts
+++ b/packages/@glimmer/tracking/index.ts
@@ -275,7 +275,7 @@ export type { CachedValue } from '@glimmer/validator/lib/cached-value';
 
   ### Standalone usage
 
-  Calling `cached` with a function creates a standalone memoized reactive
+  Calling `cached` with a function creates a standalone cached reactive
   value, usable outside of classes:
 
   ```js
@@ -284,7 +284,7 @@ export type { CachedValue } from '@glimmer/validator/lib/cached-value';
   const count = tracked(0);
   const doubled = cached(() => count.value * 2);
 
-  doubled.value; // read the memoized value, entangling with any tracking context
+  doubled.value; // read the cached value, entangling with any tracking context
   doubled.get(); // function shorthand for reading
   ```
 
@@ -292,19 +292,11 @@ export type { CachedValue } from '@glimmer/validator/lib/cached-value';
   changed; reading `value` in a template (or in a getter used by a template)
   will rerender just like a `@cached` getter.
 
-  This form accepts an options object containing an `equals` function and a
-  `description` used for debugging. When a re-computation produces a value
-  that `equals` deems equal to the previous one (it defaults to `Object.is`),
-  the previous value -- and its identity -- is retained, so downstream
-  consumers do not update:
+  This form accepts an options object containing a `description` used for
+  debugging:
 
   ```js
-  const letters = tracked(['b', 'a']);
-  const sorted = cached(() => letters.value.slice().sort(), {
-    equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-  });
-
-  letters.value = ['a', 'b']; // recomputes, but `sorted.value` keeps its identity
+  const doubled = cached(() => count.value * 2, { description: 'doubled' });
   ```
 
   @method cached

--- a/packages/@glimmer/tracking/index.ts
+++ b/packages/@glimmer/tracking/index.ts
@@ -6,7 +6,6 @@ export type {
   ReadOnlyReactive,
   TrackedValue,
 } from '@glimmer/validator/lib/tracked-value';
-export type { CachedValue } from '@glimmer/validator/lib/cached-value';
 
 /**
   In order to tell Ember a value might change, we need to mark it as trackable.

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -8,6 +8,7 @@ if (Reflect.has(globalThis, GLIMMER_VALIDATOR_REGISTRATION)) {
 
 Reflect.set(globalThis, GLIMMER_VALIDATOR_REGISTRATION, true);
 
+export { CachedValue, cachedValue } from './lib/cached-value';
 export { trackedArray } from './lib/collections/array';
 export { trackedMap } from './lib/collections/map';
 export { trackedObject } from './lib/collections/object';

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -8,7 +8,7 @@ if (Reflect.has(globalThis, GLIMMER_VALIDATOR_REGISTRATION)) {
 
 Reflect.set(globalThis, GLIMMER_VALIDATOR_REGISTRATION, true);
 
-export { CachedValue, cachedValue } from './lib/cached-value';
+export { cachedValue } from './lib/cached-value';
 export { trackedArray } from './lib/collections/array';
 export { trackedMap } from './lib/collections/map';
 export { trackedObject } from './lib/collections/object';

--- a/packages/@glimmer/validator/lib/cached-value.ts
+++ b/packages/@glimmer/validator/lib/cached-value.ts
@@ -9,7 +9,7 @@ import { type Cache, createCache, getValue } from './tracking';
  * re-invokes the wrapped function when tracked state it previously read has
  * changed.
  */
-export class CachedValue<Value = unknown> implements ReadOnlyReactive<Value> {
+class CachedValue<Value = unknown> implements ReadOnlyReactive<Value> {
   readonly #cache: Cache<Value>;
 
   constructor(fn: () => Value, options?: { description?: string }) {
@@ -35,6 +35,6 @@ export class CachedValue<Value = unknown> implements ReadOnlyReactive<Value> {
 export function cachedValue<Value>(
   fn: () => Value,
   options?: { description?: string }
-): CachedValue<Value> {
+): ReadOnlyReactive<Value> {
   return new CachedValue(fn, options);
 }

--- a/packages/@glimmer/validator/lib/cached-value.ts
+++ b/packages/@glimmer/validator/lib/cached-value.ts
@@ -1,0 +1,60 @@
+import type { ReactiveOptions } from './collections/types';
+import type { ReadOnlyReactive } from './tracked-value';
+
+import { type Cache, createCache, getValue } from './tracking';
+
+/**
+ * A memoized, read-only reactive value.
+ *
+ * Reading `value` entangles with the current tracking frame, and only
+ * re-invokes the wrapped function when tracked state it previously read has
+ * changed.
+ */
+export class CachedValue<Value = unknown> implements ReadOnlyReactive<Value> {
+  #hasPrevious = false;
+  #previous: Value | undefined;
+  readonly #cache: Cache<Value>;
+
+  constructor(fn: () => Value, options: ReactiveOptions<Value>) {
+    this.#cache = createCache(() => {
+      let next = fn();
+
+      if (this.#hasPrevious && options.equals(this.#previous as Value, next)) {
+        return this.#previous as Value;
+      }
+
+      this.#hasPrevious = true;
+      this.#previous = next;
+
+      return next;
+    }, options.description);
+  }
+
+  /**
+   * The underlying value.
+   *
+   * Reading entangles with the current tracking frame. When a re-computation
+   * produces a value the configured `equals` deems equal to the previous one,
+   * the previous value (and its identity) is retained.
+   */
+  get value(): Value {
+    return getValue(this.#cache) as Value;
+  }
+
+  /**
+   * Function short-hand for reading `value`.
+   */
+  get = (): Value => {
+    return this.value;
+  };
+}
+
+export function cachedValue<Value>(
+  fn: () => Value,
+  options?: { equals?: (a: Value, b: Value) => boolean; description?: string }
+): CachedValue<Value> {
+  return new CachedValue(fn, {
+    equals: options?.equals ?? Object.is,
+    description: options?.description,
+  });
+}

--- a/packages/@glimmer/validator/lib/cached-value.ts
+++ b/packages/@glimmer/validator/lib/cached-value.ts
@@ -1,41 +1,24 @@
-import type { ReactiveOptions } from './collections/types';
 import type { ReadOnlyReactive } from './tracked-value';
 
 import { type Cache, createCache, getValue } from './tracking';
 
 /**
- * A memoized, read-only reactive value.
+ * A cached, read-only reactive value.
  *
  * Reading `value` entangles with the current tracking frame, and only
  * re-invokes the wrapped function when tracked state it previously read has
  * changed.
  */
 export class CachedValue<Value = unknown> implements ReadOnlyReactive<Value> {
-  #hasPrevious = false;
-  #previous: Value | undefined;
   readonly #cache: Cache<Value>;
 
-  constructor(fn: () => Value, options: ReactiveOptions<Value>) {
-    this.#cache = createCache(() => {
-      let next = fn();
-
-      if (this.#hasPrevious && options.equals(this.#previous as Value, next)) {
-        return this.#previous as Value;
-      }
-
-      this.#hasPrevious = true;
-      this.#previous = next;
-
-      return next;
-    }, options.description);
+  constructor(fn: () => Value, options?: { description?: string }) {
+    this.#cache = createCache(fn, options?.description);
   }
 
   /**
-   * The underlying value.
-   *
-   * Reading entangles with the current tracking frame. When a re-computation
-   * produces a value the configured `equals` deems equal to the previous one,
-   * the previous value (and its identity) is retained.
+   * The underlying value, re-computed only when tracked state read by the
+   * wrapped function has changed.
    */
   get value(): Value {
     return getValue(this.#cache) as Value;
@@ -51,10 +34,7 @@ export class CachedValue<Value = unknown> implements ReadOnlyReactive<Value> {
 
 export function cachedValue<Value>(
   fn: () => Value,
-  options?: { equals?: (a: Value, b: Value) => boolean; description?: string }
+  options?: { description?: string }
 ): CachedValue<Value> {
-  return new CachedValue(fn, {
-    equals: options?.equals ?? Object.is,
-    description: options?.description,
-  });
+  return new CachedValue(fn, options);
 }

--- a/packages/@glimmer/validator/lib/tracked-value.ts
+++ b/packages/@glimmer/validator/lib/tracked-value.ts
@@ -20,6 +20,11 @@ export interface Reactive<Value> {
  */
 export interface ReadOnlyReactive<Value> extends Reactive<Value> {
   readonly value: Value;
+
+  /**
+   * Function short-hand for reading `value`.
+   */
+  get: () => Value;
 }
 
 export class TrackedValue<Value = unknown> implements Reactive<Value> {

--- a/packages/@glimmer/validator/test/cached-value-test.ts
+++ b/packages/@glimmer/validator/test/cached-value-test.ts
@@ -1,0 +1,78 @@
+import { cachedValue, track, trackedValue, validateTag, valueForTag } from '@glimmer/validator';
+
+import { module, test } from './-utils';
+
+module('@glimmer/validator: cachedValue()', () => {
+  test('creates a memoized derived value', (assert) => {
+    const count = trackedValue(1);
+
+    let computations = 0;
+    const doubled = cachedValue(() => {
+      computations++;
+      return count.value * 2;
+    });
+
+    assert.strictEqual(doubled.value, 2);
+    assert.strictEqual(doubled.get(), 2);
+    assert.strictEqual(computations, 1, 'repeated reads do not recompute');
+
+    count.value = 2;
+
+    assert.strictEqual(doubled.value, 4);
+    assert.strictEqual(computations, 2, 'a changed input recomputes');
+
+    assert.strictEqual(doubled.value, 4);
+    assert.strictEqual(computations, 2, 'repeated reads still do not recompute');
+  });
+
+  test('reading entangles with the state the function reads', (assert) => {
+    const count = trackedValue(0);
+    const doubled = cachedValue(() => count.value * 2);
+
+    const tag = track(() => doubled.value);
+    const snapshot = valueForTag(tag);
+
+    assert.true(validateTag(tag, snapshot), 'tag is valid before a change');
+
+    count.value = 1;
+    assert.false(validateTag(tag, snapshot), 'tag is invalidated by a change to an input');
+  });
+
+  test('options.equals retains the previous value and its identity', (assert) => {
+    const letters = trackedValue(['b', 'a']);
+    const sorted = cachedValue(() => letters.value.slice().sort(), {
+      equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+    });
+
+    const first = sorted.value;
+    assert.deepEqual(first, ['a', 'b']);
+
+    letters.value = ['a', 'b'];
+    assert.strictEqual(sorted.value, first, 'an equal recomputation retains the previous array');
+
+    letters.value = ['c', 'a'];
+    assert.notStrictEqual(sorted.value, first, 'an unequal recomputation produces a new array');
+    assert.deepEqual(sorted.value, ['a', 'c']);
+  });
+
+  test('default equals is Object.is (new identities count as new values)', (assert) => {
+    const input = trackedValue(0);
+    const wrapped = cachedValue(() => ({ input: input.value }));
+
+    const first = wrapped.value;
+
+    input.value = 1;
+    assert.notStrictEqual(wrapped.value, first, 'a recomputed object is a new value');
+  });
+
+  test('get can be detached from the instance', (assert) => {
+    const count = trackedValue(1);
+    const doubled = cachedValue(() => count.value * 2);
+    const { get } = doubled;
+
+    assert.strictEqual(get(), 2);
+
+    count.value = 2;
+    assert.strictEqual(get(), 4);
+  });
+});

--- a/packages/@glimmer/validator/test/cached-value-test.ts
+++ b/packages/@glimmer/validator/test/cached-value-test.ts
@@ -3,7 +3,7 @@ import { cachedValue, track, trackedValue, validateTag, valueForTag } from '@gli
 import { module, test } from './-utils';
 
 module('@glimmer/validator: cachedValue()', () => {
-  test('creates a memoized derived value', (assert) => {
+  test('creates a cached computation', (assert) => {
     const count = trackedValue(1);
 
     let computations = 0;
@@ -36,33 +36,6 @@ module('@glimmer/validator: cachedValue()', () => {
 
     count.value = 1;
     assert.false(validateTag(tag, snapshot), 'tag is invalidated by a change to an input');
-  });
-
-  test('options.equals retains the previous value and its identity', (assert) => {
-    const letters = trackedValue(['b', 'a']);
-    const sorted = cachedValue(() => letters.value.slice().sort(), {
-      equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-    });
-
-    const first = sorted.value;
-    assert.deepEqual(first, ['a', 'b']);
-
-    letters.value = ['a', 'b'];
-    assert.strictEqual(sorted.value, first, 'an equal recomputation retains the previous array');
-
-    letters.value = ['c', 'a'];
-    assert.notStrictEqual(sorted.value, first, 'an unequal recomputation produces a new array');
-    assert.deepEqual(sorted.value, ['a', 'c']);
-  });
-
-  test('default equals is Object.is (new identities count as new values)', (assert) => {
-    const input = trackedValue(0);
-    const wrapped = cachedValue(() => ({ input: input.value }));
-
-    const first = wrapped.value;
-
-    input.value = 1;
-    assert.notStrictEqual(wrapped.value, first, 'a recomputed object is a new value');
   });
 
   test('get can be detached from the instance', (assert) => {

--- a/type-tests/@glimmer/tracking-test.ts
+++ b/type-tests/@glimmer/tracking-test.ts
@@ -1,5 +1,5 @@
-import { tracked } from '@glimmer/tracking';
-import type { Reactive, ReadOnlyReactive, TrackedValue } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
+import type { CachedValue, Reactive, ReadOnlyReactive, TrackedValue } from '@glimmer/tracking';
 import { expectTypeOf } from 'expect-type';
 
 // ------- public types -------
@@ -49,3 +49,37 @@ expectTypeOf(tracked({ equals: (a: number, b: number) => a === b })).toMatchType
 
 // specifying the options gets you a Reactive
 expectTypeOf(tracked({ value: 'Zoey' }, {})).toMatchTypeOf<Reactive<Record<string, unknown>>>();
+
+// ------- cached: standalone form -------
+const doubled = cached(() => count.value * 2);
+
+expectTypeOf(doubled).toMatchTypeOf<ReadOnlyReactive<number>>();
+expectTypeOf(doubled).toMatchTypeOf<CachedValue<number>>();
+expectTypeOf(doubled.value).toEqualTypeOf<number>();
+expectTypeOf(doubled.get()).toEqualTypeOf<number>();
+
+// @ts-expect-error -- a CachedValue is read-only
+doubled.value = 4;
+
+// ------- cached: standalone form with options -------
+const sorted = cached(() => ['a', 'b'], {
+  equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
+  description: 'sorted letters',
+});
+
+expectTypeOf(sorted.value).toEqualTypeOf<string[]>();
+
+// @ts-expect-error -- equals must compare the value type
+cached(() => 0, { equals: (a: string, b: string) => a === b });
+
+// ------- cached: decorator form -------
+class Person {
+  @tracked first = 'Tom';
+
+  @cached
+  get greeting(): string {
+    return `hello, ${this.first}`;
+  }
+}
+
+expectTypeOf(new Person().greeting).toEqualTypeOf<string>();

--- a/type-tests/@glimmer/tracking-test.ts
+++ b/type-tests/@glimmer/tracking-test.ts
@@ -62,15 +62,12 @@ expectTypeOf(doubled.get()).toEqualTypeOf<number>();
 doubled.value = 4;
 
 // ------- cached: standalone form with options -------
-const sorted = cached(() => ['a', 'b'], {
-  equals: (a, b) => a.length === b.length && a.every((x, i) => x === b[i]),
-  description: 'sorted letters',
-});
+const sorted = cached(() => ['a', 'b'], { description: 'sorted letters' });
 
 expectTypeOf(sorted.value).toEqualTypeOf<string[]>();
 
-// @ts-expect-error -- equals must compare the value type
-cached(() => 0, { equals: (a: string, b: string) => a === b });
+// @ts-expect-error -- description must be a string
+cached(() => 0, { description: 123 });
 
 // ------- cached: decorator form -------
 class Person {

--- a/type-tests/@glimmer/tracking-test.ts
+++ b/type-tests/@glimmer/tracking-test.ts
@@ -1,5 +1,5 @@
 import { cached, tracked } from '@glimmer/tracking';
-import type { CachedValue, Reactive, ReadOnlyReactive, TrackedValue } from '@glimmer/tracking';
+import type { Reactive, ReadOnlyReactive, TrackedValue } from '@glimmer/tracking';
 import { expectTypeOf } from 'expect-type';
 
 // ------- public types -------
@@ -53,12 +53,11 @@ expectTypeOf(tracked({ value: 'Zoey' }, {})).toMatchTypeOf<Reactive<Record<strin
 // ------- cached: standalone form -------
 const doubled = cached(() => count.value * 2);
 
-expectTypeOf(doubled).toMatchTypeOf<ReadOnlyReactive<number>>();
-expectTypeOf(doubled).toMatchTypeOf<CachedValue<number>>();
+expectTypeOf(doubled).toEqualTypeOf<ReadOnlyReactive<number>>();
 expectTypeOf(doubled.value).toEqualTypeOf<number>();
 expectTypeOf(doubled.get()).toEqualTypeOf<number>();
 
-// @ts-expect-error -- a CachedValue is read-only
+// @ts-expect-error -- the returned value is read-only
 doubled.value = 4;
 
 // ------- cached: standalone form with options -------


### PR DESCRIPTION
Implements the standalone form of `cached` proposed in [Overload cached for non-class use](https://github.com/NullVoxPopuli/rfcs/pull/19) — the caching companion to RFC 1071's overloaded `tracked`, and mirrors that implementation (#21471) throughout.

```js
import { tracked, cached } from '@glimmer/tracking';

const count = tracked(0);
const doubled = cached(() => count.value * 2);

doubled.value; // read the cached value, entangling with any tracking context
doubled.get(); // function shorthand for reading
```

- New `cachedValue(fn, options)` in `@glimmer/validator`, returning RFC 1071's `ReadOnlyReactive` — no `set`/`update`/`freeze`, it has no storage of its own. Backed by `createCache`/`getValue`. Per RFC review there is no new public type: `get()` joins the `ReadOnlyReactive` interface (an RFC 1071 oversight) and the implementation class stays internal.
- `options.description` labels the cache for debugging. (An earlier revision proposed `options.equals`; removed per RFC review — calling `fn` is the expensive part, so re-running it only to discard the result has unclear benefit.)
- `@ember/-internals/metal` `cached` dispatches between the two forms: a legacy decorator invocation always receives three arguments, so `cached(fn)` / `cached(fn, options)` can never collide with `@cached` on a getter (including static getters). Decorator behavior is unchanged.
- The docs blocks gain a "Standalone usage" section; the existing `Reactive`/`ReadOnlyReactive`/`TrackedValue` type re-exports from `@glimmer/tracking` are unchanged.
- Tests at every layer, mirroring #21471: `@glimmer/validator` unit tests, glimmer integration-tests rendering tests, metal standalone + assertion tests, an ember rendering test (`Component Standalone Cached Values`), and type-tests covering overload resolution, read-only `value`, and the options object.

Draft until the RFC is proposed/accepted upstream.

Test results: `filter=cached` 33/33 pass, `filter=tracked` 273 pass / 3 skip, `type-check` clean, `lint:docs` pass, prettier/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
