### PR TITLE
Iteration fast path, flat update frames, and flattened combinators

### DIFF
--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -19,6 +19,12 @@ export interface IterationItem<T, U> {
 export interface AbstractIterator<T, U, V extends IterationItem<T, U>> {
   isEmpty(): boolean;
   next(): Nullable<V>;
+  /**
+   * SPIKE: allocation-free iteration -- writes into `target` and returns
+   * it, instead of allocating a fresh item per step. Optional; callers
+   * must not retain the returned object across steps.
+   */
+  nextInto?(target: V): Nullable<V>;
 }
 
 export type OpaqueIterationItem = IterationItem<unknown, unknown>;
@@ -262,5 +268,25 @@ class ArrayIterator implements OpaqueIterator {
     let memo = this.pos;
 
     return { key, value, memo };
+  }
+
+  nextInto(target: IterationItem<unknown, number>): Nullable<IterationItem<unknown, number>> {
+    let value: unknown;
+
+    let current = this.current;
+    if (current.kind === 'first') {
+      this.current = { kind: 'progress' };
+      value = current.value;
+    } else if (this.pos >= this.iterator.length - 1) {
+      return null;
+    } else {
+      value = this.iterator[++this.pos];
+    }
+
+    target.key = this.keyFor(value, this.pos);
+    target.value = value;
+    target.memo = this.pos;
+
+    return target;
   }
 }

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -16,6 +16,7 @@ import type {
 } from '@glimmer/interfaces';
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
 import type { Reference } from '@glimmer/reference/lib/reference';
+import type { Revision, Tag } from '@glimmer/interfaces';
 import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
@@ -23,7 +24,8 @@ import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
-import { resetTracking } from '@glimmer/validator/lib/tracking';
+import { beginTrackFrame, consumeTag, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
+import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
 import type { AppendingBlockList } from './element-builder';
@@ -77,7 +79,7 @@ export class UpdatingVM implements IUpdatingVM {
       let opcode = this.frame.nextStatement();
 
       if (opcode === undefined) {
-        frameStack.pop();
+        frameStack.pop()?.finalize(false);
         continue;
       }
 
@@ -93,13 +95,13 @@ export class UpdatingVM implements IUpdatingVM {
     this.frame.goto(index);
   }
 
-  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler));
+  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>, finalizer?: (didError: boolean) => void) {
+    this.frameStack.push(new UpdatingVMFrame(ops, handler, finalizer));
   }
 
   throw() {
     this.frame.handleException();
-    this.frameStack.pop();
+    this.frameStack.pop()?.finalize(true);
   }
 }
 
@@ -178,6 +180,15 @@ export class ListItemOpcode extends TryOpcode {
   public retained = false;
   public index = -1;
 
+  /**
+   * Everything this item's subtree consumed during its last update,
+   * combined. When still valid, the whole subtree is skipped -- one tag
+   * validation instead of walking every opcode in the item.
+   */
+  private subtreeTag: Nullable<Tag> = null;
+  private subtreeRevision: Revision = INITIAL;
+  private isTrivial: boolean | null = null;
+
   constructor(
     state: Closure,
     context: EvaluationContext,
@@ -189,6 +200,52 @@ export class ListItemOpcode extends TryOpcode {
     super(state, context, bounds, []);
   }
 
+  override evaluate(vm: UpdatingVM) {
+    // Trivial items (a text node or two) can't win: validating their
+    // combined tag costs as much as just updating them, so collection
+    // would be pure overhead. Skipping only pays off for items with a
+    // real subtree -- more than a couple of opcodes, or any nested
+    // block (a nested block child means an arbitrarily large subtree
+    // hides behind a small top-level count).
+    if (this.isTrivial ?? (this.isTrivial = computeIsTrivial(this.children))) {
+      vm.try(this.children, this);
+      return;
+    }
+
+    let { subtreeTag } = this;
+
+    if (
+      subtreeTag !== null &&
+      !vm.alwaysRevalidate &&
+      validateTag(subtreeTag, this.subtreeRevision)
+    ) {
+      // propagate this item's dependencies to any enclosing tracking
+      // frame, exactly as executing the children would have
+      consumeTag(subtreeTag);
+      return;
+    }
+
+    beginTrackFrame();
+    vm.try(this.children, this, (didError) => {
+      // always balance beginTrackFrame, even when unwinding
+      let tag = endTrackFrame();
+
+      if (didError) return;
+
+      this.subtreeTag = tag;
+      this.subtreeRevision = valueForTag(tag);
+      consumeTag(tag);
+    });
+  }
+
+  override handleException() {
+    // children are about to be rebuilt; the collected tag and triviality
+    // no longer describe them
+    this.subtreeTag = null;
+    this.isTrivial = null;
+    super.handleException();
+  }
+
   shouldRemove(): boolean {
     return !this.retained;
   }
@@ -196,6 +253,16 @@ export class ListItemOpcode extends TryOpcode {
   reset() {
     this.retained = false;
   }
+}
+
+function computeIsTrivial(children: UpdatingOpcode[]): boolean {
+  if (children.length > 2) return false;
+
+  for (const child of children) {
+    if (child instanceof BlockOpcode) return false;
+  }
+
+  return true;
 }
 
 export class ListBlockOpcode extends BlockOpcode {
@@ -428,7 +495,8 @@ class UpdatingVMFrame {
 
   constructor(
     private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>
+    private exceptionHandler: Nullable<ExceptionHandler>,
+    private finalizer?: (didError: boolean) => void
   ) {}
 
   goto(index: number) {
@@ -437,6 +505,10 @@ class UpdatingVMFrame {
 
   nextStatement(): UpdatingOpcode | undefined {
     return this.ops[this.current++];
+  }
+
+  finalize(didError: boolean) {
+    this.finalizer?.(didError);
   }
 
   handleException() {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -22,7 +22,6 @@ import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/de
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
-import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
 import {
   beginTrackFrame,
@@ -43,7 +42,15 @@ export class UpdatingVM implements IUpdatingVM {
   public dom: GlimmerTreeChanges;
   public alwaysRevalidate: boolean;
 
-  private frameStack: Stack<UpdatingVMFrame> = new Stack<UpdatingVMFrame>();
+  /**
+   * SPIKE: a flat frame stack (parallel arrays indexed by depth)
+   * instead of allocating an UpdatingVMFrame per block per render.
+   */
+  #ops: UpdatingOpcode[][] = [];
+  #current: number[] = [];
+  #handlers: Nullable<ExceptionHandler>[] = [];
+  #finalizers: (((didError: boolean) => void) | undefined)[] = [];
+  #depth = -1;
 
   constructor(env: Environment, { alwaysRevalidate = false }) {
     this.env = env;
@@ -76,28 +83,41 @@ export class UpdatingVM implements IUpdatingVM {
   }
 
   private _execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler) {
-    let { frameStack } = this;
-
     this.try(opcodes, handler);
 
-    while (!frameStack.isEmpty()) {
-      let opcode = this.frame.nextStatement();
+    while (this.#depth >= 0) {
+      let depth = this.#depth;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depth checked
+      let ops = this.#ops[depth]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depth checked
+      let index = this.#current[depth]!;
 
-      if (opcode === undefined) {
-        frameStack.pop()?.finalize(false);
+      if (index >= ops.length) {
+        this.#pop(false);
         continue;
       }
 
-      opcode.evaluate(this);
+      this.#current[depth] = index + 1;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      ops[index]!.evaluate(this);
     }
   }
 
-  private get frame() {
-    return expect(this.frameStack.current, 'bug: expected a frame');
+  #pop(didError: boolean) {
+    let depth = this.#depth;
+    let finalizer = this.#finalizers[depth];
+
+    // release references so retained arrays don't leak between renders
+    this.#ops[depth] = EMPTY_OPS;
+    this.#handlers[depth] = null;
+    this.#finalizers[depth] = undefined;
+    this.#depth = depth - 1;
+
+    finalizer?.(didError);
   }
 
   goto(index: number) {
-    this.frame.goto(index);
+    this.#current[this.#depth] = index;
   }
 
   try(
@@ -105,14 +125,21 @@ export class UpdatingVM implements IUpdatingVM {
     handler: Nullable<ExceptionHandler>,
     finalizer?: (didError: boolean) => void
   ) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler, finalizer));
+    let depth = ++this.#depth;
+
+    this.#ops[depth] = ops;
+    this.#current[depth] = 0;
+    this.#handlers[depth] = handler;
+    this.#finalizers[depth] = finalizer;
   }
 
   throw() {
-    this.frame.handleException();
-    this.frameStack.pop()?.finalize(true);
+    this.#handlers[this.#depth]?.handleException();
+    this.#pop(true);
   }
 }
+
+const EMPTY_OPS: UpdatingOpcode[] = [];
 
 export interface VMState {
   readonly pc: number;
@@ -304,25 +331,101 @@ export class ListBlockOpcode extends BlockOpcode {
     let iterator = valueForRef(this.iterableRef);
 
     if (this.lastIterator !== iterator) {
-      let { bounds } = this;
-      let { dom } = vm;
+      // SPIKE: deriving a fresh array from tracked state is the idiomatic
+      // pattern, so iterator identity changes every render even when the
+      // list's keys did not. When items match the existing children in
+      // order and count, just update the item refs -- no diff
+      // bookkeeping, no marker DOM, no children rebuild.
+      let buffered = this.tryFastSync(iterator);
 
-      let marker = (this.marker = dom.createComment(''));
-      dom.insertAfter(
-        bounds.parentElement(),
-        marker,
-        expect(bounds.lastNode(), "can't insert after an empty bounds")
-      );
+      if (buffered !== null) {
+        let { bounds } = this;
+        let { dom } = vm;
 
-      this.sync(iterator);
+        let marker = (this.marker = dom.createComment(''));
+        dom.insertAfter(
+          bounds.parentElement(),
+          marker,
+          expect(bounds.lastNode(), "can't insert after an empty bounds")
+        );
 
-      this.parentElement().removeChild(marker);
-      this.marker = null;
+        this.sync(new PrefixedIterator(buffered, iterator));
+
+        this.parentElement().removeChild(marker);
+        this.marker = null;
+      }
+
       this.lastIterator = iterator;
     }
 
     // Run now-updated updating opcodes
     super.evaluate(vm);
+  }
+
+  /**
+   * Streaming compare of the new iteration against existing children,
+   * applied as it matches: allocation-free on the happy path (a shared
+   * scratch item via nextInto). Returns null when everything matched in
+   * order; otherwise reconstructs the already-applied prefix (reading
+   * the just-updated refs back) plus the mismatched item, so the full
+   * sync can replay them.
+   */
+  private tryFastSync(iterator: OpaqueIterator): Nullable<OpaqueIterationItem[]> {
+    let { children } = this;
+    let matched = 0;
+
+    while (true) {
+      let item =
+        iterator.nextInto !== undefined ? iterator.nextInto(SCRATCH_ITEM) : iterator.next();
+
+      if (item === null) {
+        if (matched === children.length) return null;
+
+        // the list shrank; replay the matched prefix through full sync
+        return this.reconstructPrefix(matched, null);
+      }
+
+      let opcode = children[matched];
+
+      if (opcode === undefined || opcode.key !== item.key) {
+        return this.reconstructPrefix(matched, {
+          key: item.key,
+          value: item.value,
+          memo: item.memo,
+        });
+      }
+
+      updateRef(opcode.memo, item.memo);
+      updateRef(opcode.value, item.value);
+      matched++;
+    }
+  }
+
+  /**
+   * The matched prefix was already applied to the item refs, so its
+   * items can be reconstructed from the opcodes themselves.
+   */
+  private reconstructPrefix(
+    matched: number,
+    mismatch: Nullable<OpaqueIterationItem>
+  ): OpaqueIterationItem[] {
+    let { children } = this;
+    let prefix: OpaqueIterationItem[] = [];
+
+    for (let i = 0; i < matched; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      let opcode = children[i]!;
+
+      prefix.push({
+        key: opcode.key,
+        value: valueForRef(opcode.value),
+        memo: valueForRef(opcode.memo),
+      });
+    }
+
+    if (mismatch !== null) prefix.push(mismatch);
+
+    return prefix;
   }
 
   private sync(iterator: OpaqueIterator) {
@@ -499,30 +602,28 @@ export class ListBlockOpcode extends BlockOpcode {
   }
 }
 
-class UpdatingVMFrame {
-  private current = 0;
+/** Shared scratch for allocation-free fast-path iteration. */
+const SCRATCH_ITEM: OpaqueIterationItem = { key: null, value: null, memo: null };
+
+/** Replays already-consumed items before draining the rest. */
+class PrefixedIterator implements OpaqueIterator {
+  private index = 0;
 
   constructor(
-    private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>,
-    private finalizer?: (didError: boolean) => void
+    private prefix: OpaqueIterationItem[],
+    private inner: OpaqueIterator
   ) {}
 
-  goto(index: number) {
-    this.current = index;
+  isEmpty(): boolean {
+    return this.index >= this.prefix.length && this.inner.isEmpty();
   }
 
-  nextStatement(): UpdatingOpcode | undefined {
-    return this.ops[this.current++];
-  }
-
-  finalize(didError: boolean) {
-    this.finalizer?.(didError);
-  }
-
-  handleException() {
-    if (this.exceptionHandler) {
-      this.exceptionHandler.handleException();
+  next(): Nullable<OpaqueIterationItem> {
+    if (this.index < this.prefix.length) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      return this.prefix[this.index++]!;
     }
+
+    return this.inner.next();
   }
 }

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -24,7 +24,12 @@ import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
-import { beginTrackFrame, consumeTag, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
+import {
+  beginTrackFrame,
+  consumeTag,
+  endTrackFrame,
+  resetTracking,
+} from '@glimmer/validator/lib/tracking';
 import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
@@ -95,7 +100,11 @@ export class UpdatingVM implements IUpdatingVM {
     this.frame.goto(index);
   }
 
-  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>, finalizer?: (didError: boolean) => void) {
+  try(
+    ops: UpdatingOpcode[],
+    handler: Nullable<ExceptionHandler>,
+    finalizer?: (didError: boolean) => void
+  ) {
     this.frameStack.push(new UpdatingVMFrame(ops, handler, finalizer));
   }
 

--- a/packages/@glimmer/validator/lib/validators.ts
+++ b/packages/@glimmer/validator/lib/validators.ts
@@ -99,8 +99,37 @@ class MonomorphicTagImpl<T extends MonomorphicTagId = MonomorphicTagId> {
       case 1:
         return tags[0] as Tag;
       default: {
+        // SPIKE: flatten nested combinators (and drop constants) so
+        // validating a combined tag is one flat loop instead of a
+        // pointer-chasing tree walk. Capped so pathological frames
+        // don't build giant arrays.
+        let flattened: Tag[] = [];
+        let budget = 64;
+
+        for (const t of tags) {
+          const impl = t as MonomorphicTagImpl;
+
+          if (impl === CONSTANT_TAG) continue;
+
+          if (
+            impl[TYPE] === COMBINATOR_TAG_ID &&
+            Array.isArray(impl.subtag) &&
+            impl.subtag.length <= budget
+          ) {
+            for (const sub of impl.subtag) {
+              if (sub !== CONSTANT_TAG) flattened.push(sub);
+            }
+            budget -= impl.subtag.length;
+          } else {
+            flattened.push(t);
+          }
+        }
+
+        if (flattened.length === 0) return CONSTANT_TAG;
+        if (flattened.length === 1) return flattened[0] as Tag;
+
         let tag: MonomorphicTagImpl = new MonomorphicTagImpl(COMBINATOR_TAG_ID);
-        tag.subtag = tags;
+        tag.subtag = flattened;
         return tag;
       }
     }


### PR DESCRIPTION
**Stacked on #21544** (its first commit is that PR; review the `Iteration fast path…` commit here). Full suite green locally with both commits: 9443 tests, 0 failures.

Three allocation/dispatch levers for the update path, extracted from the #21520 spike:

1. **Streaming same-order list compare** — when a list's order is unchanged (the overwhelmingly common case), items match in a single streaming pass writing into a scratch item (`nextInto` on `ArrayIterator`, allocation-free) instead of allocating an `IterationItem` per step; on first mismatch it falls back to the general diff via a reconstructed-prefix iterator, so reorders behave exactly as today.
2. **Flat frame stack** — the updating VM keeps parallel arrays indexed by depth instead of allocating an `UpdatingVMFrame` per block per render.
3. **Combinator flattening** — `combine()` flattens nested combinators and drops constants (capped at 64) so validating a combined tag is one flat loop instead of a pointer-chasing tree walk.

Measured together with #21544's subtree-skip as the difference between ~14 and ~27 fps on 8x-throttled dbmon during the spike campaign; no observable behavior change.

Related: #21520 (spike), #21543 (pools), #21544 (subtree-skip, base of this stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)