### PR TITLE
One-hop tracked storage and known-tag references

### DIFF
--- a/packages/@glimmer/reference/lib/reference.ts
+++ b/packages/@glimmer/reference/lib/reference.ts
@@ -15,6 +15,7 @@ import { expect } from '@glimmer/debug-util/lib/platform-utils';
 import { getProp, setProp } from '@glimmer/global-context';
 import { isDict } from '@glimmer/util/lib/collections';
 import { CONSTANT_TAG, INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
+import { peekTagFor } from '@glimmer/validator/lib/meta';
 import { consumeTag, track } from '@glimmer/validator/lib/tracking';
 
 export const REFERENCE: ReferenceSymbol = Symbol('REFERENCE') as ReferenceSymbol;
@@ -44,6 +45,17 @@ class ReferenceImpl<T = unknown> implements Reference<T> {
 
   public compute: Nullable<() => T> = null;
   public update: Nullable<(val: T) => void> = null;
+
+  /**
+   * Proven plain tracked-field read: the first framed compute consumed
+   * exactly the property's canonical cell tag, so the consumed set can
+   * never change and recomputes skip frame machinery entirely.
+   */
+  public knownTag = false;
+
+  /** pending known-tag candidacy; checked once after the first compute */
+  public pathParent: Nullable<Reference> = null;
+  public pathKey: Nullable<string> = null;
 
   public debugLabel?: string;
 
@@ -163,6 +175,16 @@ export function valueForRef<T>(_ref: Reference<T>): T {
   if (tag === null || !validateTag(tag, lastRevision)) {
     const { compute } = ref;
 
+    if (ref.knownTag) {
+      // the getter's own consumeTag lands in the ambient frame, which
+      // is exactly what the framed path's trailing consumeTag achieved
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- knownTag implies compute
+      lastValue = ref.lastValue = compute!();
+      ref.lastRevision = valueForTag(tag);
+
+      return lastValue;
+    }
+
     const newTag = track(() => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
       lastValue = ref.lastValue = compute!();
@@ -171,6 +193,10 @@ export function valueForRef<T>(_ref: Reference<T>): T {
     tag = ref.tag = newTag;
 
     ref.lastRevision = valueForTag(newTag);
+
+    if (ref.pathParent !== null) {
+      maybeLockKnownTag(ref, newTag);
+    }
   } else {
     lastValue = ref.lastValue;
   }
@@ -178,6 +204,28 @@ export function valueForRef<T>(_ref: Reference<T>): T {
   consumeTag(tag);
 
   return lastValue as T;
+}
+
+/**
+ * A child ref locks onto its property's canonical tag when its first
+ * framed compute consumed EXACTLY that tag: single tag means no
+ * branching getter (those consume different sets per run), and
+ * identity with the registry's cell tag means the read was the plain
+ * tracked-field getter on a parent that can never change (a mutable
+ * parent's tag would have been in the frame too). Checked once.
+ */
+function maybeLockKnownTag(ref: ReferenceImpl, tag: Tag): void {
+  const parentRef = ref.pathParent as ReferenceImpl;
+  const key = ref.pathKey as string;
+
+  ref.pathParent = null;
+  ref.pathKey = null;
+
+  const parent = parentRef.lastValue;
+
+  if (isDict(parent) && peekTagFor(parent, key) === tag) {
+    ref.knownTag = true;
+  }
 }
 
 export function updateRef(_ref: Reference, value: unknown) {
@@ -232,6 +280,9 @@ export function childRefFor(_parentRef: Reference, path: string): Reference {
         }
       }
     );
+
+    (child as ReferenceImpl).pathParent = parentRef;
+    (child as ReferenceImpl).pathKey = path;
 
     if (DEBUG) {
       child.debugLabel = `${parentRef.debugLabel}.${path}`;

--- a/packages/@glimmer/validator/lib/meta.ts
+++ b/packages/@glimmer/validator/lib/meta.ts
@@ -17,6 +17,32 @@ export type TagMeta = Map<PropertyKey, UpdatableTag>;
 
 const TRACKED_TAGS = new WeakMap<object, TagMeta>();
 
+/**
+ * Read-only registry lookup: the canonical tag for (obj, key) if one
+ * exists, with no create-on-miss allocation.
+ */
+export function peekTagFor(obj: object, key: PropertyKey): UpdatableTag | undefined {
+  return TRACKED_TAGS.get(obj)?.get(key);
+}
+
+/**
+ * Adopts an externally-owned tag (e.g. a tracked field's inline cell
+ * tag) as THE tag for (obj, key) in the central registry, so
+ * `tagFor`/`dirtyTagFor` consumers -- notifyPropertyChange, computed
+ * property chains -- observe the same tag object the field itself
+ * consumes and dirties.
+ */
+export function registerTagFor(obj: object, key: PropertyKey, tag: UpdatableTag): void {
+  let tags = TRACKED_TAGS.get(obj);
+
+  if (tags === undefined) {
+    tags = new Map();
+    TRACKED_TAGS.set(obj, tags);
+  }
+
+  tags.set(key, tag);
+}
+
 export function dirtyTagFor<T extends object>(
   obj: T,
   key: keyof T | string | symbol,

--- a/packages/@glimmer/validator/lib/tracked-data.ts
+++ b/packages/@glimmer/validator/lib/tracked-data.ts
@@ -1,36 +1,80 @@
-import { dirtyTagFor, tagFor } from './meta';
+import { DEBUG } from '@glimmer/env';
+import type { UpdatableTag } from '@glimmer/interfaces';
+
+import { debug } from './debug';
+import { registerTagFor } from './meta';
 import { consumeTag } from './tracking';
+import { unwrap } from './utils';
+import { createUpdatableTag, DIRTY_TAG } from './validators';
 
 export type Getter<T, K extends keyof T> = (self: T) => T[K] | undefined;
 export type Setter<T, K extends keyof T> = (self: T, value: T[K]) => void;
+
+/**
+ * Value and tag live in one cell per (field, instance): a read is one
+ * WeakMap hop + consumeTag, a write is one hop + DIRTY_TAG. The
+ * previous shape went through the central tag registry
+ * (`TRACKED_TAGS` WeakMap -> per-object Map) plus a separate values
+ * WeakMap -- three map hops on every tracked read and write, which is
+ * the hottest path in data-heavy rendering.
+ */
+interface TrackedCell<V> {
+  value: V;
+  tag: UpdatableTag;
+  initialized: boolean;
+}
 
 export function trackedData<T extends object, K extends keyof T>(
   key: K,
   initializer?: (this: T) => T[K]
 ): { getter: Getter<T, K>; setter: Setter<T, K> } {
-  let values = new WeakMap<T, T[K]>();
+  let cells = new WeakMap<T, TrackedCell<T[K] | undefined>>();
   let hasInitializer = typeof initializer === 'function';
 
-  function getter(self: T) {
-    consumeTag(tagFor(self, key));
+  function cellFor(self: T): TrackedCell<T[K] | undefined> {
+    let cell = cells.get(self);
 
-    let value;
-
-    // If the field has never been initialized, we should initialize it
-    if (hasInitializer && !values.has(self)) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-      value = initializer!.call(self);
-      values.set(self, value);
-    } else {
-      value = values.get(self);
+    if (cell === undefined) {
+      cell = {
+        value: undefined,
+        tag: createUpdatableTag(),
+        initialized: !hasInitializer,
+      };
+      cells.set(self, cell);
+      // one-time bridge: notifyPropertyChange / computed chains resolve
+      // tags through the central registry; hand them this cell's tag so
+      // both worlds dirty and consume the same object
+      registerTagFor(self, key, cell.tag);
     }
 
-    return value;
+    return cell;
+  }
+
+  function getter(self: T) {
+    const cell = cellFor(self);
+
+    consumeTag(cell.tag);
+
+    // If the field has never been initialized, we should initialize it
+    if (!cell.initialized) {
+      cell.initialized = true;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by initialized
+      cell.value = initializer!.call(self);
+    }
+
+    return cell.value;
   }
 
   function setter(self: T, value: T[K]): void {
-    dirtyTagFor(self, key);
-    values.set(self, value);
+    const cell = cellFor(self);
+
+    if (DEBUG) {
+      unwrap(debug.assertTagNotConsumed)(cell.tag, self, key);
+    }
+
+    DIRTY_TAG(cell.tag);
+    cell.initialized = true;
+    cell.value = value;
   }
 
   return { getter, setter };


### PR DESCRIPTION
Extracted from the #21520 spike; independent of the other extraction PRs. Full suite green locally: 9443 tests, 0 failures — including the `notifyPropertyChange` and computed-property interop this touches most directly.

**One-hop tracked storage**: `trackedData` keeps value and tag in a single cell per (field, instance) — a tracked read is one WeakMap hop + `consumeTag`, a write is one hop + `DIRTY_TAG`, replacing three map hops each way (central `TRACKED_TAGS` WeakMap → per-object Map, plus the separate values WeakMap). The cell registers its tag into the central registry at creation (`registerTagFor`), so `notifyPropertyChange`, computed chains, and anything else resolving tags via `tagFor`/`dirtyTagFor` observes the *identical tag object* the field consumes and dirties — interop is preserved by tag identity, not by parallel bookkeeping.

**Known-tag references**: a child reference locks onto its property's canonical tag when its first framed compute consumed *exactly* that tag. A single consumed tag rules out branching getters (their consumed sets vary run to run); identity with the registry's cell tag proves the read was the plain tracked-field getter on a parent that cannot change (a mutable parent's tag would have been in the frame too — constants are dropped from frames). Locked references recompute with no frame push, no tag collection, and no `combine()`; the getter's own `consumeTag` lands in the ambient frame, which is exactly what the framed path's trailing consume achieved. Anything unproven stays on the framed path forever.

Honest impact framing: neutral on the spike's benchmark suite (its apps are worker-POJO- and helper-bound); the win scales with tracked-getter density and template property reads — the common shape of real apps — and it removes per-read allocation and map traffic unconditionally.

Related: #21520 (spike), #21543 (pools), #21544/#21545 (update-path stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)