### PR TITLE
[SPIKE] {{#try}}/{{else catch}} template error boundaries

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/keywords/try-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/keywords/try-test.ts
@@ -1,0 +1,152 @@
+import { jitSuite, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+class TryTest extends RenderTest {
+  static suiteName = '{{#try}} keyword';
+
+  beforeEach() {
+    this.registerHelper('throw-if', ([condition, message]) => {
+      if (condition) {
+        throw new Error(String(message ?? 'boom'));
+      }
+
+      return '';
+    });
+  }
+
+  @test
+  'renders the try branch when nothing throws'() {
+    this.render(`{{#try}}hello {{this.name}}{{else catch as |e|}}caught {{e.message}}{{/try}}`, {
+      name: 'world',
+    });
+
+    this.assertHTML('hello world');
+    this.assertStableRerender();
+
+    this.rerender({ name: 'glimmer' });
+    this.assertHTML('hello glimmer');
+  }
+
+  @test
+  'renders the catch branch when the try branch throws during initial render'() {
+    this.render(
+      `{{#try}}before {{throw-if true "kaboom"}} after{{else catch as |e|}}caught: {{e.message}}{{/try}}`
+    );
+
+    this.assertHTML('caught: kaboom');
+    this.assertStableRerender();
+  }
+
+  @test
+  'rolls back partially-rendered DOM, including open elements'() {
+    this.render(
+      `<ul>{{#try}}<li>first</li><li>{{throw-if true "mid-element"}}</li>{{else catch as |e|}}<li>error: {{e.message}}</li>{{/try}}</ul>`
+    );
+
+    this.assertHTML('<ul><li>error: mid-element</li></ul>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'content around the try region is unaffected'() {
+    this.render(`before-{{#try}}{{throw-if true "x"}}{{else catch}}fallback{{/try}}-after`);
+
+    this.assertHTML('before-fallback-after');
+    this.assertStableRerender();
+  }
+
+  @test
+  'a plain else block works as a catch branch'() {
+    this.render(`{{#try}}{{throw-if true "x"}}{{else}}fallback{{/try}}`);
+
+    this.assertHTML('fallback');
+    this.assertStableRerender();
+  }
+
+  @test
+  'a try region with no catch branch renders nothing on error'() {
+    this.render(`a{{#try}}{{throw-if true "x"}}{{/try}}b`);
+
+    this.assertHTML('a<!---->b');
+    this.assertStableRerender();
+  }
+
+  @test
+  'catches errors thrown during update'() {
+    this.render(
+      `{{#try}}value: {{throw-if this.shouldThrow "later"}}ok{{else catch as |e|}}caught: {{e.message}}{{/try}}`,
+      { shouldThrow: false }
+    );
+
+    this.assertHTML('value: ok');
+
+    this.rerender({ shouldThrow: true });
+    this.assertHTML('caught: later');
+  }
+
+  @test
+  'recovers when a dependency of the failed render changes back'() {
+    this.render(
+      `{{#try}}value: {{throw-if this.shouldThrow "later"}}ok{{else catch as |e|}}caught: {{e.message}}{{/try}}`,
+      { shouldThrow: false }
+    );
+
+    this.assertHTML('value: ok');
+
+    this.rerender({ shouldThrow: true });
+    this.assertHTML('caught: later');
+
+    this.rerender({ shouldThrow: false });
+    this.assertHTML('value: ok');
+  }
+
+  @test
+  'catches errors thrown during initial render and recovers on change'() {
+    this.render(
+      `{{#try}}value: {{throw-if this.shouldThrow "early"}}ok{{else catch as |e|}}caught: {{e.message}}{{/try}}`,
+      { shouldThrow: true }
+    );
+
+    this.assertHTML('caught: early');
+
+    this.rerender({ shouldThrow: false });
+    this.assertHTML('value: ok');
+  }
+
+  @test
+  'nested try regions catch independently'() {
+    this.render(
+      `{{#try}}outer-start {{#try}}{{throw-if true "inner"}}{{else catch as |e|}}inner-caught: {{e.message}}{{/try}} outer-end{{else catch}}outer-caught{{/try}}`
+    );
+
+    this.assertHTML('outer-start inner-caught: inner outer-end');
+    this.assertStableRerender();
+  }
+
+  @test
+  'an error outside any try region still propagates'() {
+    this.assert.throws(() => {
+      this.render(`{{throw-if true "unhandled"}}`);
+    }, /unhandled/u);
+  }
+
+  @test
+  'conditionals inside the try branch keep working after recovery'() {
+    this.render(
+      `{{#try}}{{throw-if this.shouldThrow "x"}}{{#if this.cond}}yes{{else}}no{{/if}}{{else catch}}caught{{/try}}`,
+      { shouldThrow: false, cond: true }
+    );
+
+    this.assertHTML('yes');
+
+    this.rerender({ shouldThrow: true });
+    this.assertHTML('caught');
+
+    this.rerender({ shouldThrow: false, cond: false });
+    this.assertHTML('no');
+
+    this.rerender({ cond: true });
+    this.assertHTML('yes');
+  }
+}
+
+jitSuite(TryTest);

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/keywords/block.ts
@@ -11,6 +11,14 @@ import { VISIT_STMTS } from '../visitors/statements';
 import { keywords } from './impl';
 import { assertCurryKeyword } from './utils/curry';
 
+function isCatchInvocation(stmt: ASTv2.ContentNode): stmt is ASTv2.InvokeBlock {
+  if (stmt.type !== 'InvokeBlock') return false;
+
+  let callee = stmt.callee;
+
+  return callee.type === 'Path' && callee.ref.type === 'Free' && callee.ref.name === 'catch';
+}
+
 export const BLOCK_KEYWORDS = keywords('Block')
   .kw('in-element', {
     assert(node: ASTv2.InvokeBlock): Result<{
@@ -211,6 +219,76 @@ export const BLOCK_KEYWORDS = keywords('Block')
             inverse,
           })
       );
+    },
+  })
+  .kw('try', {
+    assert(node: ASTv2.InvokeBlock): Result<{
+      catchBlock: ASTv2.NamedBlock | null;
+    }> {
+      let { args } = node;
+
+      if (!args.named.isEmpty() || args.positional.size > 0) {
+        return Err(generateSyntaxError(`{{#try}} does not accept any parameters`, node.loc));
+      }
+
+      let inverse = node.blocks.get('else');
+
+      if (inverse === null) {
+        return Ok({ catchBlock: null });
+      }
+
+      // `{{#try}}...{{else catch as |error|}}...{{/try}}` parses as an `else`
+      // block whose only statement is an invocation of the `catch` block
+      // keyword. Unwrap it so the catch body (and its `|error|` block param)
+      // becomes the handler block. A plain `{{else}}` block is also allowed
+      // as a handler that ignores the error value.
+      let body = inverse.block.body;
+      let first = body[0];
+
+      if (body.length === 1 && first !== undefined && isCatchInvocation(first)) {
+        let stmt = first;
+
+        if (!stmt.args.named.isEmpty() || stmt.args.positional.size > 0) {
+          return Err(generateSyntaxError(`{{catch}} does not accept any parameters`, stmt.loc));
+        }
+
+        return Ok({ catchBlock: stmt.blocks.get('default') });
+      }
+
+      return Ok({ catchBlock: inverse });
+    },
+
+    translate(
+      { node, state }: { node: ASTv2.InvokeBlock; state: NormalizationState },
+      { catchBlock }: { catchBlock: ASTv2.NamedBlock | null }
+    ): Result<mir.TryCatch> {
+      let block = node.blocks.get('default');
+
+      let blockResult = VISIT_STMTS.NamedBlock(block, state);
+      let catchResult = catchBlock ? VISIT_STMTS.NamedBlock(catchBlock, state) : Ok(null);
+
+      return Result.all(blockResult, catchResult).mapOk(
+        ([block, catchBlock]) =>
+          new mir.TryCatch({
+            loc: node.loc,
+            block,
+            catchBlock,
+          })
+      );
+    },
+  })
+  .kw('catch', {
+    assert(node: ASTv2.InvokeBlock): Result<never> {
+      return Err(
+        generateSyntaxError(
+          `{{catch}} can only be used as \`{{else catch as |error|}}\` inside {{#try}}`,
+          node.loc
+        )
+      );
+    },
+
+    translate(): Result<never> {
+      throw new Error(`unreachable: {{catch}} always fails to assert`);
     },
   })
   .kw('each', {

--- a/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/strict-mode.ts
+++ b/packages/@glimmer/compiler/lib/passes/1-normalization/visitors/strict-mode.ts
@@ -90,6 +90,9 @@ export default class StrictModeValidationPass {
       case 'If':
         return this.If(statement);
 
+      case 'TryCatch':
+        return this.TryCatch(statement);
+
       case 'Each':
         return this.Each(statement);
 
@@ -285,6 +288,16 @@ export default class StrictModeValidationPass {
           return Ok(null);
         }
       });
+  }
+
+  TryCatch(statement: mir.TryCatch): Result<null> {
+    return this.NamedBlock(statement.block).andThen(() => {
+      if (statement.catchBlock) {
+        return this.NamedBlock(statement.catchBlock);
+      } else {
+        return Ok(null);
+      }
+    });
   }
 
   Each(statement: mir.Each): Result<null> {

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
@@ -75,6 +75,8 @@ export class ContentEncoder {
         return this.InvokeBlock(stmt);
       case 'If':
         return this.If(stmt);
+      case 'TryCatch':
+        return this.TryCatch(stmt);
       case 'Each':
         return this.Each(stmt);
       case 'Let':
@@ -198,6 +200,14 @@ export class ContentEncoder {
       EXPR.expr(condition),
       CONTENT.NamedBlock(block)[1],
       inverse ? CONTENT.NamedBlock(inverse)[1] : null,
+    ];
+  }
+
+  TryCatch({ block, catchBlock }: mir.TryCatch): WireFormat.Statements.TryCatch {
+    return [
+      SexpOpcodes.TryCatch,
+      CONTENT.NamedBlock(block)[1],
+      catchBlock ? CONTENT.NamedBlock(catchBlock)[1] : null,
     ];
   }
 

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/mir.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/mir.ts
@@ -36,6 +36,11 @@ export class IfInline extends node('IfInline').fields<{
   falsy: ExpressionNode | null;
 }>() {}
 
+export class TryCatch extends node('TryCatch').fields<{
+  block: NamedBlock;
+  catchBlock: NamedBlock | null;
+}>() {}
+
 export class Each extends node('Each').fields<{
   value: ExpressionNode;
   key: ExpressionNode | null;
@@ -220,4 +225,5 @@ export type Statement =
   | Each
   | Let
   | WithDynamicVars
-  | InvokeComponent;
+  | InvokeComponent
+  | TryCatch;

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -203,6 +203,13 @@ export default class WireFormatDebugger {
             opcode[3] ? this.formatBlock(opcode[3]) : null,
           ];
 
+        case Op.TryCatch:
+          return [
+            'try',
+            this.formatBlock(opcode[1]),
+            opcode[2] ? this.formatBlock(opcode[2]) : null,
+          ];
+
         case Op.IfInline:
           return ['if-inline'];
 

--- a/packages/@glimmer/constants/lib/syscall-ops.ts
+++ b/packages/@glimmer/constants/lib/syscall-ops.ts
@@ -30,6 +30,7 @@ import type {
   VmDynamicModifier,
   VmEnter,
   VmEnterList,
+  VmEnterTry,
   VmExit,
   VmExitList,
   VmFetch,
@@ -61,6 +62,7 @@ import type {
   VmPop,
   VmPopDynamicScope,
   VmPopRemoteElement,
+  VmPopTryFrame,
   VmPopScope,
   VmPopulateLayout,
   VmPrepareArgs,
@@ -72,6 +74,7 @@ import type {
   VmPushDynamicComponentInstance,
   VmPushDynamicScope,
   VmPushEmptyArgs,
+  VmPushTryFrame,
   VmPushRemoteElement,
   VmPushSymbolTable,
   VmPutComponentOperations,
@@ -183,7 +186,10 @@ export const VM_IF_INLINE_OP = 109 satisfies VmIfInline;
 export const VM_NOT_OP = 110 satisfies VmNot;
 export const VM_GET_DYNAMIC_VAR_OP = 111 satisfies VmGetDynamicVar;
 export const VM_LOG_OP = 112 satisfies VmLog;
-export const VM_SYSCALL_SIZE = 113 satisfies VmSize;
+export const VM_ENTER_TRY_OP = 113 satisfies VmEnterTry;
+export const VM_PUSH_TRY_FRAME_OP = 114 satisfies VmPushTryFrame;
+export const VM_POP_TRY_FRAME_OP = 115 satisfies VmPopTryFrame;
+export const VM_SYSCALL_SIZE = 116 satisfies VmSize;
 
 export function isOp(value: number): value is VmOp {
   return value >= 16;

--- a/packages/@glimmer/debug/lib/opcode-metadata.ts
+++ b/packages/@glimmer/debug/lib/opcode-metadata.ts
@@ -43,8 +43,11 @@ import {
   VM_DYNAMIC_HELPER_OP,
   VM_ENTER_LIST_OP,
   VM_ENTER_OP,
+  VM_ENTER_TRY_OP,
   VM_EXIT_LIST_OP,
   VM_EXIT_OP,
+  VM_PUSH_TRY_FRAME_OP,
+  VM_POP_TRY_FRAME_OP,
   VM_FETCH_OP,
   VM_FLUSH_ELEMENT_OP,
   VM_GET_BLOCK_OP,
@@ -534,6 +537,26 @@ if (LOCAL_DEBUG) {
   METADATA[VM_EXIT_OP] = {
     name: 'Exit',
     mnemonic: 'blk_end',
+    stackChange: 0,
+  };
+
+  METADATA[VM_ENTER_TRY_OP] = {
+    name: 'EnterTry',
+    mnemonic: 'try_start',
+    stackChange: 0,
+    ops: ['args:imm/u32'],
+  };
+
+  METADATA[VM_PUSH_TRY_FRAME_OP] = {
+    name: 'PushTryFrame',
+    mnemonic: 'try_frame_push',
+    stackChange: 0,
+    ops: ['catch:imm/pc'],
+  };
+
+  METADATA[VM_POP_TRY_FRAME_OP] = {
+    name: 'PopTryFrame',
+    mnemonic: 'try_frame_pop',
     stackChange: 0,
   };
 

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
@@ -42,6 +42,7 @@ import type {
   TrustingAppendOpcode,
   TrustingComponentAttrOpcode,
   TrustingDynamicAttrOpcode,
+  TryCatchOpcode,
   UndefinedOpcode,
   WithDynamicVarsOpcode,
   YieldOpcode,
@@ -296,6 +297,12 @@ export namespace Statements {
     blocks: Blocks | null,
   ];
 
+  export type TryCatch = [
+    op: TryCatchOpcode,
+    block: SerializedInlineBlock,
+    catchBlock: Nullable<SerializedInlineBlock>,
+  ];
+
   /**
    * A Handlebars statement
    */
@@ -319,7 +326,8 @@ export namespace Statements {
     | Each
     | Let
     | WithDynamicVars
-    | InvokeComponent;
+    | InvokeComponent
+    | TryCatch;
 
   export type Attribute =
     | StaticAttr

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/opcodes.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/opcodes.d.ts
@@ -51,6 +51,7 @@ export type EachOpcode = 42;
 export type LetOpcode = 44;
 export type WithDynamicVarsOpcode = 45;
 export type InvokeComponentOpcode = 46;
+export type TryCatchOpcode = 55;
 
 // Keyword Expressions
 export type HasBlockOpcode = 48;

--- a/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
@@ -112,6 +112,28 @@ export interface TreeBuilder extends Cursor, DOMStack, TreeOperations {
   popBlock(): AppendingBlock;
 
   didAppendBounds(bounds: Bounds): void;
+
+  mark(): TreeBuilderMark;
+  unwindTo(mark: TreeBuilderMark): void;
+}
+
+/**
+ * An opaque snapshot of a `TreeBuilder`'s open cursors, blocks, and modifiers,
+ * plus the DOM position of the current cursor, used to roll the builder back
+ * if a `{{#try}}` region throws while appending.
+ *
+ * The DOM position is captured as real nodes (the node just before the
+ * region's content, and the fixed node the cursor inserts before) rather than
+ * block bounds: partially-appended content can contain inner blocks that are
+ * still empty, whose bounds cannot be queried.
+ */
+export interface TreeBuilderMark {
+  readonly cursors: number;
+  readonly blocks: number;
+  readonly modifiers: number;
+  readonly parent: SimpleElement;
+  readonly prevSibling: Nullable<SimpleNode>;
+  readonly nextSibling: Nullable<SimpleNode>;
 }
 
 export interface AttributeCursor {

--- a/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
+++ b/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
@@ -109,7 +109,10 @@ export type VmIfInline = 109;
 export type VmNot = 110;
 export type VmGetDynamicVar = 111;
 export type VmLog = 112;
-export type VmSize = 113;
+export type VmEnterTry = 113;
+export type VmPushTryFrame = 114;
+export type VmPopTryFrame = 115;
+export type VmSize = 116;
 
 export type VmOp =
   | VmHelper
@@ -202,6 +205,9 @@ export type VmOp =
   | VmIfInline
   | VmNot
   | VmGetDynamicVar
-  | VmLog;
+  | VmLog
+  | VmEnterTry
+  | VmPushTryFrame
+  | VmPopTryFrame;
 
 export type SomeVmOp = VmOp | VmMachineOp;

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/conditional.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/conditional.ts
@@ -1,9 +1,12 @@
 import {
   VM_ENTER_OP,
+  VM_ENTER_TRY_OP,
   VM_EXIT_OP,
   VM_JUMP_EQ_OP,
   VM_JUMP_UNLESS_OP,
   VM_POP_OP,
+  VM_POP_TRY_FRAME_OP,
+  VM_PUSH_TRY_FRAME_OP,
 } from '@glimmer/constants/lib/syscall-ops';
 import {
   VM_JUMP_OP,
@@ -179,6 +182,47 @@ export function Replayable(op: PushStatementOp, args: () => number, body: () => 
 
   // Cleanup code for the block. Runs on initial execution
   // but not on updating.
+  op(HighLevelBuilderOpcodes.Label, 'ENDINITIAL');
+  op(VM_POP_FRAME_OP);
+  op(HighLevelBuilderOpcodes.StopLabels);
+}
+
+/**
+ * A variant of `Replayable` for `{{#try}}`/`{{else catch}}`.
+ *
+ * The overall shape matches `Replayable`: the whole try/catch region lives in
+ * a single updatable block (created by `EnterTry`), so re-rendering the region
+ * from its closure re-attempts the `try` branch from scratch.
+ *
+ * `PushTryFrame` marks the beginning of the protected range and records the
+ * address of the CATCH label. If a JavaScript error is thrown while appending
+ * the `try` branch, the VM unwinds its internal stacks back to the state
+ * captured by the frame, pushes a reference to the caught error, and resumes
+ * execution at CATCH. `PopTryFrame` disarms the handler when the `try` branch
+ * completes without throwing.
+ *
+ * Because `PushTryFrame` sits after `EnterTry` (and therefore after the pc
+ * captured by the region's closure), a structural or error-triggered re-render
+ * of the region re-arms the handler before re-attempting the `try` branch.
+ */
+export function ReplayableTry(
+  op: PushStatementOp,
+  tryBody: () => void,
+  catchBody: () => void
+): void {
+  op(HighLevelBuilderOpcodes.StartLabels);
+  op(VM_PUSH_FRAME_OP);
+  op(VM_RETURN_TO_OP, labelOperand('ENDINITIAL'));
+  op(VM_ENTER_TRY_OP, 0);
+  op(VM_PUSH_TRY_FRAME_OP, labelOperand('CATCH'));
+  tryBody();
+  op(VM_POP_TRY_FRAME_OP);
+  op(VM_JUMP_OP, labelOperand('FINALLY'));
+  op(HighLevelBuilderOpcodes.Label, 'CATCH');
+  catchBody();
+  op(HighLevelBuilderOpcodes.Label, 'FINALLY');
+  op(VM_EXIT_OP);
+  op(VM_RETURN_OP);
   op(HighLevelBuilderOpcodes.Label, 'ENDINITIAL');
   op(VM_POP_FRAME_OP);
   op(HighLevelBuilderOpcodes.StopLabels);

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -56,7 +56,12 @@ import {
   InvokeDynamicComponent,
   InvokeNonStaticComponent,
 } from '../opcode-builder/helpers/components';
-import { Replayable, ReplayableIf, SwitchCases } from '../opcode-builder/helpers/conditional';
+import {
+  Replayable,
+  ReplayableIf,
+  ReplayableTry,
+  SwitchCases,
+} from '../opcode-builder/helpers/conditional';
 import { expr } from '../opcode-builder/helpers/expr';
 import {
   isGetFreeComponent,
@@ -315,6 +320,23 @@ STATEMENTS.add(SexpOpcodes.If, (op, [, condition, block, inverse]) =>
           InvokeStaticBlock(op, inverse);
         }
       : undefined
+  )
+);
+
+STATEMENTS.add(SexpOpcodes.TryCatch, (op, [, block, catchBlock]) =>
+  ReplayableTry(
+    op,
+    () => {
+      InvokeStaticBlock(op, block);
+    },
+    () => {
+      // The unwinder pushes a reference to the caught error before jumping
+      // here; hand it to the catch block as its block param, then drop it.
+      if (catchBlock) {
+        InvokeStaticBlockWithStack(op, catchBlock, 1);
+      }
+      op(VM_POP_OP, 1);
+    }
   )
 );
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -12,6 +12,7 @@ import {
   VM_CONSTANT_REFERENCE_OP,
   VM_DUP_OP,
   VM_ENTER_OP,
+  VM_ENTER_TRY_OP,
   VM_EXIT_OP,
   VM_FETCH_OP,
   VM_INVOKE_YIELD_OP,
@@ -21,11 +22,13 @@ import {
   VM_POP_DYNAMIC_SCOPE_OP,
   VM_POP_OP,
   VM_POP_SCOPE_OP,
+  VM_POP_TRY_FRAME_OP,
   VM_PRIMITIVE_OP,
   VM_PRIMITIVE_REFERENCE_OP,
   VM_PUSH_BLOCK_SCOPE_OP,
   VM_PUSH_DYNAMIC_SCOPE_OP,
   VM_PUSH_SYMBOL_TABLE_OP,
+  VM_PUSH_TRY_FRAME_OP,
   VM_TO_BOOLEAN_OP,
 } from '@glimmer/constants/lib/syscall-ops';
 import {
@@ -140,6 +143,18 @@ APPEND_OPCODES.add(VM_ENTER_OP, (vm, { op1: args }) => {
 
 APPEND_OPCODES.add(VM_EXIT_OP, (vm) => {
   vm.exit();
+});
+
+APPEND_OPCODES.add(VM_ENTER_TRY_OP, (vm, { op1: args }) => {
+  vm.enterTry(args);
+});
+
+APPEND_OPCODES.add(VM_PUSH_TRY_FRAME_OP, (vm, { op1: catchOffset }) => {
+  vm.pushTryFrame(vm.lowlevel.target(catchOffset));
+});
+
+APPEND_OPCODES.add(VM_POP_TRY_FRAME_OP, (vm) => {
+  vm.popTryFrame();
 });
 
 APPEND_OPCODES.add(VM_PUSH_SYMBOL_TABLE_OP, (vm, { op1: _table }) => {

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -16,8 +16,10 @@ import type {
   RenderResult,
   RichIteratorResult,
   Scope,
+  Nullable,
   SyscallRegisters,
   TreeBuilder,
+  TreeBuilderMark,
   UpdatingOpcode,
 } from '@glimmer/interfaces';
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
@@ -25,16 +27,23 @@ import type { Reference } from '@glimmer/reference/lib/reference';
 import type { MachineRegister, Register, SyscallRegister } from '@glimmer/vm/lib/registers';
 import { dev, expect } from '@glimmer/debug-util/lib/platform-utils';
 import { unwrapHandle } from '@glimmer/debug-util/lib/template';
-import { associateDestroyableChild } from '@glimmer/destroyable';
+import { associateDestroyableChild, destroyChildren } from '@glimmer/destroyable';
 import { assertGlobalContextWasSet } from '@glimmer/global-context';
 import { LOCAL_DEBUG, LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 import { createIteratorItemRef } from '@glimmer/reference/lib/iterable';
-import { UNDEFINED_REFERENCE } from '@glimmer/reference/lib/reference';
+import { createUnboundRef, UNDEFINED_REFERENCE } from '@glimmer/reference/lib/reference';
 import { reverse } from '@glimmer/util/lib/array-utils';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { LOCAL_LOGGER } from '@glimmer/util';
-import { beginTrackFrame, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
-import { $pc, isLowLevelRegister } from '@glimmer/vm/lib/registers';
+import {
+  beginTrackFrame,
+  consumeTag,
+  endTrackFrame,
+  resetTracking,
+  trackingFrameDepth,
+  unwindTracking,
+} from '@glimmer/validator/lib/tracking';
+import { $fp, $pc, $ra, $sp, isLowLevelRegister } from '@glimmer/vm/lib/registers';
 
 import type { ScopeOptions } from '../scope';
 import type { AppendingBlockList } from './element-builder';
@@ -52,7 +61,7 @@ import { VMArgumentsImpl } from './arguments';
 import { LowLevelVM } from './low-level';
 import RenderResultImpl from './render-result';
 import EvaluationStackImpl from './stack';
-import { ListBlockOpcode, ListItemOpcode, TryOpcode } from './update';
+import { ListBlockOpcode, ListItemOpcode, TryErrorOpcode, TryOpcode } from './update';
 
 class Stacks {
   declare debug?: () => DebugStacks;
@@ -398,6 +407,146 @@ export class VM {
     let tryOpcode = new TryOpcode(state, this.context, block, updating);
 
     this.didEnter(tryOpcode);
+  }
+
+  /**
+   * ## Opcodes
+   *
+   * - Append: `EnterTry`
+   *
+   * Like `Enter`, but the block opcode is a `TryErrorOpcode`: the error
+   * boundary for a `{{#try}}` region. The subsequent `PushTryFrame` opcode
+   * attaches to the boundary created here.
+   */
+  enterTry(args: number) {
+    let updating: UpdatingOpcode[] = [];
+
+    let state = this.capture(args);
+    let block = this.tree().pushResettableBlock();
+
+    let tryOpcode = new TryErrorOpcode(state, this.context, block, updating);
+
+    this.didEnter(tryOpcode);
+    this.#pendingTryBoundary = tryOpcode;
+  }
+
+  #tryFrames: TryFrame[] = [];
+  #pendingTryBoundary: Nullable<TryErrorOpcode> = null;
+
+  /**
+   * When a `{{#try}}` region re-renders (via `TryErrorOpcode.handleException`),
+   * the resumed VM starts executing after the region's `EnterTry`, so no
+   * boundary is freshly entered when `PushTryFrame` runs. The re-render
+   * registers the existing boundary here instead.
+   */
+  setResumingTryBoundary(boundary: TryErrorOpcode): void {
+    this.#pendingTryBoundary = boundary;
+  }
+
+  /**
+   * ## Opcodes
+   *
+   * - Append: `PushTryFrame`
+   *
+   * Snapshot every piece of VM state needed to resume at the CATCH label if
+   * appending the `try` branch throws.
+   */
+  pushTryFrame(catchPc: number): void {
+    let boundary = this.#pendingTryBoundary;
+    this.#pendingTryBoundary = null;
+
+    this.#tryFrames.push({
+      catchPc,
+      ra: this.lowlevel.fetchRegister($ra),
+      sp: this.lowlevel.fetchRegister($sp),
+      fp: this.lowlevel.fetchRegister($fp),
+      registers: this.#registers.slice() as SyscallRegisters,
+      scope: this.#stacks.scope.size,
+      dynamicScope: this.#stacks.dynamicScope.size,
+      cache: this.#stacks.cache.size,
+      list: this.#stacks.list.size,
+      destroyable: this.#stacks.destroyable.size,
+      updating: this.#stacks.updating.size,
+      updatingListLength: this.updating().length,
+      tree: this.tree().mark(),
+      tracking: trackingFrameDepth(),
+      boundary,
+    });
+
+    // Hold a tracking frame open across the try branch. Compute references
+    // balance their own frames even when they throw, so without a parent
+    // frame the failed branch's dependencies would be discarded before the
+    // unwind can capture them for retry.
+    beginTrackFrame(DEBUG ? 'try boundary' : undefined);
+  }
+
+  /**
+   * ## Opcodes
+   *
+   * - Append: `PopTryFrame`
+   *
+   * The `try` branch finished appending without throwing; disarm the handler.
+   */
+  popTryFrame(): void {
+    this.#tryFrames.pop();
+
+    // Close the frame opened by `pushTryFrame`, forwarding what the try
+    // branch consumed to any enclosing tracker (as if the frame wasn't there).
+    consumeTag(endTrackFrame());
+  }
+
+  get canUnwind(): boolean {
+    return this.#tryFrames.length > 0;
+  }
+
+  /**
+   * A JavaScript error was thrown while appending a `{{#try}}` region's `try`
+   * branch. Roll every piece of VM state back to the `PushTryFrame` snapshot,
+   * discard the region's partially-rendered DOM, updating opcodes, and
+   * destroyables, then resume at the CATCH label with a reference to the
+   * error on the stack.
+   */
+  unwind(error: unknown): void {
+    let frame = expect(this.#tryFrames.pop(), 'BUG: unwind called without an open try frame');
+    let { lowlevel } = this;
+    let stacks = this.#stacks;
+
+    // Rebalance the tracking frames the throw skipped, capturing what the
+    // failed branch consumed so the boundary re-attempts the try branch when
+    // one of those dependencies changes.
+    let failedDeps = unwindTracking(frame.tracking);
+
+    lowlevel.loadRegister($ra, frame.ra);
+    lowlevel.loadRegister($sp, frame.sp);
+    lowlevel.loadRegister($fp, frame.fp);
+    lowlevel.setPc(frame.catchPc);
+    this.#registers = frame.registers;
+
+    truncate(stacks.scope, frame.scope);
+    truncate(stacks.dynamicScope, frame.dynamicScope);
+    truncate(stacks.cache, frame.cache);
+    truncate(stacks.list, frame.list);
+    truncate(stacks.updating, frame.updating);
+
+    // Discard the updating opcodes the failed branch appended to the region.
+    this.updating().length = frame.updatingListLength;
+
+    // Destroy anything the failed branch registered (component instances,
+    // modifiers, remote blocks). The destroyable parent at frame-push time
+    // owns exactly the region's content.
+    truncate(stacks.destroyable, frame.destroyable);
+    destroyChildren(expect(stacks.destroyable.current, 'Expected destructor parent'));
+
+    // Remove the region's partially-appended DOM.
+    this.tree().unwindTo(frame.tree);
+
+    // Surface the failed branch's dependencies to any enclosing tracking
+    // frame (e.g. a component's cache group), and remember them on the
+    // boundary so it revalidates.
+    consumeTag(failedDeps);
+    frame.boundary?.didUnwind(failedDeps);
+
+    this.stack.push(createUnboundRef(error, DEBUG ? 'a caught rendering error' : false));
   }
 
   /**
@@ -767,8 +916,20 @@ export class VM {
 
     let result: RichIteratorResult<null, RenderResult>;
 
-    do result = this.next();
-    while (!result.done);
+    while (true) {
+      try {
+        result = this.next();
+      } catch (error) {
+        // A `{{#try}}` region is open: unwind to its catch branch and keep
+        // appending. Without one, the error propagates as before.
+        if (!this.canUnwind) throw error;
+
+        this.unwind(error);
+        continue;
+      }
+
+      if (result.done) break;
+    }
 
     return result.value;
   }
@@ -796,6 +957,32 @@ export class VM {
     }
     return result;
   }
+}
+
+/**
+ * The snapshot taken by `PushTryFrame`: enough state to roll the VM back to
+ * the top of a `{{#try}}` region and resume at its CATCH label.
+ */
+interface TryFrame {
+  readonly catchPc: number;
+  readonly ra: number;
+  readonly sp: number;
+  readonly fp: number;
+  readonly registers: SyscallRegisters;
+  readonly scope: number;
+  readonly dynamicScope: number;
+  readonly cache: number;
+  readonly list: number;
+  readonly destroyable: number;
+  readonly updating: number;
+  readonly updatingListLength: number;
+  readonly tree: TreeBuilderMark;
+  readonly tracking: number;
+  readonly boundary: Nullable<TryErrorOpcode>;
+}
+
+function truncate<T>(stack: Stack<T>, size: number): void {
+  while (stack.size > size) stack.pop();
 }
 
 function closureState(pc: number, scope: Scope, dynamicScope: DynamicScope): ClosureState {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -17,6 +17,7 @@ import type {
   SimpleNode,
   SimpleText,
   TreeBuilder,
+  TreeBuilderMark,
 } from '@glimmer/interfaces';
 import { expect } from '@glimmer/debug-util/lib/platform-utils';
 import assert from '@glimmer/debug-util/lib/assert';
@@ -184,6 +185,48 @@ export class NewTreeBuilder implements TreeBuilder {
     this.block().finalize(this);
     this.__closeBlock();
     return expect(this.blockStack.pop(), 'Expected popBlock to return a block');
+  }
+
+  mark(): TreeBuilderMark {
+    let nextSibling = this.nextSibling;
+
+    return {
+      cursors: this.cursors.size,
+      blocks: this.blockStack.size,
+      modifiers: this.modifierStack.size,
+      parent: this.element,
+      prevSibling: nextSibling ? nextSibling.previousSibling : this.element.lastChild,
+      nextSibling,
+    };
+  }
+
+  unwindTo(mark: TreeBuilderMark): void {
+    while (this.cursors.size > mark.cursors) this.cursors.pop();
+    while (this.blockStack.size > mark.blocks) this.blockStack.pop();
+    while (this.modifierStack.size > mark.modifiers) this.modifierStack.pop();
+
+    this.constructing = null;
+    this.operations = null;
+
+    // Remove every node the region appended: the range between the node that
+    // preceded the region's content and the cursor's (fixed) next sibling.
+    let { parent, prevSibling, nextSibling } = mark;
+    let node = prevSibling ? prevSibling.nextSibling : parent.firstChild;
+
+    while (node !== null && node !== nextSibling) {
+      let next = node.nextSibling;
+      parent.removeChild(node);
+      node = next;
+    }
+
+    // The now-current block is the `{{#try}}` region's resettable block.
+    // Discard its (partial, possibly unqueryable) bounds bookkeeping so the
+    // catch branch appends into a clean region.
+    let block = this.block();
+
+    if (block instanceof ResettableBlockImpl) {
+      block.unwindAppending();
+    }
   }
 
   __openBlock(): void {}
@@ -524,6 +567,19 @@ export class ResettableBlockImpl extends AppendingBlockImpl implements Resettabl
     this.nesting = 0;
 
     return nextSibling;
+  }
+
+  /**
+   * Discard the block's bounds bookkeeping after a caught rendering error.
+   * The DOM itself is removed by `unwindTo` using real node positions; the
+   * bounds may reference inner blocks that are still empty and cannot be
+   * queried. Unlike `reset`, the block is not destroyed: it remains open so
+   * the catch branch can append into it.
+   */
+  unwindAppending(): void {
+    this.first = null;
+    this.last = null;
+    this.nesting = 0;
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -16,6 +16,8 @@ import type {
 } from '@glimmer/interfaces';
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
 import type { Reference } from '@glimmer/reference/lib/reference';
+import type { Tag } from '@glimmer/interfaces';
+import type { Revision } from '@glimmer/validator/lib/validators';
 import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
@@ -23,7 +25,13 @@ import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
-import { resetTracking } from '@glimmer/validator/lib/tracking';
+import {
+  consumeTag,
+  resetTracking,
+  trackingFrameDepth,
+  unwindTracking,
+} from '@glimmer/validator/lib/tracking';
+import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
 import type { AppendingBlockList } from './element-builder';
@@ -68,8 +76,12 @@ export class UpdatingVM implements IUpdatingVM {
     }
   }
 
+  #entryTrackingDepth = 0;
+
   private _execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler) {
     let { frameStack } = this;
+
+    this.#entryTrackingDepth = trackingFrameDepth();
 
     this.try(opcodes, handler);
 
@@ -81,8 +93,44 @@ export class UpdatingVM implements IUpdatingVM {
         continue;
       }
 
-      opcode.evaluate(this);
+      try {
+        opcode.evaluate(this);
+      } catch (error) {
+        if (!this.#unwindToErrorBoundary()) {
+          throw error;
+        }
+      }
     }
+  }
+
+  /**
+   * An updating opcode threw a JavaScript error. Pop frames until we find one
+   * whose exception handler is a `{{#try}}` boundary, then re-render that
+   * region from scratch. The re-render re-attempts the `try` branch; if the
+   * error persists, the append-time unwind renders the catch branch instead.
+   *
+   * Returns false (and leaves the error to propagate) when no boundary
+   * encloses the failed opcode.
+   */
+  #unwindToErrorBoundary(): boolean {
+    let { frameStack } = this;
+
+    while (!frameStack.isEmpty()) {
+      let boundary = this.frame.errorBoundary;
+
+      frameStack.pop();
+
+      if (boundary !== null) {
+        // Rebalance the tracking frames the throw skipped, and surface what
+        // the failed opcodes consumed to any enclosing cache group.
+        consumeTag(unwindTracking(this.#entryTrackingDepth));
+
+        boundary.handleException();
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private get frame() {
@@ -162,6 +210,77 @@ export class TryOpcode extends BlockOpcode implements ExceptionHandler {
 
     let tree = NewTreeBuilder.resume(env, bounds);
     let vm = state.evaluate(tree);
+
+    let children = (this.children = []);
+
+    let result = vm.execute((vm) => {
+      vm.updateWith(this);
+      vm.pushUpdating(children);
+    });
+
+    associateDestroyableChild(this, result.drop);
+  }
+}
+
+/**
+ * The block opcode for a `{{#try}}` region. In addition to `TryOpcode`'s
+ * structural re-render behavior, it acts as an error boundary:
+ *
+ * - When the region's append-time render throws, the VM unwinds to the
+ *   region's try frame and records the dependencies the failed branch
+ *   consumed (via `didUnwind`).
+ * - When any of those dependencies change, the region re-renders from
+ *   scratch, re-attempting the `try` branch.
+ * - When an updating opcode inside the region throws, the `UpdatingVM`
+ *   unwinds to this boundary and re-renders the region; if the error
+ *   persists, the append-time unwind renders the catch branch.
+ */
+export class TryErrorOpcode extends TryOpcode implements ExceptionHandler {
+  override type = 'try-error';
+
+  #failedDeps: Nullable<Tag> = null;
+  #failedDepsRevision: Revision = INITIAL;
+
+  didUnwind(failedDeps: Tag): void {
+    this.#failedDeps = failedDeps;
+    this.#failedDepsRevision = valueForTag(failedDeps);
+  }
+
+  override evaluate(vm: UpdatingVM) {
+    let failedDeps = this.#failedDeps;
+
+    if (failedDeps !== null) {
+      // Keep the failed branch's dependencies visible to any enclosing cache
+      // group, so a change to them re-runs this opcode at all.
+      consumeTag(failedDeps);
+
+      if (!validateTag(failedDeps, this.#failedDepsRevision)) {
+        this.handleException();
+        return;
+      }
+    }
+
+    super.evaluate(vm);
+  }
+
+  override handleException() {
+    this.#failedDeps = null;
+
+    let {
+      state,
+      bounds,
+      context: { env },
+    } = this;
+
+    destroyChildren(this);
+
+    let tree = NewTreeBuilder.resume(env, bounds);
+    let vm = state.evaluate(tree);
+
+    // The resumed VM starts executing after this region's `EnterTry`, so its
+    // `PushTryFrame` has no freshly-entered boundary to attach to. Register
+    // this opcode so an error during the re-render still unwinds to it.
+    vm.setResumingTryBoundary(this);
 
     let children = (this.children = []);
 
@@ -430,6 +549,10 @@ class UpdatingVMFrame {
     private ops: UpdatingOpcode[],
     private exceptionHandler: Nullable<ExceptionHandler>
   ) {}
+
+  get errorBoundary(): Nullable<TryErrorOpcode> {
+    return this.exceptionHandler instanceof TryErrorOpcode ? this.exceptionHandler : null;
+  }
 
   goto(index: number) {
     this.current = index;

--- a/packages/@glimmer/syntax/lib/keywords.ts
+++ b/packages/@glimmer/syntax/lib/keywords.ts
@@ -23,6 +23,7 @@ export function isKeyword(word: string, type?: KeywordType): boolean {
  */
 export const KEYWORDS_TYPES = {
   action: ['Call', 'Modifier'],
+  catch: ['Block'],
   component: ['Call', 'Append', 'Block'],
   debugger: ['Append'],
   'each-in': ['Block'],
@@ -39,6 +40,7 @@ export const KEYWORDS_TYPES = {
   mut: ['Call', 'Append'],
   outlet: ['Append'],
   readonly: ['Call', 'Append'],
+  try: ['Block'],
   unbound: ['Call', 'Append'],
   unless: ['Call', 'Append', 'Block'],
   yield: ['Append'],

--- a/packages/@glimmer/validator/index.ts
+++ b/packages/@glimmer/validator/index.ts
@@ -36,7 +36,9 @@ export {
   isTracking,
   resetTracking,
   track,
+  trackingFrameDepth,
   untrack,
+  unwindTracking,
 } from './lib/tracking';
 export {
   ALLOW_CYCLES,

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -95,6 +95,42 @@ export function endUntrackFrame(): void {
   CURRENT_TRACKER = OPEN_TRACK_FRAMES.pop() || null;
 }
 
+/**
+ * The number of currently open tracking frames (including untrack frames).
+ * Rendering error recovery snapshots this before a `{{#try}}` region and
+ * passes it back to `unwindTracking` if the region throws.
+ */
+export function trackingFrameDepth(): number {
+  return OPEN_TRACK_FRAMES.length;
+}
+
+/**
+ * Pop open tracking frames down to `depth`, combining the tags consumed by the
+ * discarded frames into a single tag. A thrown error skips the `endTrackFrame`
+ * calls that would normally balance the frame stack; this restores balance
+ * while preserving what the failed render consumed, so an error boundary can
+ * revalidate (and retry) when one of those dependencies changes.
+ */
+export function unwindTracking(depth: number): Tag {
+  let tags: Tag[] = [];
+
+  while (OPEN_TRACK_FRAMES.length > depth) {
+    let current = CURRENT_TRACKER;
+
+    if (current !== null) {
+      tags.push(current.combine());
+
+      if (DEBUG) {
+        unwrap(debug.endTrackingTransaction)();
+      }
+    }
+
+    CURRENT_TRACKER = OPEN_TRACK_FRAMES.pop() || null;
+  }
+
+  return tags.length === 0 ? CONSTANT_TAG : combine(tags);
+}
+
 // This function is only for handling errors and resetting to a valid state
 export function resetTracking(): string | void {
   while (OPEN_TRACK_FRAMES.length > 0) {
@@ -234,11 +270,20 @@ export function track(block: () => void, debugLabel?: string | false): Tag {
   beginTrackFrame(debugLabel);
 
   let tag;
+  let didError = true;
 
   try {
     block();
+    didError = false;
   } finally {
     tag = endTrackFrame();
+
+    // When `block` throws, the caller never sees the combined tag. Surface it
+    // to the parent tracker so an error boundary that catches the throw can
+    // retry when one of the failed computation's dependencies changes.
+    if (didError) {
+      consumeTag(tag);
+    }
   }
 
   return tag;

--- a/packages/@glimmer/wire-format/lib/opcodes.ts
+++ b/packages/@glimmer/wire-format/lib/opcodes.ts
@@ -38,6 +38,7 @@ import type {
   TrustingAppendOpcode,
   TrustingComponentAttrOpcode,
   TrustingDynamicAttrOpcode,
+  TryCatchOpcode,
   UndefinedOpcode,
   WithDynamicVarsOpcode,
   YieldOpcode,
@@ -86,4 +87,5 @@ export const opcodes = {
   IfInline: 52 satisfies IfInlineOpcode,
   GetDynamicVar: 53 satisfies GetDynamicVarOpcode,
   Log: 54 satisfies LogOpcode,
+  TryCatch: 55 satisfies TryCatchOpcode,
 } as const;


### PR DESCRIPTION
## Summary

Prototype of a `{{#try}}` block keyword that acts as a template error boundary: JavaScript errors thrown while rendering the block — during initial render **or** during updates — render a catch branch instead of wedging the renderer.

```hbs
{{#try}}
  {{this.mightThrow}}
{{else catch as |error|}}
  caught: {{error.message}}
{{/try}}
```

No parser changes needed: handlebars' chained-else grammar already parses `{{else catch as |error|}}` as an inverse invoking `catch` with block params, closed by `{{/try}}`. The `try` keyword unwraps it during normalization. A plain `{{else}}` works as a catch branch that ignores the error, and a standalone `{{#catch}}` is a syntax error.

## How it works

The region compiles like the other `Replayable` constructs — a single resettable block whose `TryOpcode`-style closure can re-render it from scratch — plus three new opcodes:

- **`EnterTry`** creates a `TryErrorOpcode`, a `TryOpcode` marked as an error boundary.
- **`PushTryFrame`** snapshots the machine/syscall registers, the six VM stacks, the tree builder's open cursors/blocks and the region's DOM position, and the open tracking-frame depth, and records the CATCH address. It sits *after* `EnterTry`, so closure re-renders (which resume at the pc captured by `EnterTry`) re-arm the handler.
- **`PopTryFrame`** disarms the handler when the try branch completes.

**Append-time errors**: the execute loop catches, rolls every piece of snapshotted state back, destroys the partial content's destroyables, removes its DOM, pushes a reference to the caught error, and resumes at CATCH. DOM removal uses real node positions captured in the frame rather than block bounds — partially-appended content contains inner blocks that are still empty, whose bounds can't be queried.

**Update-time errors**: `UpdatingVM` catches a throwing updating opcode, unwinds its frame stack to the nearest `TryErrorOpcode`, and re-renders that region from scratch (the same recovery path structural invalidation already uses). If the error persists, the append-time handler renders the catch branch with the fresh error.

**Automatic retry**: the unwind captures everything the failed branch consumed and stores it on the boundary, which revalidates those dependencies on each update pass and re-attempts the try branch when one changes. Two supporting changes make that possible: `track()` now forwards a failed computation's combined tag to its parent tracker (a throw otherwise discards it in the `finally`), and the try frame holds a wrapper tracking frame open across the try branch so those tags have somewhere to land (`PopTryFrame` closes it transparently on the happy path).

## Testing

- 12 new integration tests (`test/keywords/try-test.ts`): initial-render catch, update-time catch, recovery on dependency change, DOM rollback mid-element, nested boundaries, plain-else catch, no-catch swallow, and errors outside any boundary still propagating.
- Full browser suite passes: 9483 tests, 0 failures.

## Known limitations / open questions

- Modifiers already scheduled on elements the unwind discards still install (on detached elements).
- Errors thrown inside the catch branch propagate; no re-entrancy guard.
- An update-time error outside any enclosing cache group may not self-schedule the retry render.
- Should caught errors also report to `onerror`? Retry policy, `{{catch}}` ergonomics, and interaction with SSR/rehydration are RFC territory — this spike is meant to show the VM machinery is tractable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)