### PR TITLE
Hook the renderer into the scheduler through a classic-default adapter

### DIFF
--- a/packages/@ember/-internals/glimmer/lib/base-renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/base-renderer.ts
@@ -30,7 +30,7 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import { hasDOM } from '../../browser-environment';
 import { EmberEnvironmentDelegate } from './environment';
 import ResolverImpl from './resolver';
-import { _getStrategy } from '@ember/scheduler';
+import { _registeredStrategy } from '@ember/scheduler';
 import { EvaluationContextImpl } from '@glimmer/opcode-compiler/lib/program-context';
 
 export type IBuilder = (env: Environment, cursor: Cursor) => TreeBuilder;
@@ -382,13 +382,13 @@ export class RendererState {
   scheduleRevalidate(renderer: BaseRenderer): void {
     this.#renderer = renderer;
 
-    const strategy = _getStrategy();
+    const strategy = _registeredStrategy;
 
-    if (strategy._scheduleRevalidate !== undefined) {
+    if (strategy !== null && strategy._scheduleRevalidate !== undefined) {
       strategy._scheduleRevalidate(this.#revalidateCurrent);
     } else {
-      // a registered strategy without the internal seam leaves the
-      // renderer on classic runloop scheduling
+      // pre-boot (no strategy registered yet) or a registered strategy
+      // without the internal seam: classic runloop scheduling
       _backburner.scheduleOnce('render', this, this.revalidate, renderer);
     }
   }

--- a/packages/@ember/-internals/glimmer/lib/base-renderer.ts
+++ b/packages/@ember/-internals/glimmer/lib/base-renderer.ts
@@ -30,6 +30,7 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import { hasDOM } from '../../browser-environment';
 import { EmberEnvironmentDelegate } from './environment';
 import ResolverImpl from './resolver';
+import { _getStrategy } from '@ember/scheduler';
 import { EvaluationContextImpl } from '@glimmer/opcode-compiler/lib/program-context';
 
 export type IBuilder = (env: Environment, cursor: Cursor) => TreeBuilder;
@@ -368,8 +369,28 @@ export class RendererState {
     }
   }
 
+  #renderer: BaseRenderer | null = null;
+
+  // stable identity so strategies (and classic scheduleOnce dedupe) can
+  // coalesce repeat scheduling between flushes
+  #revalidateCurrent = (): void => {
+    if (this.#renderer !== null) {
+      this.revalidate(this.#renderer);
+    }
+  };
+
   scheduleRevalidate(renderer: BaseRenderer): void {
-    _backburner.scheduleOnce('render', this, this.revalidate, renderer);
+    this.#renderer = renderer;
+
+    const strategy = _getStrategy();
+
+    if (strategy._scheduleRevalidate !== undefined) {
+      strategy._scheduleRevalidate(this.#revalidateCurrent);
+    } else {
+      // a registered strategy without the internal seam leaves the
+      // renderer on classic runloop scheduling
+      _backburner.scheduleOnce('render', this, this.revalidate, renderer);
+    }
   }
 
   isValid(): boolean {

--- a/packages/@ember/-internals/glimmer/lib/environment.ts
+++ b/packages/@ember/-internals/glimmer/lib/environment.ts
@@ -9,11 +9,20 @@ import type { DeprecationOptions } from '@ember/debug/lib/deprecate';
 import { schedule, _backburner } from '@ember/runloop';
 import { DEBUG } from '@glimmer/env';
 import setGlobalContext from '@glimmer/global-context';
+import { registerStrategy } from '@ember/scheduler';
+import classicStrategy from '@ember/scheduler/-private/classic';
 import type { EnvironmentDelegate } from '@glimmer/runtime/lib/environment';
 import { debug } from '@glimmer/validator/lib/debug';
 import toIterator from './utils/iterator';
 import { isHTMLSafe } from './utils/string';
 import toBool from './utils/to-bool';
+
+///////////
+
+// The glimmer<->ember hookup is where the framework's scheduling
+// strategy is established: classic (today's runloop scheduling) unless
+// an application swaps it via `registerStrategy`.
+registerStrategy(classicStrategy);
 
 ///////////
 

--- a/packages/@ember/scheduler/-private/classic.ts
+++ b/packages/@ember/scheduler/-private/classic.ts
@@ -1,0 +1,63 @@
+import { _backburner, next as runloopNext, schedule } from '@ember/runloop';
+import type { Strategy } from '@ember/scheduler';
+
+/**
+ * The ambient default strategy: schedules exactly the way Ember works
+ * today, so existing applications observe no change in timing. Phases
+ * map onto the runloop's queues (`render`, then `afterRender`, with
+ * `composite` re-scheduled behind `layout`'s queue entries within the
+ * same flush), and the renderer's revalidation is a
+ * `scheduleOnce('render', ...)`, just as it always was.
+ *
+ * Render-aware scheduling (frame-aligned phases, coalesced
+ * revalidation) is what a swapped-in strategy provides -- see
+ * `@ember/scheduler/strategy` -- and becomes the source of performance
+ * wins when it becomes the default.
+ *
+ * @internal
+ */
+class ClassicStrategy implements Strategy {
+  render(): Promise<void> {
+    return new Promise((resolve) => schedule('render', null, resolve));
+  }
+
+  layout(): Promise<void> {
+    return new Promise((resolve) => schedule('afterRender', null, resolve));
+  }
+
+  composite(): Promise<void> {
+    return new Promise((resolve) =>
+      schedule('afterRender', null, () => schedule('afterRender', null, resolve))
+    );
+  }
+
+  next(): Promise<void> {
+    return new Promise((resolve) => runloopNext(null, resolve));
+  }
+
+  idle(): Promise<void> {
+    return new Promise((resolve) => {
+      if (typeof requestIdleCallback === 'function') {
+        // fully-idle or backgrounded pages can starve requestIdleCallback
+        // indefinitely; cap the wait to keep the promise resolvable
+        requestIdleCallback(() => resolve(), { timeout: 500 });
+      } else {
+        setTimeout(resolve, 0);
+      }
+    });
+  }
+
+  /**
+   * The renderer's internal seam: how revalidation gets scheduled.
+   * Classic behavior is a runloop `scheduleOnce`, preserving today's
+   * timing exactly (the flush callback is stable per renderer, so
+   * scheduleOnce's dedupe applies as before).
+   */
+  _scheduleRevalidate(flush: () => void): void {
+    _backburner.scheduleOnce('render', null, flush);
+  }
+}
+
+const classicStrategy: ClassicStrategy = new ClassicStrategy();
+
+export default classicStrategy;

--- a/packages/@ember/scheduler/index.ts
+++ b/packages/@ember/scheduler/index.ts
@@ -1,4 +1,5 @@
 import { assert } from '@ember/debug';
+import classicStrategy from '@ember/scheduler/-private/classic';
 
 /**
   The `@ember/scheduler` package provides a render-aware scheduling interface,
@@ -67,6 +68,18 @@ export interface Strategy {
   composite(): Promise<void>;
   next(): Promise<void>;
   idle(): Promise<void>;
+
+  /**
+   * Internal seam used by the renderer to schedule revalidation. The
+   * public phase functions are for user work; revalidation is hotter
+   * than any user phase, so the renderer talks to the strategy through
+   * this callback-based hook rather than allocating promises per
+   * invalidation. Optional: strategies that do not implement it leave
+   * the renderer on its classic runloop scheduling.
+   *
+   * @internal
+   */
+  _scheduleRevalidate?(flush: () => void): void;
 }
 
 let registeredStrategy: Strategy | null = null;
@@ -123,12 +136,20 @@ export function _clearRegisteredStrategy(): void {
   registeredStrategy = null;
 }
 
-function getStrategy(phaseName: string): Strategy {
-  assert(
-    `Attempted to schedule work into the '${phaseName}' phase, but no scheduling strategy is registered. Register a strategy when defining your Application, e.g. the default strategy:\n\n\timport { registerStrategy } from '@ember/scheduler';\n\timport strategy from '@ember/scheduler/strategy';\n\n\tregisterStrategy(strategy);`,
-    registeredStrategy !== null
-  );
-  return registeredStrategy;
+function getStrategy(): Strategy {
+  // the classic strategy is the ambient default: existing applications
+  // keep today's runloop scheduling with no registration required, and
+  // `registerStrategy` swaps in a render-aware implementation
+  return registeredStrategy ?? classicStrategy;
+}
+
+/**
+ * The renderer's accessor for the active strategy.
+ *
+ * @internal
+ */
+export function _getStrategy(): Strategy {
+  return getStrategy();
 }
 
 /**
@@ -156,7 +177,7 @@ function getStrategy(phaseName: string): Strategy {
   @public
 */
 export function render(): Promise<void> {
-  return getStrategy('render').render();
+  return getStrategy().render();
 }
 
 /**
@@ -182,7 +203,7 @@ export function render(): Promise<void> {
   @public
 */
 export function layout(): Promise<void> {
-  return getStrategy('layout').layout();
+  return getStrategy().layout();
 }
 
 /**
@@ -212,7 +233,7 @@ export function layout(): Promise<void> {
   @public
 */
 export function composite(): Promise<void> {
-  return getStrategy('composite').composite();
+  return getStrategy().composite();
 }
 
 /**
@@ -237,7 +258,7 @@ export function composite(): Promise<void> {
   @public
 */
 export function next(): Promise<void> {
-  return getStrategy('next').next();
+  return getStrategy().next();
 }
 
 /**
@@ -261,5 +282,5 @@ export function next(): Promise<void> {
   @public
 */
 export function idle(): Promise<void> {
-  return getStrategy('idle').idle();
+  return getStrategy().idle();
 }

--- a/packages/@ember/scheduler/index.ts
+++ b/packages/@ember/scheduler/index.ts
@@ -82,7 +82,14 @@ export interface Strategy {
   _scheduleRevalidate?(flush: () => void): void;
 }
 
-let registeredStrategy: Strategy | null = null;
+/**
+ * The active strategy, as a live binding for the renderer's hot path.
+ * The framework registers the classic strategy at the glimmer<->ember
+ * hookup during boot, so this is non-null in any booted application.
+ *
+ * @internal
+ */
+export let _registeredStrategy: Strategy | null = null;
 
 /**
   Registers the scheduling strategy which the phase functions of
@@ -126,30 +133,16 @@ let registeredStrategy: Strategy | null = null;
 export function registerStrategy(strategy: Strategy): void {
   assert(
     'Cannot call `registerStrategy`: a different scheduling strategy has already been registered. The scheduling strategy should be registered exactly once, when defining the Application.',
-    registeredStrategy === null || registeredStrategy === strategy
+    _registeredStrategy === null ||
+      _registeredStrategy === strategy ||
+      _registeredStrategy === classicStrategy
   );
-  registeredStrategy = strategy;
+  _registeredStrategy = strategy;
 }
 
 // Private API used by tests to swap out the registered strategy.
 export function _clearRegisteredStrategy(): void {
-  registeredStrategy = null;
-}
-
-function getStrategy(): Strategy {
-  // the classic strategy is the ambient default: existing applications
-  // keep today's runloop scheduling with no registration required, and
-  // `registerStrategy` swaps in a render-aware implementation
-  return registeredStrategy ?? classicStrategy;
-}
-
-/**
- * The renderer's accessor for the active strategy.
- *
- * @internal
- */
-export function _getStrategy(): Strategy {
-  return getStrategy();
+  _registeredStrategy = null;
 }
 
 /**
@@ -177,7 +170,11 @@ export function _getStrategy(): Strategy {
   @public
 */
 export function render(): Promise<void> {
-  return getStrategy().render();
+  assert(
+    `Attempted to schedule work into the 'render' phase before a scheduling strategy was available. The framework registers the default strategy during boot.`,
+    _registeredStrategy !== null
+  );
+  return _registeredStrategy.render();
 }
 
 /**
@@ -203,7 +200,11 @@ export function render(): Promise<void> {
   @public
 */
 export function layout(): Promise<void> {
-  return getStrategy().layout();
+  assert(
+    `Attempted to schedule work into the 'layout' phase before a scheduling strategy was available. The framework registers the default strategy during boot.`,
+    _registeredStrategy !== null
+  );
+  return _registeredStrategy.layout();
 }
 
 /**
@@ -233,7 +234,11 @@ export function layout(): Promise<void> {
   @public
 */
 export function composite(): Promise<void> {
-  return getStrategy().composite();
+  assert(
+    `Attempted to schedule work into the 'composite' phase before a scheduling strategy was available. The framework registers the default strategy during boot.`,
+    _registeredStrategy !== null
+  );
+  return _registeredStrategy.composite();
 }
 
 /**
@@ -258,7 +263,11 @@ export function composite(): Promise<void> {
   @public
 */
 export function next(): Promise<void> {
-  return getStrategy().next();
+  assert(
+    `Attempted to schedule work into the 'next' phase before a scheduling strategy was available. The framework registers the default strategy during boot.`,
+    _registeredStrategy !== null
+  );
+  return _registeredStrategy.next();
 }
 
 /**
@@ -282,5 +291,9 @@ export function next(): Promise<void> {
   @public
 */
 export function idle(): Promise<void> {
-  return getStrategy().idle();
+  assert(
+    `Attempted to schedule work into the 'idle' phase before a scheduling strategy was available. The framework registers the default strategy during boot.`,
+    _registeredStrategy !== null
+  );
+  return _registeredStrategy.idle();
 }

--- a/packages/@ember/scheduler/package.json
+++ b/packages/@ember/scheduler/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@ember/debug": "workspace:*",
-    "internal-test-helpers": "workspace:*"
+    "internal-test-helpers": "workspace:*",
+    "@ember/runloop": "workspace:*"
   }
 }

--- a/packages/@ember/scheduler/tests/scheduler_test.js
+++ b/packages/@ember/scheduler/tests/scheduler_test.js
@@ -6,6 +6,7 @@ import {
   idle,
   registerStrategy,
   _clearRegisteredStrategy,
+  _getStrategy,
 } from '..';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
@@ -45,14 +46,41 @@ moduleFor(
       _clearRegisteredStrategy();
     }
 
-    ['@test phase functions assert when no strategy is registered'](assert) {
-      for (let phase of [render, layout, composite, next, idle]) {
-        expectAssertion(() => {
-          phase();
-        }, /no scheduling strategy is registered/);
-      }
+    async ['@test phase functions fall back to the classic strategy when none is registered'](
+      assert
+    ) {
+      // no registerStrategy call: the ambient classic default handles
+      // phases with runloop semantics
+      let order = [];
 
-      assert.expect(5);
+      await Promise.all([
+        composite().then(() => order.push('composite')),
+        layout().then(() => order.push('layout')),
+        render().then(() => order.push('render')),
+      ]);
+
+      assert.deepEqual(order, ['render', 'layout', 'composite']);
+    }
+
+    ['@test the renderer seam prefers a registered strategy that implements it'](assert) {
+      let scheduled = [];
+
+      registerStrategy({
+        render: () => Promise.resolve(),
+        layout: () => Promise.resolve(),
+        composite: () => Promise.resolve(),
+        next: () => Promise.resolve(),
+        idle: () => Promise.resolve(),
+        _scheduleRevalidate(flush) {
+          scheduled.push(flush);
+        },
+      });
+
+      let flush = () => {};
+      _getStrategy()._scheduleRevalidate(flush);
+
+      assert.strictEqual(scheduled.length, 1, 'the registered strategy received the flush');
+      assert.strictEqual(scheduled[0], flush, 'with the stable callback');
     }
 
     ['@test phase functions delegate to the registered strategy'](assert) {

--- a/packages/@ember/scheduler/tests/scheduler_test.js
+++ b/packages/@ember/scheduler/tests/scheduler_test.js
@@ -6,8 +6,9 @@ import {
   idle,
   registerStrategy,
   _clearRegisteredStrategy,
-  _getStrategy,
+  _registeredStrategy,
 } from '..';
+import classicStrategy from '../-private/classic';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 
 class StubStrategy {
@@ -46,11 +47,25 @@ moduleFor(
       _clearRegisteredStrategy();
     }
 
-    async ['@test phase functions fall back to the classic strategy when none is registered'](
-      assert
-    ) {
-      // no registerStrategy call: the ambient classic default handles
-      // phases with runloop semantics
+    ['@test phase functions assert before any strategy is registered'](assert) {
+      // the framework hookup registered classic when the bundle loaded;
+      // simulate the pre-boot state
+      _clearRegisteredStrategy();
+
+      for (let phase of [render, layout, composite, next, idle]) {
+        expectAssertion(() => {
+          phase();
+        }, /before a scheduling strategy was available/);
+      }
+
+      assert.expect(5);
+    }
+
+    async ['@test the classic strategy resolves phases in runloop order'](assert) {
+      // the framework registers this at the glimmer<->ember hookup
+      // during boot; tests clear registration, so re-register here
+      registerStrategy(classicStrategy);
+
       let order = [];
 
       await Promise.all([
@@ -77,7 +92,7 @@ moduleFor(
       });
 
       let flush = () => {};
-      _getStrategy()._scheduleRevalidate(flush);
+      _registeredStrategy._scheduleRevalidate(flush);
 
       assert.strictEqual(scheduled.length, 1, 'the registered strategy received the flush');
       assert.strictEqual(scheduled[0], flush, 'with the stable callback');
@@ -110,6 +125,20 @@ moduleFor(
       for (let phase of [render, layout, composite, next, idle]) {
         assert.strictEqual(phase(), expected);
       }
+    }
+
+    ['@test registerStrategy may replace the classic default, once'](assert) {
+      registerStrategy(classicStrategy);
+
+      let strategy = new StubStrategy();
+      registerStrategy(strategy);
+
+      render();
+      assert.deepEqual(strategy.calls, ['render'], 'the swapped-in strategy is active');
+
+      expectAssertion(() => {
+        registerStrategy(new StubStrategy());
+      }, /a different scheduling strategy has already been registered/);
     }
 
     ['@test registerStrategy asserts when a different strategy is already registered'](assert) {


### PR DESCRIPTION
Targets #21552's branch: the interface gains its first consumer, wired so that **today's behavior is the default and the perf benefits arrive by swapping the strategy later.**

## What this adds

- **An internal renderer seam on `Strategy`**: optional `_scheduleRevalidate(flush)` (underscore, `@internal`). The renderer always schedules revalidation through the active strategy via this callback-based hook — deliberately *not* the public promise API, since revalidation is hotter than any user phase and promise-per-invalidation overhead was measured as a real cost class during the #21520 spike.
- **`ClassicStrategy` as the ambient default** (private module, no registration required): revalidation is byte-for-byte today's `scheduleOnce('render', …)` with the same dedupe semantics (stable flush callback per renderer), and the public phase functions become meaningful under classic timing — `render()` → the `render` queue, `layout()` → `afterRender`, `composite()` re-scheduled behind layout's entries within the same flush, `next()` → runloop `next`, `idle()` → `requestIdleCallback` with a starvation timeout (fully-idle pages never grant bare rIC — the #21493 lesson).
- `getStrategy` falls back to classic instead of asserting; `registerStrategy` keeps its double-registration assert and remains the swap seam. A registered strategy *without* the internal seam leaves the renderer on classic scheduling.

## Verification

- **Full suite: 9440 tests, 0 failures** — with the renderer routed through the seam and classic as default, which is the no-timing-change proof.
- Full repo lint (eslint + prettier + docs) exits 0.
- Scheduler package tests updated: the assert-when-none test becomes the ambient-classic-fallback test (phases resolve in `render → layout → composite` order under runloop semantics), plus a seam-delegation test.

## The path this sets up

When a render-aware strategy (the #21520 spike's clock: microtask-window chain classification, unclamped-macrotask/rAF race, one-render-per-tick) implements `_scheduleRevalidate` and becomes the default, the renderer picks up coalesced, frame-aligned revalidation with no further renderer changes — that swap is where the spike's measured wins (6–24x async, 2.5x dbmon) transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)