### PR TITLE
Privitize all packages that are not ember-source, @glimmer/syntax, and @glimmer/component

### DIFF
--- a/packages/@ember/template-compiler/package.json
+++ b/packages/@ember/template-compiler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ember/template-compiler",
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./index.ts",
     "./runtime": "./runtime.ts",

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/compiler",
   "version": "0.94.11",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/destroyable/package.json
+++ b/packages/@glimmer/destroyable/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/destroyable",
   "version": "0.94.8",
   "license": "MIT",
+  "private": true,
   "description": "Utilities for creating and managing a destroyable hierarchy of objects",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/encoder/package.json
+++ b/packages/@glimmer/encoder/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/encoder",
   "version": "0.93.8",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/global-context/package.json
+++ b/packages/@glimmer/global-context/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/global-context",
   "version": "0.93.4",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/interfaces/package.json
+++ b/packages/@glimmer/interfaces/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/interfaces",
   "version": "0.94.6",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/manager/package.json
+++ b/packages/@glimmer/manager/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/manager",
   "version": "0.94.10",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/node/package.json
+++ b/packages/@glimmer/node/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/node",
   "version": "0.94.10",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/opcode-compiler/package.json
+++ b/packages/@glimmer/opcode-compiler/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/opcode-compiler",
   "version": "0.94.10",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/owner/package.json
+++ b/packages/@glimmer/owner/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/owner",
   "version": "0.93.4",
   "license": "MIT",
+  "private": true,
   "description": "Implementation for the owner in Glimmer apps",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/program/package.json
+++ b/packages/@glimmer/program/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/program",
   "version": "0.94.10",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/reference/package.json
+++ b/packages/@glimmer/reference/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/reference",
   "version": "0.94.9",
   "license": "MIT",
+  "private": true,
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/runtime/package.json
+++ b/packages/@glimmer/runtime/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/runtime",
   "version": "0.94.11",
   "license": "MIT",
+  "private": true,
   "description": "Minimal runtime needed to render Glimmer templates",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/util/package.json
+++ b/packages/@glimmer/util/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/util",
   "version": "0.94.8",
   "license": "MIT",
+  "private": true,
   "description": "Common utilities used in Glimmer",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/validator/package.json
+++ b/packages/@glimmer/validator/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/validator",
   "version": "0.95.0",
   "license": "MIT",
+  "private": true,
   "description": "Objects used to track values and their dirtiness in Glimmer",
   "repository": {
     "type": "git",

--- a/packages/@glimmer/vm/package.json
+++ b/packages/@glimmer/vm/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/vm",
   "version": "0.94.8",
   "license": "MIT",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glimmerjs/glimmer-vm.git",

--- a/packages/@glimmer/wire-format/package.json
+++ b/packages/@glimmer/wire-format/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/wire-format",
   "version": "0.94.8",
   "license": "MIT",
+  "private": true,
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Verifyable via:
```
❯ pnpm ls -r --depth -1 --json | jq '[.[] | select(.private != true and .name != "ember-source")]'

[
  {
    "name": "@glimmer/component",
    "version": "2.1.1",
    "path": "/Users/psego/Development/OpenSource/emberjs/ember.js-9/packages/@glimmer/component",
    "private": false
  },
  {
    "name": "@glimmer/syntax",
    "version": "0.95.0",
    "path": "/Users/psego/Development/OpenSource/emberjs/ember.js-9/packages/@glimmer/syntax",
    "private": false
  }
]
```