### PR TITLE
Skip unchanged {{#each}} item subtrees during updates

### DIFF
--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -9,8 +9,10 @@ import type {
   GlimmerTreeChanges,
   Nullable,
   ResettableBlock,
+  Revision,
   Scope,
   SimpleComment,
+  Tag,
   UpdatingOpcode,
   UpdatingVM as IUpdatingVM,
 } from '@glimmer/interfaces';
@@ -23,7 +25,16 @@ import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
-import { resetTracking } from '@glimmer/validator/lib/tracking';
+import {
+  beginTrackFrame,
+  beginUntrackFrame,
+  consumeTag,
+  endTrackFrame,
+  endUntrackFrame,
+  resetTracking,
+  trackFrameDepth,
+} from '@glimmer/validator/lib/tracking';
+import { INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
 import type { AppendingBlockList } from './element-builder';
@@ -64,7 +75,20 @@ export class UpdatingVM implements IUpdatingVM {
         }
       }
     } else {
-      this._execute(opcodes, handler);
+      let hasErrored = true;
+      try {
+        this._execute(opcodes, handler);
+        hasErrored = false;
+      } finally {
+        // `{{#each}}` items open a tracking frame that is closed when their
+        // frame is popped, so an exception that escapes the loop leaves it
+        // open: `CURRENT_TRACKER` would keep pointing at a dead item and
+        // the next balanced `endTrackFrame` (a component's, say) would pop
+        // the wrong one, corrupting every tag computed afterwards. Only the
+        // DEBUG branch above used to reset, so in production a single
+        // render error poisoned autotracking for the rest of the page.
+        if (hasErrored) resetTracking();
+      }
     }
   }
 
@@ -77,7 +101,9 @@ export class UpdatingVM implements IUpdatingVM {
       let opcode = this.frame.nextStatement();
 
       if (opcode === undefined) {
-        frameStack.pop();
+        let frame = expect(frameStack.pop(), 'bug: expected a frame');
+
+        frame.finalize(false);
         continue;
       }
 
@@ -93,13 +119,20 @@ export class UpdatingVM implements IUpdatingVM {
     this.frame.goto(index);
   }
 
-  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler));
+  try(
+    ops: UpdatingOpcode[],
+    handler: Nullable<ExceptionHandler>,
+    finalizer?: (didError: boolean) => void
+  ) {
+    this.frameStack.push(new UpdatingVMFrame(ops, handler, finalizer));
   }
 
   throw() {
     this.frame.handleException();
-    this.frameStack.pop();
+
+    let frame = expect(this.frameStack.pop(), 'bug: expected a frame');
+
+    frame.finalize(true);
   }
 }
 
@@ -178,6 +211,14 @@ export class ListItemOpcode extends TryOpcode {
   public retained = false;
   public index = -1;
 
+  /**
+   * Everything this item's subtree consumed during its last update,
+   * combined. When still valid, the whole subtree is skipped -- one tag
+   * validation instead of walking every opcode in the item.
+   */
+  private subtreeTag: Nullable<Tag> = null;
+  private subtreeRevision: Revision = INITIAL;
+
   constructor(
     state: Closure,
     context: EvaluationContext,
@@ -187,6 +228,70 @@ export class ListItemOpcode extends TryOpcode {
     public value: Reference
   ) {
     super(state, context, bounds, []);
+  }
+
+  override evaluate(vm: UpdatingVM) {
+    let { subtreeTag } = this;
+
+    if (
+      subtreeTag !== null &&
+      !vm.alwaysRevalidate &&
+      validateTag(subtreeTag, this.subtreeRevision)
+    ) {
+      if (LOCAL_DEBUG) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
+        logStep!('list-item-subtrees', ['skip', this.key]);
+      }
+
+      // propagate this item's dependencies to any enclosing tracking
+      // frame, exactly as executing the children would have
+      consumeTag(subtreeTag);
+      return;
+    }
+
+    if (LOCAL_DEBUG) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
+      logStep!('list-item-subtrees', ['walk', this.key]);
+    }
+
+    // The frame opened here is closed from the finalizer below, once the
+    // children have run -- so by then it is not necessarily the innermost
+    // one. `vm.throw()` unwinds a single frame, and a component's
+    // `BeginTrackFrameOpcode`/`EndTrackFrameOpcode` pair lives in the same
+    // ops array as the rest of this item's children, so an `Assert` that
+    // fires between the two leaves the component's frame open. Closing
+    // blindly would hand us that frame's partial tag and then skip this
+    // item forever against it. Recording the depth lets us tell that case
+    // apart and fall back to "no tag", which only costs a re-render.
+    let depth = trackFrameDepth();
+
+    beginTrackFrame();
+    vm.try(this.children, this, (didError) => {
+      let unbalanced = trackFrameDepth() > depth + 1;
+      let tag: Nullable<Tag> = null;
+
+      // always balance, even when unwinding; the last frame closed is ours
+      while (trackFrameDepth() > depth) {
+        tag = endTrackFrame();
+      }
+
+      if (didError || unbalanced || tag === null) return;
+
+      this.subtreeTag = tag;
+      this.subtreeRevision = valueForTag(tag);
+      consumeTag(tag);
+    });
+  }
+
+  override handleException() {
+    // The children are about to be replaced, so the collected tag no longer
+    // describes them. Belt and braces rather than load-bearing: whatever
+    // threw did so because a ref this item's tag already covers changed, so
+    // the tag is invalid regardless and the item would be walked anyway.
+    // Kept because that reasoning holds for today's `Assert`s, not for any
+    // future opcode that might unwind on something the tag never saw.
+    this.subtreeTag = null;
+    super.handleException();
   }
 
   shouldRemove(): boolean {
@@ -228,25 +333,109 @@ export class ListBlockOpcode extends BlockOpcode {
     let iterator = valueForRef(this.iterableRef);
 
     if (this.lastIterator !== iterator) {
-      let { bounds } = this;
-      let { dom } = vm;
+      // Deriving a fresh array from tracked state is the idiomatic pattern,
+      // so the iterator's identity changes on every update even when none
+      // of the list's keys did. When the new iteration turns out to match
+      // the existing children one-for-one, the item refs can be updated in
+      // place -- no marker node, no diff bookkeeping, no children rebuild.
+      let replay = this.tryFastSync(iterator);
 
-      let marker = (this.marker = dom.createComment(''));
-      dom.insertAfter(
-        bounds.parentElement(),
-        marker,
-        expect(bounds.lastNode(), "can't insert after an empty bounds")
-      );
+      if (replay !== null) {
+        let { bounds } = this;
+        let { dom } = vm;
 
-      this.sync(iterator);
+        let marker = (this.marker = dom.createComment(''));
+        dom.insertAfter(
+          bounds.parentElement(),
+          marker,
+          expect(bounds.lastNode(), "can't insert after an empty bounds")
+        );
 
-      this.parentElement().removeChild(marker);
-      this.marker = null;
+        this.sync(new PrefixedIterator(replay, iterator));
+
+        this.parentElement().removeChild(marker);
+        this.marker = null;
+      }
+
       this.lastIterator = iterator;
     }
 
     // Run now-updated updating opcodes
     super.evaluate(vm);
+  }
+
+  /**
+   * Walks the new iteration against the existing children, applying it in
+   * place for as long as it matches. Returns null when everything matched
+   * in order and in count, which means the update is already complete.
+   *
+   * Otherwise the items consumed so far still have to reach the full
+   * `sync`, which needs the iteration from the beginning -- so the matched
+   * prefix is rebuilt (from the opcodes, whose refs were just updated)
+   * along with the item that mismatched.
+   */
+  private tryFastSync(iterator: OpaqueIterator): Nullable<OpaqueIterationItem[]> {
+    let { children } = this;
+    let matched = 0;
+
+    for (;;) {
+      let item = iterator.next();
+
+      if (item === null) {
+        // ran out of items: either an exact match, or the list shrank
+        return matched === children.length ? null : this.replayPrefix(matched, null);
+      }
+
+      let opcode = children[matched];
+
+      if (opcode === undefined || opcode.key !== item.key) {
+        return this.replayPrefix(matched, item);
+      }
+
+      updateRef(opcode.memo, item.memo);
+      updateRef(opcode.value, item.value);
+      matched++;
+    }
+  }
+
+  /**
+   * The matched prefix was already applied to the item refs, so those items
+   * can be read back off the opcodes.
+   *
+   * The reads are untracked deliberately. This runs inside whatever
+   * tracking frame happens to be open -- an enclosing `{{#each}}` item's,
+   * or a component's cache group -- and `valueForRef` consumes. Letting
+   * these escape would make that frame depend on every item ref in the
+   * list, so any list mutation would invalidate the enclosing component
+   * and re-run its update hooks for no reason.
+   */
+  private replayPrefix(
+    matched: number,
+    mismatch: Nullable<OpaqueIterationItem>
+  ): OpaqueIterationItem[] {
+    let { children } = this;
+    let prefix: OpaqueIterationItem[] = [];
+
+    beginUntrackFrame();
+
+    try {
+      for (let i = 0; i < matched; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+        let opcode = children[i]!;
+
+        prefix.push({
+          key: opcode.key,
+          value: valueForRef(opcode.value),
+          memo: valueForRef(opcode.memo),
+        });
+      }
+    } finally {
+      endUntrackFrame();
+    }
+
+    if (mismatch !== null) prefix.push(mismatch);
+
+    return prefix;
   }
 
   private sync(iterator: OpaqueIterator) {
@@ -428,7 +617,8 @@ class UpdatingVMFrame {
 
   constructor(
     private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>
+    private exceptionHandler: Nullable<ExceptionHandler>,
+    private finalizer?: (didError: boolean) => void
   ) {}
 
   goto(index: number) {
@@ -443,5 +633,40 @@ class UpdatingVMFrame {
     if (this.exceptionHandler) {
       this.exceptionHandler.handleException();
     }
+  }
+
+  finalize(didError: boolean) {
+    this.finalizer?.(didError);
+  }
+}
+
+/**
+ * Replays items the fast path already pulled off an iterator, then drains
+ * the rest of it, so `sync` can see an iteration from the beginning that
+ * has in fact been partly consumed.
+ */
+class PrefixedIterator implements OpaqueIterator {
+  private index = 0;
+
+  constructor(
+    private prefix: OpaqueIterationItem[],
+    private inner: OpaqueIterator
+  ) {}
+
+  /**
+   * Only meaningful before the inner iterator has been advanced, which is
+   * all `sync` needs -- it drives iteration with `next` alone.
+   */
+  isEmpty(): boolean {
+    return this.index >= this.prefix.length && this.inner.isEmpty();
+  }
+
+  next(): Nullable<OpaqueIterationItem> {
+    if (this.index < this.prefix.length) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+      return this.prefix[this.index++]!;
+    }
+
+    return this.inner.next();
   }
 }

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -112,6 +112,21 @@ export function isTracking(): boolean {
   return CURRENT_TRACKER !== null;
 }
 
+/**
+ * How many tracking frames are currently open.
+ *
+ * A caller that opens a frame and closes it somewhere else -- rather than
+ * in the same function -- cannot assume the frame it opened is still the
+ * innermost one by the time it gets to close it, because an unwind in
+ * between can leave frames open. Recording this before `beginTrackFrame`
+ * lets such a caller tell "my frame is on top" from "something in between
+ * leaked", and unwind to a known depth instead of closing a frame that
+ * belongs to somebody else.
+ */
+export function trackFrameDepth(): number {
+  return OPEN_TRACK_FRAMES.length;
+}
+
 export function consumeTag(tag: Tag): void {
   if (CURRENT_TRACKER !== null) {
     CURRENT_TRACKER.add(tag);


### PR DESCRIPTION
Perf improvement for update-based behavior in apps

I could not find a way to test this :(

(without benchmarking)

> [!NOTE]
> My goal is to not regress anything -- improve update performance without sacrificing initial rendering


<details><summary>pnpm bench</summary>

(remember that this bench is mostly _insert / append_  focused, and I haven't gotten around to figuring out how we can optimize that without wholly needing a new approach to the VM )

Ran on d61e33dcdd



```
duration phase no difference [-419ms to 250ms]
renderEnd phase no difference [-15ms to 5ms]
render1000Items1End phase no difference [-19ms to 12ms]
clearItems1End phase no difference [-3ms to 1ms]
render1000Items2End phase no difference [-7ms to 28ms]
clearItems2End phase no difference [-1ms to 2ms]
render10000Items1End phase no difference [-59ms to 125ms]
clearManyItems1End phase no difference [-10ms to 9ms]
render10000Items2End phase no difference [-72ms to 63ms]
clearManyItems2End phase no difference [-9ms to 21ms]
render1000Items3End phase no difference [-12ms to 12ms]
append1000Items1End phase no difference [-41ms to 12ms]
append1000Items2End phase no difference [-31ms to 7ms]
updateEvery10thItem1End phase estimated improvement -23ms [-41ms to -9ms] OR -7.15% [-12.49% to -2.65%]
updateEvery10thItem2End phase estimated improvement -26ms [-41ms to -11ms] OR -7.26% [-11.69% to -3.18%]
selectFirstRow1End phase estimated regression +11ms [3ms to 18ms] OR +9.64% [2.34% to 16.07%]
selectSecondRow1End phase no difference [-2ms to 16ms]
removeFirstRow1End phase estimated improvement -18ms [-27ms to -7ms] OR -7.64% [-11.5% to -3.12%]
removeSecondRow1End phase estimated improvement -21ms [-32ms to -11ms] OR -9.21% [-13.79% to -4.7%]
swapRows1End phase estimated improvement -14ms [-23ms to -4ms] OR -8.22% [-13.11% to -2.27%]
swapRows2End phase estimated improvement -25ms [-47ms to -12ms] OR -12.61% [-23.94% to -6.27%]
clearItems4End phase no difference [0ms to 9ms]
paint phase no difference [-1ms to 0ms]
```


</details>

<details><summary>local comparison of main vs this branch on rere-benchmark</summary>

```

```


</details>

---------------

<details><summary>

Messages from: 
 - https://github.com/emberjs/ember.js/pull/21545


</summary>

The UpdatingVM walks every updating opcode of every list item on every render: cache groups (JumpIfNotModifiedOpcode) exist only at component boundaries, so a list of plain template rows revalidates every binding even when nothing in a row changed.

Collect each item's consumed tags in a tracking frame (via a new frame-finalizer hook on UpdatingVMFrame) and skip the item's entire subtree while that combined tag validates.

Trivial items opt out: for a text node or two, validating a combined tag costs as much as updating, so collection would be pure overhead. An item is trivial when it has <= 2 opcodes and no nested block -- a nested block child means an arbitrarily large subtree hides behind a small top-level count.

dbmon-style workloads (fat rows, sparse changes): ~1.6x fps at 8x CPU throttle, ~6x (rAF-capped) at 4x. Dense-change / tiny-item workloads and the krausest bench: neutral.

Iteration fast path, flat update frames, and flattened combinators

Three allocation/dispatch levers for the update path, measured together with subtree-skipping as the difference between ~14 and ~27 fps on an 8x-throttled dbmon:

- streaming same-order list compare: when a list's order is unchanged (the overwhelmingly common case), items are matched in a single streaming pass writing into a scratch item (nextInto) instead of allocating an IterationItem per step, falling back to the general diff via a reconstructed prefix iterator on first mismatch
- flat frame stack: the updating VM keeps parallel arrays indexed by depth instead of allocating an UpdatingVMFrame per block per render
- combinator flattening: combine() flattens nested combinators and drops constants (capped) so validating a combined tag is one flat loop instead of a pointer-chasing tree walk


</details>