### PR TITLE
Prepare `@glimmer/component` for being published and remove `@glimmer/env`, using export conditions for dev and prod

### DIFF
--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -3,8 +3,12 @@
   "version": "2.1.1",
   "description": "Glimmer component library",
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./*.ts"
+    ".": {
+      "types": "./dist/component/src/index.d.ts",
+      "development": "./dist/dev/index.js",
+      "production": "./dist/prod/index.js",
+      "default": "./dist/prod/index.js"
+    }
   },
   "keywords": [
     "ember-addon"
@@ -18,8 +22,7 @@
   "repository": "https://github.com/emberjs/ember.js",
   "scripts": {},
   "dependencies": {
-    "@embroider/addon-shim": "^1.10.2",
-    "@glimmer/env": "workspace:*"
+    "@embroider/addon-shim": "^1.10.2"
   },
   "devDependencies": {
     "@ember/component": "workspace:*",

--- a/packages/@glimmer/component/tsconfig.json
+++ b/packages/@glimmer/component/tsconfig.json
@@ -9,7 +9,8 @@
       "@ember/owner": ["../../../types/stable/@ember/owner/index.d.ts"],
       "@ember/destroyable": ["../../../types/stable/@ember/destroyable/index.d.ts"],
       "@ember/component": ["../../../types/stable/@ember/component/index.d.ts"],
-      "@ember/runloop": ["../../../types/stable/@ember/runloop/index.d.ts"]
+      "@ember/runloop": ["../../../types/stable/@ember/runloop/index.d.ts"],
+      "@glimmer/env": ["../env/index.ts"]
     },
     "target": "esnext",
     "module": "esnext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1572,9 +1572,6 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.10.2
         version: 1.10.2
-      '@glimmer/env':
-        specifier: workspace:*
-        version: link:../env
     devDependencies:
       '@ember/component':
         specifier: workspace:*

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -27,7 +27,8 @@ const testDependencies = [
 let configs = [
   esmConfig(),
   esmProdConfig(),
-  glimmerComponent(),
+  glimmerComponent({ prod: false }),
+  glimmerComponent({ prod: true }),
   glimmerSyntaxESM(),
   glimmerSyntaxCJS(),
 ];
@@ -168,7 +169,11 @@ function glimmerSyntaxCJS() {
   };
 }
 
-function glimmerComponent() {
+function glimmerComponent({ prod }) {
+  let babelConfig = { ...sharedBabelConfig };
+  let outputDir = prod ? 'dist/prod' : 'dist/dev';
+  let isDebug = !prod;
+
   return {
     onLog: handleRollupWarnings,
     input: {
@@ -176,7 +181,7 @@ function glimmerComponent() {
     },
     output: {
       format: 'es',
-      dir: 'packages/@glimmer/component/dist',
+      dir: `packages/@glimmer/component/${outputDir}`,
       hoistTransitiveImports: false,
       generatedCode: 'es2015',
     },
@@ -185,7 +190,8 @@ function glimmerComponent() {
         babelHelpers: 'bundled',
         extensions: ['.js', '.ts'],
         configFile: false,
-        ...sharedBabelConfig,
+        ...babelConfig,
+        plugins: [...babelConfig.plugins, ...buildDebugMacroPlugin(isDebug)],
       }),
       resolveTS(),
       externalizePackages({ ...exposedDependencies(), ...hiddenDependencies() }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig/compiler-options.json",
   "compilerOptions": {
     "outDir": "dist",
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      // We compile away @glimmer/env during all our builds
+      "@glimmer/env": ["./packages/@glimmer/env/index.ts"]
+    }
   },
   "include": ["packages/**/*.ts"],
   "exclude": ["dist", "node_modules", "tmp", "types"]


### PR DESCRIPTION
`@glimmer/component`s build was wrong.

now is fixed (using the same style of build ember-source uses).


Solves this error:
```
Error: broken "workspace:" reference to @glimmer/env in @glimmer/component
 at publishedInterPackageDeps (file:///opt/hostedtoolcache/node/24.18.0/x64/lib/node_modules/release-plan/dist/interdep.js:42:35)
```

https://github.com/emberjs/ember.js/pull/21555

You _could_ argue that this is a release-plan bug, sure.

But, no one should be using `@glimmer/env` anymore anyway.