### PR TITLE
Correct dependency declarations for `@glimmer/syntax` so that it can be published

### DIFF
--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -35,16 +35,16 @@
     "test:publint": "publint"
   },
   "dependencies": {
-    "@glimmer/interfaces": "workspace:*",
-    "@glimmer/util": "workspace:*",
-    "@glimmer/wire-format": "workspace:*",
-    "@handlebars/parser": "workspace:*",
     "simple-html-tokenizer": "^0.5.11"
   },
   "devDependencies": {
     "@glimmer/debug-util": "workspace:*",
     "@glimmer/env": "workspace:*",
     "@glimmer/local-debug-flags": "workspace:*",
+    "@glimmer/interfaces": "workspace:*",
+    "@glimmer/util": "workspace:*",
+    "@glimmer/wire-format": "workspace:*",
+    "@handlebars/parser": "workspace:*",
     "eslint": "^9.20.1",
     "publint": "^0.3.2",
     "rollup": "^4.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2157,18 +2157,6 @@ importers:
 
   packages/@glimmer/syntax:
     dependencies:
-      '@glimmer/interfaces':
-        specifier: workspace:*
-        version: link:../interfaces
-      '@glimmer/util':
-        specifier: workspace:*
-        version: link:../util
-      '@glimmer/wire-format':
-        specifier: workspace:*
-        version: link:../wire-format
-      '@handlebars/parser':
-        specifier: workspace:*
-        version: link:../../@handlebars/parser
       simple-html-tokenizer:
         specifier: ^0.5.11
         version: 0.5.11
@@ -2179,9 +2167,21 @@ importers:
       '@glimmer/env':
         specifier: workspace:*
         version: link:../env
+      '@glimmer/interfaces':
+        specifier: workspace:*
+        version: link:../interfaces
       '@glimmer/local-debug-flags':
         specifier: workspace:*
         version: link:../local-debug-flags
+      '@glimmer/util':
+        specifier: workspace:*
+        version: link:../util
+      '@glimmer/wire-format':
+        specifier: workspace:*
+        version: link:../wire-format
+      '@handlebars/parser':
+        specifier: workspace:*
+        version: link:../../@handlebars/parser
       eslint:
         specifier: ^9.20.1
         version: 9.39.4


### PR DESCRIPTION
The build for `@glimmer/syntax` was already correct, and the publishConfig.exports are already correct / match what is in `@glimmer/syntax`'s dist.