### PR TITLE
Update @glimmer/component's package.json to declare type=module

### DIFF
--- a/packages/@glimmer/component/package.json
+++ b/packages/@glimmer/component/package.json
@@ -2,6 +2,7 @@
   "name": "@glimmer/component",
   "version": "2.1.1",
   "description": "Glimmer component library",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/component/src/index.d.ts",


### PR DESCRIPTION
I believe this to be safe, because 
- the failure case for `type=module` and ember-addons only comes up when a type=module library depends on a v1 addon
- the requirement ember-source had for it to enable `type=module` (min ember-cli @ 7.0.1) is not relevant here because `@glimmer/component` does not have blueprints
- `@glimmer/component` already required ember-auto-import @ v2