### PR TITLE
Make the rendering test context tracked

### DIFF
--- a/packages/internal-test-helpers/lib/test-cases/rendering.ts
+++ b/packages/internal-test-helpers/lib/test-cases/rendering.ts
@@ -1,5 +1,6 @@
 import type { Renderer } from '@ember/-internals/glimmer';
 import { _resetRenderers, helper, Helper } from '@ember/-internals/glimmer';
+import { isClassicDecorator, tracked } from '@ember/-internals/metal';
 import { EventDispatcher } from '@ember/-internals/views';
 import Component from '@ember/component';
 import type { EmberPrecompileOptions } from 'ember-template-compiler';
@@ -16,6 +17,28 @@ import { runAppend, runDestroy, runTask } from '../run';
 import AbstractTestCase from './abstract';
 
 const TextNode = window.Text;
+
+/**
+ * Test state reaches templates through the top-level component, and tests
+ * update it with `set(this.context, ...)`. That only drives a rerender
+ * because non-tracked reads currently entangle a per-property tag, which
+ * is a legacy read path on its way out (and which the async scheduler's
+ * end state removes). Declaring the properties tracked makes the same
+ * `set` calls reactive under modern semantics, so the suite stops
+ * depending on the legacy path.
+ *
+ * Values that are already decorators (computed properties, injections)
+ * define their own reactivity and are passed through untouched.
+ */
+function trackedContext(context: object): Record<string, unknown> {
+  let attrs: Record<string, unknown> = {};
+
+  for (let [key, value] of Object.entries(context)) {
+    attrs[key] = isClassicDecorator(value) ? value : tracked({ value });
+  }
+
+  return attrs;
+}
 
 export default abstract class RenderingTestCase extends AbstractTestCase {
   owner: EngineInstance;
@@ -106,7 +129,7 @@ export default abstract class RenderingTestCase extends AbstractTestCase {
       })
     );
 
-    let attrs = Object.assign({}, context, {
+    let attrs = Object.assign(trackedContext(context), {
       tagName: '',
       layoutName: '-top-level',
     });


### PR DESCRIPTION
`RenderingTestCase` now declares its context properties tracked, so the suite stops depending on a legacy read path that RFC 957's end state removes.

Groundwork for emberjs/rfcs#1203 ("Deprecate `this.get` and `this.set` on test contexts"): the framework's own suite is the largest consumer of the pattern that RFC deprecates.

## Why

Test state reaches templates through the top-level component, and tests mutate it with `set(this.context, ...)`:

```js
this.render(`{{#let (array this.personOne) as |people|}}...{{/let}}`, { personOne: 'Tom' });
runTask(() => set(this.context, 'personOne', 'Yehuda'));
this.assertText('Yehuda');
```

That drives a rerender only because a non-tracked property read still entangles a per-property tag. `_getProp` pays for that on every property read, and removing it is one of the levers measured in #21520. Today the framework's own suite is a large consumer of that path, with 771 `set(this.context, ...)` call sites across 43 files.

I have not yet been able to measure how many #21520 failures this accounts for. That branch aborts partway through its own suite, so the two runs I have cover different amounts of it and are not comparable. The claim here is only the one verified below: this is behaviour-neutral on `main`.

## What

`this.context` is `Component.extend(attrs)`, so the fix is one place rather than the 771 `set(this.context, ...)` call sites. Context properties are declared with `tracked({ value })`, which keeps every existing `set` call reactive under modern semantics. Values that are already decorators (computed properties, injections) bring their own reactivity and pass through untouched.

No behaviour change here: 9448 tests, 0 failures.

## Not in this PR

`runTask` is the other half of the same migration and is harder. 1678 call sites across 84 files assume rendering flushed synchronously:

```js
runTask(() => set(this.context, 'x', 'y'));
this.assertText('y');   // no await
```

Under the async scheduler it has not flushed. Rewriting those to `await` turns most of the suite async. The cheaper route is redefining `runTask` on a `flushSync`-style escape hatch, which does not exist yet. Worth settling that before touching call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

