### PR TITLE
Simplify the VM's hot paths

### DIFF
--- a/packages/@glimmer/debug/lib/debug.ts
+++ b/packages/@glimmer/debug/lib/debug.ts
@@ -50,14 +50,14 @@ export function logOpcodeSlice(context: CompilationContext, start: number, end: 
 
     let _size = 0;
     for (let i = start; i <= end; i = i + _size) {
-      opcode.offset = i;
+      opcode.seek(i);
       const op = describeOp(opcode, program, context.meta);
 
       logger.log(frag`${i}. ${op}`);
 
       _size = opcode.size;
     }
-    opcode.offset = -_size;
+    opcode.seek(-_size);
     LOCAL_LOGGER.groupEnd();
   }
 }

--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -28,12 +28,8 @@ interface UndestroyedDestroyablesError extends Error {
   destroyables: object[];
 }
 
-/**
- * Meta lives on the destroyable itself rather than in a side table. Rendering a
- * list associates a destroyable per item, and a `WeakMap` lookup (plus the
- * identity hash it forces onto the key) was the single hottest function in a
- * profile of the benchmark app.
- */
+// Meta lives on the destroyable rather than in a side table. A `WeakMap.get`
+// also forces an identity hash onto the key, and every list item pays for one.
 const META = Symbol('DESTROYABLE_META');
 
 type WithMeta = { [META]?: DestroyableMeta<Destroyable> };
@@ -58,10 +54,8 @@ function push<T extends object>(collection: OneOrMany<T>, newItem: T): OneOrMany
   }
 }
 
-/**
- * `arg` is threaded through rather than captured so callers can pass a
- * module-level function instead of allocating a closure per call.
- */
+// `arg` is threaded through so callers pass a module-level function instead of
+// allocating a closure per call.
 function iterate<T extends object, A>(
   collection: OneOrMany<T>,
   fn: (item: T, arg: A) => void,
@@ -216,11 +210,9 @@ function deferDestructor<T extends Destroyable>(destructor: Destructor<T>, destr
   scheduleDestroy(destroyable, destructor);
 }
 
-// Finalizing detaches a destroyable from its parents and marks it destroyed.
-// Every destroy still schedules a pass, so a dropped or cancelled queue can't
-// strand anything, but whichever pass runs first drains everyone who has piled
-// up since — clearing a large list destroys tens of thousands of these, and one
-// shared function reference is a lot cheaper than a closure apiece.
+// Every destroy schedules a pass, so a cancelled queue cannot strand anything,
+// but the first pass to run drains everyone queued since. Clearing a large list
+// produces tens of thousands of these.
 let pendingFinalize: Destroyable[] = [];
 
 function finalizeDestroyed() {
@@ -305,8 +297,7 @@ export function isDestroyed(destroyable: Destroyable) {
 export let enableDestroyableTracking: undefined | (() => void);
 export let assertDestroyablesDestroyed: undefined | (() => void);
 
-// Only populated between `enableDestroyableTracking()` and
-// `assertDestroyablesDestroyed()`, since meta itself is not enumerable.
+// Meta is not enumerable, so tracking needs its own registry.
 let TRACKED_DESTROYABLES: Set<Destroyable> | null = null;
 
 if (DEBUG) {

--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -17,6 +17,7 @@ type DestroyableState = 0 | 1 | 2;
 type OneOrMany<T> = null | T | BrandedArray<T>;
 
 interface DestroyableMeta<T extends Destroyable> {
+  source?: T;
   parents: OneOrMany<Destroyable>;
   children: OneOrMany<Destroyable>;
   eagerDestructors: OneOrMany<Destructor<T>>;
@@ -28,11 +29,9 @@ interface UndestroyedDestroyablesError extends Error {
   destroyables: object[];
 }
 
-// Meta lives on the destroyable rather than in a side table. A `WeakMap.get`
-// also forces an identity hash onto the key, and every list item pays for one.
-const META = Symbol('DESTROYABLE_META');
-
-type WithMeta = { [META]?: DestroyableMeta<Destroyable> };
+let DESTROYABLE_META:
+  | Map<Destroyable, DestroyableMeta<Destroyable>>
+  | WeakMap<Destroyable, DestroyableMeta<Destroyable>> = new WeakMap();
 
 const branded = Symbol('BrandedArray');
 type BrandedArray<T> = T[] & { [branded]: true };
@@ -135,7 +134,7 @@ function getDestroyableMeta<T extends Destroyable>(destroyable: T): DestroyableM
     DESTROYABLE_META.set(destroyable, meta);
   }
 
-  return meta;
+  return meta as unknown as DestroyableMeta<T>;
 }
 
 export function associateDestroyableChild<T extends Destroyable>(parent: Destroyable, child: T): T {
@@ -210,38 +209,23 @@ function deferDestructor<T extends Destroyable>(destructor: Destructor<T>, destr
   scheduleDestroy(destroyable, destructor);
 }
 
-// Every destroy schedules a pass, so a cancelled queue cannot strand anything,
-// but the first pass to run drains everyone queued since. Clearing a large list
-// produces tens of thousands of these.
-let pendingFinalize: Destroyable[] = [];
-
-function finalizeDestroyed() {
-  if (pendingFinalize.length === 0) return;
-
-  let batch = pendingFinalize;
-  pendingFinalize = [];
-
-  for (const destroyable of batch) {
-    let meta = getDestroyableMeta(destroyable);
-
-    iterate(meta.parents, removeChildFromParent, destroyable);
-    meta.state = DESTROYED_STATE;
-  }
-}
-
 export function destroy(destroyable: Destroyable) {
   let meta = getDestroyableMeta(destroyable);
 
   if (meta.state >= DESTROYING_STATE) return;
 
+  let { parents, children, eagerDestructors, destructors } = meta;
+
   meta.state = DESTROYING_STATE;
 
-  iterate(meta.children, destroy, undefined);
-  iterate(meta.eagerDestructors, runDestructor, destroyable);
-  iterate(meta.destructors, deferDestructor, destroyable);
+  iterate(children, destroy, undefined);
+  iterate(eagerDestructors, runDestructor, destroyable);
+  iterate(destructors, deferDestructor, destroyable);
 
-  pendingFinalize.push(destroyable);
-  scheduleDestroyed(finalizeDestroyed);
+  scheduleDestroyed(() => {
+    iterate(parents, removeChildFromParent, destroyable);
+    meta.state = DESTROYED_STATE;
+  });
 }
 
 function removeChildFromParent(parent: Destroyable, child: Destroyable) {
@@ -297,36 +281,40 @@ export function isDestroyed(destroyable: Destroyable) {
 export let enableDestroyableTracking: undefined | (() => void);
 export let assertDestroyablesDestroyed: undefined | (() => void);
 
-// Meta is not enumerable, so tracking needs its own registry.
-let TRACKED_DESTROYABLES: Set<Destroyable> | null = null;
-
 if (DEBUG) {
+  let isTesting = false;
+
   enableDestroyableTracking = () => {
-    if (TRACKED_DESTROYABLES !== null) {
-      TRACKED_DESTROYABLES = null;
+    if (isTesting) {
+      // Reset destroyable meta just in case, before throwing the error
+      DESTROYABLE_META = new WeakMap();
       throw new Error(
         'Attempted to start destroyable testing, but you did not end the previous destroyable test. Did you forget to call `assertDestroyablesDestroyed()`'
       );
     }
 
-    TRACKED_DESTROYABLES = new Set();
+    isTesting = true;
+    DESTROYABLE_META = new Map();
   };
 
   assertDestroyablesDestroyed = () => {
-    if (TRACKED_DESTROYABLES === null) {
+    if (!isTesting) {
       throw new Error(
         'Attempted to assert destroyables destroyed, but you did not start a destroyable test. Did you forget to call `enableDestroyableTracking()`'
       );
     }
 
-    let tracked = TRACKED_DESTROYABLES;
-    TRACKED_DESTROYABLES = null;
+    isTesting = false;
+
+    let map = DESTROYABLE_META as Map<Destroyable, DestroyableMeta<Destroyable>>;
+    DESTROYABLE_META = new WeakMap();
 
     let undestroyed: object[] = [];
 
-    tracked.forEach((destroyable) => {
-      if (getDestroyableMeta(destroyable).state !== DESTROYED_STATE) {
-        undestroyed.push(destroyable);
+    map.forEach((meta) => {
+      if (meta.state !== DESTROYED_STATE) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
+        undestroyed.push(meta.source!);
       }
     });
 

--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -17,7 +17,6 @@ type DestroyableState = 0 | 1 | 2;
 type OneOrMany<T> = null | T | BrandedArray<T>;
 
 interface DestroyableMeta<T extends Destroyable> {
-  source?: T;
   parents: OneOrMany<Destroyable>;
   children: OneOrMany<Destroyable>;
   eagerDestructors: OneOrMany<Destructor<T>>;
@@ -29,9 +28,15 @@ interface UndestroyedDestroyablesError extends Error {
   destroyables: object[];
 }
 
-let DESTROYABLE_META:
-  | Map<Destroyable, DestroyableMeta<Destroyable>>
-  | WeakMap<Destroyable, DestroyableMeta<Destroyable>> = new WeakMap();
+/**
+ * Meta lives on the destroyable itself rather than in a side table. Rendering a
+ * list associates a destroyable per item, and a `WeakMap` lookup (plus the
+ * identity hash it forces onto the key) was the single hottest function in a
+ * profile of the benchmark app.
+ */
+const META = Symbol('DESTROYABLE_META');
+
+type WithMeta = { [META]?: DestroyableMeta<Destroyable> };
 
 const branded = Symbol('BrandedArray');
 type BrandedArray<T> = T[] & { [branded]: true };
@@ -53,11 +58,21 @@ function push<T extends object>(collection: OneOrMany<T>, newItem: T): OneOrMany
   }
 }
 
-function iterate<T extends object>(collection: OneOrMany<T>, fn: (item: T) => void) {
+/**
+ * `arg` is threaded through rather than captured so callers can pass a
+ * module-level function instead of allocating a closure per call.
+ */
+function iterate<T extends object, A>(
+  collection: OneOrMany<T>,
+  fn: (item: T, arg: A) => void,
+  arg: A
+) {
   if (isBrandedArray(collection)) {
-    collection.forEach(fn);
+    for (let i = 0; i < collection.length; i++) {
+      fn(collection[i] as T, arg);
+    }
   } else if (collection !== null) {
-    fn(collection);
+    fn(collection, arg);
   }
 }
 
@@ -126,7 +141,7 @@ function getDestroyableMeta<T extends Destroyable>(destroyable: T): DestroyableM
     DESTROYABLE_META.set(destroyable, meta);
   }
 
-  return meta as unknown as DestroyableMeta<T>;
+  return meta;
 }
 
 export function associateDestroyableChild<T extends Destroyable>(parent: Destroyable, child: T): T {
@@ -193,33 +208,51 @@ export function unregisterDestructor<T extends Destroyable>(
 
 ////////////
 
+function runDestructor<T extends Destroyable>(destructor: Destructor<T>, destroyable: T) {
+  destructor(destroyable);
+}
+
+function deferDestructor<T extends Destroyable>(destructor: Destructor<T>, destroyable: T) {
+  scheduleDestroy(destroyable, destructor);
+}
+
+// Finalizing detaches a destroyable from its parents and marks it destroyed.
+// Every destroy still schedules a pass, so a dropped or cancelled queue can't
+// strand anything, but whichever pass runs first drains everyone who has piled
+// up since — clearing a large list destroys tens of thousands of these, and one
+// shared function reference is a lot cheaper than a closure apiece.
+let pendingFinalize: Destroyable[] = [];
+
+function finalizeDestroyed() {
+  if (pendingFinalize.length === 0) return;
+
+  let batch = pendingFinalize;
+  pendingFinalize = [];
+
+  for (const destroyable of batch) {
+    let meta = getDestroyableMeta(destroyable);
+
+    iterate(meta.parents, removeChildFromParent, destroyable);
+    meta.state = DESTROYED_STATE;
+  }
+}
+
 export function destroy(destroyable: Destroyable) {
   let meta = getDestroyableMeta(destroyable);
 
   if (meta.state >= DESTROYING_STATE) return;
 
-  let { parents, children, eagerDestructors, destructors } = meta;
-
   meta.state = DESTROYING_STATE;
 
-  iterate(children, destroy);
-  iterate(eagerDestructors, (destructor) => {
-    destructor(destroyable);
-  });
-  iterate(destructors, (destructor) => {
-    scheduleDestroy(destroyable, destructor);
-  });
+  iterate(meta.children, destroy, undefined);
+  iterate(meta.eagerDestructors, runDestructor, destroyable);
+  iterate(meta.destructors, deferDestructor, destroyable);
 
-  scheduleDestroyed(() => {
-    iterate(parents, (parent) => {
-      removeChildFromParent(destroyable, parent);
-    });
-
-    meta.state = DESTROYED_STATE;
-  });
+  pendingFinalize.push(destroyable);
+  scheduleDestroyed(finalizeDestroyed);
 }
 
-function removeChildFromParent(child: Destroyable, parent: Destroyable) {
+function removeChildFromParent(parent: Destroyable, child: Destroyable) {
   let parentMeta = getDestroyableMeta(parent);
 
   if (parentMeta.state !== DESTROYED_STATE) {
@@ -233,9 +266,7 @@ function removeChildFromParent(child: Destroyable, parent: Destroyable) {
 }
 
 export function destroyChildren(destroyable: Destroyable) {
-  let { children } = getDestroyableMeta(destroyable);
-
-  iterate(children, destroy);
+  iterate(getDestroyableMeta(destroyable).children, destroy, undefined);
 }
 
 /** Meta if there is any, without creating it. Mirrors `getDestroyableMeta`. */
@@ -274,40 +305,37 @@ export function isDestroyed(destroyable: Destroyable) {
 export let enableDestroyableTracking: undefined | (() => void);
 export let assertDestroyablesDestroyed: undefined | (() => void);
 
-if (DEBUG) {
-  let isTesting = false;
+// Only populated between `enableDestroyableTracking()` and
+// `assertDestroyablesDestroyed()`, since meta itself is not enumerable.
+let TRACKED_DESTROYABLES: Set<Destroyable> | null = null;
 
+if (DEBUG) {
   enableDestroyableTracking = () => {
-    if (isTesting) {
-      // Reset destroyable meta just in case, before throwing the error
-      DESTROYABLE_META = new WeakMap();
+    if (TRACKED_DESTROYABLES !== null) {
+      TRACKED_DESTROYABLES = null;
       throw new Error(
         'Attempted to start destroyable testing, but you did not end the previous destroyable test. Did you forget to call `assertDestroyablesDestroyed()`'
       );
     }
 
-    isTesting = true;
-    DESTROYABLE_META = new Map();
+    TRACKED_DESTROYABLES = new Set();
   };
 
   assertDestroyablesDestroyed = () => {
-    if (!isTesting) {
+    if (TRACKED_DESTROYABLES === null) {
       throw new Error(
         'Attempted to assert destroyables destroyed, but you did not start a destroyable test. Did you forget to call `enableDestroyableTracking()`'
       );
     }
 
-    isTesting = false;
-
-    let map = DESTROYABLE_META as Map<Destroyable, DestroyableMeta<Destroyable>>;
-    DESTROYABLE_META = new WeakMap();
+    let tracked = TRACKED_DESTROYABLES;
+    TRACKED_DESTROYABLES = null;
 
     let undestroyed: object[] = [];
 
-    map.forEach((meta) => {
-      if (meta.state !== DESTROYED_STATE) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-        undestroyed.push(meta.source!);
+    tracked.forEach((destroyable) => {
+      if (getDestroyableMeta(destroyable).state !== DESTROYED_STATE) {
+        undestroyed.push(destroyable);
       }
     });
 

--- a/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
@@ -1,6 +1,5 @@
 import type { Maybe, Nullable } from '../core.js';
 import type { ElementOperations, Environment, ModifierInstance } from '../runtime.js';
-import type { Stack } from '../stack.js';
 import type { Bounds, Cursor } from './bounds.js';
 import type { GlimmerTreeChanges, GlimmerTreeConstruction } from './changes.js';
 import type {
@@ -90,7 +89,7 @@ export interface TreeOperations {
 }
 
 export interface TreeBuilder extends Cursor, DOMStack, TreeOperations {
-  readonly cursors: Stack<Cursor>;
+  readonly cursors: readonly Cursor[];
   readonly debug?: () => {
     blocks: AppendingBlock[];
     constructing: Nullable<SimpleElement>;

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -10,13 +10,16 @@ import type { SomeVmOp, VmMachineOp, VmOp } from './vm-opcodes.js';
 export type CreateRuntimeOp = (heap: ProgramHeap) => RuntimeOp;
 
 export interface RuntimeOp {
-  offset: number;
-  type: SomeVmOp;
-  op1: number;
-  op2: number;
-  op3: number;
-  size: number;
-  isMachine: 0 | 1;
+  readonly offset: number;
+  readonly type: SomeVmOp;
+  readonly op1: number;
+  readonly op2: number;
+  readonly op3: number;
+  readonly size: number;
+  readonly isMachine: 0 | 1;
+
+  /** Point the cursor at `offset` and decode that instruction's header. */
+  seek(offset: number): this;
 }
 
 export interface SerializedHeap {

--- a/packages/@glimmer/manager/lib/internal/defaults.ts
+++ b/packages/@glimmer/manager/lib/internal/defaults.ts
@@ -29,14 +29,16 @@ export class FunctionHelperManager implements HelperManagerWithValue<State> {
     return { fn, args };
   }
 
-  getValue({ fn, args }: State): unknown {
-    if (Object.keys(args.named).length > 0) {
-      let argsForFn: FnArgs = [...args.positional, args.named];
+  getValue({ fn, args: { named, positional } }: State): unknown {
+    // Named args are passed as a trailing hash, but only when there are any.
+    // `for..in` answers that without allocating a key array on every call.
+    for (const _ in named) {
+      let argsForFn: FnArgs = [...positional, named];
 
       return fn(...argsForFn);
     }
 
-    return fn(...args.positional);
+    return fn(...positional);
   }
 
   getDebugName(fn: AnyFunction): string {

--- a/packages/@glimmer/manager/lib/internal/defaults.ts
+++ b/packages/@glimmer/manager/lib/internal/defaults.ts
@@ -30,8 +30,7 @@ export class FunctionHelperManager implements HelperManagerWithValue<State> {
   }
 
   getValue({ fn, args: { named, positional } }: State): unknown {
-    // Named args are passed as a trailing hash, but only when there are any.
-    // `for..in` answers that without allocating a key array on every call.
+    // `for..in` tests for named args without allocating a key array per call.
     for (const _ in named) {
       let argsForFn: FnArgs = [...positional, named];
 

--- a/packages/@glimmer/program/lib/opcode.ts
+++ b/packages/@glimmer/program/lib/opcode.ts
@@ -1,22 +1,28 @@
 import type { ProgramHeap, RuntimeOp, SomeVmOp } from '@glimmer/interfaces';
 import { ARG_SHIFT, MACHINE_MASK, OPERAND_LEN_MASK, TYPE_MASK } from '@glimmer/vm/lib/flags';
 
+/**
+ * A cursor over the program heap. `seek` decodes the header word once and
+ * caches `type`, `size` and `isMachine` as plain fields — the VM reads all
+ * three for every instruction it executes.
+ */
 export class RuntimeOpImpl implements RuntimeOp {
   public offset = 0;
+  public type: SomeVmOp = 0;
+  public size = 0;
+  public isMachine: 0 | 1 = 0;
+
   constructor(readonly heap: ProgramHeap) {}
 
-  get size() {
-    let rawType = this.heap.getbyaddr(this.offset);
-    return ((rawType & OPERAND_LEN_MASK) >> ARG_SHIFT) + 1;
-  }
+  seek(offset: number): this {
+    let header = this.heap.getbyaddr(offset);
 
-  get isMachine(): 0 | 1 {
-    let rawType = this.heap.getbyaddr(this.offset);
-    return rawType & MACHINE_MASK ? 1 : 0;
-  }
+    this.offset = offset;
+    this.type = (header & TYPE_MASK) as SomeVmOp;
+    this.size = ((header & OPERAND_LEN_MASK) >> ARG_SHIFT) + 1;
+    this.isMachine = header & MACHINE_MASK ? 1 : 0;
 
-  get type(): SomeVmOp {
-    return (this.heap.getbyaddr(this.offset) & TYPE_MASK) as SomeVmOp;
+    return this;
   }
 
   get op1() {

--- a/packages/@glimmer/program/lib/opcode.ts
+++ b/packages/@glimmer/program/lib/opcode.ts
@@ -2,9 +2,8 @@ import type { ProgramHeap, RuntimeOp, SomeVmOp } from '@glimmer/interfaces';
 import { ARG_SHIFT, MACHINE_MASK, OPERAND_LEN_MASK, TYPE_MASK } from '@glimmer/vm/lib/flags';
 
 /**
- * A cursor over the program heap. `seek` decodes the header word once and
- * caches `type`, `size` and `isMachine` as plain fields — the VM reads all
- * three for every instruction it executes.
+ * A cursor over the program heap. `seek` decodes the header word once, because
+ * the VM reads `type`, `size` and `isMachine` for every instruction.
  */
 export class RuntimeOpImpl implements RuntimeOp {
   public offset = 0;

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -5,13 +5,6 @@ import { MACHINE_MASK } from '@glimmer/vm/lib/flags';
 
 import { RuntimeOpImpl } from './opcode';
 
-const ALLOCATED = 0;
-const FREED = 1;
-const PURGED = 2;
-const POINTER = 3;
-
-type TableSlotState = typeof ALLOCATED | typeof FREED | typeof PURGED | typeof POINTER;
-
 export type Placeholder = [number, () => number];
 export type StdlibPlaceholder = [number, StdLibOperand];
 
@@ -31,23 +24,18 @@ const PAGE_SIZE = 0x100000;
  * | ... |  Handle  | Scope Size | State | Size       |
  * | ... | 32bits   | 30bits     | 2bits | 32bit      |
  *
- * With this information we effectively have the ability to
- * control when we want to free memory. That being said you
- * can not free during execution as raw address are only
- * valid during the execution. This means you cannot close
- * over them as you will have a bad memory access exception.
+ * Memory is never reclaimed: templates live for the lifetime of the
+ * application, so the heap only ever grows.
  */
 export class ProgramHeapImpl implements ProgramHeap {
   offset = 0;
 
   private heap: Int32Array;
   private handleTable: number[];
-  private handleState: TableSlotState[];
 
   constructor() {
     this.heap = new Int32Array(PAGE_SIZE);
     this.handleTable = [];
-    this.handleState = [];
   }
   entries(): number {
     return this.offset;
@@ -91,11 +79,9 @@ export class ProgramHeapImpl implements ProgramHeap {
   }
 
   finishMalloc(handle: number): void {
-    // @TODO: At the moment, garbage collection isn't actually used, so this is
-    // wrapped to prevent us from allocating extra space in prod. In the future,
-    // if we start using the compact API, we should change this.
+    // Only the debug tooling needs to know how big a template is, and tracking
+    // it costs a table slot per handle, so it's debug-only.
     if (LOCAL_DEBUG) {
-      this.handleState[handle] = ALLOCATED;
       this.handleTable[handle + 1] = this.offset;
     }
   }
@@ -104,57 +90,12 @@ export class ProgramHeapImpl implements ProgramHeap {
     return this.offset;
   }
 
-  // It is illegal to close over this address, as compaction
-  // may move it. However, it is legal to use this address
-  // multiple times between compactions.
   getaddr(handle: number): number {
     return unwrap(this.handleTable[handle]);
   }
 
   sizeof(handle: number): number {
     return sizeof(this.handleTable, handle);
-  }
-
-  free(handle: number): void {
-    this.handleState[handle] = FREED;
-  }
-
-  /**
-   * The heap uses the [Mark-Compact Algorithm](https://en.wikipedia.org/wiki/Mark-compact_algorithm) to shift
-   * reachable memory to the bottom of the heap and freeable
-   * memory to the top of the heap. When we have shifted all
-   * the reachable memory to the top of the heap, we move the
-   * offset to the next free position.
-   */
-  compact(): void {
-    let compactedSize = 0;
-    let { handleTable, handleState, heap } = this;
-
-    for (let i = 0; i < length; i++) {
-      let offset = unwrap(handleTable[i]);
-      let size = unwrap(handleTable[i + 1]) - unwrap(offset);
-      let state = handleState[i];
-
-      if (state === PURGED) {
-        continue;
-      } else if (state === FREED) {
-        // transition to "already freed" aka "purged"
-        // a good improvement would be to reuse
-        // these slots
-        handleState[i] = PURGED;
-        compactedSize += size;
-      } else if (state === ALLOCATED) {
-        for (let j = offset; j <= i + size; j++) {
-          heap[j - compactedSize] = unwrap(heap[j]);
-        }
-
-        handleTable[i] = offset - compactedSize;
-      } else if (state === POINTER) {
-        handleTable[i] = offset - compactedSize;
-      }
-    }
-
-    this.offset = this.offset - compactedSize;
   }
 }
 
@@ -171,8 +112,7 @@ export class ProgramImpl implements Program {
   }
 
   opcode(offset: number): RuntimeOpImpl {
-    this._opcode.offset = offset;
-    return this._opcode;
+    return this._opcode.seek(offset);
   }
 }
 

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -79,8 +79,7 @@ export class ProgramHeapImpl implements ProgramHeap {
   }
 
   finishMalloc(handle: number): void {
-    // Only the debug tooling needs to know how big a template is, and tracking
-    // it costs a table slot per handle, so it's debug-only.
+    // Only the debug tooling needs a template's size, and it costs a table slot.
     if (LOCAL_DEBUG) {
       this.handleTable[handle + 1] = this.offset;
     }

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -115,8 +115,8 @@ function identityForNthOccurence(value: unknown, count: number) {
  * Glimmer know that it should reuse the DOM for the previous nth occurence.
  */
 function uniqueKeyFor(keyFor: KeyFor) {
-  // Two maps rather than one wrapper: this runs for every item on every pass
-  // over a list, and duplicate keys are the rare case.
+  // Two maps rather than a wrapper object: this runs for every item on every
+  // pass over a list, and duplicate keys are the rare case.
   let seenObjects: WeakMap<object, number> | undefined;
   let seenPrimitives: Map<unknown, number> | undefined;
 
@@ -201,14 +201,9 @@ class IteratorWrapper implements OpaqueIterator {
 class ArrayIterator implements OpaqueIterator {
   private pos = -1;
 
-  /**
-   * Reading `length` in the constructor is load-bearing, not just convenient:
-   * the constructor runs inside the iterator reference's tracking frame, so
-   * this is the read that attributes a tracked collection's tag to that
-   * reference. Read lazily from `next()` instead and the tag lands in whichever
-   * frame happens to be open during iteration, and the list stops revalidating
-   * when its contents change.
-   */
+  // The constructor runs inside the iterator reference's tracking frame, so
+  // reading `length` here is what attributes a tracked collection's tag to that
+  // reference. Read it from `next()` instead and the list stops revalidating.
   private length: number;
 
   constructor(

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -225,42 +225,36 @@ class IteratorWrapper implements OpaqueIterator {
 }
 
 class ArrayIterator implements OpaqueIterator {
-  private current: { kind: 'empty' } | { kind: 'first'; value: unknown } | { kind: 'progress' };
-  private pos = 0;
+  private pos = -1;
+
+  /**
+   * Reading `length` in the constructor is load-bearing, not just convenient:
+   * the constructor runs inside the iterator reference's tracking frame, so
+   * this is the read that attributes a tracked collection's tag to that
+   * reference. Read lazily from `next()` instead and the tag lands in whichever
+   * frame happens to be open during iteration, and the list stops revalidating
+   * when its contents change.
+   */
+  private length: number;
 
   constructor(
     private iterator: unknown[] | readonly unknown[],
     private keyFor: KeyFor
   ) {
-    if (iterator.length === 0) {
-      this.current = { kind: 'empty' };
-    } else {
-      this.current = { kind: 'first', value: iterator[this.pos] };
-    }
+    this.length = iterator.length;
   }
 
   isEmpty(): boolean {
-    return this.current.kind === 'empty';
+    return this.length === 0;
   }
 
   next(): Nullable<IterationItem<unknown, number>> {
-    let value: unknown;
+    let memo = ++this.pos;
 
-    let current = this.current;
-    if (current.kind === 'first') {
-      this.current = { kind: 'progress' };
-      value = current.value;
-    } else if (this.pos >= this.iterator.length - 1) {
-      return null;
-    } else {
-      value = this.iterator[++this.pos];
-    }
+    if (memo >= this.length) return null;
 
-    let { keyFor } = this;
+    let value = this.iterator[memo];
 
-    let key = keyFor(value, this.pos);
-    let memo = this.pos;
-
-    return { key, value, memo };
+    return { key: this.keyFor(value, memo), value, memo };
   }
 }

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -75,51 +75,18 @@ function makeKeyFor(key: string) {
   }
 }
 
-class WeakMapWithPrimitives<T> {
-  private _weakMap?: WeakMap<object, T>;
-  private _primitiveMap?: Map<unknown, T>;
-
-  private get weakMap() {
-    if (this._weakMap === undefined) {
-      this._weakMap = new WeakMap();
-    }
-
-    return this._weakMap;
-  }
-
-  private get primitiveMap() {
-    if (this._primitiveMap === undefined) {
-      this._primitiveMap = new Map();
-    }
-
-    return this._primitiveMap;
-  }
-
-  set(key: unknown, value: T) {
-    if (isIndexable(key)) {
-      this.weakMap.set(key, value);
-    } else {
-      this.primitiveMap.set(key, value);
-    }
-  }
-
-  get(key: unknown): T | undefined {
-    if (isIndexable(key)) {
-      return this.weakMap.get(key);
-    } else {
-      return this.primitiveMap.get(key);
-    }
-  }
-}
-
-const IDENTITIES = new WeakMapWithPrimitives<object[]>();
+const OBJECT_IDENTITIES = new WeakMap<object, object[]>();
+const PRIMITIVE_IDENTITIES = new Map<unknown, object[]>();
 
 function identityForNthOccurence(value: unknown, count: number) {
-  let identities = IDENTITIES.get(value);
+  let identities: object[] | undefined;
 
-  if (identities === undefined) {
-    identities = [];
-    IDENTITIES.set(value, identities);
+  if (isIndexable(value)) {
+    identities = OBJECT_IDENTITIES.get(value);
+    if (identities === undefined) OBJECT_IDENTITIES.set(value, (identities = []));
+  } else {
+    identities = PRIMITIVE_IDENTITIES.get(value);
+    if (identities === undefined) PRIMITIVE_IDENTITIES.set(value, (identities = []));
   }
 
   let identity = identities[count];
@@ -148,19 +115,26 @@ function identityForNthOccurence(value: unknown, count: number) {
  * Glimmer know that it should reuse the DOM for the previous nth occurence.
  */
 function uniqueKeyFor(keyFor: KeyFor) {
-  let seen = new WeakMapWithPrimitives<number>();
+  // Two maps rather than one wrapper: this runs for every item on every pass
+  // over a list, and duplicate keys are the rare case.
+  let seenObjects: WeakMap<object, number> | undefined;
+  let seenPrimitives: Map<unknown, number> | undefined;
 
   return (value: unknown, memo: unknown) => {
     let key = keyFor(value, memo);
-    let count = seen.get(key) || 0;
+    let count: number | undefined;
 
-    seen.set(key, count + 1);
-
-    if (count === 0) {
-      return key;
+    if (isIndexable(key)) {
+      seenObjects ??= new WeakMap();
+      count = seenObjects.get(key);
+      seenObjects.set(key, count === undefined ? 1 : count + 1);
+    } else {
+      seenPrimitives ??= new Map();
+      count = seenPrimitives.get(key);
+      seenPrimitives.set(key, count === undefined ? 1 : count + 1);
     }
 
-    return identityForNthOccurence(key, count);
+    return count === undefined ? key : identityForNthOccurence(key, count);
   };
 }
 

--- a/packages/@glimmer/runtime/lib/opcodes.ts
+++ b/packages/@glimmer/runtime/lib/opcodes.ts
@@ -6,7 +6,6 @@ import type {
   Nullable,
   Optional,
   RuntimeOp,
-  SomeVmOp,
   VmMachineOp,
   VmOp,
 } from '@glimmer/interfaces';
@@ -18,12 +17,11 @@ import { opcodeMetadata } from '@glimmer/debug/lib/opcode-metadata';
 import { recordStackSize } from '@glimmer/debug/lib/stack-check';
 import { VmSnapshot } from '@glimmer/debug/lib/vm/snapshot';
 import { dev, unwrap } from '@glimmer/debug-util/lib/platform-utils';
-import assert from '@glimmer/debug-util/lib/assert';
 import { LOCAL_DEBUG, LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 import { LOCAL_LOGGER } from '@glimmer/util';
 import { $pc, $ra, $s0, $s1, $sp, $t0, $t1, $v0 } from '@glimmer/vm/lib/registers';
 
-import type { LowLevelVM, VM } from './vm';
+import type { VM } from './vm';
 import type { Externs } from './vm/low-level';
 
 export interface OpcodeJSON {
@@ -40,11 +38,6 @@ export type Operand2 = number;
 export type Operand3 = number;
 
 export type Syscall = (vm: VM, opcode: RuntimeOp) => void;
-export type MachineOpcode = (vm: LowLevelVM, opcode: RuntimeOp) => void;
-
-export type Evaluate =
-  | { syscall: true; evaluate: Syscall }
-  | { syscall: false; evaluate: MachineOpcode };
 
 export type DebugState = {
   opcode: {
@@ -63,7 +56,7 @@ export class AppendOpcodes {
   // This code is intentionally putting unsafe `null`s into the array that it
   // will intentionally overwrite before anyone can see them.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  private evaluateOpcode: Evaluate[] = new Array(VM_SYSCALL_SIZE).fill(null);
+  private evaluateOpcode: Syscall[] = new Array(VM_SYSCALL_SIZE).fill(null);
 
   declare debugBefore?: (vm: DebugVmSnapshot, opcode: RuntimeOp) => DebugState;
   declare debugAfter?: (debug: DebugVmSnapshot, pre: DebugState) => void;
@@ -170,35 +163,12 @@ export class AppendOpcodes {
     }
   }
 
-  add<Name extends VmOp>(name: Name, evaluate: Syscall): void;
-  add<Name extends VmMachineOp>(name: Name, evaluate: MachineOpcode, kind: 'machine'): void;
-  add<Name extends SomeVmOp>(
-    name: Name,
-    evaluate: Syscall | MachineOpcode,
-    kind = 'syscall'
-  ): void {
-    this.evaluateOpcode[name as number] = {
-      syscall: kind !== 'machine',
-      evaluate,
-    } as Evaluate;
+  add<Name extends VmOp>(name: Name, evaluate: Syscall): void {
+    this.evaluateOpcode[name as number] = evaluate;
   }
 
   evaluate(vm: VM, opcode: RuntimeOp, type: number) {
-    let operation = unwrap(this.evaluateOpcode[type]);
-
-    if (operation.syscall) {
-      assert(
-        !opcode.isMachine,
-        `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
-      );
-      operation.evaluate(vm, opcode);
-    } else {
-      assert(
-        opcode.isMachine,
-        `BUG: Mismatch between operation.syscall (${operation.syscall}) and opcode.isMachine (${opcode.isMachine}) for ${opcode.type}`
-      );
-      operation.evaluate(vm.lowlevel, opcode);
-    }
+    unwrap(this.evaluateOpcode[type])(vm, opcode);
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -64,9 +64,8 @@ class Drop {
 }
 
 /**
- * The VM's bookkeeping stacks. A VM is constructed for every block that gets
- * re-rendered independently (each `{{#each}}` item, for instance), so these are
- * plain arrays rather than wrapper objects — one allocation each instead of two.
+ * A VM is constructed for every block that re-renders independently, one per
+ * `{{#each}}` item included, so these are arrays rather than wrapper objects.
  */
 class Stacks {
   declare debug?: () => DebugStacks;

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -32,7 +32,6 @@ import { LOCAL_DEBUG, LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 import { createIteratorItemRef } from '@glimmer/reference/lib/iterable';
 import { UNDEFINED_REFERENCE } from '@glimmer/reference/lib/reference';
 import { reverse } from '@glimmer/util/lib/array-utils';
-import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { LOCAL_LOGGER } from '@glimmer/util';
 import { beginTrackFrame, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
 import { $pc, isLowLevelRegister } from '@glimmer/vm/lib/registers';
@@ -64,16 +63,21 @@ class Drop {
   [DESTROYABLE_META_KEY]: object | undefined;
 }
 
+/**
+ * The VM's bookkeeping stacks. A VM is constructed for every block that gets
+ * re-rendered independently (each `{{#each}}` item, for instance), so these are
+ * plain arrays rather than wrapper objects — one allocation each instead of two.
+ */
 class Stacks {
   declare debug?: () => DebugStacks;
   readonly drop: object = new Drop();
 
-  readonly scope = new Stack<Scope>();
-  readonly dynamicScope = new Stack<DynamicScope>();
-  readonly updating = new Stack<UpdatingOpcode[]>();
-  readonly cache = new Stack<JumpIfNotModifiedOpcode>();
-  readonly list = new Stack<ListBlockOpcode>();
-  readonly destroyable = new Stack<object>();
+  readonly scope: Scope[] = [];
+  readonly dynamicScope: DynamicScope[] = [];
+  readonly updating: UpdatingOpcode[][] = [];
+  readonly cache: JumpIfNotModifiedOpcode[] = [];
+  readonly list: ListBlockOpcode[] = [];
+  readonly destroyable: object[] = [];
 
   constructor(scope: Scope, dynamicScope: DynamicScope) {
     this.scope.push(scope);
@@ -81,18 +85,20 @@ class Stacks {
     this.destroyable.push(this.drop);
 
     if (LOCAL_DEBUG) {
-      this.debug = (): DebugStacks => {
-        return {
-          scope: this.scope.snapshot(),
-          dynamicScope: this.dynamicScope.snapshot(),
-          updating: this.updating.snapshot(),
-          cache: this.cache.snapshot(),
-          list: this.list.snapshot(),
-          destroyable: this.destroyable.snapshot(),
-        };
-      };
+      this.debug = (): DebugStacks => ({
+        scope: [...this.scope],
+        dynamicScope: [...this.dynamicScope],
+        updating: [...this.updating],
+        cache: [...this.cache],
+        list: [...this.list],
+        destroyable: [...this.destroyable],
+      });
     }
   }
+}
+
+function top<T>(stack: T[]): T | undefined {
+  return stack[stack.length - 1];
 }
 
 type Handle = number;
@@ -671,7 +677,7 @@ export class VM {
   }
 
   private listBlock(): ListBlockOpcode {
-    return expect(this.#stacks.list.current, 'expected a list block');
+    return expect(top(this.#stacks.list), 'expected a list block');
   }
 
   /**
@@ -682,13 +688,13 @@ export class VM {
    * @utility
    */
   associateDestroyable(child: Destroyable): void {
-    let parent = expect(this.#stacks.destroyable.current, 'Expected destructor parent');
+    let parent = expect(top(this.#stacks.destroyable), 'Expected destructor parent');
     associateDestroyableChild(parent, child);
   }
 
   private updating(): UpdatingOpcode[] {
     return expect(
-      this.#stacks.updating.current,
+      top(this.#stacks.updating),
       'expected updating opcode on the updating opcode stack'
     );
   }
@@ -704,7 +710,7 @@ export class VM {
    * Get current Scope
    */
   scope(): Scope {
-    return expect(this.#stacks.scope.current, 'expected scope on the scope stack');
+    return expect(top(this.#stacks.scope), 'expected scope on the scope stack');
   }
 
   /**
@@ -712,7 +718,7 @@ export class VM {
    */
   dynamicScope(): DynamicScope {
     return expect(
-      this.#stacks.dynamicScope.current,
+      top(this.#stacks.dynamicScope),
       'expected dynamic scope on the dynamic scope stack'
     );
   }
@@ -775,38 +781,42 @@ export class VM {
 
     if (initialize) initialize(this);
 
-    let result: RichIteratorResult<null, RenderResult>;
+    let { lowlevel } = this;
 
-    do result = this.next();
-    while (!result.done);
+    for (
+      let opcode = lowlevel.nextStatement();
+      opcode !== null;
+      opcode = lowlevel.nextStatement()
+    ) {
+      lowlevel.evaluateOuter(opcode, this);
+    }
 
-    return result.value;
+    return this.#finish();
   }
 
   next(): RichIteratorResult<null, RenderResult> {
-    let { env } = this;
     let opcode = this.lowlevel.nextStatement();
-    let result: RichIteratorResult<null, RenderResult>;
-    if (opcode !== null) {
-      this.lowlevel.evaluateOuter(opcode, this);
-      result = { done: false, value: null };
-    } else {
-      // Unload the stack
-      this.stack.reset();
 
-      result = {
-        done: true,
-        value: new RenderResultImpl(
-          env,
-          this.popUpdating(),
-          this.#tree.popBlock(),
-          this.#stacks.drop
-        ),
-      };
-    }
-    return result;
+    if (opcode === null) return { done: true, value: this.#finish() };
+
+    this.lowlevel.evaluateOuter(opcode, this);
+    return NOT_DONE;
+  }
+
+  #finish(): RenderResult {
+    // Unload the stack
+    this.stack.reset();
+
+    return new RenderResultImpl(
+      this.env,
+      this.popUpdating(),
+      this.#tree.popBlock(),
+      this.#stacks.drop
+    );
   }
 }
+
+const NOT_DONE: RichIteratorResult<null, never> = { done: false, value: null };
 
 function closureState(pc: number, scope: Scope, dynamicScope: DynamicScope): ClosureState {
   return {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -41,8 +41,8 @@ export interface LastNode {
 }
 
 /**
- * A block's edge is either a node it appended directly, or a nested block whose
- * own edges aren't known until it finishes building.
+ * A block's edge is either a node it appended, or a nested block whose own edges
+ * are not known until it finishes building.
  */
 type Edge = SimpleNode | Bounds;
 
@@ -50,10 +50,7 @@ function isBounds(edge: Edge): edge is Bounds {
   return 'firstNode' in edge;
 }
 
-/**
- * Resolve an edge for debug output without throwing while a nested block is
- * still being built.
- */
+/** Resolve an edge for debug output without throwing mid-build. */
 function debugEdge(edge: Nullable<Edge>, which: 'first' | 'last'): Nullable<SimpleNode> {
   if (edge === null) return null;
   if (!isBounds(edge)) return edge;
@@ -93,11 +90,9 @@ export class NewTreeBuilder implements TreeBuilder {
   public operations: Nullable<ElementOperations> = null;
   private env: Environment;
 
-  // Slots above `cursorDepth` are retained and reused. Opening an element is
-  // one of the most frequent operations the VM performs, and a builder is
-  // created per re-rendered block, so this is a lot of short-lived garbage
-  // otherwise. Subclasses that need a richer cursor push their own via
-  // `pushCursor`.
+  // Slots above `cursorDepth` are retained and reused, because opening an
+  // element is one of the most frequent operations the VM performs. Subclasses
+  // that need a richer cursor push their own through `pushCursor`.
   readonly cursors: CursorImpl[] = [];
   protected cursorDepth = -1;
   private modifierStack: Nullable<ModifierInstance[]>[] = [];
@@ -287,10 +282,7 @@ export class NewTreeBuilder implements TreeBuilder {
     }
   }
 
-  /**
-   * Push a cursor a subclass built itself. Unlike `pushElement` this cannot
-   * reuse the slot, so it always stores the object it was given.
-   */
+  /** Store a subclass-built cursor. Unlike `pushElement`, this cannot reuse a slot. */
   pushCursor(cursor: CursorImpl): void {
     this.cursors[++this.cursorDepth] = cursor;
   }

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -40,21 +40,15 @@ export interface LastNode {
   lastNode(): SimpleNode;
 }
 
-/**
- * A block's edge is either a node it appended, or a nested block whose own edges
- * are not known until it finishes building.
- */
-type Edge = SimpleNode | Bounds;
-
-function isBounds(edge: Edge): edge is Bounds {
-  return 'firstNode' in edge;
-}
-
-/** Resolve an edge for debug output without throwing mid-build. */
-function debugEdge(edge: Nullable<Edge>, which: 'first' | 'last'): Nullable<SimpleNode> {
-  if (edge === null) return null;
-  if (!isBounds(edge)) return edge;
-  return (edge as FirstNode & LastNode).debug?.[which]() ?? null;
+/** Resolve a block edge for debug output without throwing mid-build. */
+function debugEdge(
+  node: Nullable<SimpleNode>,
+  block: Nullable<Bounds>,
+  which: 'first' | 'last'
+): Nullable<SimpleNode> {
+  if (node !== null) return node;
+  if (block === null) return null;
+  return (block as FirstNode & LastNode).debug?.[which]() ?? null;
 }
 
 export class Fragment implements Bounds {
@@ -422,8 +416,13 @@ export class AppendingBlockImpl implements AppendingBlock {
 
   [DESTROYABLE_META_KEY]: object | undefined;
 
-  protected first: Nullable<Edge> = null;
-  protected last: Nullable<Edge> = null;
+  // A block's edge is either a node it appended, or a nested block whose own
+  // edges are not known until it finishes building. Keeping the two apart keeps
+  // both fields monomorphic; `clear` reads them for every bounds it removes.
+  protected first: Nullable<SimpleNode> = null;
+  protected firstBlock: Nullable<Bounds> = null;
+  protected last: Nullable<SimpleNode> = null;
+  protected lastBlock: Nullable<Bounds> = null;
   protected nesting = 0;
 
   constructor(private parent: SimpleElement) {
@@ -431,8 +430,8 @@ export class AppendingBlockImpl implements AppendingBlock {
 
     if (LOCAL_DEBUG) {
       this.debug = {
-        first: () => debugEdge(this.first, 'first'),
-        last: () => debugEdge(this.last, 'last'),
+        first: () => debugEdge(this.first, this.firstBlock, 'first'),
+        last: () => debugEdge(this.last, this.lastBlock, 'last'),
       };
     }
   }
@@ -442,21 +441,25 @@ export class AppendingBlockImpl implements AppendingBlock {
   }
 
   firstNode(): SimpleNode {
-    let first = expect(
-      this.first,
-      'cannot call `firstNode()` while `AppendingBlock` is still initializing'
-    );
+    let first = this.first;
 
-    return isBounds(first) ? first.firstNode() : first;
+    if (first !== null) return first;
+
+    return expect(
+      this.firstBlock,
+      'cannot call `firstNode()` while `AppendingBlock` is still initializing'
+    ).firstNode();
   }
 
   lastNode(): SimpleNode {
-    let last = expect(
-      this.last,
-      'cannot call `lastNode()` while `AppendingBlock` is still initializing'
-    );
+    let last = this.last;
 
-    return isBounds(last) ? last.lastNode() : last;
+    if (last !== null) return last;
+
+    return expect(
+      this.lastBlock,
+      'cannot call `lastNode()` while `AppendingBlock` is still initializing'
+    ).lastNode();
   }
 
   openElement(element: SimpleElement) {
@@ -469,21 +472,29 @@ export class AppendingBlockImpl implements AppendingBlock {
   }
 
   didAppendNode(node: SimpleNode) {
-    this.didAppendBounds(node);
-  }
-
-  didAppendBounds(bounds: Edge) {
     if (this.nesting !== 0) return;
 
-    if (this.first === null) {
-      this.first = bounds;
+    if (this.first === null && this.firstBlock === null) {
+      this.first = node;
     }
 
-    this.last = bounds;
+    this.last = node;
+    this.lastBlock = null;
+  }
+
+  didAppendBounds(bounds: Bounds) {
+    if (this.nesting !== 0) return;
+
+    if (this.first === null && this.firstBlock === null) {
+      this.firstBlock = bounds;
+    }
+
+    this.lastBlock = bounds;
+    this.last = null;
   }
 
   finalize(stack: TreeBuilder) {
-    if (this.first === null) {
+    if (this.first === null && this.firstBlock === null) {
       stack.appendComment('');
     }
   }
@@ -538,7 +549,9 @@ export class ResettableBlockImpl extends AppendingBlockImpl implements Resettabl
     let nextSibling = clear(this);
 
     this.first = null;
+    this.firstBlock = null;
     this.last = null;
+    this.lastBlock = null;
     this.nesting = 0;
 
     return nextSibling;

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -41,20 +41,24 @@ export interface LastNode {
   lastNode(): SimpleNode;
 }
 
-class First {
-  constructor(private node: SimpleNode) {}
+/**
+ * A block's edge is either a node it appended directly, or a nested block whose
+ * own edges aren't known until it finishes building.
+ */
+type Edge = SimpleNode | Bounds;
 
-  firstNode(): SimpleNode {
-    return this.node;
-  }
+function isBounds(edge: Edge): edge is Bounds {
+  return 'firstNode' in edge;
 }
 
-class Last {
-  constructor(private node: SimpleNode) {}
-
-  lastNode(): SimpleNode {
-    return this.node;
-  }
+/**
+ * Resolve an edge for debug output without throwing while a nested block is
+ * still being built.
+ */
+function debugEdge(edge: Nullable<Edge>, which: 'first' | 'last'): Nullable<SimpleNode> {
+  if (edge === null) return null;
+  if (!isBounds(edge)) return edge;
+  return (edge as FirstNode & LastNode).debug?.[which]() ?? null;
 }
 
 export class Fragment implements Bounds {
@@ -91,8 +95,8 @@ export class NewTreeBuilder implements TreeBuilder {
   private env: Environment;
 
   readonly cursors = new Stack<Cursor>();
-  private modifierStack = new Stack<Nullable<ModifierInstance[]>>();
-  private blockStack = new Stack<AppendingBlock>();
+  private modifierStack: Nullable<ModifierInstance[]>[] = [];
+  private blockStack: AppendingBlock[] = [];
 
   static forInitialRender(env: Environment, cursor: CursorImpl) {
     return new this(env, cursor.element, cursor.nextSibling).initialize();
@@ -116,7 +120,7 @@ export class NewTreeBuilder implements TreeBuilder {
 
     if (LOCAL_DEBUG) {
       this.debug = () => ({
-        blocks: this.blockStack.snapshot(),
+        blocks: [...this.blockStack],
         constructing: this.constructing,
         cursors: this.cursors.snapshot(),
       });
@@ -129,7 +133,7 @@ export class NewTreeBuilder implements TreeBuilder {
   }
 
   debugBlocks(): AppendingBlock[] {
-    return this.blockStack.toArray();
+    return this.blockStack;
   }
 
   get element(): SimpleElement {
@@ -143,11 +147,11 @@ export class NewTreeBuilder implements TreeBuilder {
   }
 
   get hasBlocks() {
-    return this.blockStack.size > 0;
+    return this.blockStack.length > 0;
   }
 
   protected block(): AppendingBlock {
-    return expect(this.blockStack.current, 'Expected a current live block');
+    return expect(this.blockStack.at(-1), 'Expected a current live block');
   }
 
   popElement() {
@@ -168,9 +172,9 @@ export class NewTreeBuilder implements TreeBuilder {
   }
 
   protected pushBlock<T extends AppendingBlock>(block: T, isRemote = false): T {
-    let current = this.blockStack.current;
+    let current = this.blockStack.at(-1);
 
-    if (current !== null) {
+    if (current !== undefined) {
       if (!isRemote) {
         current.didAppendBounds(block);
       }
@@ -271,7 +275,7 @@ export class NewTreeBuilder implements TreeBuilder {
   }
 
   private popModifiers(): Nullable<ModifierInstance[]> {
-    return this.modifierStack.pop();
+    return this.modifierStack.pop() ?? null;
   }
 
   didAppendBounds(bounds: Bounds): Bounds {
@@ -401,8 +405,8 @@ export class AppendingBlockImpl implements AppendingBlock {
 
   [DESTROYABLE_META_KEY]: object | undefined;
 
-  protected first: Nullable<FirstNode> = null;
-  protected last: Nullable<LastNode> = null;
+  protected first: Nullable<Edge> = null;
+  protected last: Nullable<Edge> = null;
   protected nesting = 0;
 
   constructor(private parent: SimpleElement) {
@@ -410,8 +414,8 @@ export class AppendingBlockImpl implements AppendingBlock {
 
     if (LOCAL_DEBUG) {
       this.debug = {
-        first: () => this.first?.debug?.first() ?? null,
-        last: () => this.last?.debug?.last() ?? null,
+        first: () => debugEdge(this.first, 'first'),
+        last: () => debugEdge(this.last, 'last'),
       };
     }
   }
@@ -426,7 +430,7 @@ export class AppendingBlockImpl implements AppendingBlock {
       'cannot call `firstNode()` while `AppendingBlock` is still initializing'
     );
 
-    return first.firstNode();
+    return isBounds(first) ? first.firstNode() : first;
   }
 
   lastNode(): SimpleNode {
@@ -435,7 +439,7 @@ export class AppendingBlockImpl implements AppendingBlock {
       'cannot call `lastNode()` while `AppendingBlock` is still initializing'
     );
 
-    return last.lastNode();
+    return isBounds(last) ? last.lastNode() : last;
   }
 
   openElement(element: SimpleElement) {
@@ -448,19 +452,13 @@ export class AppendingBlockImpl implements AppendingBlock {
   }
 
   didAppendNode(node: SimpleNode) {
-    if (this.nesting !== 0) return;
-
-    if (!this.first) {
-      this.first = new First(node);
-    }
-
-    this.last = new Last(node);
+    this.didAppendBounds(node);
   }
 
-  didAppendBounds(bounds: Bounds) {
+  didAppendBounds(bounds: Edge) {
     if (this.nesting !== 0) return;
 
-    if (!this.first) {
+    if (this.first === null) {
       this.first = bounds;
     }
 

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -24,7 +24,6 @@ import { setLocalDebugType } from '@glimmer/debug-util/lib/debug-brand';
 import { destroy, registerDestructor } from '@glimmer/destroyable';
 import { DESTROYABLE_META_KEY } from '@glimmer/util/lib/destroyable-key';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
-import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 
 import type { DynamicAttribute } from './attributes/dynamic';
 
@@ -94,7 +93,13 @@ export class NewTreeBuilder implements TreeBuilder {
   public operations: Nullable<ElementOperations> = null;
   private env: Environment;
 
-  readonly cursors = new Stack<Cursor>();
+  // Slots above `cursorDepth` are retained and reused. Opening an element is
+  // one of the most frequent operations the VM performs, and a builder is
+  // created per re-rendered block, so this is a lot of short-lived garbage
+  // otherwise. Subclasses that need a richer cursor push their own via
+  // `pushCursor`.
+  readonly cursors: CursorImpl[] = [];
+  protected cursorDepth = -1;
   private modifierStack: Nullable<ModifierInstance[]>[] = [];
   private blockStack: AppendingBlock[] = [];
 
@@ -122,7 +127,7 @@ export class NewTreeBuilder implements TreeBuilder {
       this.debug = () => ({
         blocks: [...this.blockStack],
         constructing: this.constructing,
-        cursors: this.cursors.snapshot(),
+        cursors: this.cursors.slice(0, this.cursorDepth + 1),
       });
     }
   }
@@ -138,12 +143,16 @@ export class NewTreeBuilder implements TreeBuilder {
 
   get element(): SimpleElement {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-    return this.cursors.current!.element;
+    return this.cursors[this.cursorDepth]!.element;
   }
 
   get nextSibling(): Nullable<SimpleNode> {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-    return this.cursors.current!.nextSibling;
+    return this.cursors[this.cursorDepth]!.nextSibling;
+  }
+
+  protected get currentCursor(): Nullable<CursorImpl> {
+    return this.cursors[this.cursorDepth] ?? null;
   }
 
   get hasBlocks() {
@@ -155,8 +164,8 @@ export class NewTreeBuilder implements TreeBuilder {
   }
 
   popElement() {
-    this.cursors.pop();
-    expect(this.cursors.current, "can't pop past the last element");
+    this.cursorDepth--;
+    assert(this.cursorDepth >= 0, "can't pop past the last element");
   }
 
   pushAppendingBlock(): AppendingBlock {
@@ -267,7 +276,23 @@ export class NewTreeBuilder implements TreeBuilder {
   }
 
   protected pushElement(element: SimpleElement, nextSibling: Maybe<SimpleNode> = null): void {
-    this.cursors.push(new CursorImpl(element, nextSibling));
+    let depth = ++this.cursorDepth;
+    let existing = this.cursors[depth];
+
+    if (existing === undefined) {
+      this.cursors[depth] = new CursorImpl(element, nextSibling);
+    } else {
+      existing.element = element;
+      existing.nextSibling = nextSibling ?? null;
+    }
+  }
+
+  /**
+   * Push a cursor a subclass built itself. Unlike `pushElement` this cannot
+   * reuse the slot, so it always stores the object it was given.
+   */
+  pushCursor(cursor: CursorImpl): void {
+    this.cursors[++this.cursorDepth] = cursor;
   }
 
   private pushModifiers(modifiers: Nullable<ModifierInstance[]>): void {

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -17,29 +17,14 @@ import type { DebugState } from '../opcodes';
 import type { VM } from './append';
 
 // Loading the VM is what creates the demand for opcode handlers — its
-// `evaluateSyscall` calls `APPEND_OPCODES.evaluate(...)`. Pull bootstrap in
+// `evaluate` calls `APPEND_OPCODES.evaluate(...)`. Pull bootstrap in
 // here (rather than at the package barrel) so consumers using deep imports
 // still get every opcode handler registered before the VM runs.
 import '../bootstrap';
 import { APPEND_OPCODES } from '../opcodes';
 
-export type LowLevelRegisters = [$pc: number, $ra: number, $sp: number, $fp: number];
-
-export function initializeRegisters(): LowLevelRegisters {
-  return [0, -1, 0, 0];
-}
-
-export function restoreRegisters(pc: number, sp: number): LowLevelRegisters {
-  return [pc, -1, sp, 0];
-}
-
-export function initializeRegistersWithSP(sp: number): LowLevelRegisters {
-  return [0, -1, sp, 0];
-}
-
-export function initializeRegistersWithPC(pc: number): LowLevelRegisters {
-  return [pc, -1, 0, 0];
-}
+// Positional order matches the register constants: $pc=0, $ra=1, $fp=2, $sp=3.
+export type LowLevelRegisters = [$pc: number, $ra: number, $fp: number, $sp: number];
 
 export interface VmStack {
   readonly registers: LowLevelRegisters;
@@ -162,41 +147,37 @@ export class LowLevelVM {
         externs: { debugBefore, debugAfter },
       } = this;
       let state = debugBefore(opcode);
-      this.evaluateInner(opcode, vm);
+      this.evaluate(opcode, vm);
       debugAfter(state);
     } else {
-      this.evaluateInner(opcode, vm);
+      this.evaluate(opcode, vm);
     }
   }
 
-  evaluateInner(opcode: RuntimeOp, vm: VM) {
-    if (opcode.isMachine) {
-      this.evaluateMachine(opcode, vm);
-    } else {
-      this.evaluateSyscall(opcode, vm);
-    }
-  }
+  /**
+   * Machine opcodes manipulate the low-level registers directly and are handled
+   * inline; everything else is a syscall dispatched through `APPEND_OPCODES`.
+   */
+  evaluate(opcode: RuntimeOp, vm: VM) {
+    let type = opcode.type;
 
-  evaluateMachine(opcode: RuntimeOp, vm: VM) {
-    switch (opcode.type) {
+    if (!opcode.isMachine) return APPEND_OPCODES.evaluate(vm, opcode, type);
+
+    switch (type) {
       case VM_PUSH_FRAME_OP:
-        return void this.pushFrame();
+        return this.pushFrame();
       case VM_POP_FRAME_OP:
-        return void this.popFrame();
+        return this.popFrame();
       case VM_INVOKE_STATIC_OP:
-        return void this.call(opcode.op1);
+        return this.call(opcode.op1);
       case VM_INVOKE_VIRTUAL_OP:
-        return void vm.call(this.stack.pop());
+        return vm.call(this.stack.pop());
       case VM_JUMP_OP:
-        return void this.goto(opcode.op1);
+        return this.goto(opcode.op1);
       case VM_RETURN_OP:
-        return void vm.return();
+        return vm.return();
       case VM_RETURN_TO_OP:
-        return void this.returnTo(opcode.op1);
+        return this.returnTo(opcode.op1);
     }
-  }
-
-  evaluateSyscall(opcode: RuntimeOp, vm: VM) {
-    APPEND_OPCODES.evaluate(vm, opcode, opcode.type);
   }
 }

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -16,7 +16,7 @@ import { $fp, $pc, $ra, $sp } from '@glimmer/vm/lib/registers';
 import type { DebugState } from '../opcodes';
 import type { VM } from './append';
 
-// Loading the VM is what creates the demand for opcode handlers — its
+// Loading the VM is what creates the demand for opcode handlers. Its
 // `evaluate` calls `APPEND_OPCODES.evaluate(...)`. Pull bootstrap in
 // here (rather than at the package barrel) so consumers using deep imports
 // still get every opcode handler registered before the VM runs.

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -11,7 +11,6 @@ import type {
   SimpleText,
   TreeBuilder,
 } from '@glimmer/interfaces';
-import type { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { COMMENT_NODE, ELEMENT_NODE, NS_SVG, TEXT_NODE } from '@glimmer/constants/lib/dom';
 import { castToBrowser, castToSimple } from '@glimmer/debug-util/lib/simple-cast';
 import { expect } from '@glimmer/debug-util/lib/platform-utils';
@@ -42,7 +41,7 @@ export class RehydratingCursor extends CursorImpl {
 
 export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
   private unmatchedAttributes: Nullable<SimpleAttr[]> = null;
-  declare cursors: Stack<RehydratingCursor>; // Hides property on base class
+  declare cursors: RehydratingCursor[]; // Narrows property on base class
   blockDepth = 0;
   startingBlockOffset: number;
 
@@ -91,8 +90,8 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
     }
   }
 
-  get currentCursor(): Nullable<RehydratingCursor> {
-    return this.cursors.current;
+  override get currentCursor(): Nullable<RehydratingCursor> {
+    return this.cursors[this.cursorDepth] ?? null;
   }
 
   get candidate(): Nullable<SimpleNode> {
@@ -156,7 +155,7 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
       this.candidate = element.nextSibling;
     }
 
-    this.cursors.push(cursor);
+    this.pushCursor(cursor);
   }
 
   // clears until the end of the current container
@@ -486,7 +485,7 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
     }
 
     const cursor = new RehydratingCursor(element, null, this.blockDepth);
-    this.cursors.push(cursor);
+    this.pushCursor(cursor);
 
     if (marker === null) {
       this.disableRehydration(insertBefore);

--- a/packages/@glimmer/runtime/lib/vm/stack.ts
+++ b/packages/@glimmer/runtime/lib/vm/stack.ts
@@ -1,10 +1,8 @@
 import assert from '@glimmer/debug-util/lib/assert';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
-import { $fp, $pc, $sp } from '@glimmer/vm/lib/registers';
+import { $fp, $sp } from '@glimmer/vm/lib/registers';
 
 import type { LowLevelRegisters } from './low-level';
-
-import { initializeRegistersWithSP } from './low-level';
 
 export interface EvaluationStack {
   readonly registers: LowLevelRegisters;
@@ -25,15 +23,10 @@ export interface EvaluationStack {
 
 export default class EvaluationStackImpl implements EvaluationStack {
   static restore(snapshot: unknown[], pc: number): EvaluationStackImpl {
-    const stack = new this(snapshot.slice(), initializeRegistersWithSP(snapshot.length - 1));
-
     assert(typeof pc === 'number', 'pc is a number');
 
-    stack.registers[$pc] = pc;
-    stack.registers[$sp] = snapshot.length - 1;
-    stack.registers[$fp] = -1;
-
-    return stack;
+    // [$pc, $ra, $fp, $sp]
+    return new this(snapshot.slice(), [pc, -1, -1, snapshot.length - 1]);
   }
 
   readonly registers: LowLevelRegisters;
@@ -100,12 +93,4 @@ export default class EvaluationStackImpl implements EvaluationStack {
   }
 
   declare snapshot?: (this: EvaluationStackImpl) => unknown[];
-
-  static {
-    if (LOCAL_DEBUG) {
-      EvaluationStackImpl.prototype.snapshot = function () {
-        return this.stack.slice(this.registers[$fp], this.registers[$sp] + 1);
-      };
-    }
-  }
 }

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -36,9 +36,8 @@ export class UpdatingVM implements IUpdatingVM {
   public dom: GlimmerTreeChanges;
   public alwaysRevalidate: boolean;
 
-  // Frames are held as three parallel stacks. Revalidation pushes a frame for
-  // every block in the tree — one per `{{#each}}` item — so the frames
-  // themselves are the allocation worth avoiding.
+  // Revalidation pushes a frame for every block in the tree, one per
+  // `{{#each}}` item, so the frame objects are the allocation worth avoiding.
   readonly #ops: UpdatingOpcode[][] = [];
   readonly #handlers: Nullable<ExceptionHandler>[] = [];
   readonly #pcs: number[] = [];
@@ -266,10 +265,8 @@ export class ListBlockOpcode extends BlockOpcode {
   private sync(iterator: OpaqueIterator) {
     let { opcodeMap: itemMap, children } = this;
 
-    // Both loops below walk off the end of `children` in the normal case (a
-    // list that grew). Reading past the end turns these into generic element
-    // loads for the rest of the process, and they run once per item, so the
-    // bounds are checked explicitly instead.
+    // Both loops below walk off the end of `children` when a list grows.
+    // Reading past the end leaves the load generic for the rest of the process.
     let childCount = children.length;
 
     let currentOpcodeIndex = 0;

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -266,6 +266,12 @@ export class ListBlockOpcode extends BlockOpcode {
   private sync(iterator: OpaqueIterator) {
     let { opcodeMap: itemMap, children } = this;
 
+    // Both loops below walk off the end of `children` in the normal case (a
+    // list that grew). Reading past the end turns these into generic element
+    // loads for the rest of the process, and they run once per item, so the
+    // bounds are checked explicitly instead.
+    let childCount = children.length;
+
     let currentOpcodeIndex = 0;
     let seenIndex = 0;
 
@@ -276,13 +282,13 @@ export class ListBlockOpcode extends BlockOpcode {
 
       if (item === null) break;
 
-      let opcode = children[currentOpcodeIndex];
+      let opcode = currentOpcodeIndex < childCount ? children[currentOpcodeIndex] : undefined;
       let { key } = item;
 
       // Items that have already been found and moved will already be retained,
       // we can continue until we find the next unretained item
       while (opcode !== undefined && opcode.retained) {
-        opcode = children[++currentOpcodeIndex];
+        opcode = ++currentOpcodeIndex < childCount ? children[currentOpcodeIndex] : undefined;
       }
 
       if (opcode !== undefined && opcode.key === key) {

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -22,7 +22,6 @@ import { DESTROYABLE_META_KEY } from '@glimmer/util/lib/destroyable-key';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
-import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
 import { resetTracking } from '@glimmer/validator/lib/tracking';
 
@@ -37,7 +36,12 @@ export class UpdatingVM implements IUpdatingVM {
   public dom: GlimmerTreeChanges;
   public alwaysRevalidate: boolean;
 
-  private frameStack: Stack<UpdatingVMFrame> = new Stack<UpdatingVMFrame>();
+  // Frames are held as three parallel stacks. Revalidation pushes a frame for
+  // every block in the tree — one per `{{#each}}` item — so the frames
+  // themselves are the allocation worth avoiding.
+  readonly #ops: UpdatingOpcode[][] = [];
+  readonly #handlers: Nullable<ExceptionHandler>[] = [];
+  readonly #pcs: number[] = [];
 
   constructor(env: Environment, { alwaysRevalidate = false }) {
     this.env = env;
@@ -70,15 +74,18 @@ export class UpdatingVM implements IUpdatingVM {
   }
 
   private _execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler) {
-    let { frameStack } = this;
+    let ops = this.#ops;
+    let pcs = this.#pcs;
 
     this.try(opcodes, handler);
 
-    while (!frameStack.isEmpty()) {
-      let opcode = this.frame.nextStatement();
+    while (ops.length > 0) {
+      let frame = ops.length - 1;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds-checked above
+      let opcode = ops[frame]![pcs[frame]!++];
 
       if (opcode === undefined) {
-        frameStack.pop();
+        this.#pop();
         continue;
       }
 
@@ -86,21 +93,25 @@ export class UpdatingVM implements IUpdatingVM {
     }
   }
 
-  private get frame() {
-    return expect(this.frameStack.current, 'bug: expected a frame');
+  #pop() {
+    this.#ops.pop();
+    this.#handlers.pop();
+    this.#pcs.pop();
   }
 
   goto(index: number) {
-    this.frame.goto(index);
+    this.#pcs[this.#pcs.length - 1] = index;
   }
 
   try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler));
+    this.#ops.push(ops);
+    this.#handlers.push(handler);
+    this.#pcs.push(0);
   }
 
   throw() {
-    this.frame.handleException();
-    this.frameStack.pop();
+    this.#handlers[this.#handlers.length - 1]?.handleException();
+    this.#pop();
   }
 }
 
@@ -423,28 +434,5 @@ export class ListBlockOpcode extends BlockOpcode {
     destroy(opcode);
     clear(opcode);
     this.opcodeMap.delete(opcode.key);
-  }
-}
-
-class UpdatingVMFrame {
-  private current = 0;
-
-  constructor(
-    private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>
-  ) {}
-
-  goto(index: number) {
-    this.current = index;
-  }
-
-  nextStatement(): UpdatingOpcode | undefined {
-    return this.ops[this.current++];
-  }
-
-  handleException() {
-    if (this.exceptionHandler) {
-      this.exceptionHandler.handleException();
-    }
   }
 }

--- a/packages/@glimmer/validator/lib/tracking.ts
+++ b/packages/@glimmer/validator/lib/tracking.ts
@@ -11,31 +11,31 @@ import { combine, CONSTANT_TAG, isConstTag, validateTag, valueForTag } from './v
  * An object that that tracks @tracked properties that were consumed.
  */
 class Tracker {
-  private tags = new Set<Tag>();
-  private last: Tag | null = null;
+  // The overwhelming majority of frames consume zero or one distinct tag, so
+  // the Set is only allocated once a *second* tag shows up.
+  private first: Tag | null = null;
+  private rest: Set<Tag> | null = null;
 
   add(tag: Tag) {
     if (tag === CONSTANT_TAG) return;
-
-    this.tags.add(tag);
 
     if (DEBUG) {
       unwrap(debug.markTagAsConsumed)(tag);
     }
 
-    this.last = tag;
+    if (this.rest !== null) {
+      this.rest.add(tag);
+    } else if (this.first === null) {
+      this.first = tag;
+    } else if (this.first !== tag) {
+      this.rest = new Set([this.first, tag]);
+    }
   }
 
   combine(): Tag {
-    let { tags } = this;
+    if (this.rest !== null) return combine(Array.from(this.rest));
 
-    if (tags.size === 0) {
-      return CONSTANT_TAG;
-    } else if (tags.size === 1) {
-      return this.last as Tag;
-    } else {
-      return combine(Array.from(this.tags));
-    }
+    return this.first ?? CONSTANT_TAG;
   }
 }
 
@@ -67,7 +67,7 @@ export function beginTrackFrame(debuggingContext?: string | false): void {
 }
 
 export function endTrackFrame(): Tag {
-  let current = CURRENT_TRACKER;
+  let current = CURRENT_TRACKER as Tracker;
 
   if (DEBUG) {
     if (OPEN_TRACK_FRAMES.length === 0) {
@@ -79,7 +79,7 @@ export function endTrackFrame(): Tag {
 
   CURRENT_TRACKER = OPEN_TRACK_FRAMES.pop() || null;
 
-  return unwrap(current).combine();
+  return current.combine();
 }
 
 export function beginUntrackFrame(): void {


### PR DESCRIPTION
Removes indirection and per-item allocation from the VM's hot paths, and fixes two bugs found along the way. Net **-120 lines**. No behaviour change.

Three benchmarks, three different answers. The short version: partial updates over a list get 9 to 22% faster, one bench is consistently 4% slower, and most of the rest sits under the noise floor.

## Numbers

### rere-benchmark

The closest benchmark to what this PR touches, since it measures rendering after boot rather than boot itself. Three independent pairs, `--count=10`, 8x CPU throttle. A bench only counts as moved when all three pairs agree. Positive means this branch is better.

| bench | pair 1 | pair 2 | pair 3 | |
| --- | ---: | ---: | ---: | --- |
| 1k items, 1 update on 5% (random, async) | +21.9% | +14.5% | +9.4% | faster |
| 1k items, 1 update on 5% (random) | +2.1% | +3.6% | +7.5% | faster |
| Incrementing Render Effect | +1.8% | +1.5% | +2.4% | faster |
| 1k items, 1 update each (sequentially, async) | -3.6% | -4.1% | -3.8% | **slower** |
| DB Monitor w/ chat simulation | +0.3% | +0.2% | -0.1% | flat |
| 1 value, 1k consumers (single burst) | +1.6% | -1.8% | -0.6% | flat |
| the other 9 benches | | | | unstable |

Nine of fifteen benches flip sign between pairs, so I am not reporting numbers for them. The widest was `1 item, 1k updates`: +22.1%, then +9.8%, then -12.6%. At `--count=10` most of these benches move more between identical runs than this PR moves them.

The `1k items, 1 update each (sequentially, async)` regression is the only consistent negative anywhere in this PR, and it is tight enough across pairs to be worth chasing.

### VM work in isolation

Measured in Node against SimpleDOM so DOM cost does not mask it. Interleaved pairs, medians in ms:

| phase | main | branch | delta |
| --- | ---: | ---: | ---: |
| create | 30.25 | 19.00 | -34.6% |
| update every 10th | 16.91 | 8.81 | -46.1% |
| select row | 5.37 | 4.69 | -8.8% |
| swap rows | 5.24 | 4.81 | -6.1% |
| remove row | 4.80 | 4.23 | -2.0% |
| append 1000 | 50.03 | 48.12 | -5.1% |
| clear | 13.68 | 13.12 | -5.5% |
| **total** | **128.40** | **107.80** | **-15.8%** |

### pnpm bench

Fidelity 20, 8x CPU throttle. This one renders and clears large lists, where DOM cost dominates and VM cost is a minority of the run:

| phase | branch vs main |
| --- | --- |
| **duration (total)** | **no difference** [-862ms to +763ms] |
| render1000Items1 | -5.44% |
| append1000Items1 | -7.63% |
| selectFirstRow1 | -13.37% |
| clearItems2 | +6.16% |
| clearManyItems2 | +7.56% |
| the other 16 phases | no difference |

Two clear phases regress, and they regressed in an earlier run of this branch too, on the same two phases. That is reproducible rather than harness noise, and I have not found the cause. The other three clear phases show no difference, and the total is not significant either way.

## What changed

Five groups. The diff is small enough to read.

1. Opcode dispatch. `AppendOpcodes` wrapped every handler in an object so it could dispatch machine opcodes, which nothing ever registered. `RuntimeOpImpl` decoded the same instruction header once per getter, so the VM read one heap word three or four times per instruction. `LowLevelVM` had four methods where two do.
2. Per-VM allocation. A VM is built for every block that re-renders on its own, one per `{{#each}}` item. Its six bookkeeping stacks, the tree builder's two stacks, and the updating VM's frames were wrapper objects over arrays. They are arrays now.
3. Per-item allocation. `AppendingBlockImpl` wrapped every appended node in two objects, and now keeps node edges and nested block edges in separate monomorphic fields. `Tracker` allocated a `Set` per tracking frame, and almost every frame holds zero or one tag. `ArrayIterator` carried a state object to remember whether it had yielded its first item. `pushElement` allocated a cursor per opened element, roughly eight per row.
4. Per-call allocation. `VM._execute` allocated an iterator result per instruction. `destroy` allocated two closures per call. `uniqueKeyFor` went through a wrapper with lazy accessors for every item on every pass over a list. `FunctionHelperManager.getValue` allocated a key array to test whether named args exist.
5. Dead code. `ProgramHeapImpl.compact()` and `free()` were unreachable, and `compact()` looped over the global `length` rather than the handle table. Three unused register tuple factories. A duplicate `snapshot` definition assigned in two places with different behaviour.

## Two bugs found on the way

`ListBlockOpcode.sync` read `children[i]` past the end for every list that grew. That deoptimizes the load and leaves it generic for the rest of the process, and it runs once per item. Present on `main` today.

`LowLevelRegisters` was typed `[$pc, $ra, $sp, $fp]`, but the constants are `$fp = 2` and `$sp = 3`. Anyone who writes a register tuple positionally gets the last two backwards. That happened to me and cost about 700 test failures.

## Needs a reviewer's eye

Three type-level changes. None alters runtime behaviour, but all three touch published surface:

1. `RuntimeOp` gains `seek(offset)`, and its fields become readonly.
2. `TreeBuilder.cursors` goes from `Stack<Cursor>` to `readonly Cursor[]`.
3. `ProgramHeapImpl` loses two public methods that could not work.

## Split out of this PR

Two earlier commits changed behaviour and are reverted here. Each became its own PR with its own measurement:

- #21565 stored destroyable meta on the object under a symbol. Worth 23% of VM time on its own, but it threw on frozen and sealed destroyables. Closed in favour of #21571, which makes the slot opt-in: only the VM's own classes declare it, so foreign objects keep the `WeakMap` path. #21571 is merged.
- #21566 batched destroy finalizers. Worth nothing once written correctly. Closed as a negative result.

Measuring them separately is what showed that the first was the entire destroyable win and the second was noise. Together they looked like one result.

This branch is now rebased onto `main` with #21571 in it. The conflicts were where this PR's array-stack and block-edge changes touch the same lines as #21571's slot declarations, and the resolution keeps both.

## Testing

After the rebase onto #21571: 9456 tests, 9439 pass, 17 skip, 0 fail. `tsc`, `eslint` and `prettier` are clean.

## On the benchmark harness

Worth knowing separately from this PR. I ran `pnpm bench` from a `main` worktree, comparing `main` against itself. It reported two significant phase improvements of about 7%, on `render1000Items2` and `updateEvery10thItem2`. At fidelity 20 the harness has a real false positive rate on individual phases. The `duration` total behaved correctly.

That is also why an earlier `render1000Items3` regression here was not real. A paired re-measurement over 26 runs put it at -8.6% [-17.3% to +3.2%], and the interval excludes the reported +11%.

## Not done

- The `1k items, 1 update each (sequentially, async)` regression in rere-benchmark, consistent at about -4%.
- The two `pnpm bench` clear phase regressions above.
- `UpdatingVM._execute` has a megamorphic call site at `opcode.evaluate(this)`, which is inherent to an opcode interpreter.
- `ArrayIterator.next` calls `this.keyFor` polymorphically, because each key strategy is a different closure.

