### PR TITLE
[PERF] Store destroyable meta on the destroyable

### DIFF
--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -11,7 +11,6 @@ type DestroyableState = 0 | 1 | 2;
 type OneOrMany<T> = null | T | BrandedArray<T>;
 
 interface DestroyableMeta<T extends Destroyable> {
-  source?: T;
   parents: OneOrMany<Destroyable>;
   children: OneOrMany<Destroyable>;
   eagerDestructors: OneOrMany<Destructor<T>>;
@@ -23,9 +22,11 @@ interface UndestroyedDestroyablesError extends Error {
   destroyables: object[];
 }
 
-let DESTROYABLE_META:
-  | Map<Destroyable, DestroyableMeta<Destroyable>>
-  | WeakMap<Destroyable, DestroyableMeta<Destroyable>> = new WeakMap();
+// A `WeakMap.get` forces an identity hash onto the key the first time it is
+// used as one, and every rendered list item pays for one.
+const META = Symbol('DESTROYABLE_META');
+
+type WithMeta = { [META]?: DestroyableMeta<Destroyable> };
 
 const branded = Symbol('BrandedArray');
 type BrandedArray<T> = T[] & { [branded]: true };
@@ -79,7 +80,7 @@ function remove<T extends object>(collection: OneOrMany<T>, item: T, message: st
 }
 
 function getDestroyableMeta<T extends Destroyable>(destroyable: T): DestroyableMeta<T> {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = (destroyable as WithMeta)[META];
 
   if (meta === undefined) {
     meta = {
@@ -91,13 +92,13 @@ function getDestroyableMeta<T extends Destroyable>(destroyable: T): DestroyableM
     };
 
     if (DEBUG) {
-      meta.source = destroyable;
+      TRACKED_DESTROYABLES?.add(destroyable);
     }
 
-    DESTROYABLE_META.set(destroyable, meta);
+    (destroyable as WithMeta)[META] = meta;
   }
 
-  return meta as unknown as DestroyableMeta<T>;
+  return meta;
 }
 
 export function associateDestroyableChild<T extends Destroyable>(parent: Destroyable, child: T): T {
@@ -210,19 +211,19 @@ export function destroyChildren(destroyable: Destroyable) {
 }
 
 export function _hasDestroyableChildren(destroyable: Destroyable) {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = (destroyable as WithMeta)[META];
 
   return meta === undefined ? false : meta.children !== null;
 }
 
 export function isDestroying(destroyable: Destroyable) {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = (destroyable as WithMeta)[META];
 
   return meta === undefined ? false : meta.state >= DESTROYING_STATE;
 }
 
 export function isDestroyed(destroyable: Destroyable) {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = (destroyable as WithMeta)[META];
 
   return meta === undefined ? false : meta.state >= DESTROYED_STATE;
 }
@@ -232,40 +233,36 @@ export function isDestroyed(destroyable: Destroyable) {
 export let enableDestroyableTracking: undefined | (() => void);
 export let assertDestroyablesDestroyed: undefined | (() => void);
 
-if (DEBUG) {
-  let isTesting = false;
+// Meta is not enumerable, so tracking needs its own registry.
+let TRACKED_DESTROYABLES: Set<Destroyable> | null = null;
 
+if (DEBUG) {
   enableDestroyableTracking = () => {
-    if (isTesting) {
-      // Reset destroyable meta just in case, before throwing the error
-      DESTROYABLE_META = new WeakMap();
+    if (TRACKED_DESTROYABLES !== null) {
+      TRACKED_DESTROYABLES = null;
       throw new Error(
         'Attempted to start destroyable testing, but you did not end the previous destroyable test. Did you forget to call `assertDestroyablesDestroyed()`'
       );
     }
 
-    isTesting = true;
-    DESTROYABLE_META = new Map();
+    TRACKED_DESTROYABLES = new Set();
   };
 
   assertDestroyablesDestroyed = () => {
-    if (!isTesting) {
+    if (TRACKED_DESTROYABLES === null) {
       throw new Error(
         'Attempted to assert destroyables destroyed, but you did not start a destroyable test. Did you forget to call `enableDestroyableTracking()`'
       );
     }
 
-    isTesting = false;
-
-    let map = DESTROYABLE_META as Map<Destroyable, DestroyableMeta<Destroyable>>;
-    DESTROYABLE_META = new WeakMap();
+    let tracked = TRACKED_DESTROYABLES;
+    TRACKED_DESTROYABLES = null;
 
     let undestroyed: object[] = [];
 
-    map.forEach((meta) => {
-      if (meta.state !== DESTROYED_STATE) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-        undestroyed.push(meta.source!);
+    tracked.forEach((destroyable) => {
+      if (getDestroyableMeta(destroyable).state !== DESTROYED_STATE) {
+        undestroyed.push(destroyable);
       }
     });
 


### PR DESCRIPTION
Breaking. Filed for the numbers and the discussion, not to merge as is. Split out of #21564 at @NullVoxPopuli's request.

`getDestroyableMeta` is the hottest Glimmer function in a CPU profile of `smoke-tests/benchmark-app`, at 1.7% self time. Every associated destroyable costs a `WeakMap.get`, and the first use of an object as a `WeakMap` key forces an identity hash onto it. Rendering a list associates one per item.

Storing meta on the destroyable under a symbol instead is worth **23% of VM time**.

## Numbers

Measured in Node against SimpleDOM, so DOM cost does not mask the VM. 15 interleaved pairs, medians in ms:

| phase | main | branch | delta |
| --- | ---: | ---: | ---: |
| create | 32.60 | 25.11 | -24.4% |
| update every 10th | 11.14 | 8.87 | -24.4% |
| select row | 5.90 | 4.73 | -17.7% |
| swap rows | 5.87 | 5.21 | -13.5% |
| remove row | 5.40 | 4.79 | -4.1% |
| append 1000 | 53.08 | 39.48 | -25.6% |
| clear | 13.93 | 10.16 | -26.1% |
| **total** | **132.73** | **103.40** | **-23.1%** |

I have not measured this one alone through `pnpm bench`. On that harness, browser DOM work dominates and an A/A run reports false positives of about 7% on individual phases, so a single phase number there would not mean much.

## Why it is breaking

```
main:   registerDestructor(Object.freeze({}), fn)  ->  OK
branch: registerDestructor(Object.freeze({}), fn)  ->  TypeError: Cannot add property
                                                       Symbol(DESTROYABLE_META),
                                                       object is not extensible
```

`registerDestructor`, `destroy` and `associateDestroyableChild` are public through `@ember/destroyable`, and they accept frozen and sealed objects today. A symbol property is also visible to `Reflect.ownKeys` and `Object.getOwnPropertySymbols`.

Nothing in the framework freezes a destroyable and no test covers it, so the suite passes either way. That is the decision this PR exists to raise.

If the answer is that Ember cannot break it, one option is a symbol with a `WeakMap` fallback for non-extensible objects. That keeps the fast path and never throws, at the cost of an `Object.isExtensible` check when meta is first created. I have not measured that variant.

## Also in here

Destroyable tracking needs its own registry, because meta is no longer enumerable. It is a `Set` populated only between `enableDestroyableTracking()` and `assertDestroyablesDestroyed()`.

## Testing

9449 tests, 9432 pass, 17 skip, 0 fail. Identical to `main` on the same machine. `tsc`, `eslint` and `prettier` are clean.

Conflicts textually with #21564, which also touches `destroy`.
