### PR TITLE
escape iframe srcdoc so bound values do not execute as html

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/attributes-test.ts
@@ -627,6 +627,38 @@ export class AttributesTests extends RenderTest {
   }
 
   @test
+  'iframe[srcdoc] escapes a bound string so it renders as text, not markup'() {
+    this.render('<iframe srcdoc={{this.foo}}></iframe>', {
+      foo: '<script>alert(1)</script>',
+    });
+    let iframe = this.element.firstChild as SimpleElement;
+    this.assert.strictEqual(
+      this.readDOMAttr('srcdoc', iframe),
+      '&lt;script&gt;alert(1)&lt;/script&gt;'
+    );
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'plain text' });
+    this.assert.strictEqual(this.readDOMAttr('srcdoc', iframe), 'plain text');
+
+    this.rerender({ foo: '<img src=x onerror=alert(1)>' });
+    this.assert.strictEqual(
+      this.readDOMAttr('srcdoc', iframe),
+      '&lt;img src=x onerror=alert(1)&gt;'
+    );
+  }
+
+  @test
+  'iframe[srcdoc] renders a SafeString as html'() {
+    let html = '<p>hello</p>';
+    this.render('<iframe srcdoc={{this.foo}}></iframe>', {
+      foo: { toHTML: () => html },
+    });
+    let iframe = this.element.firstChild as SimpleElement;
+    this.assert.strictEqual(this.readDOMAttr('srcdoc', iframe), html);
+  }
+
+  @test
   'marks javascript: protocol as unsafe on a camelCased url attribute'() {
     // `formAction` resolves to the DOM property, so the attribute name reaches
     // the sanitizer camelCased rather than as the lowercase `formaction`.

--- a/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
+++ b/packages/@glimmer/runtime/lib/dom/sanitized-values.ts
@@ -12,6 +12,25 @@ const badAttributes = ['href', 'src', 'background', 'action', 'formaction', 'xli
 const badAttributesForDataURI = ['src'];
 const badAttributesForDataProtocol = ['src', 'data'];
 
+// Unlike the attributes above, `srcdoc` does not hold a URL: the browser parses
+// its value as a full HTML document, so the protocol checks can never catch a
+// `<script>` in it. It is the one iframe content channel not already guarded.
+const badTagsForHTMLContent = ['IFRAME'];
+const badAttributesForHTMLContent = ['srcdoc'];
+
+function escapeHTMLContent(str: string): string {
+  return str.replace(/[&<>]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      default:
+        return '&gt;';
+    }
+  });
+}
+
 function has(array: Array<string>, item: string): boolean {
   return array.indexOf(item) !== -1;
 }
@@ -44,11 +63,20 @@ function checkDataProtocol(tagName: Nullable<string>, attribute: string): boolea
   );
 }
 
+function checkHTMLContent(tagName: Nullable<string>, attribute: string): boolean {
+  if (tagName === null) return false;
+  return (
+    has(badTagsForHTMLContent, tagName.toUpperCase()) &&
+    has(badAttributesForHTMLContent, attribute.toLowerCase())
+  );
+}
+
 export function requiresSanitization(tagName: Nullable<string>, attribute: string): boolean {
   return (
     checkURI(tagName, attribute) ||
     checkDataURI(tagName, attribute) ||
-    checkDataProtocol(tagName, attribute)
+    checkDataProtocol(tagName, attribute) ||
+    checkHTMLContent(tagName, attribute)
   );
 }
 
@@ -155,6 +183,10 @@ export function sanitizeAttributeValue(
 
   if (checkDataURI(tagName, attribute)) {
     return `unsafe:${str}`;
+  }
+
+  if (checkHTMLContent(tagName, attribute)) {
+    return escapeHTMLContent(str);
   }
 
   return str;


### PR DESCRIPTION
An `<iframe srcdoc={{value}}>` binding assigns the value straight onto the srcdoc property, and the browser parses that string as a full HTML document, so a plain (non-SafeString) value like `<script>...` runs even though a double-curly binding is meant to be safe. Every other iframe channel already passes through the sanitizer (`src` with `javascript:`/`data:`), so srcdoc was the one content channel that slipped by. This escapes a bound srcdoc string the way text content is escaped, so markup renders as text in the frame, and leaves `htmlSafe`/`trustHTML` as the opt-in for trusted HTML.