### PR TITLE
Give Glimmer's own destroyables a meta slot

### DIFF
--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -27,6 +27,18 @@ let DESTROYABLE_META:
   | Map<Destroyable, DestroyableMeta<Destroyable>>
   | WeakMap<Destroyable, DestroyableMeta<Destroyable>> = new WeakMap();
 
+/**
+ * Classes Glimmer constructs itself declare a slot for their meta, which skips
+ * the `WeakMap` and the identity hash it forces onto a key. Objects that arrive
+ * from anywhere else are never touched: they keep using the `WeakMap`, so a
+ * frozen instance still works and nothing new shows up in `Reflect.ownKeys`.
+ */
+export const DESTROYABLE_META_SLOT = Symbol('DESTROYABLE_META_SLOT');
+
+export interface HasDestroyableMetaSlot {
+  [DESTROYABLE_META_SLOT]?: object | undefined;
+}
+
 const branded = Symbol('BrandedArray');
 type BrandedArray<T> = T[] & { [branded]: true };
 
@@ -78,22 +90,45 @@ function remove<T extends object>(collection: OneOrMany<T>, item: T, message: st
   }
 }
 
+function createMeta<T extends Destroyable>(destroyable: T): DestroyableMeta<T> {
+  let meta: DestroyableMeta<Destroyable> = {
+    parents: null,
+    children: null,
+    eagerDestructors: null,
+    destructors: null,
+    state: LIVE_STATE,
+  };
+
+  if (DEBUG) {
+    meta.source = destroyable;
+  }
+
+  return meta as unknown as DestroyableMeta<T>;
+}
+
 function getDestroyableMeta<T extends Destroyable>(destroyable: T): DestroyableMeta<T> {
+  let slotted = destroyable as HasDestroyableMetaSlot;
+  let own = slotted[DESTROYABLE_META_SLOT];
+
+  if (own !== undefined) return own as DestroyableMeta<T>;
+
+  // `in` rather than a write, so this stays a read for everything else.
+  if (DESTROYABLE_META_SLOT in slotted) {
+    let meta = createMeta(destroyable);
+
+    slotted[DESTROYABLE_META_SLOT] = meta;
+
+    if (DEBUG && DESTROYABLE_META instanceof Map) {
+      DESTROYABLE_META.set(destroyable, meta as unknown as DestroyableMeta<Destroyable>);
+    }
+
+    return meta;
+  }
+
   let meta = DESTROYABLE_META.get(destroyable);
 
   if (meta === undefined) {
-    meta = {
-      parents: null,
-      children: null,
-      eagerDestructors: null,
-      destructors: null,
-      state: LIVE_STATE,
-    };
-
-    if (DEBUG) {
-      meta.source = destroyable;
-    }
-
+    meta = createMeta(destroyable) as unknown as DestroyableMeta<Destroyable>;
     DESTROYABLE_META.set(destroyable, meta);
   }
 

--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -246,9 +246,13 @@ export function destroyChildren(destroyable: Destroyable) {
 
 /** Meta if there is any, without creating it. Mirrors `getDestroyableMeta`. */
 function peekDestroyableMeta(destroyable: Destroyable): DestroyableMeta<Destroyable> | undefined {
-  let own = (destroyable as HasDestroyableMetaSlot)[DESTROYABLE_META_SLOT];
+  let slotted = destroyable as HasDestroyableMetaSlot;
+  let own = slotted[DESTROYABLE_META_SLOT];
 
   if (own !== undefined) return own as DestroyableMeta<Destroyable>;
+
+  // An empty slot is proof there is no meta, so the map can be skipped.
+  if (DESTROYABLE_META_SLOT in slotted) return undefined;
 
   return DESTROYABLE_META.get(destroyable);
 }

--- a/packages/@glimmer/destroyable/index.ts
+++ b/packages/@glimmer/destroyable/index.ts
@@ -244,20 +244,29 @@ export function destroyChildren(destroyable: Destroyable) {
   iterate(children, destroy);
 }
 
+/** Meta if there is any, without creating it. Mirrors `getDestroyableMeta`. */
+function peekDestroyableMeta(destroyable: Destroyable): DestroyableMeta<Destroyable> | undefined {
+  let own = (destroyable as HasDestroyableMetaSlot)[DESTROYABLE_META_SLOT];
+
+  if (own !== undefined) return own as DestroyableMeta<Destroyable>;
+
+  return DESTROYABLE_META.get(destroyable);
+}
+
 export function _hasDestroyableChildren(destroyable: Destroyable) {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = peekDestroyableMeta(destroyable);
 
   return meta === undefined ? false : meta.children !== null;
 }
 
 export function isDestroying(destroyable: Destroyable) {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = peekDestroyableMeta(destroyable);
 
   return meta === undefined ? false : meta.state >= DESTROYING_STATE;
 }
 
 export function isDestroyed(destroyable: Destroyable) {
-  let meta = DESTROYABLE_META.get(destroyable);
+  let meta = peekDestroyableMeta(destroyable);
 
   return meta === undefined ? false : meta.state >= DESTROYED_STATE;
 }

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -25,7 +25,7 @@ import type { Reference } from '@glimmer/reference/lib/reference';
 import type { MachineRegister, Register, SyscallRegister } from '@glimmer/vm/lib/registers';
 import { dev, expect } from '@glimmer/debug-util/lib/platform-utils';
 import { unwrapHandle } from '@glimmer/debug-util/lib/template';
-import { associateDestroyableChild } from '@glimmer/destroyable';
+import { associateDestroyableChild, DESTROYABLE_META_SLOT } from '@glimmer/destroyable';
 import { assertGlobalContextWasSet } from '@glimmer/global-context';
 import { LOCAL_DEBUG, LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 import { createIteratorItemRef } from '@glimmer/reference/lib/iterable';
@@ -54,9 +54,18 @@ import RenderResultImpl from './render-result';
 import EvaluationStackImpl from './stack';
 import { ListBlockOpcode, ListItemOpcode, TryOpcode } from './update';
 
+/** The VM's own root destroyable, on the fast path like the block opcodes. */
+class Drop {
+  declare [DESTROYABLE_META_SLOT]: object | undefined;
+
+  constructor() {
+    this[DESTROYABLE_META_SLOT] = undefined;
+  }
+}
+
 class Stacks {
   declare debug?: () => DebugStacks;
-  readonly drop: object = {};
+  readonly drop: object = new Drop();
 
   readonly scope = new Stack<Scope>();
   readonly dynamicScope = new Stack<DynamicScope>();

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -17,7 +17,12 @@ import type {
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
 import type { Reference } from '@glimmer/reference/lib/reference';
 import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
-import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/destroyable';
+import {
+  associateDestroyableChild,
+  DESTROYABLE_META_SLOT,
+  destroy,
+  destroyChildren,
+} from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
@@ -111,6 +116,10 @@ export interface VMState {
 }
 
 export abstract class BlockOpcode implements UpdatingOpcode, Bounds {
+  // Declaring the slot is what opts these into the fast path in
+  // `@glimmer/destroyable`. One of these exists per `{{#each}}` item.
+  declare [DESTROYABLE_META_SLOT]: object | undefined;
+
   public children: UpdatingOpcode[];
 
   protected readonly bounds: AppendingBlock;
@@ -123,6 +132,7 @@ export abstract class BlockOpcode implements UpdatingOpcode, Bounds {
   ) {
     this.children = children;
     this.bounds = bounds;
+    this[DESTROYABLE_META_SLOT] = undefined;
   }
 
   parentElement() {


### PR DESCRIPTION
Replaces #21565, which did the same thing in a way that was breaking.

`getDestroyableMeta` is the hottest Glimmer function in a CPU profile of `smoke-tests/benchmark-app`, at 1.7% self time. Every association costs a `WeakMap.get`, and the first use of an object as a `WeakMap` key forces an identity hash onto it. Rendering a list associates one per item, so a 10,000 row list pays about 40,000 lookups before anything is destroyed.

Classes Glimmer constructs declare a slot for their meta and skip the map. Everything else keeps the `WeakMap`, untouched.

## Numbers

VM work, measured in Node against SimpleDOM so DOM cost does not mask it. 15 interleaved pairs, medians in ms:

| phase | main | branch | delta |
| --- | ---: | ---: | ---: |
| update every 10th | 12.30 | 5.86 | -50.6% |
| clear | 8.96 | 6.36 | -31.9% |
| select row | 2.72 | 2.05 | -22.6% |
| append 1000 | 37.57 | 32.50 | -11.2% |
| swap rows | 1.93 | 1.73 | -9.6% |
| remove row | 1.85 | 1.69 | -9.6% |
| create | 23.05 | 23.23 | +1.0% |
| **total** | **88.54** | **74.28** | **-15.3%** |

Browser, `pnpm bench` at fidelity 20 and 8x CPU throttle:

| phase | delta |
| --- | ---: |
| **duration (total)** | **-2.4%** [-4.26%, -0.37%] |
| selectFirstRow1 | -10.58% |
| clearManyItems2 | -6.66% |
| clearItems4 | -6.65% |
| append1000Items2 | -5.72% |
| render10000Items2 | -4.34% |
| clearManyItems1 | -3.17% |
| render10000Items1 | -2.85% |
| clearItems2 | -2.37% |
| the other 14 phases | no difference |

No phase regresses. For scale, running the same harness from a `main` worktree against itself reported `duration` as no difference across -1368ms to +739ms, so a total whose whole interval sits below zero is a real result. That A/A run also produced two falsely significant phase results at about 7%, so read the total first.

#21565 measured -3.66% on the same harness. This keeps about two thirds of that, and gives up none of `@ember/destroyable`'s guarantees.

## How it avoids touching user objects

Destroyables are public through `@ember/destroyable`, and a destroyable can be any object a user hands in. The docs' own example is `associateDestroyableChild(this, {})`.

So the rule is: read the slot always, write it only when the slot already exists.

```ts
let own = slotted[DESTROYABLE_META_SLOT];

if (own !== undefined) return own;

// `in` rather than a write, so this stays a read for everything else.
if (DESTROYABLE_META_SLOT in slotted) {
  // one of ours
}

// anything else: the WeakMap, exactly as before
```

Only `BlockOpcode` and its subclasses (`TryOpcode`, `ListItemOpcode`, `ListBlockOpcode`) and the VM's root destroyable declare the slot. Those are what the list benchmark associates per item.

## Why #21565 could not ship

It wrote the meta onto the destroyable unconditionally. Probing the built branch found four problems, and the second is the one that killed it:

| | #21565 | this PR |
| --- | --- | --- |
| `registerDestructor(Object.freeze({}), fn)` | TypeError | ok |
| spread copy shares one destroy state | yes | no |
| own symbol on a user object | 1 | 0 |
| proxy `set` trap fires | yes | no |

The second row means two distinct instances could report a single destroy state, since a plain assignment creates an enumerable own symbol and spread copies it:

```
copy shares the original meta object: true
after destroy: isDestroying(original) = true
after destroy: isDestroying(copy)     = true
```

Instances need their own destroy state. Under this PR a user instance is never written to, so that cannot happen.

## Also in here

Destroyable tracking enumerates meta to find leaks, and slotted objects bypass the `WeakMap`. While `enableDestroyableTracking()` is on, the slot path also records into the tracking map, so `assertDestroyablesDestroyed()` still sees them. All 99 destroyable tests pass.

## Testing

9449 tests, 9432 pass, 17 skip, 0 fail. Identical to `main` on the same machine. `tsc`, `eslint` and `prettier` are clean.

## Next

Component managers, modifiers and helper caches are also framework-owned and still take the `WeakMap` path. Widening the slot to them is a follow-up rather than more surface here.
