### PR TITLE
Materialize static template subtrees in one step

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/lib/suites.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites.ts
@@ -11,5 +11,6 @@ export * from './suites/initial-render';
 export * from './suites/scope';
 export * from './suites/shadowing';
 export * from './suites/ssr';
+export * from './suites/static-tree';
 export * from './suites/with-dynamic-vars';
 export * from './suites/yield';

--- a/packages/@glimmer-workspace/integration-tests/lib/suites/static-tree.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/static-tree.ts
@@ -1,0 +1,97 @@
+import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
+import { beginTestSteps, endTestSteps, verifySteps } from '@glimmer/util';
+
+import { RenderTest } from '../render-test';
+import { test } from '../test-decorator';
+
+export class StaticTreeSuite extends RenderTest {
+  static suiteName = 'static trees';
+
+  beforeEach() {
+    if (LOCAL_DEBUG) {
+      beginTestSteps?.();
+    }
+  }
+
+  afterEach() {
+    if (LOCAL_DEBUG) {
+      endTestSteps?.();
+    }
+  }
+
+  @test
+  'a static subtree is built once, then cloned'() {
+    // Cloning is invisible in the output, so the step log is the only way to
+    // assert the optimization runs.
+    if (!LOCAL_DEBUG) return;
+
+    this.render('{{#each this.rows key="@index" as |row|}}<p><i>{{row}}</i></p>{{/each}}', {
+      rows: ['a', 'b', 'c'],
+    });
+
+    this.assertHTML('<p><i>a</i></p><p><i>b</i></p><p><i>c</i></p>');
+    verifySteps?.(
+      'static-trees',
+      [
+        ['build', 'p'],
+        ['clone', 'p'],
+        ['clone', 'p'],
+      ],
+      'the first row builds the tree, the rest clone it'
+    );
+  }
+
+  @test
+  'a cloned subtree gets its own dynamic values'() {
+    this.render(
+      '{{#each this.rows key="@index" as |row|}}<p class={{row.cls}}><i>{{row.text}}</i></p>{{/each}}',
+      {
+        rows: [
+          { cls: 'x', text: '1' },
+          { cls: 'y', text: '2' },
+        ],
+      }
+    );
+
+    this.assertHTML('<p class="x"><i>1</i></p><p class="y"><i>2</i></p>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'a subtree containing a component is not extracted'() {
+    if (!LOCAL_DEBUG) return;
+
+    this.registerComponent('TemplateOnly', 'Inner', '<i>inner</i>');
+    this.render('{{#each this.rows key="@index" as |row|}}<p><Inner />{{row}}</p>{{/each}}', {
+      rows: ['a', 'b'],
+    });
+
+    this.assertHTML('<p><i>inner</i>a</p><p><i>inner</i>b</p>');
+    verifySteps?.('static-trees', [], 'a component ends the run');
+  }
+
+  @test
+  'a single element is below the extraction threshold'() {
+    if (!LOCAL_DEBUG) return;
+
+    this.render('{{#each this.rows key="@index" as |row|}}<p>{{row}}</p>{{/each}}', {
+      rows: ['a', 'b'],
+    });
+
+    this.assertHTML('<p>a</p><p>b</p>');
+    verifySteps?.('static-trees', [], 'one element is not worth cloning');
+  }
+
+  @test
+  'namespaced elements survive cloning'() {
+    this.render(
+      '{{#each this.rows key="@index" as |row|}}<svg viewBox="0 0 1 1"><circle r={{row}} /></svg>{{/each}}',
+      { rows: ['1', '2'] }
+    );
+
+    this.assertHTML(
+      '<svg viewBox="0 0 1 1"><circle r="1"></circle></svg>' +
+        '<svg viewBox="0 0 1 1"><circle r="2"></circle></svg>'
+    );
+  }
+}

--- a/packages/@glimmer-workspace/integration-tests/test/jit-suites-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/jit-suites-test.ts
@@ -10,6 +10,7 @@ import {
   jitSuite,
   ScopeSuite,
   ShadowingSuite,
+  StaticTreeSuite,
   TemplateOnlyComponents,
   WithDynamicVarsSuite,
   YieldSuite,
@@ -18,6 +19,7 @@ import {
 jitComponentSuite(DebuggerSuite);
 jitSuite(EachSuite);
 jitSuite(InElementSuite);
+jitSuite(StaticTreeSuite);
 
 jitComponentSuite(GlimmerishComponents);
 jitComponentSuite(TemplateOnlyComponents);

--- a/packages/@glimmer/constants/lib/syscall-ops.ts
+++ b/packages/@glimmer/constants/lib/syscall-ops.ts
@@ -3,6 +3,7 @@ import type {
   VmAppendHTML,
   VmAppendNode,
   VmAppendSafeHTML,
+  VmAppendStaticTree,
   VmAppendText,
   VmAssertSame,
   VmBeginComponentTransaction,
@@ -29,8 +30,10 @@ import type {
   VmDynamicHelper,
   VmDynamicModifier,
   VmEnter,
+  VmEnterHole,
   VmEnterList,
   VmExit,
+  VmExitHole,
   VmExitList,
   VmFetch,
   VmFlushElement,
@@ -183,7 +186,10 @@ export const VM_IF_INLINE_OP = 109 satisfies VmIfInline;
 export const VM_NOT_OP = 110 satisfies VmNot;
 export const VM_GET_DYNAMIC_VAR_OP = 111 satisfies VmGetDynamicVar;
 export const VM_LOG_OP = 112 satisfies VmLog;
-export const VM_SYSCALL_SIZE = 113 satisfies VmSize;
+export const VM_APPEND_STATIC_TREE_OP = 113 satisfies VmAppendStaticTree;
+export const VM_ENTER_HOLE_OP = 114 satisfies VmEnterHole;
+export const VM_EXIT_HOLE_OP = 115 satisfies VmExitHole;
+export const VM_SYSCALL_SIZE = 116 satisfies VmSize;
 
 export function isOp(value: number): value is VmOp {
   return value >= 16;

--- a/packages/@glimmer/interfaces/index.d.ts
+++ b/packages/@glimmer/interfaces/index.d.ts
@@ -18,6 +18,7 @@ export type * from './lib/runtime.d.ts';
 export type * from './lib/runtime/vm.d.ts';
 export type * from './lib/serialize.d.ts';
 export type * from './lib/stack.d.ts';
+export type * from './lib/static-tree.d.ts';
 export type * from './lib/tags.d.ts';
 export type * from './lib/template.d.ts';
 export type * from './lib/tier1/symbol-table.d.ts';

--- a/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
@@ -1,6 +1,7 @@
 import type { Maybe, Nullable } from '../core.js';
 import type { ElementOperations, Environment, ModifierInstance } from '../runtime.js';
 import type { Stack } from '../stack.js';
+import type { StaticTree } from '../static-tree.js';
 import type { Bounds, Cursor } from './bounds.js';
 import type { GlimmerTreeChanges, GlimmerTreeConstruction } from './changes.js';
 import type {
@@ -74,6 +75,16 @@ export interface DOMStack {
   ): AttributeOperation;
 
   closeElement(): Nullable<ModifierInstance[]>;
+
+  /**
+   * Materialize a run of static structure in one step, and remember it so
+   * its dynamic holes can be found by index.
+   */
+  appendStaticTree(tree: StaticTree): boolean;
+  /** Position the builder at hole `index` of the current static tree. */
+  enterHole(index: number): void;
+  /** Restore the position saved by `enterHole`. */
+  exitHole(index: number): void;
 }
 
 export interface TreeOperations {

--- a/packages/@glimmer/interfaces/lib/static-tree.d.ts
+++ b/packages/@glimmer/interfaces/lib/static-tree.d.ts
@@ -1,0 +1,41 @@
+import type { Nullable } from './core.js';
+
+/**
+ * Static template structure, extracted by the compiler and materialized by
+ * the runtime in one step instead of one opcode per element, attribute and
+ * text node.
+ */
+export interface StaticElement {
+  readonly kind: 'element';
+  readonly tag: string;
+  /** `[name, value, namespace]`, in source order */
+  readonly attrs: [string, string, Nullable<string>][];
+  readonly children: StaticNode[];
+}
+
+export interface StaticText {
+  readonly kind: 'text';
+  readonly chars: string;
+}
+
+export type StaticNode = StaticElement | StaticText;
+
+/** `path` is child-node indices from the run's root element. */
+export interface AttrHole {
+  readonly kind: 'attr';
+  readonly path: readonly number[];
+}
+
+export interface ContentHole {
+  readonly kind: 'content';
+  readonly path: readonly number[];
+}
+
+export type Hole = AttrHole | ContentHole;
+
+export interface StaticTree {
+  readonly root: StaticElement;
+  readonly holes: readonly Hole[];
+  /** Clone source, filled in by the runtime on first materialization. */
+  cached?: unknown;
+}

--- a/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
+++ b/packages/@glimmer/interfaces/lib/vm-opcodes.d.ts
@@ -109,7 +109,10 @@ export type VmIfInline = 109;
 export type VmNot = 110;
 export type VmGetDynamicVar = 111;
 export type VmLog = 112;
-export type VmSize = 113;
+export type VmAppendStaticTree = 113;
+export type VmEnterHole = 114;
+export type VmExitHole = 115;
+export type VmSize = 116;
 
 export type VmOp =
   | VmHelper
@@ -202,6 +205,9 @@ export type VmOp =
   | VmIfInline
   | VmNot
   | VmGetDynamicVar
-  | VmLog;
+  | VmLog
+  | VmAppendStaticTree
+  | VmEnterHole
+  | VmExitHole;
 
 export type SomeVmOp = VmOp | VmMachineOp;

--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -99,6 +99,11 @@ class SerializeBuilder extends NewTreeBuilder implements TreeBuilder {
     return super.__appendText(string);
   }
 
+  // The serializer interleaves block markers with construction.
+  protected override get supportsCloning(): boolean {
+    return false;
+  }
+
   override closeElement(): Nullable<ModifierInstance[]> {
     if (NEEDS_EXTRA_CLOSE.has(this.element)) {
       NEEDS_EXTRA_CLOSE.delete(this.element);

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -16,6 +16,12 @@ import type {
   WireFormat,
 } from '@glimmer/interfaces';
 import { IS_COMPILABLE_TEMPLATE } from '@glimmer/constants/lib/brand';
+import { VM_JUMP_OP } from '@glimmer/constants/lib/vm-ops';
+import {
+  VM_APPEND_STATIC_TREE_OP,
+  VM_ENTER_HOLE_OP,
+  VM_EXIT_HOLE_OP,
+} from '@glimmer/constants/lib/syscall-ops';
 import { LOCAL_TRACE_LOGGING } from '@glimmer/local-debug-flags';
 import { EMPTY_ARRAY } from '@glimmer/util/lib/array-utils';
 
@@ -26,6 +32,9 @@ import { templateCompilationContext } from './opcode-builder/context';
 import { encodeOp } from './opcode-builder/encoder';
 import { meta } from './opcode-builder/helpers/shared';
 import { STATEMENTS } from './syntax/statements';
+import { HighLevelBuilderOpcodes } from './opcode-builder/opcodes';
+import { labelOperand } from './opcode-builder/operands';
+import { extractStaticTree } from './static-tree';
 
 export const PLACEHOLDER_HANDLE = -1;
 
@@ -97,8 +106,46 @@ export function compileStatements(
     encodeOp(encoder, evaluation, meta, op as BuilderOp | HighLevelOp);
   }
 
-  for (const statement of statements) {
-    sCompiler.compile(pushOp, statement);
+  for (let i = 0; i < statements.length; i++) {
+    let run = extractStaticTree(statements, i);
+
+    if (run) {
+      // Two paths for the same run, chosen at runtime. Builders that must see
+      // every construction step in order (rehydration, SSR) take the fallback
+      // and run the original statements: filling holes after the subtree
+      // exists would set attributes after their element was flushed, and
+      // would look for block markers after enclosing elements were closed.
+      let handle = syntaxContext.program.constants.value(run.tree);
+
+      pushOp(HighLevelBuilderOpcodes.StartLabels);
+      // the jump target must be op1: label offsets are patched relative to
+      // their own slot, and `goto` resolves them against the opcode address
+      pushOp(VM_APPEND_STATIC_TREE_OP, labelOperand('STATIC_TREE_FALLBACK'), handle);
+
+      for (let h = 0; h < run.holeStatements.length; h++) {
+        pushOp(VM_ENTER_HOLE_OP, h);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- parallel to holes
+        sCompiler.compile(pushOp, statements[run.holeStatements[h]!]!);
+        pushOp(VM_EXIT_HOLE_OP, h);
+      }
+
+      pushOp(VM_JUMP_OP, labelOperand('STATIC_TREE_END'));
+      pushOp(HighLevelBuilderOpcodes.Label, 'STATIC_TREE_FALLBACK');
+
+      for (let s = i; s < i + run.length; s++) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+        sCompiler.compile(pushOp, statements[s]!);
+      }
+
+      pushOp(HighLevelBuilderOpcodes.Label, 'STATIC_TREE_END');
+      pushOp(HighLevelBuilderOpcodes.StopLabels);
+
+      i += run.length - 1;
+      continue;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+    sCompiler.compile(pushOp, statements[i]!);
   }
 
   let handle = context.encoder.commit(meta.size);

--- a/packages/@glimmer/opcode-compiler/lib/static-tree.ts
+++ b/packages/@glimmer/opcode-compiler/lib/static-tree.ts
@@ -1,0 +1,171 @@
+import type { Hole, Nullable, StaticElement, StaticTree, WireFormat } from '@glimmer/interfaces';
+import { opcodes as SexpOpcodes } from '@glimmer/wire-format/lib/opcodes';
+
+import { inflateAttrName, inflateTagName } from './syntax/statements';
+
+// One element trades a few DOM calls for a clone plus an insert, which is
+// not a clear win.
+const MIN_ELEMENTS = 2;
+
+export interface ExtractedRun {
+  /** how many statements of the input the run consumed */
+  readonly length: number;
+  readonly tree: StaticTree;
+  /** the statement index of each hole, parallel to `tree.holes` */
+  readonly holeStatements: readonly number[];
+}
+
+function childCount(counts: number[]): number {
+  return counts[counts.length - 1] ?? 0;
+}
+
+function bumpChildCount(counts: number[]): void {
+  counts[counts.length - 1] = childCount(counts) + 1;
+}
+
+function isDynamicAttr(op: number): boolean {
+  return (
+    op === SexpOpcodes.DynamicAttr ||
+    op === SexpOpcodes.TrustingDynamicAttr ||
+    op === SexpOpcodes.ComponentAttr ||
+    op === SexpOpcodes.TrustingComponentAttr
+  );
+}
+
+// Returns null when the run cannot be described. Bailing is always safe:
+// the caller compiles the statements the ordinary way.
+export function extractStaticTree(
+  statements: WireFormat.Statement[],
+  start: number
+): Nullable<ExtractedRun> {
+  let first = statements[start];
+
+  if (!first || first[0] !== SexpOpcodes.OpenElement) return null;
+
+  let holes: Hole[] = [];
+  let holeStatements: number[] = [];
+  let elements = 0;
+
+  // the element currently being opened, before its FlushElement
+  let pending: { tag: string; attrs: [string, string, Nullable<string>][] } | null = null;
+  // path of child indices to the element we are inside
+  let path: number[] = [];
+  // for each open element, how many children it has so far
+  let counts: number[] = [0];
+  let stack: StaticElement[] = [];
+  let root: Nullable<StaticElement> = null;
+
+  for (let i = start; i < statements.length; i++) {
+    let statement = statements[i];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked
+    let op = statement![0];
+
+    if (op === SexpOpcodes.OpenElement) {
+      if (pending) return null;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- shape of OpenElement
+      pending = { tag: inflateTagName(statement![1] as string), attrs: [] };
+      elements++;
+      continue;
+    }
+
+    if (op === SexpOpcodes.StaticAttr) {
+      if (!pending) return null;
+      let [, name, value, namespace] = statement as WireFormat.Statements.StaticAttr;
+      pending.attrs.push([
+        inflateAttrName(name),
+        String(value ?? ''),
+        (namespace as string) ?? null,
+      ]);
+      continue;
+    }
+
+    if (isDynamicAttr(op)) {
+      if (!pending) return null;
+      // The target is the element about to be flushed. Paths are relative to
+      // the run's root, so the root itself is the empty path.
+      let target = stack.length === 0 ? [] : path.concat([childCount(counts)]);
+      holes.push({ kind: 'attr', path: target });
+      holeStatements.push(i);
+      continue;
+    }
+
+    if (op === SexpOpcodes.FlushElement) {
+      if (!pending) return null;
+      let element: StaticElement = {
+        kind: 'element',
+        tag: pending.tag,
+        attrs: pending.attrs,
+        children: [],
+      };
+      let parent = stack[stack.length - 1];
+
+      if (parent) {
+        parent.children.push(element);
+      } else {
+        root = element;
+      }
+
+      let indexInParent = childCount(counts);
+      bumpChildCount(counts);
+
+      // the root is the origin of every path, so it does not contribute one
+      if (stack.length > 0) path.push(indexInParent);
+
+      counts.push(0);
+      stack.push(element);
+      pending = null;
+      continue;
+    }
+
+    if (op === SexpOpcodes.CloseElement) {
+      if (pending || stack.length === 0) return null;
+      stack.pop();
+      counts.pop();
+
+      // mirrors the push above: the root contributed no path segment
+      if (stack.length > 0) path.pop();
+
+      if (stack.length === 0) {
+        // the run's root element closed: this is a complete tree
+        if (!root || elements < MIN_ELEMENTS) return null;
+        return { length: i - start + 1, tree: { root, holes }, holeStatements };
+      }
+      continue;
+    }
+
+    if (op === SexpOpcodes.Append || op === SexpOpcodes.TrustingAppend) {
+      if (pending || stack.length === 0) return null;
+
+      let value = (statement as WireFormat.Statements.Append)[1];
+
+      if (!Array.isArray(value)) {
+        // a static string: part of the structure, not a hole
+        if (op === SexpOpcodes.TrustingAppend) return null;
+        let parent = stack[stack.length - 1] as StaticElement;
+        parent.children.push({ kind: 'text', chars: value === null ? '' : String(value) });
+        bumpChildCount(counts);
+        continue;
+      }
+
+      // Trusted content inserts arbitrary parsed HTML: no fixed shape.
+      if (op === SexpOpcodes.TrustingAppend) return null;
+
+      // A hole that is not the last child needs a placeholder node to anchor
+      // against, which costs more than it saves.
+      let next = statements[i + 1];
+
+      if (!next || next[0] !== SexpOpcodes.CloseElement) return null;
+
+      holes.push({ kind: 'content', path: path.slice() });
+      holeStatements.push(i);
+      bumpChildCount(counts);
+      continue;
+    }
+
+    // components, blocks, splattributes, modifiers, comments, in-element:
+    // all need the full VM
+    return null;
+  }
+
+  return null;
+}

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -15,10 +15,13 @@ import type { Revision } from '@glimmer/validator/lib/validators';
 import type { Tag } from '@glimmer/interfaces';
 import { CURRIED_MODIFIER } from '@glimmer/constants/lib/curried';
 import {
+  VM_APPEND_STATIC_TREE_OP,
   VM_CLOSE_ELEMENT_OP,
   VM_COMMENT_OP,
   VM_DYNAMIC_ATTR_OP,
   VM_DYNAMIC_MODIFIER_OP,
+  VM_ENTER_HOLE_OP,
+  VM_EXIT_HOLE_OP,
   VM_FLUSH_ELEMENT_OP,
   VM_MODIFIER_OP,
   VM_OPEN_DYNAMIC_ELEMENT_OP,
@@ -57,6 +60,22 @@ import { Assert } from './vm';
 
 APPEND_OPCODES.add(VM_TEXT_OP, (vm, { op1: text }) => {
   vm.tree().appendText(vm.constants.getValue(text));
+});
+
+// The dynamic values inside the subtree are filled in by the EnterHole and
+// ExitHole pairs that follow, which refer to holes by index.
+APPEND_OPCODES.add(VM_APPEND_STATIC_TREE_OP, (vm, { op1: fallback, op2: handle }) => {
+  if (!vm.tree().appendStaticTree(vm.constants.getValue(handle))) {
+    vm.lowlevel.goto(fallback);
+  }
+});
+
+APPEND_OPCODES.add(VM_ENTER_HOLE_OP, (vm, { op1: index }) => {
+  vm.tree().enterHole(index);
+});
+
+APPEND_OPCODES.add(VM_EXIT_HOLE_OP, (vm, { op1: index }) => {
+  vm.tree().exitHole(index);
 });
 
 APPEND_OPCODES.add(VM_COMMENT_OP, (vm, { op1: text }) => {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -7,6 +7,7 @@ import type {
   Environment,
   GlimmerTreeChanges,
   GlimmerTreeConstruction,
+  Hole,
   Maybe,
   ModifierInstance,
   Nullable,
@@ -16,6 +17,8 @@ import type {
   SimpleElement,
   SimpleNode,
   SimpleText,
+  StaticElement,
+  StaticTree,
   TreeBuilder,
 } from '@glimmer/interfaces';
 import { expect } from '@glimmer/debug-util/lib/platform-utils';
@@ -24,11 +27,46 @@ import { setLocalDebugType } from '@glimmer/debug-util/lib/debug-brand';
 import { destroy, registerDestructor } from '@glimmer/destroyable';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
+import { logStep } from '@glimmer/util/lib/debug-steps';
 
 import type { DynamicAttribute } from './attributes/dynamic';
 
 import { clear, ConcreteBounds, CursorImpl } from '../bounds';
 import { dynamicAttribute } from './attributes/dynamic';
+
+// `context` only decides namespace, so one cached node suits every instance.
+function buildStaticTree(
+  dom: GlimmerTreeConstruction,
+  node: StaticElement,
+  context: SimpleElement
+): SimpleElement {
+  let element = dom.createElement(node.tag, context);
+
+  for (const [name, value, namespace] of node.attrs) {
+    dom.setAttribute(element, name, value, (namespace as AttrNamespace) ?? undefined);
+  }
+
+  for (const child of node.children) {
+    if (child.kind === 'text') {
+      element.insertBefore(dom.createTextNode(child.chars), null);
+    } else {
+      element.insertBefore(buildStaticTree(dom, child, element), null);
+    }
+  }
+
+  return element;
+}
+
+// Hole paths index the descriptor's child list, which includes text nodes.
+function elementChildAt(element: SimpleElement, index: number): SimpleElement {
+  let node = element.firstChild;
+
+  for (let i = 0; i < index; i++) {
+    node = expect(node, 'BUG: static tree shape does not match its descriptor').nextSibling;
+  }
+
+  return expect(node, 'BUG: static tree shape does not match its descriptor') as SimpleElement;
+}
 
 export interface FirstNode {
   debug?: { first: () => Nullable<SimpleNode> };
@@ -92,6 +130,27 @@ export class NewTreeBuilder implements TreeBuilder {
   readonly cursors = new Stack<Cursor>();
   private modifierStack = new Stack<Nullable<ModifierInstance[]>>();
   private blockStack = new Stack<AppendingBlock>();
+
+  /**
+   * The root of the most recently appended static tree, so `enterHole` can
+   * navigate to a hole relative to it.
+   */
+  private staticRoot: Nullable<SimpleElement> = null;
+  private staticTree: Nullable<StaticTree> = null;
+
+  /**
+   * Saved region state, one entry per hole currently being filled.
+   *
+   * A hole's own opcodes can append further static trees -- a content hole
+   * that renders a component pulls in that component's layout -- which would
+   * otherwise leave the enclosing run pointing at the wrong tree when it
+   * moves on to its next hole.
+   */
+  private readonly holeStack: {
+    root: Nullable<SimpleElement>;
+    tree: Nullable<StaticTree>;
+    hole: Hole;
+  }[] = [];
 
   static forInitialRender(env: Environment, cursor: CursorImpl) {
     return new this(env, cursor.element, cursor.nextSibling).initialize();
@@ -365,6 +424,79 @@ export class NewTreeBuilder implements TreeBuilder {
     let node = dom.createComment(string);
     dom.insertBefore(element, node, nextSibling);
     return node;
+  }
+
+  // False for builders that must observe every construction step in order.
+  protected get supportsCloning(): boolean {
+    return true;
+  }
+
+  // Returns false when the caller must compile the run the ordinary way.
+  appendStaticTree(tree: StaticTree): boolean {
+    if (!this.supportsCloning) return false;
+
+    let cached = tree.cached as Nullable<SimpleElement>;
+    let wasCached = cached !== null && cached !== undefined;
+
+    if (!cached) {
+      cached = buildStaticTree(this.dom, tree.root, this.element);
+      (tree as { cached?: unknown }).cached = cached;
+    }
+
+    if (LOCAL_DEBUG) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
+      logStep!('static-trees', [wasCached ? 'clone' : 'build', tree.root.tag]);
+    }
+
+    let root = cached.cloneNode(true) as SimpleElement;
+
+    this.dom.insertBefore(this.element, root, this.nextSibling);
+    this.didAppendNode(root);
+
+    this.staticRoot = root;
+    this.staticTree = tree;
+
+    return true;
+  }
+
+  // Positions the builder at a hole so the hole's own opcodes run unchanged.
+  enterHole(index: number): void {
+    let hole = this.holeAt(index);
+    let element = expect(this.staticRoot, 'BUG: no static tree to enter a hole in');
+
+    this.holeStack.push({ root: this.staticRoot, tree: this.staticTree, hole });
+
+    for (const step of hole.path) {
+      element = elementChildAt(element, step);
+    }
+
+    if (hole.kind === 'attr') {
+      this.constructing = element;
+    } else {
+      // a content hole is always its element's last child
+      this.pushElement(element, null);
+    }
+  }
+
+  exitHole(_index: number): void {
+    let saved = expect(this.holeStack.pop(), 'BUG: exited a hole that was never entered');
+
+    if (saved.hole.kind === 'attr') {
+      this.constructing = null;
+    } else {
+      this.popElement();
+    }
+
+    // a hole may append static trees of its own
+    this.staticRoot = saved.root;
+    this.staticTree = saved.tree;
+  }
+
+  private holeAt(index: number): Hole {
+    let tree = expect(this.staticTree, 'BUG: no static tree for this hole');
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- emitted in step with the holes
+    return tree.holes[index]!;
   }
 
   __setAttribute(name: string, value: string, namespace: Nullable<AttrNamespace>): void {

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -377,6 +377,11 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
     return super.__appendComment(string);
   }
 
+  // Rehydration matches against nodes already in the tree.
+  protected override get supportsCloning(): boolean {
+    return false;
+  }
+
   override __openElement(tag: string): SimpleElement {
     const _candidate = this.candidate;
 


### PR DESCRIPTION
> [!NOTE]
> Written by Claude Opus 5 (`claude-opus-5`) driving Claude Code, from @NullVoxPopuli's direction. All numbers come from runs on one machine.

Static template structure is now built in one step, not one opcode per element, attribute and text node. 34 DOM calls per row become 10.

## Numbers

`pnpm bench` against `main`, 8x throttle, n=20. Overall duration `-527ms`, p=0.0056.

| phase | delta | p |
| --- | --- | --- |
| `render1000Items1End` | -5.20% | 0.039 |
| `render1000Items2End` | -7.71% | 0.0051 |
| `render10000Items1End` | -5.79% | 0.0028 |
| `render10000Items2End` | -5.57% | 0.0066 |
| `render1000Items3End` | -5.56% | 0.0043 |
| `updateEvery10thItem2End` | +3.84% | 0.036 |

All five render phases improved, and the pattern replicated across two runs. The one regression is a single phase inside this harness's spurious-hit rate. It needs a replication run.

## How it works

The pre-pass runs in `compileStatements`. No wire-format change, so published templates benefit.

A run must be an element-rooted subtree of 2 or more elements. Its holes must be dynamic attributes or last-child dynamic content. Components, blocks, splattributes, modifiers, comments and trusted HTML end a run. Bailing is safe: the caller then compiles the statements the ordinary way.

Each run emits 2 paths:

1. The tree builder can clone. Build the subtree in one step, then fill the holes.
2. The tree builder cannot clone. Run the original statements, in the original order.

Path 2 is not optional. Rehydration matches server-rendered nodes, and the SSR serializer interleaves block markers. Both need each step in order. An earlier single-path version failed 16 rehydration tests and left stray `%-b:0%` markers.

Cloning keeps namespaces correct at no cost, because the cached node is built with the ordinary DOM operations in context.

## Why structure and not the rest

Rendering JS for a 1000-row create is about 37ms. Static structure is about 14.6ms of that. A hand-written clone of the same row costs about 4ms. The other 22ms is per-hole reactive machinery with no single hot spot, and this PR does not touch it.

Measured and rejected first, so nobody repeats them:

- Deferred element insertion until close. Neutral, twice.
- Bulk `replaceChildren` for clears. Saves 6ms of 32ms, not the 83% a profile implied.
- Pooling tracking-frame `Tracker`s. Already reverted in `39c062e72d`.

Profiler self-time on `insertBefore` is Blink style invalidation charged to the calling frame. It is not insertion cost.

## Coverage

Measured over 766 test templates in this repo: 40% of static structure sits in runs of 2 or more elements. 77% of runs hold one element, which sets the threshold at 2. Both benchmark rows are one 8-element run.

## Cost

Every app pays for this, including apps that never hit a qualifying run. `@glimmer/opcode-compiler` ships to the browser, so the extractor is in the app bundle.

| app | raw | brotli |
| --- | --- | --- |
| `v2-app-hello-world-template` | 132.4 kB to 135.3 kB (+2%) | 37 kB to 38 kB (+3%) |
| `v2-app-template` | 342.5 kB to 345.5 kB (+0.9%) | 95 kB to 95.9 kB (+0.9%) |
| `dist/prod` total | 1.9 MB (+0.6%) | 449.2 kB to 451.9 kB (+0.6%) |

+2% on a hello-world app is the main thing to weigh against a 5-8% render win. A build-time flag would let Rollup drop both the extractor and the runtime path for apps that do not opt in. Say the word and I will add one.

## Size

446 lines of production code, 100 of tests, 5 deleted. Nothing existing was replaced. This adds a compile-time extractor, 3 opcodes and their runtime, so there is no old path to remove. Three candidate consolidations were checked; two do not work, and the one that does (merging the 4 dynamic-attribute opcodes into 2, about 30 lines) is unrelated to this change and belongs in its own PR.

## Tests

`StaticTreeSuite` asserts the mechanism, not just the output, using the step log:

- a static subtree is built once, then cloned
- a cloned subtree gets its own dynamic values
- a component ends a run
- a single element stays below the threshold
- namespaced elements survive cloning

## rere-benchmark

No regression on any of the 15 benches. 6 interleaved rounds, alternating order, 10 samples per bench per round, 8x throttle. Per-round medians compared within the round, then a sign test across rounds.

One bench swept all 6 rounds: `1 item, 1k updates`, -6.8%, p=0.031. Treat it as noise. It is the smallest bench in the set (6.40ms to 6.00ms), and this PR touches construction only, so a win on a pure update bench has no mechanism behind it.

Nothing else reached p<0.10 with an effect of 3% or more. The one candidate regression at n=4 (`1k items 1 update on 5% (random)`, +3.1%) fell to 2/6 rounds at n=6.

## Checks

- `pnpm test:wip`: 9,454 tests, 0 failures, 17 skipped
- `pnpm type-check:internals`, `prettier`, `eslint`: clean
