### PR TITLE
platform compat: allow rendering DocumentFragments in double curlies

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/document-fragment-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/document-fragment-test.js
@@ -1,0 +1,74 @@
+import { moduleFor, RenderingTestCase, strip, equalTokens, runTask } from 'internal-test-helpers';
+
+import { set } from '@ember/object';
+
+moduleFor(
+  '{{documentFragment}}',
+  class extends RenderingTestCase {
+    ['@test it renders the children of a fragment']() {
+      let fragment = document.createDocumentFragment();
+      fragment.appendChild(document.createTextNode('hello'));
+
+      this.render('<div>{{this.fragment}}</div>', { fragment });
+
+      equalTokens(this.element, '<div><!---->hello<!----></div>');
+      this.assertStableRerender();
+      this.assert.strictEqual(fragment.childNodes.length, 0, 'the fragment is empty after render');
+    }
+
+    ['@test content rendered into the fragment afterwards stays reactive']() {
+      let fragment = document.createDocumentFragment();
+
+      this.render(
+        strip`
+          <div>{{this.fragment}}</div>
+          {{#in-element this.fragment}}[{{this.text}}]{{/in-element}}
+        `,
+        {
+          fragment,
+          text: 'Whoop!',
+        }
+      );
+
+      equalTokens(this.element, '<div><!---->[Whoop!]<!----></div><!---->');
+      this.assertStableRerender();
+
+      runTask(() => set(this.context, 'text', 'Huzzah!!'));
+      equalTokens(this.element, '<div><!---->[Huzzah!!]<!----></div><!---->');
+
+      runTask(() => set(this.context, 'text', 'Whoop!'));
+      equalTokens(this.element, '<div><!---->[Whoop!]<!----></div><!---->');
+    }
+
+    ['@test two fragments render as siblings and keep their own content']() {
+      let first = document.createDocumentFragment();
+      let second = document.createDocumentFragment();
+
+      this.render(
+        strip`
+          <div>{{this.first}}{{this.second}}</div>
+          {{#in-element this.first}}[first:{{this.one}}]{{/in-element}}
+          {{#in-element this.second}}[second:{{this.two}}]{{/in-element}}
+        `,
+        {
+          first,
+          second,
+          one: 'a',
+          two: 'b',
+        }
+      );
+
+      equalTokens(
+        this.element,
+        '<div><!---->[first:a]<!----><!---->[second:b]<!----></div><!----><!---->'
+      );
+      this.assertStableRerender();
+
+      runTask(() => set(this.context, 'one', 'c'));
+      equalTokens(
+        this.element,
+        '<div><!---->[first:c]<!----><!---->[second:b]<!----></div><!----><!---->'
+      );
+    }
+  }
+);

--- a/packages/@ember/-internals/glimmer/tests/integration/document-fragment-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/document-fragment-test.js
@@ -1,6 +1,9 @@
 import { moduleFor, RenderingTestCase, strip, equalTokens, runTask } from 'internal-test-helpers';
 
+import { Component } from '@ember/-internals/glimmer';
 import { set } from '@ember/object';
+import { precompileTemplate } from '@ember/template-compilation';
+import { setComponentTemplate } from '@glimmer/manager';
 
 moduleFor(
   '{{documentFragment}}',
@@ -38,6 +41,91 @@ moduleFor(
 
       runTask(() => set(this.context, 'text', 'Whoop!'));
       equalTokens(this.element, '<div><!---->[Whoop!]<!----></div><!---->');
+    }
+
+    ['@test content in a fragment survives the fragment leaving the DOM'](assert) {
+      let hooks = [];
+      let fragment = document.createDocumentFragment();
+
+      this.owner.register(
+        'component:counter',
+        setComponentTemplate(
+          precompileTemplate('[counter]'),
+          class extends Component {
+            tagName = '';
+
+            didInsertElement() {
+              hooks.push('didInsertElement');
+            }
+
+            willDestroyElement() {
+              hooks.push('willDestroyElement');
+            }
+          }
+        )
+      );
+
+      this.render(
+        strip`
+          <div>{{#if this.show}}{{this.fragment}}{{/if}}</div>
+          {{#in-element this.fragment}}<Counter />{{/in-element}}
+        `,
+        {
+          fragment,
+          show: true,
+        }
+      );
+
+      equalTokens(this.element, '<div><!---->[counter]<!----></div><!---->');
+      assert.deepEqual(hooks, ['didInsertElement'], 'the component rendered once');
+
+      runTask(() => set(this.context, 'show', false));
+
+      equalTokens(this.element, '<div><!----></div><!---->');
+      assert.strictEqual(fragment.textContent, '[counter]', 'the content is back in the fragment');
+      assert.deepEqual(hooks, ['didInsertElement'], 'the component was not destroyed');
+
+      runTask(() => set(this.context, 'show', true));
+
+      equalTokens(this.element, '<div><!---->[counter]<!----></div><!---->');
+      assert.deepEqual(hooks, ['didInsertElement'], 'the component was not created again');
+    }
+
+    ['@test content survives when the fragment renders inside a yielded block'](assert) {
+      let fragment = document.createDocumentFragment();
+
+      this.owner.register(
+        'component:toggler',
+        setComponentTemplate(
+          precompileTemplate('{{#if @shown}}{{yield}}{{/if}}'),
+          class extends Component {
+            tagName = '';
+          }
+        )
+      );
+
+      this.render(
+        strip`
+          <div><Toggler @shown={{this.show}}>{{this.fragment}}</Toggler></div>
+          {{#in-element this.fragment}}[{{this.text}}]{{/in-element}}
+        `,
+        {
+          fragment,
+          show: true,
+          text: 'Whoop!',
+        }
+      );
+
+      equalTokens(this.element, '<div><!---->[Whoop!]<!----></div><!---->');
+
+      runTask(() => set(this.context, 'show', false));
+      assert.strictEqual(fragment.textContent, '[Whoop!]', 'the content is back in the fragment');
+
+      runTask(() => set(this.context, 'show', true));
+      equalTokens(this.element, '<div><!---->[Whoop!]<!----></div><!---->');
+
+      runTask(() => set(this.context, 'text', 'Huzzah!!'));
+      equalTokens(this.element, '<div><!---->[Huzzah!!]<!----></div><!---->');
     }
 
     ['@test two fragments render as siblings and keep their own content']() {

--- a/packages/@glimmer-workspace/integration-tests/lib/suites.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites.ts
@@ -9,6 +9,7 @@ export * from './suites/has-block-params';
 export * from './suites/in-element';
 export * from './suites/in-element-document-fragment';
 export * from './suites/initial-render';
+export * from './suites/render-document-fragment';
 export * from './suites/scope';
 export * from './suites/shadowing';
 export * from './suites/ssr';

--- a/packages/@glimmer-workspace/integration-tests/lib/suites/render-document-fragment.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/render-document-fragment.ts
@@ -220,6 +220,101 @@ export class RenderDocumentFragmentSuite extends RenderTest {
   }
 
   @test
+  'content moves back into the fragment when the region is removed'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{#if this.show}}{{this.fragment}}{{/if}}</div>' +
+        '{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}',
+      { fragment, show: true, foo: 'kept' }
+    );
+
+    this.assertHTML('<div><!---->[kept]<!----></div><!---->');
+    this.assertStableRerender();
+
+    this.rerender({ show: false });
+    this.assertHTML('<div><!----></div><!---->');
+    this.assert.strictEqual(fragment.textContent, '[kept]', 'the content is back in the fragment');
+
+    this.rerender({ show: true });
+    this.assertHTML('<div><!---->[kept]<!----></div><!---->');
+    this.assert.strictEqual(fragment.childNodes.length, 0, 'the fragment is empty again');
+
+    this.rerender({ foo: 'updated' });
+    this.assertHTML('<div><!---->[updated]<!----></div><!---->');
+  }
+
+  @test
+  'the same nodes come back after the region is removed and rendered again'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{#if this.show}}{{this.fragment}}{{/if}}</div>' +
+        '{{#in-element this.fragment}}<p>{{this.foo}}</p>{{/in-element}}',
+      { fragment, show: true, foo: 'first' }
+    );
+
+    const paragraph = (this.element as unknown as Element).querySelector('p');
+
+    this.rerender({ show: false });
+    this.rerender({ show: true });
+
+    this.assert.strictEqual(
+      (this.element as unknown as Element).querySelector('p'),
+      paragraph,
+      'the same element is rendered, so its state survives'
+    );
+
+    this.rerender({ foo: 'second' });
+    this.assertHTML('<div><!----><p>second</p><!----></div><!---->');
+  }
+
+  @test
+  'toggling the region repeatedly keeps the content'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{#if this.show}}{{this.fragment}}{{/if}}</div>' +
+        '{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}',
+      { fragment, show: true, foo: 'kept' }
+    );
+
+    for (let round = 0; round < 3; round++) {
+      this.rerender({ show: false });
+      this.assertHTML('<div><!----></div><!---->');
+
+      this.rerender({ show: true });
+      this.assertHTML('<div><!---->[kept]<!----></div><!---->');
+    }
+  }
+
+  @test
+  'sibling regions each hand their content back'() {
+    const first = document.createDocumentFragment();
+    const second = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{#if this.show}}{{this.first}}{{this.second}}{{/if}}</div>' +
+        '{{#in-element this.first}}[first]{{/in-element}}' +
+        '{{#in-element this.second}}[second]{{/in-element}}',
+      { first, second, show: true }
+    );
+
+    this.assertHTML('<div><!---->[first]<!----><!---->[second]<!----></div><!----><!---->');
+
+    this.rerender({ show: false });
+    this.assert.strictEqual(first.textContent, '[first]', 'the first fragment holds its content');
+    this.assert.strictEqual(
+      second.textContent,
+      '[second]',
+      'the second fragment holds its content'
+    );
+
+    this.rerender({ show: true });
+    this.assertHTML('<div><!---->[first]<!----><!---->[second]<!----></div><!----><!---->');
+  }
+
+  @test
   'swapping between a fragment and other content'() {
     const fragment = document.createDocumentFragment();
     fragment.appendChild(paragraph('one'));

--- a/packages/@glimmer-workspace/integration-tests/lib/suites/render-document-fragment.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/render-document-fragment.ts
@@ -1,0 +1,258 @@
+import { RenderTest } from '../render-test';
+import { test } from '../test-decorator';
+
+function paragraph(text: string): HTMLParagraphElement {
+  const el = document.createElement('p');
+  el.textContent = text;
+  return el;
+}
+
+export class RenderDocumentFragmentSuite extends RenderTest {
+  static suiteName = '{{fragment}} (DocumentFragment)';
+
+  @test
+  'renders the children of a fragment'() {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(paragraph('one'));
+    fragment.appendChild(paragraph('two'));
+
+    this.render('<div>{{this.fragment}}</div>', { fragment });
+
+    this.assertHTML('<div><!----><p>one</p><p>two</p><!----></div>');
+    this.assert.strictEqual(fragment.childNodes.length, 0, 'the fragment is empty after render');
+    this.assertStableRerender();
+  }
+
+  @test
+  'renders an empty fragment'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render('<div>{{this.fragment}}</div>', { fragment });
+
+    this.assertHTML('<div><!----><!----></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'content rendered into the fragment afterwards goes to the rendered location'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.fragment}}{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}</div>',
+      { fragment, foo: 'first' }
+    );
+
+    this.assertHTML('<div><!---->[first]<!----><!----></div>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'second' });
+    this.assertHTML('<div><!---->[second]<!----><!----></div>');
+
+    this.rerender({ foo: 'first' });
+    this.assertHTML('<div><!---->[first]<!----><!----></div>');
+  }
+
+  @test
+  'content rendered into the fragment beforehand moves to the rendered location'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}{{this.fragment}}</div>',
+      { fragment, foo: 'first' }
+    );
+
+    this.assertHTML('<div><!----><!---->[first]<!----></div>');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'second' });
+    this.assertHTML('<div><!----><!---->[second]<!----></div>');
+  }
+
+  @test
+  'the region keeps its place when its content grows'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.fragment}}<b>after</b></div>' +
+        '{{#in-element this.fragment}}{{#each this.items key="@identity" as |item|}}[{{item}}]{{/each}}{{/in-element}}',
+      { fragment, items: ['a'] }
+    );
+
+    this.assertHTML('<div><!---->[a]<!----><b>after</b></div><!---->');
+    this.assertStableRerender();
+
+    this.rerender({ items: ['a', 'b'] });
+    this.assertHTML('<div><!---->[a][b]<!----><b>after</b></div><!---->');
+
+    this.rerender({ items: ['b'] });
+    this.assertHTML('<div><!---->[b]<!----><b>after</b></div><!---->');
+  }
+
+  @test
+  'sibling fragments keep separate regions'() {
+    const first = document.createDocumentFragment();
+    const second = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.first}}{{this.second}}</div>' +
+        '{{#in-element this.first}}[first:{{this.one}}]{{/in-element}}' +
+        '{{#in-element this.second}}[second:{{this.two}}]{{/in-element}}',
+      { first, second, one: 1, two: 2 }
+    );
+
+    this.assertHTML('<div><!---->[first:1]<!----><!---->[second:2]<!----></div><!----><!---->');
+    this.assertStableRerender();
+
+    this.rerender({ one: 3 });
+    this.assertHTML('<div><!---->[first:3]<!----><!---->[second:2]<!----></div><!----><!---->');
+
+    this.rerender({ two: 4 });
+    this.assertHTML('<div><!---->[first:3]<!----><!---->[second:4]<!----></div><!----><!---->');
+  }
+
+  @test
+  'sibling regions stay in template order when both grow'() {
+    const first = document.createDocumentFragment();
+    const second = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.first}}{{this.second}}</div>' +
+        '{{#in-element this.first}}{{#each this.left key="@identity" as |item|}}[L{{item}}]{{/each}}{{/in-element}}' +
+        '{{#in-element this.second}}{{#each this.right key="@identity" as |item|}}[R{{item}}]{{/each}}{{/in-element}}',
+      { first, second, left: [1], right: [1] }
+    );
+
+    this.assertHTML('<div><!---->[L1]<!----><!---->[R1]<!----></div><!----><!---->');
+
+    this.rerender({ left: [1, 2], right: [1, 2] });
+    this.assertHTML('<div><!---->[L1][L2]<!----><!---->[R1][R2]<!----></div><!----><!---->');
+  }
+
+  @test
+  '{{#in-element}} without insertBefore replaces the content of the region'() {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(paragraph('static'));
+
+    this.render(
+      '<div>{{this.fragment}}{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}</div>',
+      { fragment, foo: 'fresh' }
+    );
+
+    this.assertHTML('<div><!---->[fresh]<!----><!----></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  '{{#in-element}} with insertBefore=null appends to the region'() {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(paragraph('static'));
+
+    this.render(
+      '<div>{{this.fragment}}{{#in-element this.fragment insertBefore=null}}[{{this.foo}}]{{/in-element}}</div>',
+      { fragment, foo: 'extra' }
+    );
+
+    this.assertHTML('<div><!----><p>static</p>[extra]<!----><!----></div>');
+    this.assertStableRerender();
+  }
+
+  @test
+  'two {{#in-element}} blocks into one rendered fragment keep their order'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.fragment}}' +
+        '{{#in-element this.fragment}}[{{this.one}}]{{/in-element}}' +
+        '{{#in-element this.fragment insertBefore=null}}[{{this.two}}]{{/in-element}}</div>',
+      { fragment, one: 'one', two: 'two' }
+    );
+
+    this.assertHTML('<div><!---->[one][two]<!----><!----><!----></div>');
+    this.assertStableRerender();
+
+    this.rerender({ two: 'second' });
+    this.assertHTML('<div><!---->[one][second]<!----><!----><!----></div>');
+  }
+
+  @test
+  'removing and restoring the fragment renders the content again'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{#if this.show}}{{this.fragment}}' +
+        '{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}{{/if}}</div>',
+      { show: true, fragment, foo: 'here' }
+    );
+
+    this.assertHTML('<div><!---->[here]<!----><!----></div>');
+
+    this.rerender({ show: false });
+    this.assertHTML('<div><!----></div>');
+
+    this.rerender({ show: true });
+    this.assertHTML('<div><!---->[here]<!----><!----></div>');
+
+    this.rerender({ foo: 'again' });
+    this.assertHTML('<div><!---->[again]<!----><!----></div>');
+  }
+
+  @test
+  'removing and restoring the content of a live region'() {
+    const fragment = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.fragment}}<b>after</b></div>' +
+        '{{#if this.show}}{{#in-element this.fragment}}[{{this.foo}}]{{/in-element}}{{/if}}',
+      { fragment, show: true, foo: 'here' }
+    );
+
+    this.assertHTML('<div><!---->[here]<!----><b>after</b></div><!---->');
+    this.assertStableRerender();
+
+    this.rerender({ show: false });
+    this.assertHTML('<div><!----><!----><b>after</b></div><!---->');
+
+    this.rerender({ show: true });
+    this.assertHTML('<div><!---->[here]<!----><b>after</b></div><!---->');
+
+    this.rerender({ foo: 'again' });
+    this.assertHTML('<div><!---->[again]<!----><b>after</b></div><!---->');
+  }
+
+  @test
+  'swapping between a fragment and other content'() {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(paragraph('one'));
+
+    const other = document.createDocumentFragment();
+    other.appendChild(paragraph('two'));
+
+    this.render('<div>{{this.value}}</div>', { value: fragment });
+    this.assertHTML('<div><!----><p>one</p><!----></div>');
+
+    this.rerender({ value: 'plain text' });
+    this.assertHTML('<div>plain text</div>');
+
+    this.rerender({ value: other });
+    this.assertHTML('<div><!----><p>two</p><!----></div>');
+  }
+
+  @test
+  'a fragment rendered inside another fragment'() {
+    const outer = document.createDocumentFragment();
+    const inner = document.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.outer}}</div>' +
+        '{{#in-element this.outer}}{{this.inner}}{{/in-element}}' +
+        '{{#in-element this.inner}}[{{this.foo}}]{{/in-element}}',
+      { outer, inner, foo: 'nested' }
+    );
+
+    this.assertHTML('<div><!----><!---->[nested]<!----><!----></div><!----><!---->');
+    this.assertStableRerender();
+
+    this.rerender({ foo: 'updated' });
+    this.assertHTML('<div><!----><!---->[updated]<!----><!----></div><!----><!---->');
+  }
+}

--- a/packages/@glimmer-workspace/integration-tests/lib/suites/ssr.ts
+++ b/packages/@glimmer-workspace/integration-tests/lib/suites/ssr.ts
@@ -187,6 +187,50 @@ export class ServerSideSuite extends AbstractNodeTest {
 
     this.assertHTML(template);
   }
+
+  @test
+  'DocumentFragment renders between region markers'() {
+    let fragment = this.delegate.createDocumentFragment();
+    fragment.appendChild(this.delegate.createTextNode('hello'));
+
+    this.render('<div>{{this.fragment}}</div>', { fragment });
+
+    this.assertHTML('<div><!---->hello<!----></div>');
+  }
+
+  @test
+  'an empty DocumentFragment renders as a pair of region markers'() {
+    this.render('<div>{{this.fragment}}</div>', {
+      fragment: this.delegate.createDocumentFragment(),
+    });
+
+    this.assertHTML('<div><!----><!----></div>');
+  }
+
+  @test
+  '{{#in-element}} into a rendered fragment renders inside the region'() {
+    let fragment = this.delegate.createDocumentFragment();
+
+    this.render(
+      '<div>{{this.fragment}}{{#in-element this.fragment}}[content]{{/in-element}}</div>',
+      { fragment }
+    );
+
+    this.assertHTML('<div><!---->[content]<!----><!----></div>');
+  }
+
+  @test
+  'sibling fragments render as separate regions'() {
+    let first = this.delegate.createDocumentFragment();
+    let second = this.delegate.createDocumentFragment();
+
+    first.appendChild(this.delegate.createTextNode('one'));
+    second.appendChild(this.delegate.createTextNode('two'));
+
+    this.render('<div>{{this.first}}{{this.second}}</div>', { first, second });
+
+    this.assertHTML('<div><!---->one<!----><!---->two<!----></div>');
+  }
 }
 
 export class ServerSideComponentSuite extends AbstractNodeTest {

--- a/packages/@glimmer-workspace/integration-tests/test/initial-render-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/initial-render-test.ts
@@ -72,6 +72,15 @@ class AbstractRehydrationTests extends InitialRenderSuite {
   assertServerOutput(..._expected: Content[]) {
     this.assertExactServerOutput(content([OPEN, ..._expected, CLOSE]));
   }
+
+  assertServerOutputIncludes(fragment: string, message: string) {
+    let output = expect(
+      this.serverOutput,
+      'must renderServerSide before calling assertServerOutputIncludes'
+    );
+
+    this.assert.ok(output.includes(fragment), `${message}: ${fragment}`);
+  }
 }
 
 class Rehydration extends AbstractRehydrationTests {
@@ -632,6 +641,95 @@ class Rehydration extends AbstractRehydrationTests {
       toInnerHTML(clientRemote),
       '<prefix></prefix><inner>Wat Wat</inner><preexisting></preexisting>'
     );
+  }
+
+  @test
+  'a rendered DocumentFragment can rehydrate'() {
+    let template = '<div>{{this.fragment}}</div>';
+
+    let serverFragment = this.delegate.serverDoc.createDocumentFragment();
+    serverFragment.appendChild(this.delegate.serverDoc.createElement('p'));
+
+    this.renderServerSide(template, { fragment: serverFragment });
+    this.assertServerOutput('<div>', OPEN, '<!--%+f%--><p></p><!--%-f%-->', CLOSE, '</div>');
+
+    let clientFragment = this.delegate.clientDoc.createDocumentFragment();
+    clientFragment.appendChild(this.delegate.clientDoc.createElement('p'));
+
+    this.renderClientSide(template, { fragment: clientFragment });
+    this.assertHTML('<div><!----><p></p><!----></div>');
+    // The client fragment holds the live nodes, so its children win over the
+    // serialized ones.
+    this.assertRehydrationStats({ nodesRemoved: 1 });
+  }
+
+  @test
+  'an empty rendered DocumentFragment can rehydrate'() {
+    let template = '<div>{{this.fragment}}</div>';
+
+    this.renderServerSide(template, {
+      fragment: this.delegate.serverDoc.createDocumentFragment(),
+    });
+    this.assertServerOutput('<div>', OPEN, '<!--%+f%--><!--%-f%-->', CLOSE, '</div>');
+
+    this.renderClientSide(template, {
+      fragment: this.delegate.clientDoc.createDocumentFragment(),
+    });
+    this.assertHTML('<div><!----><!----></div>');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+  }
+
+  @test
+  '{{#in-element}} into a rendered DocumentFragment can rehydrate'() {
+    let template = strip`
+      <div>{{this.fragment}}</div>
+      {{#in-element this.fragment}}<inner>{{this.text}}</inner>{{/in-element}}
+      `;
+
+    this.renderServerSide(template, {
+      fragment: this.delegate.serverDoc.createDocumentFragment(),
+      text: 'Wat Wat',
+    });
+    this.assertServerOutputIncludes(
+      '<!--%+f%--><script glmr=',
+      'the in-element marker is serialized inside the region'
+    );
+
+    this.renderClientSide(template, {
+      fragment: this.delegate.clientDoc.createDocumentFragment(),
+      text: 'Wat Wat',
+    });
+    this.assertHTML('<div><!----><inner>Wat Wat</inner><!----></div><!---->');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
+    this.assertStableRerender();
+
+    this.rerender({ text: 'Wat Wat Wat' });
+    this.assertHTML('<div><!----><inner>Wat Wat Wat</inner><!----></div><!---->');
+  }
+
+  @test
+  'sibling DocumentFragments can rehydrate'() {
+    let template = strip`
+      <div>{{this.first}}{{this.second}}</div>
+      {{#in-element this.first}}<one></one>{{/in-element}}
+      {{#in-element this.second}}<two></two>{{/in-element}}
+      `;
+
+    this.renderServerSide(template, {
+      first: this.delegate.serverDoc.createDocumentFragment(),
+      second: this.delegate.serverDoc.createDocumentFragment(),
+    });
+    this.assertServerOutputIncludes(
+      '<!--%-f%--><!--%-b:1%--><!--%+b:1%--><!--%+f%-->',
+      'the two regions are serialized side by side'
+    );
+
+    this.renderClientSide(template, {
+      first: this.delegate.clientDoc.createDocumentFragment(),
+      second: this.delegate.clientDoc.createDocumentFragment(),
+    });
+    this.assertHTML('<div><!----><one></one><!----><!----><two></two><!----></div><!----><!---->');
+    this.assertRehydrationStats({ nodesRemoved: 0 });
   }
 
   @test

--- a/packages/@glimmer-workspace/integration-tests/test/jit-suites-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/jit-suites-test.ts
@@ -9,6 +9,7 @@ import {
   InElementSuite,
   jitComponentSuite,
   jitSuite,
+  RenderDocumentFragmentSuite,
   ScopeSuite,
   ShadowingSuite,
   TemplateOnlyComponents,
@@ -20,6 +21,7 @@ jitComponentSuite(DebuggerSuite);
 jitSuite(EachSuite);
 jitSuite(InElementSuite);
 jitSuite(InElementDocumentFragmentSuite);
+jitSuite(RenderDocumentFragmentSuite);
 
 jitComponentSuite(GlimmerishComponents);
 jitComponentSuite(TemplateOnlyComponents);

--- a/packages/@glimmer-workspace/integration-tests/test/updating-content-matrix-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/updating-content-matrix-test.ts
@@ -237,8 +237,12 @@ generateContentTestCase(ContentTest, {
           ]);
         }
       },
+      // A rendered fragment is bracketed by comment markers so that its place in
+      // the DOM stays addressable after the fragment itself is emptied.
       expected: (_test, isHTML) =>
-        isHTML ? '<p>one</p><p>two</p>' : '<text>one</text><text>two</text>',
+        isHTML
+          ? '<!----><p>one</p><p>two</p><!---->'
+          : '<!----><text>one</text><text>two</text><!---->',
       description: 'DOM fragment containing multiple nodes',
     },
     {
@@ -344,8 +348,12 @@ generateContentTestCase(ContentTest, {
           ]);
         }
       },
+      // A rendered fragment is bracketed by comment markers so that its place in
+      // the DOM stays addressable after the fragment itself is emptied.
       expected: (_test, isHTML) =>
-        isHTML ? '<p>one</p><p>two</p>' : '<text>one</text><text>two</text>',
+        isHTML
+          ? '<!----><p>one</p><p>two</p><!---->'
+          : '<!----><text>one</text><text>two</text><!---->',
       description: 'DOM fragment containing multiple nodes',
     },
     {

--- a/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
+++ b/packages/@glimmer/interfaces/lib/dom/attributes.d.ts
@@ -62,7 +62,7 @@ export interface DOMStack {
 
   appendDynamicHTML(value: string): void;
   appendDynamicText(value: string): SimpleText;
-  appendDynamicFragment(value: SimpleDocumentFragment): void;
+  appendDynamicFragment(value: SimpleDocumentFragment): Bounds;
   appendDynamicNode(value: SimpleNode): void;
 
   setStaticAttribute(name: string, value: string, namespace: Nullable<string>): void;

--- a/packages/@glimmer/node/lib/serialize-builder.ts
+++ b/packages/@glimmer/node/lib/serialize-builder.ts
@@ -13,6 +13,11 @@ import type {
 } from '@glimmer/interfaces';
 import type { RemoteBlock } from '@glimmer/runtime/lib/vm/element-builder';
 import { ConcreteBounds } from '@glimmer/runtime/lib/bounds';
+import {
+  FRAGMENT_REGION_CLOSE,
+  FRAGMENT_REGION_OPEN,
+  fragmentRegionFor,
+} from '@glimmer/runtime/lib/dom/fragment-region';
 import { NewTreeBuilder } from '@glimmer/runtime/lib/vm/element-builder';
 
 const TEXT_NODE = 3;
@@ -144,6 +149,10 @@ class SerializeBuilder extends NewTreeBuilder implements TreeBuilder {
     return super.openElement(tag);
   }
 
+  protected override fragmentMarker(position: 'open' | 'close'): string {
+    return position === 'open' ? FRAGMENT_REGION_OPEN : FRAGMENT_REGION_CLOSE;
+  }
+
   override pushRemoteElement(
     element: SimpleElement | SimpleDocumentFragment,
     cursorId: string,
@@ -152,7 +161,17 @@ class SerializeBuilder extends NewTreeBuilder implements TreeBuilder {
     let { dom } = this;
     let script = dom.createElement('script');
     script.setAttribute('glmr', cursorId);
-    dom.insertBefore(element, script, insertBefore);
+
+    // A fragment that already rendered is empty. Its marker belongs in the
+    // region, which is the part of the document that gets serialized.
+    let region = fragmentRegionFor(element);
+
+    if (region) {
+      dom.insertBefore(region.parentNode(), script, insertBefore ?? region.insertionPoint());
+    } else {
+      dom.insertBefore(element, script, insertBefore);
+    }
+
     return super.pushRemoteElement(element, cursorId, insertBefore);
   }
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/content.ts
@@ -124,7 +124,9 @@ APPEND_OPCODES.add(VM_APPEND_DOCUMENT_FRAGMENT_OP, (vm) => {
 
   let value = check(valueForRef(reference), CheckDocumentFragment);
 
-  vm.tree().appendDynamicFragment(value);
+  // The region owns DOM that outlives this append: when it is torn down it
+  // hands the content back to the fragment.
+  vm.associateDestroyable(vm.tree().appendDynamicFragment(value));
 });
 
 APPEND_OPCODES.add(VM_APPEND_NODE_OP, (vm) => {

--- a/packages/@glimmer/runtime/lib/dom/fragment-region.ts
+++ b/packages/@glimmer/runtime/lib/dom/fragment-region.ts
@@ -5,6 +5,7 @@ import type {
   SimpleElement,
   SimpleNode,
 } from '@glimmer/interfaces';
+import { registerDestructor } from '@glimmer/destroyable';
 
 import { parentOf } from '../bounds';
 import { isFragment } from './normalize';
@@ -17,13 +18,23 @@ import { isFragment } from './normalize';
  * A region is that address. It is a pair of comment markers around the place
  * where the fragment's children went, so `{{#in-element fragment}}` can render
  * into the same place after `{{fragment}}` already emptied the fragment.
+ *
+ * The fragment stays the owner of the content. When the region goes away, the
+ * content moves back into the fragment instead of being thrown away, so a
+ * `{{fragment}}` that renders again shows the same nodes with their state
+ * intact.
  */
 export class FragmentRegion implements Bounds {
   constructor(
+    private fragment: SimpleDocumentFragment,
     private parent: SimpleElement | SimpleDocumentFragment,
     private open: SimpleNode,
     private close: SimpleNode
-  ) {}
+  ) {
+    // Eager, because the destructor has to run before the enclosing block
+    // removes the region's nodes from the DOM.
+    registerDestructor(this, () => this.returnContent(), true);
+  }
 
   parentNode(): SimpleElement | SimpleDocumentFragment {
     return parentOf(this.open) ?? this.parent;
@@ -55,11 +66,23 @@ export class FragmentRegion implements Bounds {
    */
   clearContent(): void {
     let parent = this.parentNode();
+
+    this.eachContentNode((node) => parent.removeChild(node));
+  }
+
+  /**
+   * Moves the content of the region back into the fragment it came from.
+   */
+  private returnContent(): void {
+    this.eachContentNode((node) => this.fragment.insertBefore(node, null));
+  }
+
+  private eachContentNode(callback: (node: SimpleNode) => void): void {
     let node = this.open.nextSibling;
 
     while (node !== null && node !== this.close) {
       let next = node.nextSibling;
-      parent.removeChild(node);
+      callback(node);
       node = next;
     }
   }

--- a/packages/@glimmer/runtime/lib/dom/fragment-region.ts
+++ b/packages/@glimmer/runtime/lib/dom/fragment-region.ts
@@ -1,0 +1,93 @@
+import type {
+  Bounds,
+  Nullable,
+  SimpleDocumentFragment,
+  SimpleElement,
+  SimpleNode,
+} from '@glimmer/interfaces';
+
+import { parentOf } from '../bounds';
+import { isFragment } from './normalize';
+
+/**
+ * A DocumentFragment cannot stay in the DOM. Inserting one moves its children
+ * out and leaves the fragment empty, so the fragment is not an address that
+ * later renders can target.
+ *
+ * A region is that address. It is a pair of comment markers around the place
+ * where the fragment's children went, so `{{#in-element fragment}}` can render
+ * into the same place after `{{fragment}}` already emptied the fragment.
+ */
+export class FragmentRegion implements Bounds {
+  constructor(
+    private parent: SimpleElement | SimpleDocumentFragment,
+    private open: SimpleNode,
+    private close: SimpleNode
+  ) {}
+
+  parentNode(): SimpleElement | SimpleDocumentFragment {
+    return parentOf(this.open) ?? this.parent;
+  }
+
+  firstNode(): SimpleNode {
+    return this.open;
+  }
+
+  lastNode(): SimpleNode {
+    return this.close;
+  }
+
+  /**
+   * New content goes before the close marker. This keeps the content inside the
+   * region, and keeps sibling regions in template order.
+   */
+  insertionPoint(): SimpleNode {
+    return this.close;
+  }
+
+  isLive(): boolean {
+    return parentOf(this.open) !== null;
+  }
+
+  /**
+   * Removes the content of the region and keeps the markers, which is the
+   * fragment equivalent of removing an element's children.
+   */
+  clearContent(): void {
+    let parent = this.parentNode();
+    let node = this.open.nextSibling;
+
+    while (node !== null && node !== this.close) {
+      let next = node.nextSibling;
+      parent.removeChild(node);
+      node = next;
+    }
+  }
+}
+
+const REGIONS = new WeakMap<SimpleDocumentFragment, FragmentRegion>();
+
+export function setFragmentRegion(fragment: SimpleDocumentFragment, region: FragmentRegion): void {
+  REGIONS.set(fragment, region);
+}
+
+/**
+ * Returns the region that a fragment currently renders through, or null if the
+ * fragment was never rendered or its region was since removed from the DOM.
+ */
+export function fragmentRegionFor(
+  node: SimpleElement | SimpleDocumentFragment
+): Nullable<FragmentRegion> {
+  if (!isFragment(node)) return null;
+
+  let region = REGIONS.get(node);
+
+  if (region === undefined) return null;
+
+  if (!region.isLive()) {
+    REGIONS.delete(node);
+    return null;
+  }
+
+  return region;
+}

--- a/packages/@glimmer/runtime/lib/dom/fragment-region.ts
+++ b/packages/@glimmer/runtime/lib/dom/fragment-region.ts
@@ -88,10 +88,29 @@ export class FragmentRegion implements Bounds {
   }
 }
 
+/**
+ * Serialized region markers. The client uses empty comments, but a serialized
+ * document has to name them so that rehydration can find the region again.
+ */
+export const FRAGMENT_REGION_OPEN = '%+f%';
+export const FRAGMENT_REGION_CLOSE = '%-f%';
+
 const REGIONS = new WeakMap<SimpleDocumentFragment, FragmentRegion>();
 
-export function setFragmentRegion(fragment: SimpleDocumentFragment, region: FragmentRegion): void {
+/**
+ * Creates a region for a fragment and records it as the fragment's current one.
+ */
+export function makeFragmentRegion(
+  fragment: SimpleDocumentFragment,
+  parent: SimpleElement | SimpleDocumentFragment,
+  open: SimpleNode,
+  close: SimpleNode
+): FragmentRegion {
+  let region = new FragmentRegion(fragment, parent, open, close);
+
   REGIONS.set(fragment, region);
+
+  return region;
 }
 
 /**

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -28,6 +28,7 @@ import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import type { DynamicAttribute } from './attributes/dynamic';
 
 import { clear, ConcreteBounds, CursorImpl, liveParent } from '../bounds';
+import { fragmentRegionFor, FragmentRegion, setFragmentRegion } from '../dom/fragment-region';
 import { dynamicAttribute } from './attributes/dynamic';
 
 export interface FirstNode {
@@ -249,6 +250,23 @@ export class NewTreeBuilder implements TreeBuilder {
     _guid: string,
     insertBefore: Maybe<SimpleNode>
   ): RemoteBlock {
+    let region = fragmentRegionFor(element);
+
+    // A fragment that was already rendered through `{{fragment}}` is empty,
+    // because its children moved into the region. Render into the region,
+    // because content put into the fragment itself stays detached from the DOM.
+    if (region) {
+      let parent = region.parentNode();
+
+      this.pushElement(parent, insertBefore ?? region.insertionPoint());
+
+      if (insertBefore === undefined) {
+        region.clearContent();
+      }
+
+      return this.pushBlock(new RemoteBlock(parent), true);
+    }
+
     this.pushElement(element, insertBefore);
 
     if (insertBefore === undefined) {
@@ -319,18 +337,26 @@ export class NewTreeBuilder implements TreeBuilder {
     return node;
   }
 
+  /**
+   * Appends the fragment's children between a pair of comment markers, and
+   * records the markers as the fragment's region. The markers are always
+   * present, so the region is a stable address even when the fragment is empty
+   * and even after its content changes.
+   */
   __appendFragment(fragment: SimpleDocumentFragment): Bounds {
-    let first = fragment.firstChild;
+    let parent = this.element;
+    let open = this.__appendComment('');
 
-    if (first) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
-      let ret = new ConcreteBounds(this.element, first, fragment.lastChild!);
-      this.dom.insertBefore(this.element, fragment, this.nextSibling);
-      return ret;
-    } else {
-      const comment = this.__appendComment('');
-      return new ConcreteBounds(this.element, comment, comment);
+    if (fragment.firstChild) {
+      this.dom.insertBefore(parent, fragment, this.nextSibling);
     }
+
+    let close = this.__appendComment('');
+    let region = new FragmentRegion(parent, open, close);
+
+    setFragmentRegion(fragment, region);
+
+    return region;
   }
 
   __appendHTML(html: string): Bounds {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -28,7 +28,7 @@ import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import type { DynamicAttribute } from './attributes/dynamic';
 
 import { clear, ConcreteBounds, CursorImpl, liveParent } from '../bounds';
-import { fragmentRegionFor, FragmentRegion, setFragmentRegion } from '../dom/fragment-region';
+import { fragmentRegionFor, makeFragmentRegion } from '../dom/fragment-region';
 import { dynamicAttribute } from './attributes/dynamic';
 
 export interface FirstNode {
@@ -345,18 +345,23 @@ export class NewTreeBuilder implements TreeBuilder {
    */
   __appendFragment(fragment: SimpleDocumentFragment): Bounds {
     let parent = this.element;
-    let open = this.__appendComment('');
+    let open = this.__appendComment(this.fragmentMarker('open'));
 
     if (fragment.firstChild) {
       this.dom.insertBefore(parent, fragment, this.nextSibling);
     }
 
-    let close = this.__appendComment('');
-    let region = new FragmentRegion(fragment, parent, open, close);
+    let close = this.__appendComment(this.fragmentMarker('close'));
 
-    setFragmentRegion(fragment, region);
+    return makeFragmentRegion(fragment, parent, open, close);
+  }
 
-    return region;
+  /**
+   * The value of a region marker. It is empty on the client, and serialization
+   * gives it a name so that rehydration can find the region.
+   */
+  protected fragmentMarker(_position: 'open' | 'close'): string {
+    return '';
   }
 
   __appendHTML(html: string): Bounds {

--- a/packages/@glimmer/runtime/lib/vm/element-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/element-builder.ts
@@ -352,7 +352,7 @@ export class NewTreeBuilder implements TreeBuilder {
     }
 
     let close = this.__appendComment('');
-    let region = new FragmentRegion(parent, open, close);
+    let region = new FragmentRegion(fragment, parent, open, close);
 
     setFragmentRegion(fragment, region);
 
@@ -374,9 +374,8 @@ export class NewTreeBuilder implements TreeBuilder {
     return node;
   }
 
-  appendDynamicFragment(value: SimpleDocumentFragment): void {
-    let bounds = this.__appendFragment(value);
-    this.didAppendBounds(bounds);
+  appendDynamicFragment(value: SimpleDocumentFragment): Bounds {
+    return this.didAppendBounds(this.__appendFragment(value));
   }
 
   appendDynamicNode(value: SimpleNode): void {

--- a/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
+++ b/packages/@glimmer/runtime/lib/vm/rehydrate-builder.ts
@@ -6,6 +6,7 @@ import type {
   Nullable,
   SimpleAttr,
   SimpleComment,
+  SimpleDocumentFragment,
   SimpleElement,
   SimpleNode,
   SimpleText,
@@ -17,7 +18,15 @@ import { castToBrowser, castToSimple } from '@glimmer/debug-util/lib/simple-cast
 import { expect } from '@glimmer/debug-util/lib/platform-utils';
 import assert from '@glimmer/debug-util/lib/assert';
 
+import type { FragmentRegion } from '../dom/fragment-region';
+
 import { ConcreteBounds, CursorImpl } from '../bounds';
+import {
+  FRAGMENT_REGION_CLOSE,
+  FRAGMENT_REGION_OPEN,
+  fragmentRegionFor,
+  makeFragmentRegion,
+} from '../dom/fragment-region';
 import { NewTreeBuilder, RemoteBlock } from './element-builder';
 
 export const SERIALIZATION_FIRST_NODE_STRING = '%+b:0%';
@@ -31,7 +40,7 @@ export class RehydratingCursor extends CursorImpl {
   openBlockDepth: number;
   injectedOmittedNode = false;
   constructor(
-    element: SimpleElement,
+    element: SimpleElement | SimpleDocumentFragment,
     nextSibling: Nullable<SimpleNode>,
     public readonly startingBlockDepth: number
   ) {
@@ -311,6 +320,46 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
     }
   }
 
+  /**
+   * A serialized region is a pair of named comments around the content that was
+   * rendered for the fragment. Claim both markers and leave the content in
+   * place, so that an `{{#in-element}}` into the same fragment can claim it.
+   */
+  override __appendFragment(fragment: SimpleDocumentFragment): Bounds {
+    const open = this.candidate;
+
+    if (open === null || !isFragmentOpen(open)) {
+      return super.__appendFragment(fragment);
+    }
+
+    const close = findFragmentClose(open);
+
+    if (close === null) {
+      this.clearMismatch(open);
+      return super.__appendFragment(fragment);
+    }
+
+    // The markers are empty comments once they are on the client.
+    open.nodeValue = '';
+    close.nodeValue = '';
+
+    // A fragment that already holds content on the client wins over what the
+    // server put in the region, because the client nodes are the live ones.
+    if (fragment.firstChild) {
+      let node = open.nextSibling;
+
+      while (node !== null && node !== close) {
+        node = this.remove(node);
+      }
+
+      this.dom.insertBefore(this.element, fragment, close);
+    }
+
+    this.candidate = close.nextSibling;
+
+    return makeFragmentRegion(fragment, this.element, open, close);
+  }
+
   protected remove(node: SimpleNode): Nullable<SimpleNode> {
     const element = expect(node.parentNode, `cannot remove a detached node`) as SimpleElement;
     const next = node.nextSibling;
@@ -469,11 +518,17 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
   }
 
   override __pushRemoteElement(
-    element: SimpleElement,
+    element: SimpleElement | SimpleDocumentFragment,
     cursorId: string,
     insertBefore: Maybe<SimpleNode>
   ): RemoteBlock {
-    const marker = this.getMarker(castToBrowser(element, 'HTML'), cursorId);
+    const region = fragmentRegionFor(element);
+
+    if (region) {
+      return this.__pushRegion(region, cursorId, insertBefore);
+    }
+
+    const marker = this.getMarker(castToBrowser(element as SimpleElement, 'HTML'), cursorId);
 
     assert(
       !marker || marker.parentNode === element,
@@ -499,6 +554,43 @@ export class RehydrateTree extends NewTreeBuilder implements TreeBuilder {
 
     const block = new RemoteBlock(element);
     return this.pushBlock(block, true);
+  }
+
+  /**
+   * The destination fragment is empty, because its content is in the region.
+   * Rehydrate against the region instead.
+   */
+  private __pushRegion(
+    region: FragmentRegion,
+    cursorId: string,
+    insertBefore: Maybe<SimpleNode>
+  ): RemoteBlock {
+    const parent = region.parentNode();
+    const marker = findRegionMarker(region, cursorId);
+
+    // when insertBefore is not present, we clear the region
+    if (insertBefore === undefined) {
+      let node = region.firstNode().nextSibling;
+
+      while (node !== null && node !== marker && node !== region.lastNode()) {
+        node = this.remove(node);
+      }
+
+      insertBefore = null;
+    }
+
+    const nextSibling = insertBefore ?? region.insertionPoint();
+    const cursor = new RehydratingCursor(parent, nextSibling, this.blockDepth);
+
+    this.cursors.push(cursor);
+
+    if (marker === null) {
+      this.disableRehydration(nextSibling);
+    } else {
+      this.candidate = this.remove(marker);
+    }
+
+    return this.pushBlock(new RemoteBlock(parent), true);
   }
 
   override didAppendBounds(bounds: Bounds): Bounds {
@@ -537,6 +629,54 @@ function getBlockDepthWithOffset(node: SimpleComment, offset: number): number {
 
 function isElement(node: SimpleNode): node is SimpleElement {
   return node.nodeType === ELEMENT_NODE;
+}
+
+function isFragmentOpen(node: SimpleNode): node is SimpleComment {
+  return node.nodeType === COMMENT_NODE && node.nodeValue === FRAGMENT_REGION_OPEN;
+}
+
+function isFragmentClose(node: SimpleNode): node is SimpleComment {
+  return node.nodeType === COMMENT_NODE && node.nodeValue === FRAGMENT_REGION_CLOSE;
+}
+
+/**
+ * Regions nest, so count the openings that are passed on the way to the close.
+ */
+function findFragmentClose(open: SimpleNode): Nullable<SimpleComment> {
+  let depth = 0;
+  let node = open.nextSibling;
+
+  while (node !== null) {
+    if (isFragmentOpen(node)) {
+      depth++;
+    } else if (isFragmentClose(node)) {
+      if (depth === 0) return node;
+      depth--;
+    }
+
+    node = node.nextSibling;
+  }
+
+  return null;
+}
+
+/**
+ * Serialization puts the marker for an `{{#in-element}}` directly in the region,
+ * so a walk of the region's own nodes finds it.
+ */
+function findRegionMarker(region: FragmentRegion, cursorId: string): Nullable<SimpleNode> {
+  const close = region.lastNode();
+  let node = region.firstNode().nextSibling;
+
+  while (node !== null && node !== close) {
+    if (isElement(node) && node.tagName === 'SCRIPT' && node.getAttribute('glmr') === cursorId) {
+      return node;
+    }
+
+    node = node.nextSibling;
+  }
+
+  return null;
 }
 
 function isMarker(node: SimpleNode): boolean {


### PR DESCRIPTION
Builds on:
- https://github.com/emberjs/ember.js/pull/21551

Base branch is `nvp/in-element-document-fragment`, so this diff is only the new work. Retarget to `main` after #21551 lands.

Makes `{{fragment}}` renderable, which #21551 listed as out of scope.

## The problem

Inserting a `DocumentFragment` moves its children out and leaves the fragment empty. `{{fragment}}` inserted the children and returned bounds around them, so the fragment stopped being an address that later renders could target:

```gjs
const fragment = document.createDocumentFragment();

<template>
  {{fragment}}

  {{#in-element fragment}}
    {{state.count}}
  {{/in-element}}
</template>
```

`{{fragment}}` emptied the fragment. The `{{#in-element}}` then rendered into the detached fragment and nothing appeared in the DOM.

## The change

Rendering a fragment brackets its children with a pair of comment markers, and records that pair as the fragment's region:

```html
<div><!---->one<!----></div>
```

`{{#in-element fragment}}` renders into the region instead of the fragment. New content goes before the close marker, so it lands where the fragment was rendered.

The markers are always present, so the region is a stable address when the fragment is empty and after its content changes.

The fragment stays the owner of the content. When a region goes away, the content moves back into the fragment instead of being thrown away, so a `{{fragment}}` that renders again shows the same nodes with their state intact. The `{{#in-element}}` block is untouched by this: its components are neither destroyed nor created again.

## Serialization and rehydration

Serialization names the region markers, `%+f%` and `%-f%`, the way it names blocks:

```html
<div><!--%+b:1%--><!--%+f%--><p></p><!--%-f%--><!--%-b:1%--></div>
```

The marker for an `{{#in-element}}` is written into the region as well, because the fragment itself is empty by then and would not be serialized.

Rehydration claims the pair, turns the markers back into empty comments, and registers the region. `{{#in-element}}` into the same fragment then rehydrates against the serialized content instead of rendering it again. A client fragment that holds content of its own replaces the serialized content, because the client nodes are the live ones.

## What this supports

- Reactivity. Content rendered into the fragment updates in place, before or after `{{fragment}}` renders, and after rehydration.
- Siblings. Two fragments rendered next to each other keep separate regions, and each region keeps its place when its content grows.
- Order. Several `{{#in-element}}` blocks into one rendered fragment render in template order.
- Toggling. Removing and restoring `{{fragment}}` keeps the content and its state.
- `insertBefore=null` appends to the region. No `insertBefore` replaces the content of the region, which matches the behavior for an element destination.

## Tests

- `packages/@glimmer-workspace/integration-tests/lib/suites/render-document-fragment.ts` (18 tests)
- `packages/@ember/-internals/glimmer/tests/integration/document-fragment-test.js` (5 tests)
- `packages/@glimmer-workspace/integration-tests/lib/suites/ssr.ts` (4 tests)
- `packages/@glimmer-workspace/integration-tests/test/initial-render-test.ts` (4 rehydration tests)

Full suite passes: 9472 pass, 0 fail.

## Behavior change

`{{fragment}}` now emits two comment markers around the fragment's children. The expectations in `updating-content-matrix-test.ts` are updated for this.

## Out of scope

- Reflecting mutations made to the fragment outside of Glimmer. Glimmer does not observe DOM mutation.
- Rendering the same fragment in two places. The last render wins, because a fragment has one region.
- `insertBefore` values that point outside the region.
- Rehydrating a region whose client fragment is empty and which no `{{#in-element}}` claims. The serialized content stays, because nothing on the client says what should replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
