### PR TITLE
Manage destruction with symbol-properties, rather than weakmap

### DIFF
--- a/packages/@glimmer/component/src/-private/component.ts
+++ b/packages/@glimmer/component/src/-private/component.ts
@@ -265,11 +265,11 @@ export default class GlimmerComponent<S = unknown> {
   readonly args: Readonly<Args<S>>;
 
   get isDestroying(): boolean {
-    return this[IS_DESTROYING_KEY] || false;
+    return this[IS_DESTROYING_KEY];
   }
 
   get isDestroyed(): boolean {
-    return this[IS_DESTROYED_KEY] || false;
+    return this[IS_DESTROYED_KEY];
   }
 
   /**

--- a/packages/@glimmer/component/src/-private/component.ts
+++ b/packages/@glimmer/component/src/-private/component.ts
@@ -1,14 +1,7 @@
 import { DEBUG } from '@glimmer/env';
 
-const DESTROYING = new WeakMap<GlimmerComponent<object>, boolean>();
-const DESTROYED = new WeakMap<GlimmerComponent<object>, boolean>();
-
-export function setDestroying(component: GlimmerComponent<object>): void {
-  DESTROYING.set(component, true);
-}
-export function setDestroyed(component: GlimmerComponent<object>): void {
-  DESTROYED.set(component, true);
-}
+export const IS_DESTROYING_KEY = Symbol('__is_destroying__');
+export const IS_DESTROYED_KEY = Symbol('__is_destroyed__');
 
 // This provides a type-safe `WeakMap`: the getter and setter link the key to a
 // specific value. This is how `WeakMap`s actually behave, but the TS type
@@ -224,6 +217,9 @@ export type Args<S> = ExpandSignature<S>['Args']['Named'];
  * inside the component `this.args.firstName` would also be `Tom`.
  */
 export default class GlimmerComponent<S = unknown> {
+  [IS_DESTROYING_KEY] = false;
+  [IS_DESTROYED_KEY] = false;
+
   /**
    * Constructs a new component and assigns itself the passed properties. You
    * should not construct new components yourself. Instead, Glimmer will
@@ -240,9 +236,6 @@ export default class GlimmerComponent<S = unknown> {
     }
 
     this.args = args;
-
-    DESTROYING.set(this, false);
-    DESTROYED.set(this, false);
   }
 
   /**
@@ -272,11 +265,11 @@ export default class GlimmerComponent<S = unknown> {
   readonly args: Readonly<Args<S>>;
 
   get isDestroying(): boolean {
-    return DESTROYING.get(this) || false;
+    return this[IS_DESTROYING_KEY] || false;
   }
 
   get isDestroyed(): boolean {
-    return DESTROYED.get(this) || false;
+    return this[IS_DESTROYED_KEY] || false;
   }
 
   /**

--- a/packages/@glimmer/component/src/-private/ember-component-manager.ts
+++ b/packages/@glimmer/component/src/-private/ember-component-manager.ts
@@ -3,7 +3,7 @@ import { capabilities } from '@ember/component';
 import { schedule } from '@ember/runloop';
 import BaseComponentManager from './base-component-manager';
 
-import { type default as GlimmerComponent, setDestroyed, setDestroying } from './component';
+import { type default as GlimmerComponent, IS_DESTROYING_KEY, IS_DESTROYED_KEY } from './component';
 import type { Arguments } from '@glimmer/interfaces';
 
 const CAPABILITIES = capabilities('3.13', {
@@ -18,7 +18,7 @@ function scheduledDestroyComponent(component: GlimmerComponent): void {
   }
 
   destroy(component);
-  setDestroyed(component);
+  component[IS_DESTROYED_KEY] = true;
 }
 
 /**
@@ -35,7 +35,7 @@ class EmberGlimmerComponentManager extends BaseComponentManager<GlimmerComponent
       return;
     }
 
-    setDestroying(component);
+    component[IS_DESTROYING_KEY] = true;
 
     schedule('actions', component, component.willDestroy);
     schedule('destroy', this, scheduledDestroyComponent, component);


### PR DESCRIPTION
> [!NOTE]
> No AI was used in the making of this PR :p 

Same optimization as before.

I did look in to dropping all this and just using the built in / `@ember/destroyable` stuff -- but I'm pretty sure there are timing issues when I do that, and there are no tests -- so separately I've added: https://github.com/emberjs/ember.js/pull/21582

<details><summary>does perf change?</summary>

------------------

> [!NOTE]
> I had to make a [class-component version](https://github.com/emberjs/ember.js/compare/nvp/perf/glimmer-component-class-based-bench?expand=1#diff-939533fb1ee167ce350259ff93bbb2547e30e5d630c53ecbf824bca07994315a) of the benchmark to test this



> [!IMPORTANT]
> I'm running benches now with CPU-boost turned off, and pinning the bench run to a single CPU core for consistency (taskset)


```bash
echo 0 | sudo tee /sys/devices/system/cpu/cpufreq/boost
taskset -c 7 pnpm bench
# undo
echo 1 | sudo tee /sys/devices/system/cpu/cpufreq/boost
```

Impact:
- tiny, but tiny things add up, and it's all scoped to `@glimmer/component` (and less code than before)
<img width="129" height="47" alt="image" src="https://github.com/user-attachments/assets/bc8ef75c-95f8-4d48-a175-50708aea12c4" />


<img width="1177" height="2001" alt="image" src="https://github.com/user-attachments/assets/7669e550-35ba-4ef4-a031-9fab3fbad599" />

full report here:
[artifact-1.pdf](https://github.com/user-attachments/files/31230646/artifact-1.pdf)


</details>