### PR TITLE
Don't use build for publishing in 'pnpm bench'

### DIFF
--- a/bin/benchmark.mjs
+++ b/bin/benchmark.mjs
@@ -19,8 +19,7 @@ Options:
      --no-headless            run Chrome without headless mode (opens visible browser windows)
 
 Notes:
-	- This script runs \`pnpm install\` and \`node ./bin/build-for-publishing.cjs\` in both repos.
-	- build-for-publishing updates files in-place; it will modify your working tree.
+	- This script runs \`pnpm install\`, \`pnpm build\`, and \`pnpm pack\` in both repos.
 	- Benchmark apps are built with \`vite build\` and served using \`vite preview\`.
 `);
   process.exit(0);

--- a/bin/benchmark/utils.mjs
+++ b/bin/benchmark/utils.mjs
@@ -58,12 +58,8 @@ export async function waitForServer(url, { timeout = 30_000, interval = 500 } = 
 
 export async function buildEmberSource(cwd) {
   await run('pnpm', ['install'], { cwd });
-
-  if (existsSync(join(cwd, './bin/build-for-publishing.js'))) {
-    await run('node', ['./bin/build-for-publishing.js'], { cwd });
-    return;
-  }
-  await run('node', ['./bin/build-for-publishing.cjs'], { cwd });
+  await run('pnpm', ['build'], { cwd });
+  await run('pnpm', ['pack'], { cwd });
 }
 
 /**


### PR DESCRIPTION
build-for-publish mutates the package.json during publish -- which we don't want as we run `pnpm bench` (which was calling build-for-publish) on any PR that touches the VM