### PR TITLE
Deprecate mixins

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -133,6 +133,13 @@ export const DEPRECATIONS = {
     until: '8.0.0',
     url: 'https://deprecations.emberjs.com/id/deprecate-evented',
   }),
+  DEPRECATE_MIXINS: deprecation({
+    id: 'deprecate-mixins',
+    for: 'ember-source',
+    since: { available: '7.4.0' },
+    until: '8.0.0',
+    url: 'https://deprecations.emberjs.com/id/deprecate-mixins',
+  }),
 };
 
 export function deprecateUntil(message: string, deprecation: DeprecationObject) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/target-action-test.js
@@ -7,7 +7,6 @@ import {
 } from 'internal-test-helpers';
 
 import { action, set } from '@ember/object';
-import Mixin from '@ember/object/mixin';
 import Controller from '@ember/controller';
 import EmberObject from '@ember/object';
 import { DEPRECATIONS } from '@ember/-internals/deprecations';
@@ -149,18 +148,16 @@ moduleFor(
         }
       };
 
-      let BarViewMixin = Mixin.create({
-        actions: {
-          bar(msg) {
-            assert.equal(msg, 'HELLO');
-            this._super(msg);
-          },
-        },
-      });
-
       this.owner.register(
         'component:x-index',
-        class extends SuperComponent.extend(BarViewMixin) {
+        class extends SuperComponent.extend({
+          actions: {
+            bar(msg) {
+              assert.equal(msg, 'HELLO');
+              this._super(msg);
+            },
+          },
+        }) {
           init() {
             super.init(...arguments);
             component = this;

--- a/packages/@ember/-internals/metal/tests/accessors/get_test.js
+++ b/packages/@ember/-internals/metal/tests/accessors/get_test.js
@@ -1,7 +1,7 @@
 import { ENV } from '@ember/-internals/environment';
 import EmberObject, { observer } from '@ember/object';
 import { get } from '../..';
-import Mixin from '@ember/object/mixin';
+import { mixin } from '@ember/object/mixin';
 import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
 import { run } from '@ember/runloop';
 import { destroy } from '@glimmer/destroyable';
@@ -187,12 +187,13 @@ moduleFor(
     ['@test (regression) watched properties on unmodified inherited objects should still return their original value'](
       assert
     ) {
-      let MyMixin = Mixin.create({
-        someProperty: 'foo',
-        propertyDidChange: observer('someProperty', () => {}),
-      });
-
-      let baseObject = MyMixin.apply({});
+      let baseObject = mixin(
+        {},
+        {
+          someProperty: 'foo',
+          propertyDidChange: observer('someProperty', () => {}),
+        }
+      );
       let theRealObject = Object.create(baseObject);
 
       assert.equal(

--- a/packages/@ember/-internals/metal/tests/events_test.js
+++ b/packages/@ember/-internals/metal/tests/events_test.js
@@ -141,13 +141,13 @@ moduleFor(
     }
 
     [`${testUnless(
-      DEPRECATIONS.DEPRECATE_EVENTED.isRemoved
+      DEPRECATIONS.DEPRECATE_EVENTED.isRemoved || DEPRECATIONS.DEPRECATE_MIXINS.isRemoved
     )} @test a listener can be added as part of a mixin`](assert) {
       let triggered = 0;
-      let MyMixin;
+      let props;
       expectDeprecation(
         () => {
-          MyMixin = Mixin.create({
+          props = {
             foo1: on('bar', function () {
               triggered++;
             }),
@@ -155,10 +155,19 @@ moduleFor(
             foo2: on('bar', function () {
               triggered++;
             }),
-          });
+          };
         },
         /`on\(\)` event decorator is deprecated/,
         DEPRECATIONS.DEPRECATE_EVENTED.isEnabled
+      );
+
+      let MyMixin;
+      expectDeprecation(
+        () => {
+          MyMixin = Mixin.create(props);
+        },
+        /Using mixins is deprecated/,
+        DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
       );
 
       let obj = {};
@@ -197,17 +206,39 @@ moduleFor(
     }
 
     [`${testUnless(
-      DEPRECATIONS.DEPRECATE_EVENTED.isRemoved
+      DEPRECATIONS.DEPRECATE_EVENTED.isRemoved || DEPRECATIONS.DEPRECATE_MIXINS.isRemoved
     )} @test a listener added as part of a mixin may be overridden`](assert) {
       let triggered = 0;
-      let FirstMixin;
+      let FirstProps;
       expectDeprecation(
         () => {
-          FirstMixin = Mixin.create({
+          FirstProps = {
             foo: on('bar', function () {
               triggered++;
             }),
-          });
+          };
+        },
+        /`on\(\)` event decorator is deprecated/,
+        DEPRECATIONS.DEPRECATE_EVENTED.isEnabled
+      );
+
+      let FirstMixin;
+      expectDeprecation(
+        () => {
+          FirstMixin = Mixin.create(FirstProps);
+        },
+        /Using mixins is deprecated/,
+        DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+      );
+
+      let SecondProps;
+      expectDeprecation(
+        () => {
+          SecondProps = {
+            foo: on('baz', function () {
+              triggered++;
+            }),
+          };
         },
         /`on\(\)` event decorator is deprecated/,
         DEPRECATIONS.DEPRECATE_EVENTED.isEnabled
@@ -216,14 +247,10 @@ moduleFor(
       let SecondMixin;
       expectDeprecation(
         () => {
-          SecondMixin = Mixin.create({
-            foo: on('baz', function () {
-              triggered++;
-            }),
-          });
+          SecondMixin = Mixin.create(SecondProps);
         },
-        /`on\(\)` event decorator is deprecated/,
-        DEPRECATIONS.DEPRECATE_EVENTED.isEnabled
+        /Using mixins is deprecated/,
+        DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
       );
 
       let obj = {};

--- a/packages/@ember/-internals/metal/tests/mixin/apply_test.js
+++ b/packages/@ember/-internals/metal/tests/mixin/apply_test.js
@@ -1,13 +1,18 @@
 import { get } from '@ember/object';
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../deprecations';
 
 function K() {}
 
 moduleFor(
   'Mixin.apply',
   class extends AbstractTestCase {
-    ['@test using apply() should apply properties'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test using apply() should apply properties`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({ foo: 'FOO', baz: K });
       let obj = {};
       mixin(obj, MixinA);

--- a/packages/@ember/-internals/metal/tests/namespace_search_test.js
+++ b/packages/@ember/-internals/metal/tests/namespace_search_test.js
@@ -1,10 +1,15 @@
 import Mixin from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../deprecations';
 
 moduleFor(
   'NamespaceSearch',
   class extends AbstractTestCase {
-    ['@test classToString: null as this inside class must not throw error'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test classToString: null as this inside class must not throw error`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let mixin = Mixin.create();
       assert.equal(
         mixin.toString(),

--- a/packages/@ember/-internals/metal/tests/native_desc_decorator_test.js
+++ b/packages/@ember/-internals/metal/tests/native_desc_decorator_test.js
@@ -1,7 +1,8 @@
 import EmberObject from '@ember/object';
 import { defineProperty, nativeDescDecorator } from '..';
 import Mixin from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../deprecations';
 
 let classes = [
   class {
@@ -97,6 +98,8 @@ let classes = [
       return `${title}: in EmberObject.extend() through a mixin`;
     }
 
+    static usesMixins = true;
+
     constructor() {
       this.klass = null;
       this.props = {};
@@ -149,221 +152,290 @@ let classes = [
   },
 ];
 
-classes.forEach((TestClass) => {
-  moduleFor(
-    TestClass.module('@ember/-internals/metal/nativeDescDecorator'),
-    class extends AbstractTestCase {
-      ['@test defining a configurable property'](assert) {
-        let factory = new TestClass(assert);
+classes
+  .filter((TestClass) => !TestClass.usesMixins || !DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)
+  .forEach((TestClass) => {
+    moduleFor(
+      TestClass.module('@ember/-internals/metal/nativeDescDecorator'),
+      class extends AbstractTestCase {
+        ['@test defining a configurable property'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
 
-        factory.install('foo', nativeDescDecorator({ configurable: true, value: 'bar' }), assert);
+          let factory = new TestClass(assert);
 
-        let obj = factory.finalize();
+          factory.install('foo', nativeDescDecorator({ configurable: true, value: 'bar' }), assert);
 
-        assert.equal(obj.foo, 'bar');
+          let obj = factory.finalize();
 
-        let source = factory.source();
+          assert.equal(obj.foo, 'bar');
 
-        delete source.foo;
+          let source = factory.source();
 
-        assert.strictEqual(obj.foo, undefined);
+          delete source.foo;
 
-        Object.defineProperty(source, 'foo', { configurable: true, value: 'baz' });
+          assert.strictEqual(obj.foo, undefined);
 
-        assert.equal(obj.foo, 'baz');
-      }
+          Object.defineProperty(source, 'foo', { configurable: true, value: 'baz' });
 
-      ['@test defining a non-configurable property'](assert) {
-        let factory = new TestClass(assert);
-        factory.install('foo', nativeDescDecorator({ configurable: false, value: 'bar' }), assert);
+          assert.equal(obj.foo, 'baz');
+        }
 
-        let obj = factory.finalize();
+        ['@test defining a non-configurable property'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
 
-        assert.equal(obj.foo, 'bar');
+          let factory = new TestClass(assert);
+          factory.install(
+            'foo',
+            nativeDescDecorator({ configurable: false, value: 'bar' }),
+            assert
+          );
 
-        let source = factory.source();
+          let obj = factory.finalize();
 
-        assert.throws(() => delete source.foo, TypeError);
+          assert.equal(obj.foo, 'bar');
 
-        assert.throws(
-          () =>
-            Object.defineProperty(source, 'foo', {
-              configurable: true,
-              value: 'baz',
+          let source = factory.source();
+
+          assert.throws(() => delete source.foo, TypeError);
+
+          assert.throws(
+            () =>
+              Object.defineProperty(source, 'foo', {
+                configurable: true,
+                value: 'baz',
+              }),
+            TypeError
+          );
+
+          assert.equal(obj.foo, 'bar');
+        }
+
+        ['@test defining an enumerable property'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install('foo', nativeDescDecorator({ enumerable: true, value: 'bar' }), assert);
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.foo, 'bar');
+
+          let source = factory.source();
+
+          assert.ok(Object.keys(source).indexOf('foo') !== -1);
+        }
+
+        ['@test defining a non-enumerable property'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install('foo', nativeDescDecorator({ enumerable: false, value: 'bar' }), assert);
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.foo, 'bar');
+
+          let source = factory.source();
+
+          assert.ok(Object.keys(source).indexOf('foo') === -1);
+        }
+
+        ['@test defining a writable property'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install('foo', nativeDescDecorator({ writable: true, value: 'bar' }), assert);
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.foo, 'bar');
+
+          let source = factory.source();
+
+          source.foo = 'baz';
+
+          assert.equal(obj.foo, 'baz');
+
+          obj.foo = 'bat';
+
+          assert.equal(obj.foo, 'bat');
+        }
+
+        ['@test defining a non-writable property'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install('foo', nativeDescDecorator({ writable: false, value: 'bar' }), assert);
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.foo, 'bar');
+
+          let source = factory.source();
+
+          assert.throws(() => (source.foo = 'baz'), TypeError);
+          assert.throws(() => (obj.foo = 'baz'), TypeError);
+
+          assert.equal(obj.foo, 'bar');
+        }
+
+        ['@test defining a getter'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install(
+            'foo',
+            nativeDescDecorator({
+              get: function () {
+                return this.__foo__;
+              },
             }),
-          TypeError
-        );
+            assert
+          );
 
-        assert.equal(obj.foo, 'bar');
+          factory.set('__foo__', 'bar');
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.foo, 'bar');
+
+          obj.__foo__ = 'baz';
+
+          assert.equal(obj.foo, 'baz');
+        }
+
+        ['@test defining a setter'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install(
+            'foo',
+            nativeDescDecorator({
+              set: function (value) {
+                this.__foo__ = value;
+              },
+            }),
+            assert
+          );
+
+          factory.set('__foo__', 'bar');
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.__foo__, 'bar');
+
+          obj.foo = 'baz';
+
+          assert.equal(obj.__foo__, 'baz');
+        }
+
+        ['@test combining multiple setter and getters'](assert) {
+          if (TestClass.usesMixins) {
+            expectDeprecation(
+              /Using mixins is deprecated/,
+              DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+            );
+          }
+
+          let factory = new TestClass(assert);
+          factory.install(
+            'foo',
+            nativeDescDecorator({
+              get: function () {
+                return this.__foo__;
+              },
+
+              set: function (value) {
+                this.__foo__ = value;
+              },
+            }),
+            assert
+          );
+
+          factory.set('__foo__', 'foo');
+
+          factory.install(
+            'bar',
+            nativeDescDecorator({
+              get: function () {
+                return this.__bar__;
+              },
+
+              set: function (value) {
+                this.__bar__ = value;
+              },
+            }),
+            assert
+          );
+
+          factory.set('__bar__', 'bar');
+
+          factory.install(
+            'fooBar',
+            nativeDescDecorator({
+              get: function () {
+                return this.foo + '-' + this.bar;
+              },
+            }),
+            assert
+          );
+
+          let obj = factory.finalize();
+
+          assert.equal(obj.fooBar, 'foo-bar');
+
+          obj.foo = 'FOO';
+
+          assert.equal(obj.fooBar, 'FOO-bar');
+
+          obj.__bar__ = 'BAR';
+
+          assert.equal(obj.fooBar, 'FOO-BAR');
+
+          assert.throws(() => (obj.fooBar = 'foobar'), TypeError);
+
+          assert.equal(obj.fooBar, 'FOO-BAR');
+        }
       }
-
-      ['@test defining an enumerable property'](assert) {
-        let factory = new TestClass(assert);
-        factory.install('foo', nativeDescDecorator({ enumerable: true, value: 'bar' }), assert);
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.foo, 'bar');
-
-        let source = factory.source();
-
-        assert.ok(Object.keys(source).indexOf('foo') !== -1);
-      }
-
-      ['@test defining a non-enumerable property'](assert) {
-        let factory = new TestClass(assert);
-        factory.install('foo', nativeDescDecorator({ enumerable: false, value: 'bar' }), assert);
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.foo, 'bar');
-
-        let source = factory.source();
-
-        assert.ok(Object.keys(source).indexOf('foo') === -1);
-      }
-
-      ['@test defining a writable property'](assert) {
-        let factory = new TestClass(assert);
-        factory.install('foo', nativeDescDecorator({ writable: true, value: 'bar' }), assert);
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.foo, 'bar');
-
-        let source = factory.source();
-
-        source.foo = 'baz';
-
-        assert.equal(obj.foo, 'baz');
-
-        obj.foo = 'bat';
-
-        assert.equal(obj.foo, 'bat');
-      }
-
-      ['@test defining a non-writable property'](assert) {
-        let factory = new TestClass(assert);
-        factory.install('foo', nativeDescDecorator({ writable: false, value: 'bar' }), assert);
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.foo, 'bar');
-
-        let source = factory.source();
-
-        assert.throws(() => (source.foo = 'baz'), TypeError);
-        assert.throws(() => (obj.foo = 'baz'), TypeError);
-
-        assert.equal(obj.foo, 'bar');
-      }
-
-      ['@test defining a getter'](assert) {
-        let factory = new TestClass(assert);
-        factory.install(
-          'foo',
-          nativeDescDecorator({
-            get: function () {
-              return this.__foo__;
-            },
-          }),
-          assert
-        );
-
-        factory.set('__foo__', 'bar');
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.foo, 'bar');
-
-        obj.__foo__ = 'baz';
-
-        assert.equal(obj.foo, 'baz');
-      }
-
-      ['@test defining a setter'](assert) {
-        let factory = new TestClass(assert);
-        factory.install(
-          'foo',
-          nativeDescDecorator({
-            set: function (value) {
-              this.__foo__ = value;
-            },
-          }),
-          assert
-        );
-
-        factory.set('__foo__', 'bar');
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.__foo__, 'bar');
-
-        obj.foo = 'baz';
-
-        assert.equal(obj.__foo__, 'baz');
-      }
-
-      ['@test combining multiple setter and getters'](assert) {
-        let factory = new TestClass(assert);
-        factory.install(
-          'foo',
-          nativeDescDecorator({
-            get: function () {
-              return this.__foo__;
-            },
-
-            set: function (value) {
-              this.__foo__ = value;
-            },
-          }),
-          assert
-        );
-
-        factory.set('__foo__', 'foo');
-
-        factory.install(
-          'bar',
-          nativeDescDecorator({
-            get: function () {
-              return this.__bar__;
-            },
-
-            set: function (value) {
-              this.__bar__ = value;
-            },
-          }),
-          assert
-        );
-
-        factory.set('__bar__', 'bar');
-
-        factory.install(
-          'fooBar',
-          nativeDescDecorator({
-            get: function () {
-              return this.foo + '-' + this.bar;
-            },
-          }),
-          assert
-        );
-
-        let obj = factory.finalize();
-
-        assert.equal(obj.fooBar, 'foo-bar');
-
-        obj.foo = 'FOO';
-
-        assert.equal(obj.fooBar, 'FOO-bar');
-
-        obj.__bar__ = 'BAR';
-
-        assert.equal(obj.fooBar, 'FOO-BAR');
-
-        assert.throws(() => (obj.fooBar = 'foobar'), TypeError);
-
-        assert.equal(obj.fooBar, 'FOO-BAR');
-      }
-    }
-  );
-});
+    );
+  });

--- a/packages/@ember/-internals/metal/tests/observer_test.js
+++ b/packages/@ember/-internals/metal/tests/observer_test.js
@@ -11,7 +11,7 @@ import {
   set,
 } from '..';
 import { observer } from '@ember/object';
-import Mixin, { mixin } from '@ember/object/mixin';
+import { mixin } from '@ember/object/mixin';
 import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
 import { destroy } from '@glimmer/destroyable';
 import { meta as metaFor } from '@ember/-internals/meta';
@@ -436,18 +436,18 @@ moduleFor(
     async ['@test local observers can be removed'](assert) {
       let barObserved = 0;
 
-      let MyMixin = Mixin.create({
-        foo1: observer('bar', function () {
-          barObserved++;
-        }),
+      obj = mixin(
+        {},
+        {
+          foo1: observer('bar', function () {
+            barObserved++;
+          }),
 
-        foo2: observer('bar', function () {
-          barObserved++;
-        }),
-      });
-
-      obj = {};
-      MyMixin.apply(obj);
+          foo2: observer('bar', function () {
+            barObserved++;
+          }),
+        }
+      );
 
       set(obj, 'bar', 'HI!');
       await runLoopSettled();

--- a/packages/@ember/-internals/runtime/lib/mixins/-proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/-proxy.ts
@@ -4,6 +4,7 @@
 
 import { meta } from '@ember/-internals/meta/lib/meta';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { get } from '@ember/-internals/metal/lib/property_get';
 import { set } from '@ember/-internals/metal/lib/property_set';
 import { defineProperty } from '@ember/-internals/metal/lib/properties';
@@ -90,7 +91,7 @@ interface ProxyMixin<T = unknown> {
   setUnknownProperty<V>(key: string, value: V): V;
 }
 
-const ProxyMixin = /*@__PURE__*/ Mixin.create({
+const ProxyMixin = /*@__PURE__*/ Mixin[INTERNAL_MIXIN_CREATE]({
   /**
     The object whose properties will be forwarded.
 

--- a/packages/@ember/-internals/runtime/lib/mixins/action_handler.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/action_handler.ts
@@ -3,6 +3,7 @@
 */
 
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { get } from '@ember/-internals/metal/lib/property_get';
 import { assert } from '@ember/debug';
 import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
@@ -22,7 +23,7 @@ interface ActionHandler {
   actions?: Record<string, (...args: any[]) => unknown>;
   send(actionName: string, ...args: unknown[]): void;
 }
-const ActionHandler = Mixin.create({
+const ActionHandler = Mixin[INTERNAL_MIXIN_CREATE]({
   mergedProperties: ['actions'],
 
   /**

--- a/packages/@ember/-internals/runtime/lib/mixins/comparable.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/comparable.ts
@@ -1,4 +1,5 @@
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
 
 /**
@@ -19,7 +20,7 @@ import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
 interface Comparable {
   compare: ((a: unknown, b: unknown) => -1 | 0 | 1) | null;
 }
-const Comparable = Mixin.create({
+const Comparable = Mixin[INTERNAL_MIXIN_CREATE]({
   /**
     __Required.__ You must implement this method to apply this mixin.
 

--- a/packages/@ember/-internals/runtime/lib/mixins/container_proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/container_proxy.ts
@@ -4,6 +4,7 @@ import { schedule, join } from '@ember/runloop';
 */
 import type Container from '@ember/-internals/container/lib/container';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import type { ContainerProxy } from '@ember/-internals/owner';
 
 // This is defined as a separate interface so that it can be used in the definition of
@@ -21,7 +22,7 @@ interface ContainerProxyMixin extends ContainerProxy {
   /** @internal */
   __container__: Container;
 }
-const ContainerProxyMixin = Mixin.create({
+const ContainerProxyMixin = Mixin[INTERNAL_MIXIN_CREATE]({
   /**
    The container stores state.
 

--- a/packages/@ember/-internals/runtime/lib/mixins/registry_proxy.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/registry_proxy.ts
@@ -8,6 +8,7 @@ import type { AnyFn } from '@ember/-internals/utility-types';
 
 import { assert } from '@ember/debug';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 
 /**
   RegistryProxyMixin is used to provide public access to specific
@@ -21,7 +22,7 @@ interface RegistryProxyMixin extends RegistryProxy {
   /** @internal */
   __registry__: Registry;
 }
-const RegistryProxyMixin = Mixin.create({
+const RegistryProxyMixin = Mixin[INTERNAL_MIXIN_CREATE]({
   __registry__: null,
 
   resolveRegistration(fullName: string) {

--- a/packages/@ember/-internals/runtime/lib/mixins/target_action_support.ts
+++ b/packages/@ember/-internals/runtime/lib/mixins/target_action_support.ts
@@ -6,6 +6,7 @@ import { context } from '@ember/-internals/environment/lib/context';
 import { get } from '@ember/-internals/metal/lib/property_get';
 import computed from '@ember/-internals/metal/lib/computed';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { assert } from '@ember/debug';
 import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
 import { DEBUG } from '@glimmer/env';
@@ -32,7 +33,7 @@ interface TargetActionSupport {
   /** @internal */
   _target?: unknown;
 }
-const TargetActionSupport = Mixin.create({
+const TargetActionSupport = Mixin[INTERNAL_MIXIN_CREATE]({
   target: null,
   action: null,
   actionContext: null,

--- a/packages/@ember/-internals/utils/lib/internal-mixin-create.ts
+++ b/packages/@ember/-internals/utils/lib/internal-mixin-create.ts
@@ -1,0 +1,11 @@
+/**
+  Key for the internal Mixin constructor.
+
+  Ember's own internals are built on mixins, so they need a way to construct
+  one without triggering the mixin deprecation that `Mixin.create` emits. This
+  is deliberately a Symbol so that it does not show up as a discoverable
+  property name and cannot be reached by name from application code.
+
+  @private
+*/
+export const INTERNAL_MIXIN_CREATE = Symbol('__internal__mixin__');

--- a/packages/@ember/-internals/views/lib/mixins/action_support.ts
+++ b/packages/@ember/-internals/views/lib/mixins/action_support.ts
@@ -3,6 +3,7 @@
 */
 import { get } from '@ember/-internals/metal/lib/property_get';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import inspect from '@ember/debug/lib/inspect';
 import { assert } from '@ember/debug';
 import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
@@ -15,7 +16,7 @@ import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
 interface ActionSupport {
   send(actionName: string, ...args: unknown[]): void;
 }
-const ActionSupport = Mixin.create({
+const ActionSupport = Mixin[INTERNAL_MIXIN_CREATE]({
   send(actionName: string, ...args: unknown[]) {
     deprecateUntil(
       `Calling \`.send()\` on ${this} is deprecated. Invoke the corresponding method directly.`,

--- a/packages/@ember/array/index.ts
+++ b/packages/@ember/array/index.ts
@@ -11,6 +11,7 @@ import {
 import { get } from '@ember/-internals/metal/lib/property_get';
 import { set } from '@ember/-internals/metal/lib/property_set';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { assert } from '@ember/debug';
 import Enumerable from '@ember/enumerable';
 import MutableEnumerable from '@ember/enumerable/mutable';
@@ -1139,7 +1140,7 @@ interface EmberArray<T> extends Enumerable {
   */
   without(value: T): NativeArray<T>;
 }
-const EmberArray = Mixin.create(Enumerable, {
+const EmberArray = Mixin[INTERNAL_MIXIN_CREATE](Enumerable, {
   init() {
     this._super(...arguments);
     setEmberArray(this);
@@ -1687,7 +1688,7 @@ interface MutableArray<T> extends EmberArray<T>, MutableEnumerable {
   */
   addObjects(objects: T[]): this;
 }
-const MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
+const MutableArray = Mixin[INTERNAL_MIXIN_CREATE](EmberArray, MutableEnumerable, {
   clear() {
     let len = this.length;
     if (len === 0) {
@@ -2023,7 +2024,7 @@ interface MutableArrayWithoutNative<T> extends Omit<
 */
 interface NativeArray<T> extends Array<T>, Observable, MutableArrayWithoutNative<T> {}
 
-let NativeArray = Mixin.create(MutableArray, Observable, {
+let NativeArray = Mixin[INTERNAL_MIXIN_CREATE](MutableArray, Observable, {
   objectAt(idx: number) {
     return this[idx];
   },

--- a/packages/@ember/controller/index.ts
+++ b/packages/@ember/controller/index.ts
@@ -8,6 +8,7 @@ import type {
   ElementDescriptor,
 } from '@ember/-internals/metal/lib/decorator';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import type { RouteArgs } from '@ember/routing/-internals';
 import ActionHandler from '@ember/-internals/runtime/lib/mixins/action_handler';
 import type { Transition } from 'router_js';
@@ -233,7 +234,7 @@ interface ControllerMixin<T> extends ActionHandler {
   */
   replaceRoute(...args: RouteArgs): Transition;
 }
-const ControllerMixin = Mixin.create(ActionHandler, {
+const ControllerMixin = Mixin[INTERNAL_MIXIN_CREATE](ActionHandler, {
   /* ducktype as a controller */
   isController: true,
 

--- a/packages/@ember/controller/tests/controller_test.js
+++ b/packages/@ember/controller/tests/controller_test.js
@@ -1,7 +1,6 @@
 import Controller, { inject as injectController } from '@ember/controller';
 import Service, { service } from '@ember/service';
 import EmberObject, { get } from '@ember/object';
-import Mixin from '@ember/object/mixin';
 import { setOwner } from '@ember/-internals/owner';
 import {
   runDestroy,
@@ -170,22 +169,23 @@ moduleFor(
         },
       });
 
-      let BarControllerMixin = Mixin.create({
-        actions: {
-          bar(msg) {
-            assert.equal(msg, 'HELLO');
-            this._super(msg);
+      let IndexController = SuperController.extend(
+        {
+          actions: {
+            bar(msg) {
+              assert.equal(msg, 'HELLO');
+              this._super(msg);
+            },
           },
         },
-      });
-
-      let IndexController = SuperController.extend(BarControllerMixin, {
-        actions: {
-          baz() {
-            assert.ok(true, 'baz');
+        {
+          actions: {
+            baz() {
+              assert.ok(true, 'baz');
+            },
           },
-        },
-      });
+        }
+      );
 
       let controller = IndexController.create({});
       controller.send('foo');

--- a/packages/@ember/enumerable/index.ts
+++ b/packages/@ember/enumerable/index.ts
@@ -1,4 +1,5 @@
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 
 /**
 @module @ember/enumerable
@@ -15,6 +16,6 @@ import Mixin from '@ember/object/mixin';
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface Enumerable {}
-const Enumerable = Mixin.create();
+const Enumerable = Mixin[INTERNAL_MIXIN_CREATE]();
 
 export default Enumerable;

--- a/packages/@ember/enumerable/mutable.ts
+++ b/packages/@ember/enumerable/mutable.ts
@@ -1,5 +1,6 @@
 import Enumerable from '@ember/enumerable';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 
 /**
 @module ember
@@ -17,6 +18,6 @@ import Mixin from '@ember/object/mixin';
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface MutableEnumerable extends Enumerable {}
-const MutableEnumerable = Mixin.create(Enumerable);
+const MutableEnumerable = Mixin[INTERNAL_MIXIN_CREATE](Enumerable);
 
 export default MutableEnumerable;

--- a/packages/@ember/object/core.ts
+++ b/packages/@ember/object/core.ts
@@ -15,6 +15,7 @@ import { defineProperty } from '@ember/-internals/metal/lib/properties';
 import { descriptorForProperty, isClassicDecorator } from '@ember/-internals/metal/lib/decorator';
 import { DEBUG_INJECTION_FUNCTIONS } from '@ember/-internals/metal/lib/injected_property';
 import Mixin, { applyMixin } from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import ActionHandler from '@ember/-internals/runtime/lib/mixins/action_handler';
 import makeArray from '@ember/array/make';
 import { assert } from '@ember/debug';
@@ -851,7 +852,7 @@ class CoreObject {
       // make sure that it gets properly applied. Reusing the same mixin after
       // the first `proto` call will cause it to get skipped.
       if (prototypeMixinMap.has(this)) {
-        prototypeMixinMap.set(this, Mixin.create(this.PrototypeMixin));
+        prototypeMixinMap.set(this, Mixin[INTERNAL_MIXIN_CREATE](this.PrototypeMixin));
       }
     }
   }
@@ -1010,7 +1011,7 @@ class CoreObject {
   static get PrototypeMixin() {
     let prototypeMixin = prototypeMixinMap.get(this);
     if (prototypeMixin === undefined) {
-      prototypeMixin = Mixin.create();
+      prototypeMixin = Mixin[INTERNAL_MIXIN_CREATE]();
       prototypeMixin.ownerConstructor = this;
       prototypeMixinMap.set(this, prototypeMixin);
     }

--- a/packages/@ember/object/evented.ts
+++ b/packages/@ember/object/evented.ts
@@ -6,6 +6,7 @@ import {
   eventedHas,
 } from '@ember/-internals/metal/lib/evented-methods';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 
 export { on } from '@ember/-internals/metal/lib/events';
 
@@ -156,7 +157,7 @@ interface Evented {
    */
   has(name: string): boolean;
 }
-const Evented = Mixin.create({
+const Evented = Mixin[INTERNAL_MIXIN_CREATE]({
   on(name: string, target: object, method?: string | Function) {
     eventedOn(this, name, target, method);
     return this;

--- a/packages/@ember/object/mixin.ts
+++ b/packages/@ember/object/mixin.ts
@@ -5,6 +5,7 @@ import { INIT_FACTORY } from '@ember/-internals/container/lib/container';
 import type { Meta } from '@ember/-internals/meta/lib/meta';
 import { meta as metaFor, peekMeta } from '@ember/-internals/meta/lib/meta';
 import { observerListenerMetaFor, ROOT, wrap } from '@ember/-internals/utils/lib/super';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 import type {
@@ -28,6 +29,7 @@ import {
 } from '@ember/-internals/metal/lib/observer';
 import { defineDecorator, defineValue } from '@ember/-internals/metal/lib/properties';
 import { addListener, removeListener } from '@ember/-internals/metal/lib/events';
+import { deprecateUntil, DEPRECATIONS } from '@ember/-internals/deprecations';
 
 const a_concat = Array.prototype.concat;
 const { isArray } = Array;
@@ -577,6 +579,15 @@ export default class Mixin {
     @public
   */
   static create<M extends typeof Mixin>(...args: any[]): InstanceType<M> {
+    deprecateUntil(
+      `Using mixins is deprecated. Refactor to composition patterns or class decorators.`,
+      DEPRECATIONS.DEPRECATE_MIXINS
+    );
+    return this[INTERNAL_MIXIN_CREATE]<M>(...args);
+  }
+
+  /** @internal */
+  static [INTERNAL_MIXIN_CREATE]<M extends typeof Mixin>(...args: any[]): InstanceType<M> {
     setUnprocessedMixins();
     let M = this;
     return new M(args, undefined) as InstanceType<M>;

--- a/packages/@ember/object/observable.ts
+++ b/packages/@ember/object/observable.ts
@@ -16,6 +16,7 @@ import getProperties from '@ember/-internals/metal/lib/get_properties';
 import setProperties from '@ember/-internals/metal/lib/set_properties';
 
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import { assert } from '@ember/debug';
 
 export type ObserverMethod<Target, Sender> =
@@ -420,7 +421,7 @@ interface Observable {
   */
   cacheFor<K extends keyof this>(key: K): unknown;
 }
-const Observable = Mixin.create({
+const Observable = Mixin[INTERNAL_MIXIN_CREATE]({
   get(keyName: string) {
     return get(this, keyName);
   },

--- a/packages/@ember/object/promise-proxy-mixin.ts
+++ b/packages/@ember/object/promise-proxy-mixin.ts
@@ -2,6 +2,7 @@ import { get } from '@ember/-internals/metal/lib/property_get';
 import setProperties from '@ember/-internals/metal/lib/set_properties';
 import computed from '@ember/-internals/metal/lib/computed';
 import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
 import type { AnyFn, MethodNamesOf } from '@ember/-internals/utility-types';
 import type RSVP from 'rsvp';
 import type CoreObject from '@ember/object/core';
@@ -211,7 +212,7 @@ interface PromiseProxyMixin<T> {
   */
   finally: this['promise']['finally'];
 }
-const PromiseProxyMixin = Mixin.create({
+const PromiseProxyMixin = Mixin[INTERNAL_MIXIN_CREATE]({
   reason: null,
 
   isPending: computed('isSettled', function () {

--- a/packages/@ember/object/tests/create_test.js
+++ b/packages/@ember/object/tests/create_test.js
@@ -6,7 +6,15 @@ import Service, { service } from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import EmberObject, { computed, observer } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import { buildOwner, moduleFor, runDestroy, AbstractTestCase } from 'internal-test-helpers';
+import {
+  buildOwner,
+  moduleFor,
+  runDestroy,
+  AbstractTestCase,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../-internals/deprecations';
 import { destroy } from '@glimmer/destroyable';
 
 moduleFor(
@@ -196,7 +204,9 @@ moduleFor(
       }, 'EmberObject.create no longer supports defining methods that call _super.');
     }
 
-    ["@test throws if you try to 'mixin' a definition"]() {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test throws if you try to 'mixin' a definition`]() {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let myMixin = Mixin.create({
         adder(arg1, arg2) {
           return arg1 + arg2;

--- a/packages/@ember/object/tests/es-compatibility-test.js
+++ b/packages/@ember/object/tests/es-compatibility-test.js
@@ -174,7 +174,9 @@ moduleFor(
       });
     }
 
-    ['@test using mixins'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test using mixins`](assert) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let Mixin1 = Mixin.create({
         property1: 'data-1',
       });
@@ -394,23 +396,23 @@ moduleFor(
         }
       }
 
-      let Mixin1 = Mixin.create({
+      let classicProps1 = {
         init() {
           calls.push('Mixin1 init before _super');
           this._super(...arguments);
           calls.push('Mixin1 init after _super');
         },
-      });
+      };
 
-      let Mixin2 = Mixin.create({
+      let classicProps2 = {
         init() {
           calls.push('Mixin2 init before _super');
           this._super(...arguments);
           calls.push('Mixin2 init after _super');
         },
-      });
+      };
 
-      class B extends A.extend(Mixin1, Mixin2) {
+      class B extends A.extend(classicProps1, classicProps2) {
         init() {
           calls.push('B init before super.init');
           super.init(...arguments);

--- a/packages/@ember/object/tests/mixin/accessor_test.js
+++ b/packages/@ember/object/tests/mixin/accessor_test.js
@@ -1,10 +1,13 @@
 import Mixin from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Mixin Accessors',
   class extends AbstractTestCase {
-    ['@test works with getters'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test works with getters`](assert) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let count = 0;
 
       let MixinA = Mixin.create({
@@ -20,7 +23,9 @@ moduleFor(
       assert.equal(obj.prop, 1, 'getter defined correctly');
     }
 
-    ['@test works with setters'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test works with setters`](assert) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         set prop(value) {
           this._prop = value + 1;

--- a/packages/@ember/object/tests/mixin/apply_test.js
+++ b/packages/@ember/object/tests/mixin/apply_test.js
@@ -1,13 +1,18 @@
 import { get } from '@ember/object';
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 function K() {}
 
 moduleFor(
   'Mixin.apply',
   class extends AbstractTestCase {
-    ['@test using apply() should apply properties'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test using apply() should apply properties`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({ foo: 'FOO', baz: K });
       let obj = {};
       mixin(obj, MixinA);

--- a/packages/@ember/object/tests/mixin/computed_test.js
+++ b/packages/@ember/object/tests/mixin/computed_test.js
@@ -1,6 +1,7 @@
 import { get, set, computed, defineProperty } from '@ember/object';
 import Mixin from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 function K() {
   return this;
@@ -9,7 +10,11 @@ function K() {
 moduleFor(
   'Mixin Computed Properties',
   class extends AbstractTestCase {
-    ['@test overriding computed properties'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test overriding computed properties`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA, MixinB, MixinC, MixinD;
       let obj;
 
@@ -65,7 +70,11 @@ moduleFor(
       assert.equal(get(obj, 'aProp'), 'objD', 'should preserve original computed property');
     }
 
-    ['@test calling set on overridden computed properties'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test calling set on overridden computed properties`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let SuperMixin, SubMixin;
       let obj;
 
@@ -112,7 +121,11 @@ moduleFor(
       assert.ok(superSetOccurred, 'should pass set to _super after getting');
     }
 
-    ['@test setter behavior asserts when overriding computed properties'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test setter behavior asserts when overriding computed properties`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj = {};
 
       let MixinA = Mixin.create({

--- a/packages/@ember/object/tests/mixin/concatenated_properties_test.js
+++ b/packages/@ember/object/tests/mixin/concatenated_properties_test.js
@@ -1,11 +1,16 @@
 import { get } from '@ember/object';
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Mixin concatenatedProperties',
   class extends AbstractTestCase {
-    ['@test defining concatenated properties should concat future version'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test defining concatenated properties should concat future version`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         concatenatedProperties: ['foo'],
         foo: ['a', 'b', 'c'],
@@ -19,7 +24,11 @@ moduleFor(
       assert.deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
     }
 
-    ['@test ensure we do not needlessly scan concatenatedProperties array'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test ensure we do not needlessly scan concatenatedProperties array`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         concatenatedProperties: null,
       });
@@ -33,7 +42,11 @@ moduleFor(
       assert.deepEqual(obj.concatenatedProperties, []);
     }
 
-    ['@test concatenatedProperties should be concatenated'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test concatenatedProperties should be concatenated`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         concatenatedProperties: ['foo'],
         foo: ['a', 'b', 'c'],
@@ -59,7 +72,11 @@ moduleFor(
       assert.deepEqual(get(obj, 'bar'), [1, 2, 3, 4, 5, 6], 'get bar');
     }
 
-    ['@test adding a prop that is a number should make array'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test adding a prop that is a number should make array`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         concatenatedProperties: ['foo'],
         foo: [1, 2, 3],
@@ -73,7 +90,11 @@ moduleFor(
       assert.deepEqual(get(obj, 'foo'), [1, 2, 3, 4]);
     }
 
-    ['@test adding a prop that is a string should make array'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test adding a prop that is a string should make array`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         concatenatedProperties: ['foo'],
         foo: 'bar',
@@ -83,9 +104,11 @@ moduleFor(
       assert.deepEqual(get(obj, 'foo'), ['bar']);
     }
 
-    ['@test adding a non-concatenable property that already has a defined value should result in an array with both values'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test adding a non-concatenable property that already has a defined value should result in an array with both values`](
       assert
     ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let mixinA = Mixin.create({
         foo: 1,
       });
@@ -99,9 +122,11 @@ moduleFor(
       assert.deepEqual(get(obj, 'foo'), [1, 2]);
     }
 
-    ['@test adding a concatenable property that already has a defined value should result in a concatenated value'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test adding a concatenable property that already has a defined value should result in a concatenated value`](
       assert
     ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let mixinA = Mixin.create({
         foobar: 'foo',
       });

--- a/packages/@ember/object/tests/mixin/deprecation_test.js
+++ b/packages/@ember/object/tests/mixin/deprecation_test.js
@@ -1,0 +1,90 @@
+import EmberObject from '@ember/object';
+import Mixin from '@ember/object/mixin';
+import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
+import {
+  moduleFor,
+  AbstractTestCase,
+  expectDeprecation,
+  expectNoDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
+
+moduleFor(
+  'Mixin deprecation',
+  class extends AbstractTestCase {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_MIXINS.isRemoved
+    )} @test Mixin.create deprecates authoring a mixin`](assert) {
+      let MixinA;
+
+      expectDeprecation(
+        () => {
+          MixinA = Mixin.create({
+            foo: 'FOO',
+          });
+        },
+        /Using mixins is deprecated/,
+        DEPRECATIONS.DEPRECATE_MIXINS.isEnabled
+      );
+
+      let obj = {};
+      MixinA.apply(obj);
+
+      assert.equal(obj.foo, 'FOO', 'the mixin still applies while deprecated');
+    }
+
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_MIXINS.isRemoved
+    )} @test the internal mixin constructor does not deprecate, so Ember internals can build on mixins`](
+      assert
+    ) {
+      let MixinA;
+
+      expectNoDeprecation(() => {
+        MixinA = Mixin[INTERNAL_MIXIN_CREATE]({
+          foo: 'FOO',
+        });
+      });
+
+      let obj = {};
+      MixinA.apply(obj);
+
+      assert.equal(obj.foo, 'FOO', 'the internally created mixin applies');
+    }
+
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_MIXINS.isRemoved
+    )} @test extending EmberObject does not deprecate`](assert) {
+      // EmberObject builds a PrototypeMixin internally for every subclass, so
+      // extending must not warn apps that never author a mixin themselves.
+      let Subclass;
+
+      expectNoDeprecation(() => {
+        Subclass = EmberObject.extend({
+          foo: 'FOO',
+        });
+      });
+
+      let obj = Subclass.create();
+      assert.equal(obj.foo, 'FOO', 'the subclass works');
+      obj.destroy();
+    }
+
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_MIXINS.isRemoved
+    )} @test reopening an EmberObject subclass does not deprecate`](assert) {
+      let Subclass = EmberObject.extend();
+
+      expectNoDeprecation(() => {
+        Subclass.reopen({
+          foo: 'FOO',
+        });
+      });
+
+      let obj = Subclass.create();
+      assert.equal(obj.foo, 'FOO', 'the reopened property is present');
+      obj.destroy();
+    }
+  }
+);

--- a/packages/@ember/object/tests/mixin/detect_test.js
+++ b/packages/@ember/object/tests/mixin/detect_test.js
@@ -1,10 +1,15 @@
 import Mixin from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Mixin.detect',
   class extends AbstractTestCase {
-    ['@test detect() finds a directly applied mixin'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test detect() finds a directly applied mixin`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create();
       let obj = {};
 
@@ -14,7 +19,11 @@ moduleFor(
       assert.equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
     }
 
-    ['@test detect() finds nested mixins'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test detect() finds nested mixins`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({});
       let MixinB = Mixin.create(MixinA);
       let obj = {};
@@ -25,14 +34,22 @@ moduleFor(
       assert.equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
     }
 
-    ['@test detect() finds mixins on other mixins'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test detect() finds mixins on other mixins`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({});
       let MixinB = Mixin.create(MixinA);
       assert.equal(MixinA.detect(MixinB), true, 'MixinA is part of MixinB');
       assert.equal(MixinB.detect(MixinA), false, 'MixinB is not part of MixinA');
     }
 
-    ['@test detect handles null values'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test detect handles null values`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create();
       assert.equal(MixinA.detect(null), false);
     }

--- a/packages/@ember/object/tests/mixin/introspection_test.js
+++ b/packages/@ember/object/tests/mixin/introspection_test.js
@@ -4,42 +4,41 @@
 
 import { guidFor } from '@ember/-internals/utils';
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
-
-const PrivateProperty = Mixin.create({
-  _foo: '_FOO',
-});
-const PublicProperty = Mixin.create({
-  foo: 'FOO',
-});
-const PrivateMethod = Mixin.create({
-  _fooMethod() {},
-});
-const PublicMethod = Mixin.create({
-  fooMethod() {},
-});
-const BarProperties = Mixin.create({
-  _bar: '_BAR',
-  bar: 'bar',
-});
-const BarMethods = Mixin.create({
-  _barMethod() {},
-  barMethod() {},
-});
-
-const Combined = Mixin.create(BarProperties, BarMethods);
-
-let obj;
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Basic introspection',
   class extends AbstractTestCase {
-    beforeEach() {
-      obj = {};
-      mixin(obj, PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined);
-    }
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test Ember.mixins()`](assert) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
 
-    ['@test Ember.mixins()'](assert) {
+      let PrivateProperty = Mixin.create({
+        _foo: '_FOO',
+      });
+      let PublicProperty = Mixin.create({
+        foo: 'FOO',
+      });
+      let PrivateMethod = Mixin.create({
+        _fooMethod() {},
+      });
+      let PublicMethod = Mixin.create({
+        fooMethod() {},
+      });
+      let BarProperties = Mixin.create({
+        _bar: '_BAR',
+        bar: 'bar',
+      });
+      let BarMethods = Mixin.create({
+        _barMethod() {},
+        barMethod() {},
+      });
+
+      let Combined = Mixin.create(BarProperties, BarMethods);
+
+      let obj = {};
+      mixin(obj, PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined);
+
       function mapGuids(ary) {
         return ary.map((x) => guidFor(x));
       }

--- a/packages/@ember/object/tests/mixin/merged_properties_test.js
+++ b/packages/@ember/object/tests/mixin/merged_properties_test.js
@@ -1,11 +1,16 @@
 import EmberObject, { get } from '@ember/object';
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Mixin mergedProperties',
   class extends AbstractTestCase {
-    ['@test defining mergedProperties should merge future version'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test defining mergedProperties should merge future version`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         mergedProperties: ['foo'],
         foo: { a: true, b: true, c: true },
@@ -26,7 +31,11 @@ moduleFor(
       });
     }
 
-    ['@test defining mergedProperties on future mixin should merged into past'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test defining mergedProperties on future mixin should merged into past`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         foo: { a: true, b: true, c: true },
       });
@@ -47,7 +56,11 @@ moduleFor(
       });
     }
 
-    ['@test defining mergedProperties with null properties should keep properties null'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test defining mergedProperties with null properties should keep properties null`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         mergedProperties: ['foo'],
         foo: null,
@@ -61,7 +74,11 @@ moduleFor(
       assert.equal(get(obj, 'foo'), null);
     }
 
-    ["@test mergedProperties' properties can get overwritten"](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test mergedProperties' properties can get overwritten`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         mergedProperties: ['foo'],
         foo: { a: 1 },
@@ -75,7 +92,11 @@ moduleFor(
       assert.deepEqual(get(obj, 'foo'), { a: 2 });
     }
 
-    ['@test mergedProperties should be concatenated'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test mergedProperties should be concatenated`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         mergedProperties: ['foo'],
         foo: { a: true, b: true, c: true },
@@ -145,8 +166,12 @@ moduleFor(
       assert.equal(get(objB, 'options').a, 3);
     }
 
-    ["@test mergedProperties' overwriting methods can call _super"](assert) {
-      assert.expect(4);
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test mergedProperties' overwriting methods can call _super`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
+      assert.expect(5);
 
       let MixinA = Mixin.create({
         mergedProperties: ['foo'],
@@ -180,8 +205,12 @@ moduleFor(
       assert.equal(obj.foo.meth('WOOT'), 'WAT');
     }
 
-    ['@test Merging an Array should raise an error'](assert) {
-      assert.expect(1);
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test Merging an Array should raise an error`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
+      assert.expect(2);
 
       let MixinA = Mixin.create({
         mergedProperties: ['foo'],

--- a/packages/@ember/object/tests/mixin/method_test.js
+++ b/packages/@ember/object/tests/mixin/method_test.js
@@ -1,10 +1,15 @@
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Mixin Methods',
   class extends AbstractTestCase {
-    ['@test defining simple methods'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test defining simple methods`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA, obj, props;
 
       props = {
@@ -25,7 +30,11 @@ moduleFor(
       assert.equal(props._privateMethod(), 'privateMethod', 'privateMethod is func');
     }
 
-    ['@test overriding public methods'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test overriding public methods`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA, MixinB, MixinD, MixinF, obj;
 
       MixinA = Mixin.create({
@@ -74,7 +83,11 @@ moduleFor(
       assert.equal(obj.publicMethod(), 'objF', 'should define super for F');
     }
 
-    ['@test overriding inherited objects'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test overriding inherited objects`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let cnt = 0;
       let MixinA = Mixin.create({
         foo() {
@@ -104,7 +117,11 @@ moduleFor(
       assert.equal(cnt, 1, 'should not screw w/ parent obj');
     }
 
-    ['@test Including the same mixin more than once will only run once'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test Including the same mixin more than once will only run once`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let cnt = 0;
       let MixinA = Mixin.create({
         foo() {
@@ -140,7 +157,11 @@ moduleFor(
       assert.equal(cnt, 1, 'should invoke MixinA.foo one time');
     }
 
-    ['@test _super from a single mixin with no superclass does not error'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test _super from a single mixin with no superclass does not error`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         foo() {
           this._super(...arguments);
@@ -154,7 +175,11 @@ moduleFor(
       assert.ok(true);
     }
 
-    ['@test _super from a first-of-two mixins with no superclass function does not error'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test _super from a first-of-two mixins with no superclass function does not error`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       // _super was previously calling itself in the second assertion.
       // Use remaining count of calls to ensure it doesn't loop indefinitely.
       let remaining = 3;
@@ -188,7 +213,9 @@ moduleFor(
 moduleFor(
   'Method Conflicts',
   class extends AbstractTestCase {
-    ['@test overriding toString'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test overriding toString`](assert) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         toString() {
           return 'FOO';
@@ -216,9 +243,11 @@ moduleFor(
 moduleFor(
   'system/mixin/method_test BUGS',
   class extends AbstractTestCase {
-    ['@test applying several mixins at once with sup already defined causes infinite loop'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test applying several mixins at once with sup already defined causes infinite loop`](
       assert
     ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let cnt = 0;
       let MixinA = Mixin.create({
         foo() {

--- a/packages/@ember/object/tests/mixin/observer_test.js
+++ b/packages/@ember/object/tests/mixin/observer_test.js
@@ -1,6 +1,13 @@
 import { set, get, observer } from '@ember/object';
 import Mixin, { mixin } from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
+import {
+  moduleFor,
+  AbstractTestCase,
+  runLoopSettled,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 import { destroy } from '@glimmer/destroyable';
 
 let obj;
@@ -16,7 +23,11 @@ moduleFor(
       }
     }
 
-    async ['@test global observer helper'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test global observer helper`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MyMixin = Mixin.create({
         count: 0,
 
@@ -34,7 +45,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test global observer helper takes multiple params'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test global observer helper takes multiple params`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MyMixin = Mixin.create({
         count: 0,
 
@@ -58,7 +73,11 @@ moduleFor(
       await runLoopSettled();
     }
 
-    async ['@test replacing observer should remove old observer'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test replacing observer should remove old observer`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MyMixin = Mixin.create({
         count: 0,
 
@@ -87,7 +106,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 10, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with property before'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with property before`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
 
       let MyMixin = Mixin.create({
@@ -107,7 +130,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with property after'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with property after`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
 
       let MyMixin = Mixin.create({
@@ -127,7 +154,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with property in mixin applied later'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with property in mixin applied later`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
 
       let MyMixin = Mixin.create({
@@ -151,7 +182,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with existing property'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with existing property`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
 
       let MyMixin = Mixin.create({
@@ -170,7 +205,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with property in mixin before'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with property in mixin before`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
       let MyMixin2 = Mixin.create({ bar: obj2 });
 
@@ -190,7 +229,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with property in mixin after'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with property in mixin after`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
       let MyMixin2 = Mixin.create({ bar: obj2 });
 
@@ -210,7 +253,11 @@ moduleFor(
       assert.equal(get(obj, 'count'), 1, 'should invoke observer after change');
     }
 
-    async ['@test observing chain with overridden property'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test observing chain with overridden property`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let obj2 = { baz: 'baz' };
       let obj3 = { baz: 'foo' };
 

--- a/packages/@ember/object/tests/mixin/reopen_test.js
+++ b/packages/@ember/object/tests/mixin/reopen_test.js
@@ -1,12 +1,17 @@
 import EmberObject, { get } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import { run } from '@ember/runloop';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'Mixin#reopen',
   class extends AbstractTestCase {
-    ['@test using reopen() to add more properties to a simple'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test using reopen() to add more properties to a simple`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({ foo: 'FOO', baz: 'BAZ' });
       MixinA.reopen({ bar: 'BAR', foo: 'FOO2' });
       let obj = {};

--- a/packages/@ember/object/tests/mixin/without_test.js
+++ b/packages/@ember/object/tests/mixin/without_test.js
@@ -1,10 +1,15 @@
 import Mixin from '@ember/object/mixin';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '../../../-internals/deprecations';
 
 moduleFor(
   'without',
   class extends AbstractTestCase {
-    ['@test without should create a new mixin excluding named properties'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_MIXINS.isRemoved)} @test without should create a new mixin excluding named properties`](
+      assert
+    ) {
+      expectDeprecation(/Using mixins is deprecated/, DEPRECATIONS.DEPRECATE_MIXINS.isEnabled);
+
       let MixinA = Mixin.create({
         foo: 'FOO',
         bar: 'BAR',

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
 import Route from '@ember/routing/route';
-import Mixin from '@ember/object/mixin';
 import { QueryParamTestCase, moduleFor, runLoopSettled } from 'internal-test-helpers';
 
 moduleFor(
@@ -147,22 +146,22 @@ moduleFor(
       );
     }
 
-    async ['@test Support shared but overridable mixin pattern'](assert) {
+    async ['@test Support shared but overridable query param defaults'](assert) {
       assert.expect(7);
 
-      let HasPage = Mixin.create({
+      let hasPage = {
         queryParams: 'page',
         page: 1,
-      });
+      };
 
       this.add(
         'controller:parent',
-        Controller.extend(HasPage, {
+        Controller.extend(hasPage, {
           queryParams: { page: 'yespage' },
         })
       );
 
-      this.add('controller:parent.child', Controller.extend(HasPage));
+      this.add('controller:parent.child', Controller.extend(hasPage));
 
       await this.setupBase();
       this.assertCurrentPath('/parent/child');


### PR DESCRIPTION
Advancement:
- https://github.com/emberjs/rfcs/pull/1143

RFC:
- https://github.com/emberjs/rfcs/pull/1116


The advancement RFC gives a bunch of other mixin-using things that are public that also need to be deprecated, but I'd like to that as a followup -- there are a bunch more things that need to be deprecated as a part of this RFC

In particular, these are _not_ deprecated in this PR:

- Ember.PromiseProxyMixin
- Ember.Enumerable 
- Ember.Observable 

but will be soon (as the RFC declared they would be)