### PR TITLE
Modernize tests (part 1 -- more `@glimmer/component`)

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/debug-render-tree-test.ts
@@ -1,7 +1,8 @@
 import { ApplicationTestCase, ModuleBasedTestResolver, moduleFor } from 'internal-test-helpers';
 
 import { ENV } from '@ember/-internals/environment';
-import { Component, setComponentManager } from '@ember/-internals/glimmer';
+import { Component as EmberComponent, setComponentManager } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import type { InternalOwner } from '@ember/-internals/owner';
 import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
@@ -991,7 +992,7 @@ if (ENV._DEBUG_RENDER_TREE) {
 
         this.add(
           'component:hello-world',
-          setComponentTemplate(precompileTemplate('Hello World'), class extends Component {})
+          setComponentTemplate(precompileTemplate('Hello World'), class extends EmberComponent {})
         );
 
         await this.visit('/');
@@ -1710,8 +1711,8 @@ if (ENV._DEBUG_RENDER_TREE) {
           setComponentTemplate(
             precompileTemplate('{{@name}}'),
             class extends Component {
-              constructor(owner: InternalOwner) {
-                super(owner);
+              constructor(owner: InternalOwner, args: object) {
+                super(owner, args);
                 throw new Error('oops!');
               }
             }

--- a/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/engine-test.js
@@ -5,7 +5,7 @@ import {
   runTaskNext,
 } from 'internal-test-helpers';
 
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import Route from '@ember/routing/route';
 import { RSVP } from '@ember/-internals/runtime';
 import Controller from '@ember/controller';
@@ -235,9 +235,7 @@ moduleFor(
 
       let sharedLayout = precompileTemplate('{{ambiguous-curlies}}');
 
-      let sharedComponent = class extends Component {
-        layout = sharedLayout;
-      };
+      let sharedComponent = setComponentTemplate(sharedLayout, class extends Component {});
 
       this.add(
         'template:application',

--- a/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/hot-reload-test.js
@@ -1,7 +1,8 @@
 import { moduleFor, ApplicationTestCase, strip, runTask } from 'internal-test-helpers';
 
 import Service, { service } from '@ember/service';
-import { Component, Helper } from '@ember/-internals/glimmer';
+import { Helper } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 import templateOnly from '@ember/component/template-only';
@@ -93,8 +94,8 @@ moduleFor(
       // Create a fresh class/instance so setComponentTemplate doesn't collide
       // with the template already set on the existing class
       let FreshClass;
-      if (ComponentClass && 'extend' in ComponentClass) {
-        FreshClass = ComponentClass.extend({});
+      if (typeof ComponentClass === 'function') {
+        FreshClass = class extends ComponentClass {};
       } else {
         FreshClass = templateOnly();
       }
@@ -190,11 +191,7 @@ moduleFor(
         setComponentTemplate(
           precompileTemplate('x-foo: {{@name}} ({{this.id}})'),
           class extends Component {
-            tagName = '';
-            init() {
-              super.init(...arguments);
-              this.set('id', id++);
-            }
+            id = id++;
           }
         )
       );
@@ -204,11 +201,7 @@ moduleFor(
         setComponentTemplate(
           precompileTemplate('x-bar ({{this.id}})'),
           class extends Component {
-            tagName = '';
-            init() {
-              super.init(...arguments);
-              this.set('id', id++);
-            }
+            id = id++;
           }
         )
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/application/rendering-test.js
@@ -3,7 +3,7 @@ import { moduleFor, ApplicationTestCase, strip } from 'internal-test-helpers';
 import Controller from '@ember/controller';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { tracked } from '@ember/-internals/metal';
 import { set } from '@ember/object';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
@@ -509,11 +509,11 @@ moduleFor(
       this.add(
         'component:foo',
         setComponentTemplate(
-          precompileTemplate('Hi {{this.person.name}} from component'),
+          precompileTemplate('Hi {{@person.name}} from component'),
           class extends Component {
-            init() {
-              super.init(...arguments);
-              this.set('person.name', 'Ben');
+            constructor(owner, args) {
+              super(owner, args);
+              set(this.args.person, 'name', 'Ben');
             }
           }
         )

--- a/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/component-template-test.js
@@ -3,7 +3,8 @@ import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 
 import { setComponentTemplate, getComponentTemplate } from '@glimmer/manager';
 import { precompileTemplate } from '@ember/template-compilation';
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '../../utils/helpers';
 
 moduleFor(
   'Components test: setComponentTemplate',
@@ -16,11 +17,11 @@ moduleFor(
 
       this.render('<FooBar />');
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
 
       runTask(() => this.rerender());
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
     }
 
     '@test calling it with primitives asserts'(assert) {
@@ -66,7 +67,7 @@ moduleFor(
 
       let Thing = setComponentTemplate(
         precompileTemplate('hello'),
-        Component.extend().reopenClass({
+        EmberComponent.extend().reopenClass({
           toString() {
             return 'Thing';
           },
@@ -79,7 +80,10 @@ moduleFor(
     }
 
     '@test templates set with setComponentTemplate are inherited (EmberObject.extend())'() {
-      let Parent = setComponentTemplate(precompileTemplate('hello'), class extends Component {});
+      let Parent = setComponentTemplate(
+        precompileTemplate('hello'),
+        class extends EmberComponent {}
+      );
 
       this.owner.register('component:foo-bar', class extends Parent {});
 
@@ -99,11 +103,11 @@ moduleFor(
 
       this.render('<FooBar />');
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
 
       runTask(() => this.rerender());
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
     }
 
     '@test it can re-assign templates from another class'() {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/contextual-components-test.js
@@ -5,7 +5,8 @@ import { isEmpty } from '@ember/utils';
 import { action } from '@ember/object';
 import { A as emberA } from '@ember/array';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '../../utils/helpers';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
@@ -34,7 +35,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.greeting}} {{this.name}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name'];
           }
         )
@@ -55,7 +56,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{#each this.params as |p|}}{{p}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -93,7 +94,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{#each this.params as |p|}}{{p}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -133,7 +134,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{#each this.params as |p|}}{{p}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -173,7 +174,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{#each this.params as |p|}}{{p}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -213,7 +214,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.greeting}} {{this.name}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name'];
           }
         )
@@ -265,7 +266,7 @@ moduleFor(
     ['@test updates when curried hash argument is bound']() {
       this.owner.register(
         'component:-looked-up',
-        setComponentTemplate(precompileTemplate('{{this.greeting}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('{{@greeting}}'), class extends Component {})
       );
 
       this.render(`{{component (component "-looked-up" greeting=this.model.greeting)}}`, {
@@ -292,7 +293,7 @@ moduleFor(
     ['@test updates when curried hash arguments is bound in block form']() {
       this.owner.register(
         'component:-looked-up',
-        setComponentTemplate(precompileTemplate('{{this.greeting}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('{{@greeting}}'), class extends Component {})
       );
 
       this.render(
@@ -327,7 +328,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.name}} {{this.age}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name', 'age'];
           }
         )
@@ -349,7 +350,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.greeting}} {{this.name}} {{this.age}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['greeting', 'name', 'age'];
           }
         )
@@ -368,7 +369,7 @@ moduleFor(
       this.owner.register(
         'component:-looked-up',
         setComponentTemplate(
-          precompileTemplate('{{this.greeting}} {{this.name}} {{this.age}}'),
+          precompileTemplate('{{@greeting}} {{@name}} {{@age}}'),
           class extends Component {}
         )
       );
@@ -407,7 +408,7 @@ moduleFor(
         'component:-inner-component',
         setComponentTemplate(
           precompileTemplate('{{component this.comp "Inner"}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['comp'];
           }
         )
@@ -417,7 +418,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.name}} {{this.age}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name', 'age'];
           }
         )
@@ -462,7 +463,7 @@ moduleFor(
         'component:-inner-component',
         setComponentTemplate(
           precompileTemplate('{{component this.comp name="Inner"}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['comp'];
           }
         )
@@ -470,10 +471,7 @@ moduleFor(
 
       this.owner.register(
         'component:-looked-up',
-        setComponentTemplate(
-          precompileTemplate('{{this.name}} {{this.age}}'),
-          class extends Component {}
-        )
+        setComponentTemplate(precompileTemplate('{{@name}} {{@age}}'), class extends Component {})
       );
 
       this.render(
@@ -517,7 +515,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.greeting}} {{this.name}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name'];
           }
         )
@@ -547,7 +545,7 @@ moduleFor(
     ['@test component with dynamic component name resolving to undefined, then an existing component']() {
       this.owner.register(
         'component:foo-bar',
-        setComponentTemplate(precompileTemplate('hello {{this.name}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('hello {{@name}}'), class extends Component {})
       );
 
       this.render('{{component (component this.componentName name=this.name)}}', {
@@ -573,7 +571,7 @@ moduleFor(
     ['@test component with dynamic component name resolving to a component, then undefined']() {
       this.owner.register(
         'component:foo-bar',
-        setComponentTemplate(precompileTemplate('hello {{this.name}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('hello {{@name}}'), class extends Component {})
       );
 
       this.render('{{component (component this.componentName name=this.name)}}', {
@@ -599,7 +597,7 @@ moduleFor(
     ['@test component with dynamic component name resolving to null, then an existing component']() {
       this.owner.register(
         'component:foo-bar',
-        setComponentTemplate(precompileTemplate('hello {{this.name}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('hello {{@name}}'), class extends Component {})
       );
 
       this.render('{{component (component this.componentName name=this.name)}}', {
@@ -625,7 +623,7 @@ moduleFor(
     ['@test component with dynamic component name resolving to a component, then null']() {
       this.owner.register(
         'component:foo-bar',
-        setComponentTemplate(precompileTemplate('hello {{this.name}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('hello {{@name}}'), class extends Component {})
       );
 
       this.render('{{component (component this.componentName name=this.name)}}', {
@@ -695,10 +693,7 @@ moduleFor(
       let expectedText = 'Hodi';
       this.owner.register(
         'component:-looked-up',
-        setComponentTemplate(
-          precompileTemplate('{{this.expectedText}}'),
-          class extends Component {}
-        )
+        setComponentTemplate(precompileTemplate('{{@expectedText}}'), class extends Component {})
       );
 
       this.render(
@@ -732,10 +727,7 @@ moduleFor(
       let expectedText = 'Hodi';
       this.owner.register(
         'component:-looked-up',
-        setComponentTemplate(
-          precompileTemplate('{{this.expectedText}}'),
-          class extends Component {}
-        )
+        setComponentTemplate(precompileTemplate('{{@expectedText}}'), class extends Component {})
       );
 
       this.render(
@@ -770,7 +762,7 @@ moduleFor(
         'component:-looked-up',
         setComponentTemplate(
           precompileTemplate('{{this.params}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -813,7 +805,7 @@ moduleFor(
 
       this.owner.register(
         'component:my-component',
-        class extends Component {
+        class extends EmberComponent {
           static positionalParams = ['value'];
 
           didReceiveAttrs() {
@@ -838,7 +830,7 @@ moduleFor(
         'component:my-nested-component',
         setComponentTemplate(
           precompileTemplate('<span id="nested-prop">{{this.myProp}}</span>'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['my-parent-attr'];
 
             didReceiveAttrs() {
@@ -852,7 +844,7 @@ moduleFor(
         'component:my-component',
         setComponentTemplate(
           precompileTemplate(
-            '{{yield (hash my-nested-component=(component "my-nested-component" my-parent-attr=this.my-attr))}}'
+            '{{yield (hash my-nested-component=(component "my-nested-component" my-parent-attr=@my-attr))}}'
           ),
           class extends Component {}
         )
@@ -864,7 +856,7 @@ moduleFor(
           precompileTemplate(
             '{{#my-component my-attr=this.myProp as |api|}}{{api.my-nested-component}}{{/my-component}}<br><button onclick={{this.changeValue}}>Change value</button>'
           ),
-          class extends Component {
+          class extends EmberComponent {
             @action
             changeValue() {
               this.incrementProperty('myProp');
@@ -911,7 +903,7 @@ moduleFor(
 
       this.owner.register(
         'component:select-box-option',
-        setComponentTemplate(precompileTemplate('{{this.label}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('{{@label}}'), class extends Component {})
       );
 
       this.render(strip`
@@ -936,7 +928,7 @@ moduleFor(
           precompileTemplate(
             '<button {{on "click" (fn (mut this.val) 10)}} class="my-button">Change to 10</button>'
           ),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['val'];
           }
         )
@@ -971,7 +963,7 @@ moduleFor(
     ['@test tagless blockless components render'](assert) {
       this.owner.register(
         'component:my-comp',
-        class extends Component {
+        class extends EmberComponent {
           tagName = '';
         }
       );
@@ -990,7 +982,7 @@ moduleFor(
           precompileTemplate(
             'message: {{this.message}}{{inner-component message=this.message}}<button onclick={{this.change}} />'
           ),
-          class extends Component {
+          class extends EmberComponent {
             message = 'hello';
             @action
             change() {
@@ -1002,7 +994,7 @@ moduleFor(
 
       this.owner.register(
         'component:inner-component',
-        class extends Component {
+        class extends EmberComponent {
           tagName = '';
         }
       );
@@ -1031,15 +1023,14 @@ moduleFor(
       this.owner.register(
         'component:my-comp',
         setComponentTemplate(
-          precompileTemplate('{{if this.isOpen "open" "closed"}}'),
+          precompileTemplate('{{if @isOpen "open" "closed"}}'),
           class extends Component {
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               previousInstance = instance;
               instance = this;
               initCount++;
             }
-            isOpen = undefined;
           }
         )
       );
@@ -1098,15 +1089,14 @@ moduleFor(
       this.owner.register(
         'component:my-comp',
         setComponentTemplate(
-          precompileTemplate('{{if this.isOpen "open" "closed"}}'),
+          precompileTemplate('{{if @isOpen "open" "closed"}}'),
           class extends Component {
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               previousInstance = instance;
               instance = this;
               initCount++;
             }
-            isOpen = undefined;
           }
         )
       );
@@ -1166,15 +1156,14 @@ moduleFor(
       this.owner.register(
         'component:my-comp',
         setComponentTemplate(
-          precompileTemplate('my-comp: {{if this.isOpen "open" "closed"}}'),
+          precompileTemplate('my-comp: {{if @isOpen "open" "closed"}}'),
           class extends Component {
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               previousInstance = instance;
               instance = this;
               initCount++;
             }
-            isOpen = undefined;
           }
         )
       );
@@ -1182,15 +1171,14 @@ moduleFor(
       this.owner.register(
         'component:your-comp',
         setComponentTemplate(
-          precompileTemplate('your-comp: {{if this.isOpen "open" "closed"}}'),
+          precompileTemplate('your-comp: {{if @isOpen "open" "closed"}}'),
           class extends Component {
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               previousInstance = instance;
               instance = this;
               initCount++;
             }
-            isOpen = undefined;
           }
         )
       );
@@ -1264,7 +1252,7 @@ moduleFor(
         'component:my-link',
         setComponentTemplate(
           precompileTemplate('{{#each this.params as |p|}}{{p}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             positionalParams = 'params';
           }
         )
@@ -1306,7 +1294,7 @@ moduleFor(
         'component:my-link',
         setComponentTemplate(
           precompileTemplate('{{#each this.params as |p|}}{{p}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             positionalParams = 'params';
           }
         )
@@ -1425,7 +1413,7 @@ moduleFor(
           precompileTemplate(
             'foo-bar component:{{#each this.params as |param|}} {{param}}{{/each}}'
           ),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -1469,7 +1457,7 @@ moduleFor(
         'component:x-inner',
         setComponentTemplate(
           precompileTemplate('inner:{{#each this.params as |param|}} {{param}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'params';
           }
         )
@@ -1623,7 +1611,7 @@ class MutableParamTestGenerator {
             precompileTemplate(
               '<button {{on "click" (fn (mut this.val) 10)}} class="my-button">Change to 10</button>'
             ),
-            class extends Component {
+            class extends EmberComponent {
               static positionalParams = ['val'];
             }
           )
@@ -1666,7 +1654,7 @@ applyMixins(
           'component:my-comp',
           setComponentTemplate(
             precompileTemplate('{{component this.components.comp}}'),
-            class extends Component {
+            class extends EmberComponent {
               static positionalParams = ['components'];
             }
           )
@@ -1682,7 +1670,7 @@ applyMixins(
         this.owner.register(
           'component:my-comp',
           setComponentTemplate(
-            precompileTemplate('{{component this.component}}'),
+            precompileTemplate('{{component @component}}'),
             class extends Component {}
           )
         );
@@ -1697,7 +1685,7 @@ applyMixins(
         this.owner.register(
           'component:my-comp',
           setComponentTemplate(
-            precompileTemplate('{{component this.components.button}}'),
+            precompileTemplate('{{component @components.button}}'),
             class extends Component {}
           )
         );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/dynamic-components-test.js
@@ -5,7 +5,8 @@ import { set, computed } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '../../utils/helpers';
 import { backtrackingMessageFor } from '../../utils/debug-stack';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 
@@ -15,38 +16,38 @@ moduleFor(
     ['@test it can render a basic component with a static component name argument']() {
       this.owner.register(
         'component:foo-bar',
-        setComponentTemplate(precompileTemplate('hello {{this.name}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('hello {{@name}}'), class extends Component {})
       );
 
       this.render('{{component "foo-bar" name=this.name}}', { name: 'Sarah' });
 
-      this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
+      this.assertText('hello Sarah');
 
       runTask(() => this.rerender());
 
-      this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
+      this.assertText('hello Sarah');
 
       runTask(() => set(this.context, 'name', 'Gavin'));
 
-      this.assertComponentElement(this.firstChild, { content: 'hello Gavin' });
+      this.assertText('hello Gavin');
 
       runTask(() => set(this.context, 'name', 'Sarah'));
 
-      this.assertComponentElement(this.firstChild, { content: 'hello Sarah' });
+      this.assertText('hello Sarah');
     }
 
     ['@test it can render a basic component with a dynamic component name argument']() {
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate('hello {{this.name}} from foo-bar'),
+          precompileTemplate('hello {{@name}} from foo-bar'),
           class extends Component {}
         )
       );
       this.owner.register(
         'component:foo-bar-baz',
         setComponentTemplate(
-          precompileTemplate('hello {{this.name}} from foo-bar-baz'),
+          precompileTemplate('hello {{@name}} from foo-bar-baz'),
           class extends Component {}
         )
       );
@@ -56,36 +57,26 @@ moduleFor(
         name: 'Alex',
       });
 
-      this.assertComponentElement(this.firstChild, {
-        content: 'hello Alex from foo-bar',
-      });
+      this.assertText('hello Alex from foo-bar');
 
       runTask(() => this.rerender());
 
-      this.assertComponentElement(this.firstChild, {
-        content: 'hello Alex from foo-bar',
-      });
+      this.assertText('hello Alex from foo-bar');
 
       runTask(() => set(this.context, 'name', 'Ben'));
 
-      this.assertComponentElement(this.firstChild, {
-        content: 'hello Ben from foo-bar',
-      });
+      this.assertText('hello Ben from foo-bar');
 
       runTask(() => set(this.context, 'componentName', 'foo-bar-baz'));
 
-      this.assertComponentElement(this.firstChild, {
-        content: 'hello Ben from foo-bar-baz',
-      });
+      this.assertText('hello Ben from foo-bar-baz');
 
       runTask(() => {
         set(this.context, 'componentName', 'foo-bar');
         set(this.context, 'name', 'Alex');
       });
 
-      this.assertComponentElement(this.firstChild, {
-        content: 'hello Alex from foo-bar',
-      });
+      this.assertText('hello Alex from foo-bar');
     }
 
     ['@test it throws a useful assertion for an invalid dynamic component value in non-strict mode'](
@@ -130,7 +121,7 @@ moduleFor(
     ['@test it has an element']() {
       let instance;
 
-      let FooBarComponent = class extends Component {
+      let FooBarComponent = class extends EmberComponent {
         init() {
           super.init();
           instance = this;
@@ -160,14 +151,14 @@ moduleFor(
     ['@test it has the right parentView and childViews'](assert) {
       let fooBarInstance, fooBarBazInstance;
 
-      let FooBarComponent = class extends Component {
+      let FooBarComponent = class extends EmberComponent {
         init() {
           super.init();
           fooBarInstance = this;
         }
       };
 
-      let FooBarBazComponent = class extends Component {
+      let FooBarBazComponent = class extends EmberComponent {
         init() {
           super.init();
           fooBarBazInstance = this;
@@ -210,17 +201,17 @@ moduleFor(
 
       this.render('{{#component "foo-bar"}}hello{{/component}}');
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
 
       runTask(() => this.rerender());
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
     }
 
     ['@test it renders the layout with the component instance as the context']() {
       let instance;
 
-      let FooBarComponent = class extends Component {
+      let FooBarComponent = class extends EmberComponent {
         init() {
           super.init();
           instance = this;
@@ -260,19 +251,19 @@ moduleFor(
         message: 'hello',
       });
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
 
       runTask(() => this.rerender());
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
 
       runTask(() => set(this.context, 'message', 'goodbye'));
 
-      this.assertComponentElement(this.firstChild, { content: 'goodbye' });
+      this.assertText('goodbye');
 
       runTask(() => set(this.context, 'message', 'hello'));
 
-      this.assertComponentElement(this.firstChild, { content: 'hello' });
+      this.assertText('hello');
     }
 
     ['@test the component and its child components are destroyed'](assert) {
@@ -282,7 +273,7 @@ moduleFor(
         'component:foo-bar',
         setComponentTemplate(
           precompileTemplate('{{this.id}} {{yield}}'),
-          class extends Component {
+          class extends EmberComponent {
             willDestroy() {
               super.willDestroy();
               destroyed[this.get('id')]++;
@@ -395,7 +386,7 @@ moduleFor(
         'component:foo-bar',
         setComponentTemplate(
           precompileTemplate('hello from foo-bar'),
-          class extends Component {
+          class extends EmberComponent {
             willDestroyElement() {
               assert.equal(
                 testContext.$(`#${this.elementId}`).length,
@@ -416,7 +407,7 @@ moduleFor(
         'component:foo-bar-baz',
         setComponentTemplate(
           precompileTemplate('hello from foo-bar-baz'),
-          class extends Component {
+          class extends EmberComponent {
             willDestroy() {
               super.willDestroy();
               destroyed['foo-bar-baz']++;
@@ -449,7 +440,7 @@ moduleFor(
         'component:foo-bar',
         setComponentTemplate(
           precompileTemplate('foo-bar {{this.location}} {{this.locationCopy}} {{yield}}'),
-          class extends Component {
+          class extends EmberComponent {
             init() {
               super.init(...arguments);
               this.set('locationCopy', this.get('location'));
@@ -462,7 +453,7 @@ moduleFor(
         'component:foo-bar-baz',
         setComponentTemplate(
           precompileTemplate('foo-bar-baz {{this.location}} {{this.locationCopy}} {{yield}}'),
-          class extends Component {
+          class extends EmberComponent {
             init() {
               super.init(...arguments);
               this.set('locationCopy', this.get('location'));
@@ -477,7 +468,7 @@ moduleFor(
           precompileTemplate(
             '{{#component this.componentName location=this.location}}arepas!{{/component}}'
           ),
-          class extends Component {
+          class extends EmberComponent {
             @computed('location')
             get componentName() {
               if (this.get('location') === 'Caracas') {
@@ -590,7 +581,7 @@ moduleFor(
     ['@test component with dynamic component name resolving to a component, then non-existent component']() {
       this.owner.register(
         'component:foo-bar',
-        setComponentTemplate(precompileTemplate('hello {{this.name}}'), class extends Component {})
+        setComponentTemplate(precompileTemplate('hello {{@name}}'), class extends Component {})
       );
 
       this.render('{{component this.componentName name=this.name}}', {
@@ -618,7 +609,7 @@ moduleFor(
         'component:foo-bar',
         setComponentTemplate(
           precompileTemplate('[{{this.internalName}} - {{this.name}}]'),
-          class extends Component {
+          class extends EmberComponent {
             willRender() {
               // store internally available name to ensure that the name available in `this.attrs.name`
               // matches the template lookup name
@@ -652,7 +643,7 @@ moduleFor(
         'component:foo-bar',
         setComponentTemplate(
           precompileTemplate('hello {{this.name}} ({{this.age}}) from foo-bar'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name', 'age'];
           }
         )
@@ -662,7 +653,7 @@ moduleFor(
         'component:foo-bar-baz',
         setComponentTemplate(
           precompileTemplate('hello {{this.name}} ({{this.age}}) from foo-bar-baz'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['name', 'age'];
           }
         )
@@ -718,7 +709,7 @@ moduleFor(
         'component:normal-message',
         setComponentTemplate(
           precompileTemplate('Normal: {{this.something}}!'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['something'];
           }
         )
@@ -728,7 +719,7 @@ moduleFor(
         'component:alternative-message',
         setComponentTemplate(
           precompileTemplate('Alternative: {{this.something}} {{this.somethingElse}}!'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = ['somethingElse'];
             something = 'Another';
           }
@@ -777,7 +768,7 @@ moduleFor(
         'component:sample-component',
         setComponentTemplate(
           precompileTemplate('{{#each this.names as |name|}}{{name}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'names';
           }
         )
@@ -797,7 +788,7 @@ moduleFor(
         'component:sample-component',
         setComponentTemplate(
           precompileTemplate('{{#each this.n as |name|}}{{name}}{{/each}}'),
-          class extends Component {
+          class extends EmberComponent {
             static positionalParams = 'n';
           }
         )
@@ -837,7 +828,7 @@ moduleFor(
           precompileTemplate(
             `Hi {{this.person.name}}! {{component "error-component" person=this.person}}`
           ),
-          class extends Component {
+          class extends EmberComponent {
             init() {
               super.init(...arguments);
               this.set('person', {
@@ -855,7 +846,7 @@ moduleFor(
         'component:error-component',
         setComponentTemplate(
           precompileTemplate('{{this.person.name}}'),
-          class extends Component {
+          class extends EmberComponent {
             init() {
               super.init(...arguments);
               this.set('person.name', 'Ben');

--- a/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/error-handling-test.js
@@ -6,7 +6,8 @@ import { set } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '../../utils/helpers';
 
 moduleFor(
   'Errors thrown during render',
@@ -16,8 +17,8 @@ moduleFor(
     ) {
       let shouldThrow = true;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           if (shouldThrow) {
             throw new Error('silly mistake in init!');
           }
@@ -61,8 +62,8 @@ moduleFor(
     ) {
       let shouldThrow = false;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           if (shouldThrow) {
             throw new Error('silly mistake in init!');
           }
@@ -112,7 +113,7 @@ moduleFor(
       assert
     ) {
       let shouldThrow = true;
-      let FooBarComponent = class extends Component {
+      let FooBarComponent = class extends EmberComponent {
         didInsertElement() {
           super.didInsertElement(...arguments);
           if (shouldThrow) {
@@ -147,7 +148,7 @@ moduleFor(
 
     ['@test it can recover resets the transaction when an error is thrown during destroy'](assert) {
       let shouldThrow = true;
-      let FooBarComponent = class extends Component {
+      let FooBarComponent = class extends EmberComponent {
         destroy() {
           super.destroy(...arguments);
           if (shouldThrow) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-angle-test.js
@@ -2,7 +2,7 @@ import { moduleFor, RenderingTestCase, runDestroy, runTask } from 'internal-test
 import { action, set } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 class InputRenderingTest extends RenderingTestCase {
   $input() {
@@ -385,7 +385,7 @@ moduleFor(
       this.owner.register(
         'component:my-input',
         setComponentTemplate(
-          precompileTemplate(`<Input @type={{this.inputType}} />`),
+          precompileTemplate(`<Input @type={{@inputType}} />`),
           class extends Component {}
         )
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/input-curly-test.js
@@ -1,7 +1,7 @@
 import { RenderingTestCase, moduleFor, runDestroy, runTask } from 'internal-test-helpers';
 
 import { action, set } from '@ember/object';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
@@ -250,7 +250,7 @@ moduleFor(
       this.owner.register(
         'component:my-input',
         setComponentTemplate(
-          precompileTemplate(`{{input type=this.inputType}}`),
+          precompileTemplate(`{{input type=@inputType}}`),
           class extends Component {}
         )
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -9,7 +9,8 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
 import GlimmerishComponent from '../../utils/glimmerish-component';
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '../../utils/helpers';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
@@ -29,7 +30,7 @@ moduleFor(
         }
       }
 
-      class PersonComponent extends Component {
+      class PersonComponent extends EmberComponent {
         @tracked first;
         @tracked last;
 
@@ -447,7 +448,7 @@ moduleFor(
         get countAlias() {
           return this.count;
         }
-        increment = () => this.set('count', this.count + 1);
+        increment = () => set(this, 'count', this.count + 1);
       }
 
       this.owner.register(
@@ -521,8 +522,8 @@ moduleFor(
 
       class ChildComponent extends Component {
         updatePerson = () => {
-          this.person.first = 'Kris';
-          this.person.last = 'Selden';
+          this.args.person.first = 'Kris';
+          this.args.person.last = 'Selden';
         };
       }
 
@@ -540,7 +541,7 @@ moduleFor(
         'component:child',
         setComponentTemplate(
           precompileTemplate(
-            '<div id="child">{{this.person.full}}</div><button onclick={{this.updatePerson}}></button>'
+            '<div id="child">{{@person.full}}</div><button onclick={{this.updatePerson}}></button>'
           ),
           ChildComponent
         )

--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -7,7 +7,7 @@ import {
   defineSimpleModifier,
 } from 'internal-test-helpers';
 
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { setModifierManager, modifierCapabilities, setComponentTemplate } from '@glimmer/manager';
 import { precompileTemplate } from '@ember/template-compilation';
 import EmberObject, { set } from '@ember/object';
@@ -537,7 +537,6 @@ moduleFor(
           class extends Component {
             foo = foo;
             bar = bar;
-            tagName = '';
           }
         )
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/array-test.js
@@ -5,7 +5,7 @@ import templateOnly from '@ember/component/template-only';
 
 import { set } from '@ember/object';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 
 moduleFor(
   'Helpers test: {{array}}',
@@ -155,8 +155,8 @@ moduleFor(
     ['@test should yield hash of an array of internal properties']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init();
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
           this.model = { personOne: 'Chad' };
         }
@@ -197,8 +197,8 @@ moduleFor(
     ['@test should yield hash of an array of internal and external properties']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init();
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
           this.model = { personOne: 'Chad' };
         }
@@ -207,7 +207,7 @@ moduleFor(
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate(`{{yield (hash people=(array this.model.personOne this.personTwo))}}`),
+          precompileTemplate(`{{yield (hash people=(array this.model.personOne @personTwo))}}`),
           FooBarComponent
         )
       );
@@ -249,7 +249,7 @@ moduleFor(
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate('{{#each this.people as |personName|}}{{personName}},{{/each}}'),
+          precompileTemplate('{{#each @people as |personName|}}{{personName}},{{/each}}'),
           FooBarComponent
         )
       );
@@ -272,8 +272,8 @@ moduleFor(
     ['@test should return an entirely new array when any argument change']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init();
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
         }
       };
@@ -281,19 +281,19 @@ moduleFor(
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate('{{#each this.people as |personName|}}{{personName}},{{/each}}'),
+          precompileTemplate('{{#each @people as |personName|}}{{personName}},{{/each}}'),
           FooBarComponent
         )
       );
 
       this.render(strip`{{foo-bar people=(array "Tom" this.personTwo)}}`, { personTwo: 'Chad' });
 
-      let firstArray = fooBarInstance.people;
+      let firstArray = fooBarInstance.args.people;
 
       runTask(() => set(this.context, 'personTwo', 'Godfrey'));
 
       this.assert.ok(
-        firstArray !== fooBarInstance.people,
+        firstArray !== fooBarInstance.args.people,
         'should have created an entirely new array'
       );
     }

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/custom-helper-test.js
@@ -7,7 +7,8 @@ import {
   runTask,
   defineSimpleHelper,
 } from 'internal-test-helpers';
-import { Helper, Component } from '@ember/-internals/glimmer';
+import { Helper } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { set } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/default-helper-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/default-helper-manager-test.js
@@ -1,6 +1,6 @@
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { setComponentTemplate } from '@glimmer/manager';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 import { set } from '@ember/object';
 import { action } from '@ember/object';

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/fn-test.js
@@ -2,7 +2,7 @@ import { set } from '@ember/object';
 import { DEBUG } from '@glimmer/env';
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { template } from '@ember/template-compiler/runtime';
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 
 moduleFor(
   'Helpers test: {{fn}}',
@@ -16,9 +16,9 @@ moduleFor(
       this.owner.register(
         'component:stash',
         class extends Component {
-          init() {
-            super.init(...arguments);
-            testContext.stashedFn = this.stashedFn;
+          constructor(owner, args) {
+            super(owner, args);
+            testContext.stashedFn = this.args.stashedFn;
           }
         }
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/get-test.js
@@ -5,7 +5,7 @@ import { set, get } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 
 moduleFor(
@@ -390,8 +390,8 @@ moduleFor(
     ['@test the result of a get helper can be yielded']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
           this.mcintosh = 'red';
         }
@@ -400,7 +400,7 @@ moduleFor(
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate(`{{yield (get this.colors this.mcintosh)}}`),
+          precompileTemplate(`{{yield (get @colors this.mcintosh)}}`),
           FooBarComponent
         )
       );

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/hash-test.js
@@ -3,7 +3,7 @@ import { setComponentTemplate } from '@glimmer/manager';
 import { precompileTemplate } from '@ember/template-compilation';
 import { template } from '@ember/template-compiler/runtime';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 
 import { set, computed } from '@ember/object';
 
@@ -133,8 +133,8 @@ moduleFor(
     ['@test should yield hash of internal properties']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
           this.model = { firstName: 'Chad' };
         }
@@ -168,8 +168,8 @@ moduleFor(
     ['@test should yield hash of internal and external properties']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
           this.model = { firstName: 'Chad' };
         }
@@ -178,9 +178,7 @@ moduleFor(
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate(
-            `{{yield (hash firstName=this.model.firstName lastName=this.lastName)}}`
-          ),
+          precompileTemplate(`{{yield (hash firstName=this.model.firstName lastName=@lastName)}}`),
           FooBarComponent
         )
       );
@@ -215,9 +213,9 @@ moduleFor(
 
     ['@test works with computeds']() {
       let FooBarComponent = class extends Component {
-        @computed('hash.firstName', 'hash.lastName')
+        @computed('args.hash.firstName', 'args.hash.lastName')
         get fullName() {
-          return `${this.hash.firstName} ${this.hash.lastName}`;
+          return `${this.args.hash.firstName} ${this.args.hash.lastName}`;
         }
       };
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/invoke-helper-test.js
@@ -1,6 +1,7 @@
 import { RenderingTestCase, moduleFor, runTask } from 'internal-test-helpers';
 import { helperCapabilities, setHelperManager, setComponentTemplate } from '@glimmer/manager';
-import { Helper, helper, Component as EmberComponent } from '@ember/-internals/glimmer';
+import { Helper, helper } from '@ember/-internals/glimmer';
+import EmberComponent from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 import { tracked } from '@ember/-internals/metal';
 import { set } from '@ember/object';
@@ -22,11 +23,9 @@ moduleFor(
       }
 
       class PlusOne extends EmberComponent {
-        @tracked number;
-
         plusOne = invokeHelper(this, PlusOneHelper, () => {
           return {
-            positional: [this.number],
+            positional: [this.args.number],
           };
         });
 
@@ -59,11 +58,9 @@ moduleFor(
       let PlusOneHelper = helper(([num]) => num + 1);
 
       class PlusOne extends EmberComponent {
-        @tracked number;
-
         plusOne = invokeHelper(this, PlusOneHelper, () => {
           return {
-            positional: [this.number],
+            positional: [this.args.number],
           };
         });
 
@@ -118,7 +115,7 @@ moduleFor(
       class PlusOne extends EmberComponent {
         plusOne = invokeHelper(this, PlusOneHelper, () => {
           return {
-            positional: [this.number],
+            positional: [this.args.number],
           };
         });
 
@@ -493,11 +490,9 @@ moduleFor(
       }
 
       class PlusOne extends EmberComponent {
-        @tracked number;
-
         plusOne = invokeHelper(this, PlusOneHelper, () => {
           return {
-            positional: [this.number],
+            positional: [this.args.number],
           };
         });
 

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/tracked-test.js
@@ -11,7 +11,7 @@ import { moduleFor, RenderingTestCase, runTask } from 'internal-test-helpers';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 
 moduleFor(
   'Helper Tracked Properties',

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/unbound-test.js
@@ -11,7 +11,7 @@ import { A as emberA } from '@ember/array';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 
 moduleFor(
   'Helpers test: {{unbound}}',
@@ -604,8 +604,8 @@ moduleFor(
     ['@test yielding unbound does not update']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
         }
         model = { foo: 'bork' };
@@ -639,8 +639,8 @@ moduleFor(
     ['@test yielding unbound hash does not update']() {
       let fooBarInstance;
       let FooBarComponent = class extends Component {
-        init() {
-          super.init(...arguments);
+        constructor(owner, args) {
+          super(owner, args);
           fooBarInstance = this;
         }
         model = { foo: 'bork' };

--- a/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/helpers/yield-test.js
@@ -4,7 +4,8 @@ import { set } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '../../utils/helpers';
 
 moduleFor(
   'Helpers test: {{yield}} helper',
@@ -94,7 +95,7 @@ moduleFor(
       this.owner.register(
         'component:inner-comp',
         setComponentTemplate(
-          precompileTemplate('{{#outer-comp}}[In Block:] {{this.object.title}}{{/outer-comp}}'),
+          precompileTemplate('{{#outer-comp}}[In Block:] {{@object.title}}{{/outer-comp}}'),
           class extends Component {}
         )
       );
@@ -119,7 +120,7 @@ moduleFor(
       this.owner.register(
         'component:outer-comp',
         setComponentTemplate(
-          precompileTemplate('{{#each this.list as |item|}}{{yield}}{{/each}}'),
+          precompileTemplate('{{#each @list as |item|}}{{yield}}{{/each}}'),
           class extends Component {}
         )
       );
@@ -142,7 +143,7 @@ moduleFor(
       this.owner.register(
         'component:outer-comp',
         setComponentTemplate(
-          precompileTemplate('{{#if this.boolean}}{{yield}}{{/if}}'),
+          precompileTemplate('{{#if @boolean}}{{yield}}{{/if}}'),
           class extends Component {}
         )
       );
@@ -165,7 +166,7 @@ moduleFor(
       this.owner.register(
         'component:kiwi-comp',
         setComponentTemplate(
-          precompileTemplate('{{#if this.falsy}}{{else}}{{yield}}{{/if}}'),
+          precompileTemplate('{{#if @falsy}}{{else}}{{yield}}{{/if}}'),
           class extends Component {}
         )
       );
@@ -186,14 +187,14 @@ moduleFor(
       this.owner.register(
         'component:parent-comp',
         setComponentTemplate(
-          precompileTemplate('{{#if this.falsy}}{{else}}{{yield}}{{/if}}'),
+          precompileTemplate('{{#if @falsy}}{{else}}{{yield}}{{/if}}'),
           class extends Component {}
         )
       );
       this.owner.register(
         'component:child-comp',
         setComponentTemplate(
-          precompileTemplate('{{#if this.falsy}}{{else}}{{this.text}}{{/if}}'),
+          precompileTemplate('{{#if @falsy}}{{else}}{{@text}}{{/if}}'),
           class extends Component {}
         )
       );
@@ -220,7 +221,7 @@ moduleFor(
       this.owner.register(
         'component:outer-comp',
         setComponentTemplate(
-          precompileTemplate('{{yielding-comp}} {{this.title}}'),
+          precompileTemplate('{{yielding-comp}} {{@title}}'),
           class extends Component {}
         )
       );
@@ -323,7 +324,7 @@ moduleFor(
       this.owner.register(
         'component:kiwi-comp',
         setComponentTemplate(
-          precompileTemplate('<p>{{this.content}}</p><p>{{yield}}</p>'),
+          precompileTemplate('<p>{{@content}}</p><p>{{yield}}</p>'),
           class extends Component {}
         )
       );
@@ -345,11 +346,11 @@ moduleFor(
 
     // INUR not need with no data update
     ['@test yield should not introduce a view'](assert) {
-      let ParentCompComponent = class extends Component {
+      let ParentCompComponent = class extends EmberComponent {
         isParentComponent = true;
       };
 
-      let ChildCompComponent = class extends Component {
+      let ChildCompComponent = class extends EmberComponent {
         didReceiveAttrs() {
           super.didReceiveAttrs();
           let parentView = this.get('parentView');

--- a/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/modifiers/on-test.js
@@ -5,7 +5,7 @@ import { precompileTemplate } from '@ember/template-compilation';
 
 import { DEBUG } from '@glimmer/env';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 
 moduleFor(
   '{{on}} Modifier',
@@ -336,7 +336,6 @@ moduleFor(
         setComponentTemplate(
           precompileTemplate(`<button {{on 'click' this.fire}}>Fire!</button>`),
           class extends Component {
-            tagName = '';
             fire() {
               assert.ok(false);
             }

--- a/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/mount-test.js
@@ -14,7 +14,7 @@ import Engine, { getEngineParent } from '@ember/engine';
 import { precompileTemplate } from '@ember/template-compilation';
 
 import { backtrackingMessageFor } from '../utils/debug-stack';
-import { Component } from '../utils/helpers';
+import Component from '@glimmer/component';
 import { setComponentTemplate } from '@glimmer/manager';
 
 moduleFor(
@@ -138,14 +138,14 @@ moduleFor(
       };
 
       let ComponentWithBacktrackingSet = class extends Component {
-        init() {
-          super.init(...arguments);
-          this.set('person.name', 'Ben');
+        constructor(owner, args) {
+          super(owner, args);
+          set(this.args.person, 'name', 'Ben');
         }
       };
 
       setComponentTemplate(
-        precompileTemplate('[component {{this.person.name}}]'),
+        precompileTemplate('[component {{@person.name}}]'),
         ComponentWithBacktrackingSet
       );
 
@@ -277,10 +277,8 @@ moduleFor(
               setComponentTemplate(
                 precompileTemplate('Tagless Component'),
                 class extends Component {
-                  tagName = '';
-
-                  init() {
-                    super.init(...arguments);
+                  constructor(owner, args) {
+                    super(owner, args);
                     component = this;
                   }
                 }
@@ -408,9 +406,7 @@ moduleFor(
         'component:app-bar-component',
         setComponentTemplate(
           precompileTemplate('rendered app-bar-component from the app'),
-          class extends Component {
-            tagName = '';
-          }
+          class extends Component {}
         )
       );
       this.add(
@@ -433,9 +429,7 @@ moduleFor(
       );
 
       return this.visit('/engine-params-contextual-component').then(() => {
-        this.assertComponentElement(this.firstChild, {
-          content: 'foo-component rendered! - rendered app-bar-component from the app',
-        });
+        this.assertText('foo-component rendered! - rendered app-bar-component from the app');
       });
     }
   }

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -8,7 +8,8 @@ import { RSVP } from '@ember/-internals/runtime';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component, htmlSafe } from '../../utils/helpers';
+import Component from '@glimmer/component';
+import { Component as EmberComponent, htmlSafe } from '../../utils/helpers';
 import {
   TogglingSyntaxConditionalsTest,
   TruthyGenerator,
@@ -506,7 +507,7 @@ class EachTest extends AbstractEachTest {
   [`@test updating and setting within #each`]() {
     this.makeList([{ value: 1 }, { value: 2 }, { value: 3 }]);
 
-    let FooBarComponent = class extends Component {
+    let FooBarComponent = class extends EmberComponent {
       init() {
         super.init(...arguments);
         this.isEven = true;

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/if-unless-test.js
@@ -5,7 +5,7 @@ import { set } from '@ember/object';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from '../../utils/helpers';
+import Component from '@glimmer/component';
 import { IfUnlessWithSyntaxTest } from '../../utils/shared-conditional-tests';
 
 moduleFor(
@@ -46,7 +46,7 @@ moduleFor(
       this.owner.register(
         'component:foo-bar',
         setComponentTemplate(
-          precompileTemplate('{{this.number}}'),
+          precompileTemplate('{{@number}}'),
           class extends Component {
             willDestroy() {
               super.willDestroy();

--- a/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
+++ b/packages/@ember/-internals/glimmer/tests/unit/runtime-resolver-cache-test.js
@@ -5,7 +5,7 @@ import { set } from '@ember/object';
 import { templateCacheCounters } from '@ember/-internals/glimmer';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
-import { Component } from '../utils/helpers';
+import Component from '@glimmer/component';
 
 moduleFor(
   'ember-glimmer runtime resolver cache',

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -11,7 +11,7 @@ import ArrayProxy from '@ember/array/proxy';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
-import { Component } from './helpers';
+import Component from '@glimmer/component';
 
 class AbstractConditionalsTest extends RenderingTestCase {
   get truthyValue() {
@@ -861,8 +861,8 @@ export class TogglingSyntaxConditionalsTest extends TogglingConditionalsTest {
       setComponentTemplate(
         precompileTemplate('foo-bar'),
         class extends Component {
-          init() {
-            super.init(...arguments);
+          constructor(owner, args) {
+            super(owner, args);
             childCreated = true;
           }
         }

--- a/packages/@ember/application/tests/visit_test.js
+++ b/packages/@ember/application/tests/visit_test.js
@@ -14,7 +14,12 @@ import Application from '@ember/application';
 import ApplicationInstance from '@ember/application/instance';
 import Engine from '@ember/engine';
 import Route from '@ember/routing/route';
-import { Component, helper, isSerializationFirstNode } from '@ember/-internals/glimmer';
+import {
+  Component as EmberComponent,
+  helper,
+  isSerializationFirstNode,
+} from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 
 function expectAsyncError() {
@@ -678,7 +683,7 @@ moduleFor(
             `<h1>X-Foo</h1>
            <p>Hello {{@model.name}}, I have been clicked {{this.isolatedCounter.value}} times ({{this.sharedCounter.value}} times combined)!</p>`
           ),
-          class extends Component {
+          class extends EmberComponent {
             tagName = 'x-foo';
 
             @service
@@ -710,7 +715,7 @@ moduleFor(
             `<h1>X-Bar</h1>
           <button {{on "click" this.incrementCounter}}>Join {{this.counter.value}} others in clicking me!</button>`
           ),
-          class extends Component {
+          class extends EmberComponent {
             @service('sharedCounter')
             counter;
 

--- a/packages/@ember/object/tests/action_test.js
+++ b/packages/@ember/object/tests/action_test.js
@@ -1,4 +1,4 @@
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import EmberObject, { action } from '@ember/object';
 import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
 import { precompileTemplate } from '@ember/template-compilation';

--- a/packages/ember-template-compiler/tests/plugins/assert-against-attrs-test.js
+++ b/packages/ember-template-compiler/tests/plugins/assert-against-attrs-test.js
@@ -3,7 +3,7 @@ import { moduleFor, RenderingTestCase } from 'internal-test-helpers';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 import templateOnly from '@ember/component/template-only';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 moduleFor(
   'ember-template-compiler: assert against attrs',
@@ -69,7 +69,7 @@ moduleFor(
         )
       );
       this.render('<Foo />');
-      this.assertComponentElement(this.firstChild, { content: 'foo' });
+      this.assertText('foo');
     }
 
     ["@test it doesn't assert lexical scope values"]() {
@@ -93,7 +93,7 @@ moduleFor(
         setComponentTemplate(precompileTemplate('{{yield "foo"}}'), class extends Component {})
       );
       this.render('<Foo as |attrs|>{{attrs}}</Foo>');
-      this.assertComponentElement(this.firstChild, { content: 'foo' });
+      this.assertText('foo');
     }
 
     ["@test it doesn't assert block params with nested keys"]() {
@@ -105,7 +105,7 @@ moduleFor(
         )
       );
       this.render('<Foo as |attrs|>{{attrs.bar}}</Foo>');
-      this.assertComponentElement(this.firstChild, { content: 'baz' });
+      this.assertText('baz');
     }
   }
 );

--- a/packages/ember/tests/component_context_test.js
+++ b/packages/ember/tests/component_context_test.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
+import { Component as EmberComponent } from '@ember/-internals/glimmer';
 import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 import { moduleFor, ApplicationTestCase, getTextOf } from 'internal-test-helpers';
@@ -65,7 +66,7 @@ moduleFor(
       );
       this.add(
         'component:my-component',
-        class extends Component {
+        class extends EmberComponent {
           text = 'inner';
         }
       );
@@ -127,7 +128,7 @@ moduleFor(
       );
       this.add(
         'component:my-component',
-        class extends Component {
+        class extends EmberComponent {
           didInsertElement() {
             this.element.innerHTML = 'Some text inserted';
           }
@@ -160,7 +161,7 @@ moduleFor(
       );
       this.add(
         'component:my-component',
-        class extends Component {
+        class extends EmberComponent {
           didInsertElement() {
             this.element.innerHTML = this.get('data');
           }
@@ -194,7 +195,7 @@ moduleFor(
       );
       this.add(
         'component:my-component',
-        class extends Component {
+        class extends EmberComponent {
           didInsertElement() {
             this.element.innerHTML = this.get('attrs.attrs.value');
           }

--- a/packages/ember/tests/integration/multiple-app-test.js
+++ b/packages/ember/tests/integration/multiple-app-test.js
@@ -1,6 +1,6 @@
 import { moduleFor, ApplicationTestCase, runTask } from 'internal-test-helpers';
 import Application from '@ember/application';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { getOwner } from '@ember/-internals/owner';
 import { resolve } from 'rsvp';
 import { action } from '@ember/object';

--- a/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
+++ b/packages/ember/tests/routing/router_service_test/currenturl_lifecycle_test.js
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import Route from '@ember/routing/route';
 import { get } from '@ember/object';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';

--- a/packages/ember/tests/routing/router_service_test/isActive_test.js
+++ b/packages/ember/tests/routing/router_service_test/isActive_test.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import { RouterTestCase, moduleFor } from 'internal-test-helpers';
 import Service, { service } from '@ember/service';
 import { precompileTemplate } from '@ember/template-compilation';
@@ -192,8 +192,8 @@ moduleFor(
             @service('router')
             routerService;
 
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               componentInstance = this;
             }
 

--- a/packages/ember/tests/routing/router_service_test/non_application_test_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test_test.js
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import Router from '@ember/routing/router';
 import NoneLocation from '@ember/routing/none-location';
-import { action, get } from '@ember/object';
+import { action } from '@ember/object';
 import { run } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { setComponentTemplate } from '@glimmer/manager';

--- a/packages/ember/tests/routing/router_service_test/non_application_test_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test_test.js
@@ -102,7 +102,7 @@ moduleFor(
           }
           @action
           transitionToSister() {
-            get(this, 'routerService').transitionTo('parent.sister');
+            this.routerService.transitionTo('parent.sister');
           }
         }
       );

--- a/packages/ember/tests/routing/router_service_test/non_application_test_test.js
+++ b/packages/ember/tests/routing/router_service_test/non_application_test_test.js
@@ -3,7 +3,8 @@ import Router from '@ember/routing/router';
 import NoneLocation from '@ember/routing/none-location';
 import { action, get } from '@ember/object';
 import { run } from '@ember/runloop';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
+import { setComponentTemplate } from '@glimmer/manager';
 import { RouterNonApplicationTestCase, moduleFor } from 'internal-test-helpers';
 import { precompileTemplate } from '@ember/template-compilation';
 
@@ -90,19 +91,21 @@ moduleFor(
 
       let self = this;
 
-      let FooBar = class extends Component {
-        @service('router')
-        routerService;
-        layout = self.compile('foo-bar');
-        init() {
-          super.init(...arguments);
-          componentInstance = this;
+      let FooBar = setComponentTemplate(
+        self.compile('foo-bar'),
+        class extends Component {
+          @service('router')
+          routerService;
+          constructor(owner, args) {
+            super(owner, args);
+            componentInstance = this;
+          }
+          @action
+          transitionToSister() {
+            get(this, 'routerService').transitionTo('parent.sister');
+          }
         }
-        @action
-        transitionToSister() {
-          get(this, 'routerService').transitionTo('parent.sister');
-        }
-      };
+      );
 
       this.add('component:foo-bar', FooBar);
 

--- a/packages/ember/tests/routing/router_service_test/transitionTo_test.js
+++ b/packages/ember/tests/routing/router_service_test/transitionTo_test.js
@@ -1,5 +1,5 @@
 import Service, { service } from '@ember/service';
-import { Component } from '@ember/-internals/glimmer';
+import Component from '@glimmer/component';
 import Route from '@ember/routing/route';
 import NoneLocation from '@ember/routing/none-location';
 import Controller from '@ember/controller';
@@ -110,8 +110,8 @@ moduleFor(
           class extends Component {
             @service('router')
             routerService;
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               componentInstance = this;
             }
             @action
@@ -145,8 +145,8 @@ moduleFor(
           class extends Component {
             @service('router')
             routerService;
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               componentInstance = this;
             }
             @action
@@ -182,8 +182,8 @@ moduleFor(
           class extends Component {
             @service('router')
             routerService;
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               componentInstance = this;
             }
             @action
@@ -230,8 +230,8 @@ moduleFor(
           class extends Component {
             @service('router')
             routerService;
-            init() {
-              super.init();
+            constructor(owner, args) {
+              super(owner, args);
               componentInstance = this;
             }
             @action

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     "noEmit": true,
     "paths": {
       // We compile away @glimmer/env during all our builds
-      "@glimmer/env": ["./packages/@glimmer/env/index.ts"]
+      "@glimmer/env": ["./packages/@glimmer/env/index.ts"],
+      // @glimmer/component is published as its own addon and only gets a
+      // dist/ from rollup, so point at the source for type-checking
+      "@glimmer/component": ["./packages/@glimmer/component/src/index.ts"]
     }
   },
   "include": ["packages/**/*.ts"],

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -46,6 +46,17 @@ export default defineConfig(({ mode }) => {
       viteResolverBug(),
       version(),
     ],
+    // `@glimmer/component` is published as its own v2 addon and is only built
+    // (into `dist/`) by `rollup.config.mjs`. Tests run straight off source, so
+    // point the bare specifier at the TypeScript entrypoint instead.
+    resolve: {
+      alias: [
+        {
+          find: /^@glimmer\/component$/,
+          replacement: resolve(projectRoot, 'packages/@glimmer/component/src/index.ts'),
+        },
+      ],
+    },
     optimizeDeps: { noDiscovery: true, include: ['expect-type'] },
     publicDir: 'tests/public',
     build,


### PR DESCRIPTION
Our tests presently use a lot of things that are about to be deprecated (unintentional use, and more happenstansial use)