### PR TITLE
Update browser support per Ember's browser support policy

### DIFF
--- a/lib/browsers.cjs
+++ b/lib/browsers.cjs
@@ -1,11 +1,11 @@
 module.exports = [
   'Chrome >= 109',
-  'Edge >= 128',
-  'Firefox >= 115',
-  'iOS >= 15.6',
-  'Safari >= 15.6',
-  'ChromeAndroid >= 130',
-  'FirefoxAndroid >= 130',
+  'Edge >= 149',
+  'Firefox >= 121',
+  'iOS >= 16.6',
+  'Safari >= 18.5',
+  'ChromeAndroid >= 151',
+  'FirefoxAndroid >= 153',
 ];
 
 /*
@@ -15,33 +15,33 @@ module.exports = [
   `npx browserslist '>0.25%, Firefox ESR, last 1 Chrome version, last 1 Firefox version, last 1 Edge version, last 1 FirefoxAndroid version, last 1 ChromeAndroid version, not dead'`
 
   And then filtering out unsupported browsers.
-
-  and_chr 130
-  and_ff 130
-  chrome 130
-  chrome 129
-  chrome 128
-  chrome 127
-  chrome 126
-  chrome 125
-  chrome 124
+  
+  and_chr 151
+  and_ff 153
+  chrome 151
+  chrome 150
+  chrome 149
+  chrome 148
+  chrome 145
+  chrome 142
+  chrome 131
+  chrome 120
+  chrome 119
   chrome 109
-  edge 130
-  edge 129
-  edge 128
-  firefox 132
-  firefox 130
-  firefox 129
-  firefox 128
-  firefox 115
-  ios_saf 18.0
-  ios_saf 17.6-17.7
-  ios_saf 17.5
-  ios_saf 17.4
+  edge 151
+  edge 150
+  edge 149
+  firefox 154
+  firefox 153
+  firefox 152
+  firefox 140
+  firefox 121
+  ios_saf 26.5
+  ios_saf 26.4
+  ios_saf 26.3
+  ios_saf 26.2
+  ios_saf 18.5-18.7
   ios_saf 16.6-16.7
-  ios_saf 16.1
-  ios_saf 15.6-15.8
-  safari 17.6
-  safari 17.5
-  safari 16.6
+  safari 26.5
+  safari 18.5-18.7
 */

--- a/packages/@glimmer/validator/test/collections/weak-map-test.ts
+++ b/packages/@glimmer/validator/test/collections/weak-map-test.ts
@@ -19,7 +19,7 @@ module('@glimmer/validator: trackedWeakMap()', function () {
   test('does not work with built-ins', (assert) => {
     const map = trackedWeakMap();
     const pattern =
-      /(Invalid value used as weak map key)|(WeakMap key must be an object)|(Attempted to set a non-object key in a WeakMap)|(must be an object or an unregistered symbol)/u;
+      /(Invalid value used as weak map key)|(WeakMap key must be an object)|(Attempted to set a non-object key in a WeakMap)|(must be an object or an unregistered symbol)|(WeakMap keys must be objects or non-registered symbols)/u;
 
     assert.throws(
       // @ts-expect-error -- point is testing constructor error

--- a/packages/@glimmer/validator/test/collections/weak-set-test.ts
+++ b/packages/@glimmer/validator/test/collections/weak-set-test.ts
@@ -22,7 +22,7 @@ module('@glimmer/validator: trackedWeakSet()', function () {
   test('does not work with built-ins', (assert) => {
     const set = trackedWeakSet();
     const pattern =
-      /(Invalid value used in weak set)|(WeakSet value must be an object)|(Attempted to add a non-object value to a WeakSet)|(must be an object or an unregistered symbol)/u;
+      /(Invalid value used in weak set)|(WeakSet value must be an object)|(Attempted to add a non-object value to a WeakSet)|(must be an object or an unregistered symbol)|(WeakSet values must be objects or non-registered symbols)/u;
 
     // @ts-expect-error -- point is testing constructor error
     assert.throws(() => set.add('aoeu'), pattern);

--- a/testem.browserstack.cjs
+++ b/testem.browserstack.cjs
@@ -7,11 +7,11 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Monterey',
+      'Ventura',
       '--b',
       'safari',
       '--bv',
-      'latest', // Will always be 15.x on Monterey
+      'latest', // Will always be 16.x on Ventura
       '-t',
       '1200',
       '--u',
@@ -29,7 +29,7 @@ const BrowserStackLaunchers = {
       '--b',
       'edge',
       '--bv',
-      '128',
+      '149',
       '-t',
       '1200',
       '--u',


### PR DESCRIPTION
now

```
module.exports = [
  'Chrome >= 109',
  'Edge >= 149',
  'Firefox >= 121',
  'iOS >= 16.6',
  'Safari >= 18.5',
  'ChromeAndroid >= 151',
  'FirefoxAndroid >= 153',
];
```
