### PR TITLE
Leave trailing empty arrays out of the wire format

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/compiler/compile-options-test.ts
@@ -116,7 +116,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[2][componentNameExpr[1]];
+    let componentName = block[2]?.[componentNameExpr[1]];
     assert.strictEqual(componentName, 'ooFX', 'customized component name was used');
   });
 
@@ -140,7 +140,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[2][componentNameExpr[1]];
+    let componentName = block[2]?.[componentNameExpr[1]];
     assert.strictEqual(componentName, 'rental', 'customized component name was used');
   });
 
@@ -163,7 +163,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[2][componentNameExpr[1]];
+    let componentName = block[2]?.[componentNameExpr[1]];
     assert.strictEqual(componentName, 'my-component', 'original component name was used');
   });
 
@@ -186,7 +186,7 @@ module('[glimmer-compiler] precompile', ({ test }) => {
       `component name is a free variable lookup`
     );
 
-    let componentName = block[2][componentNameExpr[1]];
+    let componentName = block[2]?.[componentNameExpr[1]];
     assert.strictEqual(componentName, 'MyComponent', 'original component name was used');
   });
 

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/content.ts
@@ -189,7 +189,7 @@ export class ContentEncoder {
     if (nameChars === 'inverse') {
       nameChars = 'else';
     }
-    return [nameChars, [CONTENT.list(body), scope.slots]];
+    return [nameChars, inlineBlock(CONTENT.list(body), scope.slots)];
   }
 
   If({ condition, block, inverse }: mir.If): WireFormat.Statements.If {
@@ -285,4 +285,12 @@ function dynamicAttrOp(
   } else {
     return kind.trusting ? SexpOpcodes.TrustingDynamicAttr : SexpOpcodes.DynamicAttr;
   }
+}
+
+/** An empty parameter list carries no information, so leave it out. */
+function inlineBlock(
+  statements: WireFormat.Statement[],
+  parameters: number[]
+): WireFormat.SerializedInlineBlock {
+  return parameters.length === 0 ? [statements] : [statements, parameters];
 }

--- a/packages/@glimmer/compiler/lib/passes/2-encoding/index.ts
+++ b/packages/@glimmer/compiler/lib/passes/2-encoding/index.ts
@@ -12,6 +12,16 @@ export function visit(template: mir.Template): WireFormat.SerializedTemplateBloc
   let scope = template.scope;
   let block: WireFormat.SerializedTemplateBlock = [statements, scope.symbols, scope.upvars];
 
+  // Trailing empty arrays carry no information, so leave them out of the
+  // wire format. Readers default the missing entries.
+  if (scope.upvars.length === 0) {
+    block.pop();
+
+    if (scope.symbols.length === 0) {
+      block.pop();
+    }
+  }
+
   if (LOCAL_TRACE_LOGGING) {
     let debug = new WireFormatDebugger(block);
     LOCAL_LOGGER.debug(

--- a/packages/@glimmer/compiler/lib/wire-format-debug.ts
+++ b/packages/@glimmer/compiler/lib/wire-format-debug.ts
@@ -20,7 +20,7 @@ export default class WireFormatDebugger {
   private upvars: string[];
   private symbols: string[];
 
-  constructor([_statements, symbols, upvars]: SerializedTemplateBlock) {
+  constructor([_statements, symbols = [], upvars = []]: SerializedTemplateBlock) {
     this.upvars = upvars;
     this.symbols = symbols;
   }
@@ -290,7 +290,7 @@ export default class WireFormatDebugger {
   private formatBlock(block: SerializedInlineBlock): object {
     return {
       statements: block[0].map((s) => this.formatOpcode(s)),
-      parameters: block[1],
+      parameters: block[1] ?? [],
     };
   }
 }

--- a/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/wire-format/api.d.ts
@@ -356,15 +356,15 @@ export type SyntaxWithInternal =
  */
 export type SerializedBlock = [statements: Statements.Statement[]];
 
-export type SerializedInlineBlock = [statements: Statements.Statement[], parameters: number[]];
+export type SerializedInlineBlock = [statements: Statements.Statement[], parameters?: number[]];
 
 /**
  * A JSON object that the compiled TemplateBlock was serialized into.
  */
 export type SerializedTemplateBlock = [
   statements: Statements.Statement[],
-  locals: string[],
-  upvars: string[],
+  locals?: string[],
+  upvars?: string[],
 ];
 
 /**

--- a/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
+++ b/packages/@glimmer/opcode-compiler/lib/compilable-template.ts
@@ -54,7 +54,7 @@ class CompilableTemplateImpl<S extends SymbolTable> implements CompilableTemplat
 }
 
 export function compilable(layout: LayoutWithContext, moduleName: string): CompilableProgram {
-  let [statements, symbols] = layout.block;
+  let [statements, symbols = EMPTY_ARRAY as string[]] = layout.block;
   return new CompilableTemplateImpl(
     statements,
     meta(layout),

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/blocks.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/blocks.ts
@@ -1,4 +1,5 @@
 import type { Nullable, WireFormat } from '@glimmer/interfaces';
+import { EMPTY_ARRAY } from '@glimmer/util/lib/array-utils';
 import {
   VM_CHILD_SCOPE_OP,
   VM_COMPILE_BLOCK_OP,
@@ -55,7 +56,7 @@ export function PushYieldableBlock(
   op: PushStatementOp,
   block: Nullable<WireFormat.SerializedInlineBlock>
 ): void {
-  PushSymbolTable(op, block && block[1]);
+  PushSymbolTable(op, block ? (block[1] ?? (EMPTY_ARRAY as number[])) : null);
   op(VM_PUSH_BLOCK_SCOPE_OP);
   PushCompilable(op, block);
 }
@@ -88,7 +89,7 @@ export function InvokeStaticBlockWithStack(
   block: WireFormat.SerializedInlineBlock,
   callerCount: number
 ): void {
-  let parameters = block[1];
+  let parameters = block[1] ?? (EMPTY_ARRAY as number[]);
   let calleeCount = parameters.length;
   let count = Math.min(callerCount, calleeCount);
 

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/helpers/shared.ts
@@ -106,7 +106,7 @@ export function CompilePositional(
 }
 
 export function meta(layout: LayoutWithContext): BlockMetadata {
-  let [, locals, upvars] = layout.block;
+  let [, locals = EMPTY_ARRAY as string[], upvars = EMPTY_ARRAY as string[]] = layout.block;
   let scopeRecord = layout.scope?.() ?? null;
 
   return {

--- a/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
+++ b/packages/@glimmer/opcode-compiler/lib/wrapped-component.ts
@@ -30,7 +30,7 @@ export class WrappedBuilder implements CompilableProgram {
     public moduleName: string
   ) {
     let { block } = layout;
-    let [, symbols] = block;
+    let [, symbols = []] = block;
 
     symbols = symbols.slice();
 


### PR DESCRIPTION
A template with no block params serializes `,[],[]` for `locals` and `upvars`, and every inline block without parameters carries `,[]`. These arrays hold their tuple position and nothing else.

This PR drops trailing empty arrays from the encoder output and defaults the missing entries in the readers:

- `SerializedTemplateBlock` becomes `[statements, locals?, upvars?]` and `SerializedInlineBlock` becomes `[statements, parameters?]`.
- The encoder (`passes/2-encoding`) pops trailing empties.
- The readers (`compilable-template`, `meta`, `wrapped-component`, the block helpers, the wire format debugger) default a missing entry to an empty array.

Blocks that still carry the arrays keep working, so templates compiled with older compilers are unaffected.

Size, `smoke-tests/v2-app-hello-world-template`, `pnpm build`:

| | raw | gzip (9) | brotli (11) |
|---|---|---|---|
| `main` | 134,353 B | 42,576 B | 37,600 B |
| this PR | 134,371 B | 42,591 B | 37,514 B |

Size, `smoke-tests/v2-app-template`, `pnpm build`, all JS assets summed:

| | raw | gzip (9) | brotli (11) |
|---|---|---|---|
| `main` | 341,366 B | 109,243 B | 94,379 B |
| this PR | 341,381 B | 109,258 B | 94,373 B |

Both apps in this repo have only a handful of templates, so they are the worst case for this change: the reader defaults cost about 15 to 18 B raw, which cancels the savings from those few templates, and compressed sizes move by single-digit bytes. The savings scale with template count: about 6 B per template plus 3 B per parameterless block, before compression. An app with hundreds of templates saves a few kB raw.

`pnpm test`: 9456 tests, 17 skipped, 0 failures. `pnpm type-check:internals` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQyBrSj4CZaqMcKc7aW81
