### PR TITLE
Sketch: INTERNAL_MIXIN_EXTEND instead of static block for EmberObject

### DIFF
--- a/packages/@ember/-internals/utils/lib/internal-mixin-create.ts
+++ b/packages/@ember/-internals/utils/lib/internal-mixin-create.ts
@@ -9,3 +9,14 @@
   @private
 */
 export const INTERNAL_MIXIN_CREATE = Symbol('__internal__mixin__');
+
+/**
+  Key for the internal equivalent of `CoreObject.extend`.
+
+  The public `extend` notifies when a deprecated framework mixin such as
+  `Observable` is applied. Ember's own classes must still extend with those
+  mixins, so they use this Symbol-keyed method, which skips the notice.
+
+  @private
+*/
+export const INTERNAL_MIXIN_EXTEND = Symbol('__internal__mixin__extend__');

--- a/packages/@ember/object/core.ts
+++ b/packages/@ember/object/core.ts
@@ -15,7 +15,10 @@ import { defineProperty } from '@ember/-internals/metal/lib/properties';
 import { descriptorForProperty, isClassicDecorator } from '@ember/-internals/metal/lib/decorator';
 import { DEBUG_INJECTION_FUNCTIONS } from '@ember/-internals/metal/lib/injected_property';
 import Mixin, { applyMixin } from '@ember/object/mixin';
-import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
+import {
+  INTERNAL_MIXIN_CREATE,
+  INTERNAL_MIXIN_EXTEND,
+} from '@ember/-internals/utils/lib/internal-mixin-create';
 import { deprecateAppliedMixins } from '@ember/-internals/utils/lib/deprecated-mixin';
 import ActionHandler from '@ember/-internals/runtime/lib/mixins/action_handler';
 import makeArray from '@ember/array/make';
@@ -716,6 +719,15 @@ class CoreObject {
   ): Readonly<Statics> & EmberClassConstructor<Instance> & MergeArray<M>;
   static extend(...mixins: any[]) {
     deprecateAppliedMixins(mixins);
+    return this[INTERNAL_MIXIN_EXTEND](...mixins);
+  }
+
+  /** @internal */
+  static [INTERNAL_MIXIN_EXTEND]<Statics, Instance, M extends Array<unknown>>(
+    this: Statics & EmberClassConstructor<Instance>,
+    ...mixins: M
+  ): Readonly<Statics> & EmberClassConstructor<Instance> & MergeArray<M>;
+  static [INTERNAL_MIXIN_EXTEND](...mixins: any[]) {
     let Class = class extends this {};
     reopen.apply(Class.PrototypeMixin, mixins);
     return Class;

--- a/packages/@ember/object/index.ts
+++ b/packages/@ember/object/index.ts
@@ -8,6 +8,7 @@ import { isElementDescriptor, setClassicDecorator } from '@ember/-internals/meta
 import expandProperties from '@ember/-internals/metal/lib/expand_properties';
 import { getFactoryFor } from '@ember/-internals/container/lib/container';
 import { setObservers } from '@ember/-internals/utils/lib/super';
+import { INTERNAL_MIXIN_EXTEND } from '@ember/-internals/utils/lib/internal-mixin-create';
 import type { AnyFn } from '@ember/-internals/utility-types';
 import CoreObject from '@ember/object/core';
 import Observable from '@ember/object/observable';
@@ -36,12 +37,8 @@ export { default as computed } from '@ember/-internals/metal/lib/computed';
 */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface EmberObject extends Observable {}
-class EmberObject extends CoreObject {
-  static {
-    // `extend(Observable)` would fire the Observable deprecation for every app.
-    this.PrototypeMixin.reopen(Observable);
-  }
-
+// `extend(Observable)` would fire the Observable deprecation for every app.
+class EmberObject extends CoreObject[INTERNAL_MIXIN_EXTEND](Observable) {
   get _debugContainerKey() {
     let factory = getFactoryFor(this);
     return factory !== undefined && factory.fullName;


### PR DESCRIPTION
Comparison sketch for #21588, not necessarily for merge.

This replaces the `static {}` block on `EmberObject` with an `INTERNAL_MIXIN_EXTEND` symbol method on `CoreObject`. The symbol mirrors `extend` the way `INTERNAL_MIXIN_CREATE` mirrors `Mixin.create`: the public method is the deprecation notice plus the internal call.

Effects:

- `EmberObject` returns to the shape it has on `main`. The anonymous intermediate class comes back, with `Observable` on its `PrototypeMixin`. The `EmberObject` diff against `main` shrinks to one word.
- The heritage clause typechecks through the same overload signature that `extend` uses. That signature now appears twice in `core.ts`, which is the main cost.
- `type-check:internals` passes. The browser deprecation tests did not run.

If the flattening in #21588 was intentional, the `static {}` block is required and this sketch does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GSgBwzsjV3iTreDTN3fHZ
