### PR TITLE
Implement RFC #1112: Deprecate Ember Proxies

### DIFF
--- a/packages/@ember/-internals/deprecations/index.ts
+++ b/packages/@ember/-internals/deprecations/index.ts
@@ -140,6 +140,27 @@ export const DEPRECATIONS = {
     until: '8.0.0',
     url: 'https://deprecations.emberjs.com/id/deprecate-mixins',
   }),
+  DEPRECATE_ARRAY_PROXY: deprecation({
+    id: 'deprecate-array-proxy',
+    for: 'ember-source',
+    since: { available: '7.4.0' },
+    until: '8.0.0',
+    url: 'https://deprecations.emberjs.com/id/deprecate-array-proxy',
+  }),
+  DEPRECATE_OBJECT_PROXY: deprecation({
+    id: 'deprecate-object-proxy',
+    for: 'ember-source',
+    since: { available: '7.4.0' },
+    until: '8.0.0',
+    url: 'https://deprecations.emberjs.com/id/deprecate-object-proxy',
+  }),
+  DEPRECATE_PROMISE_PROXY_MIXIN: deprecation({
+    id: 'deprecate-promise-proxy-mixin',
+    for: 'ember-source',
+    since: { available: '7.4.0' },
+    until: '8.0.0',
+    url: 'https://deprecations.emberjs.com/id/deprecate-promise-proxy-mixin',
+  }),
 };
 
 export function deprecateUntil(message: string, deprecation: DeprecationObject) {

--- a/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/components/tracked-test.js
@@ -7,7 +7,15 @@ import { computed, get, set } from '@ember/object';
 import { Promise } from 'rsvp';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  strip,
+  runTask,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 import GlimmerishComponent from '../../utils/glimmerish-component';
 import Component from '@glimmer/component';
 import { Component as EmberComponent } from '../../utils/helpers';
@@ -96,7 +104,15 @@ moduleFor(
       this.assertText('max jackson | max jackson');
     }
 
-    '@test creating an array proxy inside a tracking context does not trigger backtracking assertion'() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved
+    )} @test creating an array proxy inside a tracking context does not trigger backtracking assertion`]() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+      expectDeprecation(
+        /`PromiseProxyMixin` is deprecated/,
+        DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isEnabled
+      );
+
       let PromiseArray = ArrayProxy.extend(PromiseProxyMixin);
 
       class LoaderComponent extends GlimmerishComponent {
@@ -124,7 +140,11 @@ moduleFor(
       this.assertText('123');
     }
 
-    '@test creating an array proxy inside a tracking context and immediately updating its content before usage does not trigger backtracking assertion'() {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved
+    )} @test creating an array proxy inside a tracking context and immediately updating its content before usage does not trigger backtracking assertion`]() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+
       class LoaderComponent extends GlimmerishComponent {
         get data() {
           if (!this._data) {

--- a/packages/@ember/-internals/glimmer/tests/integration/content-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/content-test.js
@@ -1,6 +1,15 @@
 import { DEBUG } from '@glimmer/env';
 
-import { RenderingTestCase, moduleFor, applyMixins, classes, runTask } from 'internal-test-helpers';
+import {
+  RenderingTestCase,
+  moduleFor,
+  applyMixins,
+  classes,
+  runTask,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 import { set, computed } from '@ember/object';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
@@ -346,7 +355,11 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertInvariants();
   }
 
-  ['@test it can read from a proxy object']() {
+  [`${testUnless(
+    DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+  )} @test it can read from a proxy object`]() {
+    expectDeprecation(/`ObjectProxy` is deprecated/, DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled);
+
     this.renderPath('this.proxy.name', {
       proxy: ObjectProxy.create({ content: { name: 'Tom Dale' } }),
     });
@@ -382,7 +395,11 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertInvariants();
   }
 
-  ['@test it can read from a nested path in a proxy object']() {
+  [`${testUnless(
+    DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+  )} @test it can read from a nested path in a proxy object`]() {
+    expectDeprecation(/`ObjectProxy` is deprecated/, DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled);
+
     this.renderPath('this.proxy.name.last', {
       proxy: ObjectProxy.create({
         content: { name: { first: 'Tom', last: 'Dale' } },
@@ -439,7 +456,11 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertInvariants();
   }
 
-  ['@test it can read from a path flipping between a proxy and a real object']() {
+  [`${testUnless(
+    DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+  )} @test it can read from a path flipping between a proxy and a real object`]() {
+    expectDeprecation(/`ObjectProxy` is deprecated/, DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled);
+
     this.renderPath('this.proxyOrObject.name.last', {
       proxyOrObject: ObjectProxy.create({
         content: { name: { first: 'Tom', last: 'Dale' } },
@@ -517,7 +538,11 @@ class DynamicContentTest extends RenderingTestCase {
     this.assertInvariants();
   }
 
-  ['@test it can read from a path flipping between a real object and a proxy']() {
+  [`${testUnless(
+    DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+  )} @test it can read from a path flipping between a real object and a proxy`]() {
+    expectDeprecation(/`ObjectProxy` is deprecated/, DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled);
+
     this.renderPath('this.objectOrProxy.name.last', {
       objectOrProxy: { name: { first: 'Tom', last: 'Dale' } },
     });

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-in-test.js
@@ -1,4 +1,12 @@
-import { applyMixins, moduleFor, RenderingTestCase, runTask, strip } from 'internal-test-helpers';
+import {
+  applyMixins,
+  moduleFor,
+  RenderingTestCase,
+  runTask,
+  strip,
+  ignoreDeprecation,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 import { get, set } from '@ember/object';
 import EmberObject from '@ember/object';
@@ -36,6 +44,14 @@ class BasicSyntaxTest extends BasicEachInTest {
 
 class EachInProxyTest extends TogglingEachInTest {}
 
+// `ObjectProxy` is deprecated; the deprecation itself is asserted by the
+// dedicated `ObjectProxy` tests, so it is silenced in these rendering fixtures.
+const OBJECT_PROXY_REMOVED = DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved;
+
+function objectProxy(props) {
+  return ignoreDeprecation(() => ObjectProxy.create(props));
+}
+
 applyMixins(
   BasicEachInTest,
   new TruthyGenerator([
@@ -63,35 +79,37 @@ applyMixins(
   ])
 );
 
-applyMixins(
-  EachInProxyTest,
+if (!OBJECT_PROXY_REMOVED) {
+  applyMixins(
+    EachInProxyTest,
 
-  new TruthyGenerator([ObjectProxy.create({ content: { 'Not empty': 1 } })]),
+    new TruthyGenerator([objectProxy({ content: { 'Not empty': 1 } })]),
 
-  new FalsyGenerator([
-    ObjectProxy.create(),
-    ObjectProxy.create({ content: null }),
-    ObjectProxy.create({ content: {} }),
-    ObjectProxy.create({ content: Object.create(null) }),
-    ObjectProxy.create({ content: Object.create({}) }),
-    ObjectProxy.create({ content: Object.create({ 'Not Empty': 1 }) }),
-    ObjectProxy.create({ content: EmberObject.create() }),
-  ])
-);
+    new FalsyGenerator([
+      objectProxy(),
+      objectProxy({ content: null }),
+      objectProxy({ content: {} }),
+      objectProxy({ content: Object.create(null) }),
+      objectProxy({ content: Object.create({}) }),
+      objectProxy({ content: Object.create({ 'Not Empty': 1 }) }),
+      objectProxy({ content: EmberObject.create() }),
+    ])
+  );
 
-// Truthy/Falsy tests
-moduleFor(
-  'Syntax test: {{#each-in}} with `ObjectProxy`',
-  class extends EachInProxyTest {
-    get truthyValue() {
-      return ObjectProxy.create({ content: { 'Not Empty': 1 } });
+  // Truthy/Falsy tests
+  moduleFor(
+    'Syntax test: {{#each-in}} with `ObjectProxy`',
+    class extends EachInProxyTest {
+      get truthyValue() {
+        return objectProxy({ content: { 'Not Empty': 1 } });
+      }
+
+      get falsyValue() {
+        return objectProxy({ content: null });
+      }
     }
-
-    get falsyValue() {
-      return ObjectProxy.create({ content: null });
-    }
-  }
-);
+  );
+}
 
 moduleFor('Syntax test: {{#each-in}}', BasicSyntaxTest);
 
@@ -515,109 +533,111 @@ moduleFor(
   }
 );
 
-moduleFor(
-  'Syntax test: {{#each-in}} with object proxies',
-  class extends EachInTest {
-    constructor() {
-      super(...arguments);
-      this.allowsSetProp = true;
-    }
-    createHash(pojo) {
-      let hash = ObjectProxy.create({ content: pojo });
-      return {
-        hash,
-        delegate: {
-          setProp(context, key, value) {
-            set(context, `hash.${key}`, value);
-          },
-          updateNestedValue(context, key, innerKey, value) {
-            let target = get(context.hash, key);
-            set(target, innerKey, value);
-          },
-        },
-      };
-    }
-
-    ['@test it iterates over the content, not the proxy']() {
-      let content = {
-        Smartphones: 8203,
-        'JavaScript Frameworks': Infinity,
-      };
-
-      let proxy = ObjectProxy.create({
-        content,
-        foo: 'bar',
-      });
-
-      this.render(
-        strip`
-      <ul>
-        {{#each-in this.categories as |category count|}}
-          <li>{{category}}: {{count}}</li>
-        {{/each-in}}
-      </ul>
-    `,
-        { categories: proxy }
-      );
-
-      this.assertHTML(strip`
-      <ul>
-        <li>Smartphones: 8203</li>
-        <li>JavaScript Frameworks: Infinity</li>
-      </ul>
-    `);
-
-      this.assertStableRerender();
-
-      runTask(() => {
-        set(proxy, 'content.Smartphones', 100);
-        set(proxy, 'content.Tweets', 443115);
-      });
-
-      this.assertHTML(strip`
-      <ul>
-        <li>Smartphones: 100</li>
-        <li>JavaScript Frameworks: Infinity</li>
-        <li>Tweets: 443115</li>
-      </ul>
-    `);
-
-      runTask(() => {
-        set(proxy, 'content', {
-          Smartphones: 100,
-          Tablets: 20,
-        });
-      });
-
-      this.assertHTML(strip`
-      <ul>
-        <li>Smartphones: 100</li>
-        <li>Tablets: 20</li>
-      </ul>
-    `);
-
-      runTask(() =>
-        set(
-          this.context,
-          'categories',
-          ObjectProxy.create({
-            content: {
-              Smartphones: 8203,
-              'JavaScript Frameworks': Infinity,
+if (!OBJECT_PROXY_REMOVED) {
+  moduleFor(
+    'Syntax test: {{#each-in}} with object proxies',
+    class extends EachInTest {
+      constructor() {
+        super(...arguments);
+        this.allowsSetProp = true;
+      }
+      createHash(pojo) {
+        let hash = objectProxy({ content: pojo });
+        return {
+          hash,
+          delegate: {
+            setProp(context, key, value) {
+              set(context, `hash.${key}`, value);
             },
-          })
-        )
-      );
+            updateNestedValue(context, key, innerKey, value) {
+              let target = get(context.hash, key);
+              set(target, innerKey, value);
+            },
+          },
+        };
+      }
 
-      this.assertHTML(strip`
-      <ul>
-        <li>Smartphones: 8203</li>
-        <li>JavaScript Frameworks: Infinity</li>
-      </ul>
-    `);
+      ['@test it iterates over the content, not the proxy']() {
+        let content = {
+          Smartphones: 8203,
+          'JavaScript Frameworks': Infinity,
+        };
+
+        let proxy = objectProxy({
+          content,
+          foo: 'bar',
+        });
+
+        this.render(
+          strip`
+        <ul>
+          {{#each-in this.categories as |category count|}}
+            <li>{{category}}: {{count}}</li>
+          {{/each-in}}
+        </ul>
+      `,
+          { categories: proxy }
+        );
+
+        this.assertHTML(strip`
+        <ul>
+          <li>Smartphones: 8203</li>
+          <li>JavaScript Frameworks: Infinity</li>
+        </ul>
+      `);
+
+        this.assertStableRerender();
+
+        runTask(() => {
+          set(proxy, 'content.Smartphones', 100);
+          set(proxy, 'content.Tweets', 443115);
+        });
+
+        this.assertHTML(strip`
+        <ul>
+          <li>Smartphones: 100</li>
+          <li>JavaScript Frameworks: Infinity</li>
+          <li>Tweets: 443115</li>
+        </ul>
+      `);
+
+        runTask(() => {
+          set(proxy, 'content', {
+            Smartphones: 100,
+            Tablets: 20,
+          });
+        });
+
+        this.assertHTML(strip`
+        <ul>
+          <li>Smartphones: 100</li>
+          <li>Tablets: 20</li>
+        </ul>
+      `);
+
+        runTask(() =>
+          set(
+            this.context,
+            'categories',
+            objectProxy({
+              content: {
+                Smartphones: 8203,
+                'JavaScript Frameworks': Infinity,
+              },
+            })
+          )
+        );
+
+        this.assertHTML(strip`
+        <ul>
+          <li>Smartphones: 8203</li>
+          <li>JavaScript Frameworks: Infinity</li>
+        </ul>
+      `);
+      }
     }
-  }
-);
+  );
+}
 
 moduleFor(
   'Syntax test: {{#each-in}} with ES6 Maps',

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/each-test.js
@@ -1,4 +1,12 @@
-import { moduleFor, RenderingTestCase, applyMixins, strip, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  applyMixins,
+  strip,
+  runTask,
+  ignoreDeprecation,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 import { notifyPropertyChange } from '@ember/-internals/metal';
 import { get, set, computed } from '@ember/object';
@@ -143,13 +151,22 @@ class TogglingEachTest extends TogglingSyntaxConditionalsTest {
 
 class BasicEachTest extends TogglingEachTest {}
 
+// `ArrayProxy` is deprecated; the deprecation itself is asserted by the
+// dedicated `ArrayProxy` tests, so it is silenced in these rendering fixtures.
+const ARRAY_PROXY_REMOVED = DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved;
+
+function arrayProxy(props) {
+  return ignoreDeprecation(() => ArrayProxy.create(props));
+}
+
 const TRUTHY_CASES = [
   ['hello'],
   emberA(['hello']),
   new Set(['hello']),
   new ForEachable(['hello']),
-  ArrayProxy.create({ content: ['hello'] }),
-  ArrayProxy.create({ content: emberA(['hello']) }),
+  ...(ARRAY_PROXY_REMOVED
+    ? []
+    : [arrayProxy({ content: ['hello'] }), arrayProxy({ content: emberA(['hello']) })]),
   new ArrayIterable(['hello']),
 ];
 
@@ -163,8 +180,9 @@ const FALSY_CASES = [
   emberA([]),
   new Set([]),
   new ForEachable([]),
-  ArrayProxy.create({ content: [] }),
-  ArrayProxy.create({ content: emberA([]) }),
+  ...(ARRAY_PROXY_REMOVED
+    ? []
+    : [arrayProxy({ content: [] }), arrayProxy({ content: emberA([]) })]),
   new ArrayIterable([]),
 ];
 
@@ -1067,66 +1085,72 @@ moduleFor(
   }
 );
 
-moduleFor(
-  'Syntax test: {{#each}} with array proxies, modifying itself',
-  class extends EachTest {
-    createList(items) {
-      let proxty = ArrayProxy.create({ content: emberA(items) });
-      return { list: proxty, delegate: proxty };
+if (!ARRAY_PROXY_REMOVED) {
+  moduleFor(
+    'Syntax test: {{#each}} with array proxies, modifying itself',
+    class extends EachTest {
+      createList(items) {
+        let proxty = arrayProxy({ content: emberA(items) });
+        return { list: proxty, delegate: proxty };
+      }
     }
-  }
-);
+  );
 
-moduleFor(
-  'Syntax test: {{#each}} with array proxies, replacing its content',
-  class extends EachTest {
-    createList(items) {
-      let wrapped = emberA(items);
-      return {
-        list: wrapped,
-        delegate: ArrayProxy.create({ content: wrapped }),
-      };
+  moduleFor(
+    'Syntax test: {{#each}} with array proxies, replacing its content',
+    class extends EachTest {
+      createList(items) {
+        let wrapped = emberA(items);
+        return {
+          list: wrapped,
+          delegate: arrayProxy({ content: wrapped }),
+        };
+      }
     }
-  }
-);
+  );
 
-moduleFor(
-  'Syntax test: {{#each}} with array proxies, arrangedContent depends on external content',
-  class extends EachTest {
-    createList(items) {
-      let wrapped = emberA(items);
-      let proxy = class extends ArrayProxy {
-        @computed('wrappedItems.[]')
-        get arrangedContent() {
-          // Slice the items to ensure that updates must be propogated
-          return this.wrappedItems.slice();
-        }
-      }.create({
-        wrappedItems: wrapped,
-      });
+  moduleFor(
+    'Syntax test: {{#each}} with array proxies, arrangedContent depends on external content',
+    class extends EachTest {
+      createList(items) {
+        let wrapped = emberA(items);
+        let proxy = ignoreDeprecation(() =>
+          class extends ArrayProxy {
+            @computed('wrappedItems.[]')
+            get arrangedContent() {
+              // Slice the items to ensure that updates must be propogated
+              return this.wrappedItems.slice();
+            }
+          }.create({
+            wrappedItems: wrapped,
+          })
+        );
 
-      return { list: proxy, delegate: wrapped };
+        return { list: proxy, delegate: wrapped };
+      }
     }
-  }
-);
+  );
 
-moduleFor(
-  'Syntax test: {{#each}} with array proxies, content is updated after init',
-  class extends EachTest {
-    createList(items) {
-      let wrapped = emberA(items);
-      let proxy = ArrayProxy.extend({
-        init: function () {
-          this._super(...arguments);
+  moduleFor(
+    'Syntax test: {{#each}} with array proxies, content is updated after init',
+    class extends EachTest {
+      createList(items) {
+        let wrapped = emberA(items);
+        let proxy = ignoreDeprecation(() =>
+          ArrayProxy.extend({
+            init: function () {
+              this._super(...arguments);
 
-          this.set('content', emberA(wrapped));
-        },
-      }).create();
+              this.set('content', emberA(wrapped));
+            },
+          }).create()
+        );
 
-      return { list: proxy, delegate: wrapped };
+        return { list: proxy, delegate: wrapped };
+      }
     }
-  }
-);
+  );
+}
 
 moduleFor(
   'Syntax test: {{#each as}} undefined path',

--- a/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/syntax/let-test.js
@@ -1,4 +1,12 @@
-import { moduleFor, RenderingTestCase, strip, runTask } from 'internal-test-helpers';
+import {
+  moduleFor,
+  RenderingTestCase,
+  strip,
+  runTask,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 import { get, set } from '@ember/object';
 import { A as emberA, removeAt } from '@ember/array';
@@ -122,7 +130,12 @@ moduleFor(
       this.assertText('-Yehuda-');
     }
 
-    ['@test can access alias of a proxy']() {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test can access alias of a proxy`]() {
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+
       this.render(`{{#let this.proxy as |person|}}{{person.name}}{{/let}}`, {
         proxy: ObjectProxy.create({ content: { name: 'Tom Dale' } }),
       });

--- a/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
+++ b/packages/@ember/-internals/glimmer/tests/utils/shared-conditional-tests.js
@@ -1,6 +1,13 @@
 /* eslint-disable no-new-wrappers */
 
-import { RenderingTestCase, applyMixins, runTask } from 'internal-test-helpers';
+import {
+  RenderingTestCase,
+  applyMixins,
+  runTask,
+  ignoreDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 import { htmlSafe } from '@ember/-internals/glimmer';
 import { get, set } from '@ember/object';
@@ -12,6 +19,24 @@ import { precompileTemplate } from '@ember/template-compilation';
 import { setComponentTemplate } from '@glimmer/manager';
 
 import Component from '@glimmer/component';
+
+// `ObjectProxy` and `ArrayProxy` are deprecated, but their interaction with
+// conditionals is still worth covering until they are removed. The deprecation
+// itself is asserted by the dedicated proxy tests, so it is silenced here.
+const OBJECT_PROXY_REMOVED = DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved;
+const ARRAY_PROXY_REMOVED = DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved;
+
+function objectProxy(props) {
+  return ignoreDeprecation(() => ObjectProxy.create(props));
+}
+
+function arrayProxy(props) {
+  return ignoreDeprecation(() => ArrayProxy.create(props));
+}
+
+function unlessRemoved(removed, cases) {
+  return removed ? [] : cases();
+}
 
 class AbstractConditionalsTest extends RenderingTestCase {
   get truthyValue() {
@@ -169,10 +194,10 @@ class ObjectProxyGenerator extends AbstractGenerator {
     // simply uses !!content to determine truthiness
     if (value) {
       return {
-        [`@test it should consider an object proxy with \`${JSON.stringify(
+        [`${testUnless(OBJECT_PROXY_REMOVED)} @test it should consider an object proxy with \`${JSON.stringify(
           value
         )}\` truthy [${idx}]`]() {
-          this.renderValues(ObjectProxy.create({ content: value }));
+          this.renderValues(objectProxy({ content: value }));
 
           this.assertText('T1');
 
@@ -184,17 +209,17 @@ class ObjectProxyGenerator extends AbstractGenerator {
 
           this.assertText('F1');
 
-          runTask(() => set(this.context, 'cond1', ObjectProxy.create({ content: value })));
+          runTask(() => set(this.context, 'cond1', objectProxy({ content: value })));
 
           this.assertText('T1');
         },
       };
     } else {
       return {
-        [`@test it should consider an object proxy with \`${JSON.stringify(
+        [`${testUnless(OBJECT_PROXY_REMOVED)} @test it should consider an object proxy with \`${JSON.stringify(
           value
         )}\` falsy [${idx}]`]() {
-          this.renderValues(ObjectProxy.create({ content: value }));
+          this.renderValues(objectProxy({ content: value }));
 
           this.assertText('F1');
 
@@ -206,7 +231,7 @@ class ObjectProxyGenerator extends AbstractGenerator {
 
           this.assertText('T1');
 
-          runTask(() => set(this.context, 'cond1', ObjectProxy.create({ content: value })));
+          runTask(() => set(this.context, 'cond1', objectProxy({ content: value })));
 
           this.assertText('F1');
         },
@@ -249,11 +274,11 @@ export class BasicConditionalsTest extends AbstractConditionalsTest {
 
 // Testing behaviors related to ember objects, object proxies, etc
 export const ObjectTestCases = {
-  ['@test it considers object proxies without content falsy']() {
+  [`${testUnless(OBJECT_PROXY_REMOVED)} @test it considers object proxies without content falsy`]() {
     this.renderValues(
-      ObjectProxy.create({ content: {} }),
-      ObjectProxy.create({ content: EmberObject.create() }),
-      ObjectProxy.create({ content: null })
+      objectProxy({ content: {} }),
+      objectProxy({ content: EmberObject.create() }),
+      objectProxy({ content: null })
     );
 
     this.assertText('T1T2F3');
@@ -278,9 +303,9 @@ export const ObjectTestCases = {
     this.assertText('T1T2T3');
 
     runTask(() => {
-      set(this.context, 'cond1', ObjectProxy.create({ content: {} }));
-      set(this.context, 'cond2', ObjectProxy.create({ content: EmberObject.create() }));
-      set(this.context, 'cond3', ObjectProxy.create({ content: null }));
+      set(this.context, 'cond1', objectProxy({ content: {} }));
+      set(this.context, 'cond2', objectProxy({ content: EmberObject.create() }));
+      set(this.context, 'cond3', objectProxy({ content: null }));
     });
 
     this.assertText('T1T2F3');
@@ -317,11 +342,8 @@ export const ArrayTestCases = {
     this.assertText('T1F2');
   },
 
-  ['@test it considers array proxies without content falsy']() {
-    this.renderValues(
-      ArrayProxy.create({ content: emberA(['hello']) }),
-      ArrayProxy.create({ content: null })
-    );
+  [`${testUnless(ARRAY_PROXY_REMOVED)} @test it considers array proxies without content falsy`]() {
+    this.renderValues(arrayProxy({ content: emberA(['hello']) }), arrayProxy({ content: null }));
 
     this.assertText('T1F2');
 
@@ -344,17 +366,17 @@ export const ArrayTestCases = {
     this.assertText('T1T2');
 
     runTask(() => {
-      set(this.context, 'cond1', ArrayProxy.create({ content: emberA(['hello']) }));
-      set(this.context, 'cond2', ArrayProxy.create({ content: null }));
+      set(this.context, 'cond1', arrayProxy({ content: emberA(['hello']) }));
+      set(this.context, 'cond2', arrayProxy({ content: null }));
     });
 
     this.assertText('T1F2');
   },
 
-  ['@test it considers array proxies with empty arrays falsy']() {
+  [`${testUnless(ARRAY_PROXY_REMOVED)} @test it considers array proxies with empty arrays falsy`]() {
     this.renderValues(
-      ArrayProxy.create({ content: emberA(['hello']) }),
-      ArrayProxy.create({ content: emberA() })
+      arrayProxy({ content: emberA(['hello']) }),
+      arrayProxy({ content: emberA() })
     );
 
     this.assertText('T1F2');
@@ -375,8 +397,8 @@ export const ArrayTestCases = {
     this.assertText('T1T2');
 
     runTask(() => {
-      set(this.context, 'cond1', ArrayProxy.create({ content: emberA(['hello']) }));
-      set(this.context, 'cond2', ArrayProxy.create({ content: emberA() }));
+      set(this.context, 'cond1', arrayProxy({ content: emberA(['hello']) }));
+      set(this.context, 'cond2', arrayProxy({ content: emberA() }));
     });
 
     this.assertText('T1F2');
@@ -398,7 +420,7 @@ const IfUnlessWithTestCases = [
     { foo: 'bar' },
     EmberObject.create(),
     EmberObject.create({ foo: 'bar' }),
-    ObjectProxy.create({ content: true }),
+    ...unlessRemoved(OBJECT_PROXY_REMOVED, () => [objectProxy({ content: true })]),
     Object,
     function () {},
     async function () {},
@@ -418,7 +440,7 @@ const IfUnlessWithTestCases = [
     0,
     [],
     emberA(),
-    ObjectProxy.create({ content: undefined }),
+    ...unlessRemoved(OBJECT_PROXY_REMOVED, () => [objectProxy({ content: undefined })]),
     htmlSafe(''),
   ]),
 
@@ -432,14 +454,18 @@ const IfUnlessWithTestCases = [
     1,
     ['hello'],
     emberA(['hello']),
-    ArrayProxy.create({ content: ['hello'] }),
-    ArrayProxy.create({ content: [] }),
+    ...unlessRemoved(ARRAY_PROXY_REMOVED, () => [
+      arrayProxy({ content: ['hello'] }),
+      arrayProxy({ content: [] }),
+    ]),
     {},
     { foo: 'bar' },
     EmberObject.create(),
     EmberObject.create({ foo: 'bar' }),
-    ObjectProxy.create({ content: true }),
-    ObjectProxy.create({ content: undefined }),
+    ...unlessRemoved(OBJECT_PROXY_REMOVED, () => [
+      objectProxy({ content: true }),
+      objectProxy({ content: undefined }),
+    ]),
     new String('hello'),
     new String(''),
     new Boolean(true),

--- a/packages/@ember/-internals/runtime/tests/core/is_array_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_array_test.js
@@ -2,7 +2,8 @@ import { A as emberA, isArray } from '@ember/array';
 import ArrayProxy from '@ember/array/proxy';
 import EmberObject from '@ember/object';
 import { window } from '@ember/-internals/browser-environment';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 const global = this;
 
@@ -19,7 +20,6 @@ moduleFor(
       let strangeLength = { length: 'yes' };
       let fn = function () {};
       let asyncFn = async function () {};
-      let arrayProxy = ArrayProxy.create({ content: emberA() });
 
       assert.equal(isArray(numarray), true, '[1,2,3]');
       assert.equal(isArray(number), false, '23');
@@ -31,7 +31,16 @@ moduleFor(
       assert.equal(isArray(global), false, 'global');
       assert.equal(isArray(fn), false, 'function() {}');
       assert.equal(isArray(asyncFn), false, 'async function() {}');
-      assert.equal(isArray(arrayProxy), true, '[]');
+    }
+
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved
+    )} @test Ember.isArray with an ArrayProxy`](assert) {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+
+      let arrayProxy = ArrayProxy.create({ content: emberA() });
+
+      assert.equal(isArray(arrayProxy), true, 'ArrayProxy');
     }
 
     '@test Ember.isArray does not trigger proxy assertion when probing for length GH#16495'(

--- a/packages/@ember/-internals/runtime/tests/core/is_empty_test.js
+++ b/packages/@ember/-internals/runtime/tests/core/is_empty_test.js
@@ -2,18 +2,31 @@ import { isEmpty } from '@ember/utils';
 import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
 import { A as emberA } from '@ember/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'Ember.isEmpty',
   class extends AbstractTestCase {
-    ['@test Ember.isEmpty ArrayProxy'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test Ember.isEmpty ArrayProxy`](
+      assert
+    ) {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+
       let arrayProxy = ArrayProxy.create({ content: emberA() });
 
       assert.equal(true, isEmpty(arrayProxy), 'for an ArrayProxy that has empty content');
     }
 
-    ['@test Ember.isEmpty ObjectProxy ArrayProxy'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test Ember.isEmpty ObjectProxy ArrayProxy`](
+      assert
+    ) {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+
       let arrayProxy = ArrayProxy.create({ content: emberA([]) });
       let objectProxy = ObjectProxy.create({ content: arrayProxy });
 

--- a/packages/@ember/-internals/runtime/tests/helpers/array.js
+++ b/packages/@ember/-internals/runtime/tests/helpers/array.js
@@ -9,7 +9,8 @@ import {
   arrayContentDidChange,
 } from '@ember/-internals/metal';
 import EmberObject, { get, computed } from '@ember/object';
-import { moduleFor } from 'internal-test-helpers';
+import { moduleFor, ignoreDeprecation } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 export function newFixture(cnt) {
   let ret = [];
@@ -152,7 +153,10 @@ class NativeArrayHelpers extends AbstractArrayHelper {
 
 class ArrayProxyHelpers extends AbstractArrayHelper {
   newObject(ary) {
-    return ArrayProxy.create({ content: emberA(super.newObject(ary)) });
+    // These suites exercise the shared array APIs rather than `ArrayProxy`
+    // itself, so we let the `ArrayProxy` deprecation pass silently here. The
+    // deprecation itself is covered by the dedicated `ArrayProxy` tests.
+    return ignoreDeprecation(() => ArrayProxy.create({ content: emberA(super.newObject(ary)) }));
   }
 
   mutate(obj) {
@@ -255,30 +259,38 @@ class EmberArrayHelpers extends MutableArrayHelpers {
   }
 }
 
+const ARRAY_TEST_HELPERS = {
+  ArrayProxy: ArrayProxyHelpers,
+  EmberArray: EmberArrayHelpers,
+  MutableArray: MutableArrayHelpers,
+  NativeArray: NativeArrayHelpers,
+};
+
+const DEFAULT_ARRAY_TEST_TYPES = ['ArrayProxy', 'EmberArray', 'MutableArray', 'NativeArray'];
+
 export function runArrayTests(name, Tests, ...types) {
-  if (types.length > 0) {
-    types.forEach((type) => {
-      switch (type) {
-        case 'ArrayProxy':
-          moduleFor(`ArrayProxy: ${name}`, Tests, ArrayProxyHelpers);
-          break;
-        case 'EmberArray':
-          moduleFor(`EmberArray: ${name}`, Tests, EmberArrayHelpers);
-          break;
-        case 'MutableArray':
-          moduleFor(`MutableArray: ${name}`, Tests, MutableArrayHelpers);
-          break;
-        case 'NativeArray':
-          moduleFor(`NativeArray: ${name}`, Tests, NativeArrayHelpers);
-          break;
-        default:
-          throw new Error(`runArrayTests passed unexpected type ${type}`);
-      }
-    });
-  } else {
-    moduleFor(`ArrayProxy: ${name}`, Tests, ArrayProxyHelpers);
-    moduleFor(`EmberArray: ${name}`, Tests, EmberArrayHelpers);
-    moduleFor(`MutableArray: ${name}`, Tests, MutableArrayHelpers);
-    moduleFor(`NativeArray: ${name}`, Tests, NativeArrayHelpers);
+  let requested = types.length > 0 ? types : DEFAULT_ARRAY_TEST_TYPES;
+
+  for (let type of requested) {
+    if (!ARRAY_TEST_HELPERS[type]) {
+      throw new Error(`runArrayTests passed unexpected type ${type}`);
+    }
+  }
+
+  // NOTE: `moduleFor` mixes each helper onto the prototype of the *shared*
+  // `Tests` class, so the helper registered last supplies `newObject` for every
+  // module here -- in practice these suites all run against `ArrayProxy`. That
+  // means they cannot be split apart one type at a time: dropping `ArrayProxy`
+  // hands `newObject` to a helper that has never actually run, and those
+  // helpers have rotted (`EmberObject.create` with `_super`, `destroy` on
+  // native arrays). Until that is untangled, skip the whole family once
+  // `ArrayProxy` is removed rather than run it against helpers it was never
+  // really exercising. See the `deprecate-array-proxy` deprecation.
+  if (requested.includes('ArrayProxy') && DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved) {
+    return;
+  }
+
+  for (let type of requested) {
+    moduleFor(`${type}: ${name}`, Tests, ARRAY_TEST_HELPERS[type]);
   }
 }

--- a/packages/@ember/-internals/runtime/tests/mixins/mutable_enumerable_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/mutable_enumerable_test.js
@@ -1,7 +1,8 @@
 import MutableEnumerable from '@ember/enumerable/mutable';
 import ArrayProxy from '@ember/array/proxy';
 import { A } from '@ember/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'MutableEnumerable',
@@ -10,7 +11,11 @@ moduleFor(
       assert.ok(MutableEnumerable.detect(A()));
     }
 
-    ['@test should be mixed into ArrayProxy'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test should be mixed into ArrayProxy`](
+      assert
+    ) {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+
       assert.ok(MutableEnumerable.detect(ArrayProxy.create()));
     }
   }

--- a/packages/@ember/-internals/runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/mixins/promise_proxy_test.js
@@ -5,7 +5,14 @@ import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import EmberRSVP from '../../lib/ext/rsvp';
 import { onerrorDefault } from '../../lib/ext/rsvp';
 import * as RSVP from 'rsvp';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import {
+  moduleFor,
+  AbstractTestCase,
+  expectDeprecation,
+  ignoreDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 let ObjectPromiseProxy, proxy;
 
@@ -16,17 +23,34 @@ moduleFor(
       ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
     }
 
+    expectProxyDeprecations() {
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+      expectDeprecation(
+        /`PromiseProxyMixin` is deprecated/,
+        DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isEnabled
+      );
+    }
+
     afterEach() {
       RSVP.on('error', onerrorDefault);
       if (proxy) proxy.destroy();
       proxy = undefined;
     }
 
-    ['@test present on ember namespace'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test present on ember namespace`](
+      assert
+    ) {
       assert.ok(PromiseProxyMixin, 'expected PromiseProxyMixin to exist');
     }
 
-    ['@test no promise, invoking then should raise'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test no promise, invoking then should raise`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       proxy = ObjectPromiseProxy.create();
 
       assert.throws(function () {
@@ -41,7 +65,11 @@ moduleFor(
       }, new RegExp("PromiseProxy's promise must be set"));
     }
 
-    ['@test fulfillment'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test fulfillment`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let value = {
         firstName: 'stef',
         lastName: 'penner',
@@ -155,7 +183,11 @@ moduleFor(
       // rest of the promise semantics are tested in directly in RSVP
     }
 
-    ['@test rejection'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test rejection`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let reason = new Error('failure');
       let deferred = RSVP.defer();
       proxy = ObjectPromiseProxy.create({
@@ -259,7 +291,11 @@ moduleFor(
     }
 
     // https://github.com/emberjs/ember.js/issues/15694
-    ['@test rejection without specifying reason'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test rejection without specifying reason`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let deferred = RSVP.defer();
       proxy = ObjectPromiseProxy.create({
         promise: deferred.promise,
@@ -328,7 +364,9 @@ moduleFor(
       );
     }
 
-    ["@test unhandled rejects still propagate to RSVP.on('error', ...) "](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test unhandled rejects still propagate to RSVP.on('error', ...) `](
+      assert
+    ) {
       assert.expect(1);
 
       RSVP.on('error', onerror);
@@ -337,9 +375,14 @@ moduleFor(
       let expectedReason = new Error('failure');
       let deferred = RSVP.defer();
 
-      proxy = ObjectPromiseProxy.create({
-        promise: deferred.promise,
-      });
+      // This test asserts an exact assertion count, so the proxy deprecations
+      // are silenced here rather than expected; they are covered by the other
+      // tests in this module.
+      proxy = ignoreDeprecation(() =>
+        ObjectPromiseProxy.create({
+          promise: deferred.promise,
+        })
+      );
 
       proxy.get('promise');
 
@@ -361,7 +404,11 @@ moduleFor(
       RSVP.off('error', onerror);
     }
 
-    ['@test should work with promise inheritance'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test should work with promise inheritance`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       class PromiseSubclass extends RSVP.Promise {}
 
       proxy = ObjectPromiseProxy.create({
@@ -371,7 +418,11 @@ moduleFor(
       assert.ok(proxy.then() instanceof PromiseSubclass, 'promise proxy respected inheritance');
     }
 
-    ['@test should reset isFulfilled and isRejected when promise is reset'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test should reset isFulfilled and isRejected when promise is reset`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let deferred = EmberRSVP.defer();
 
       proxy = ObjectPromiseProxy.create({
@@ -470,7 +521,11 @@ moduleFor(
       );
     }
 
-    ['@test should have content when isFulfilled is set'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test should have content when isFulfilled is set`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let deferred = EmberRSVP.defer();
 
       proxy = ObjectPromiseProxy.create({
@@ -482,7 +537,11 @@ moduleFor(
       run(deferred, 'resolve', true);
     }
 
-    ['@test should have reason when isRejected is set'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test should have reason when isRejected is set`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let error = new Error('Y U REJECT?!?');
       let deferred = EmberRSVP.defer();
 
@@ -499,7 +558,11 @@ moduleFor(
       }
     }
 
-    ['@test should not error if promise is resolved after proxy has been destroyed'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test should not error if promise is resolved after proxy has been destroyed`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let deferred = EmberRSVP.defer();
 
       proxy = ObjectPromiseProxy.create({
@@ -521,7 +584,11 @@ moduleFor(
       );
     }
 
-    ['@test should not error if promise is rejected after proxy has been destroyed'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test should not error if promise is rejected after proxy has been destroyed`](
+      assert
+    ) {
+      this.expectProxyDeprecations();
+
       let deferred = EmberRSVP.defer();
 
       proxy = ObjectPromiseProxy.create({
@@ -543,9 +610,11 @@ moduleFor(
       );
     }
 
-    ['@test promise chain is not broken if promised is resolved after proxy has been destroyed'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test promise chain is not broken if promised is resolved after proxy has been destroyed`](
       assert
     ) {
+      this.expectProxyDeprecations();
+
       let deferred = EmberRSVP.defer();
       let expectedValue = {};
       let receivedValue;
@@ -575,9 +644,11 @@ moduleFor(
       );
     }
 
-    ['@test promise chain is not broken if promised is rejected after proxy has been destroyed'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN.isRemoved)} @test promise chain is not broken if promised is rejected after proxy has been destroyed`](
       assert
     ) {
+      this.expectProxyDeprecations();
+
       let deferred = EmberRSVP.defer();
       let expectedReason = 'some reason';
       let receivedReason;

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/arranged_content_test.js
@@ -3,7 +3,8 @@ import { objectAt } from '@ember/-internals/metal';
 import { computed } from '@ember/object';
 import ArrayProxy from '@ember/array/proxy';
 import { A as emberA } from '@ember/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 let array;
 
@@ -11,6 +12,7 @@ moduleFor(
   'ArrayProxy - arrangedContent',
   class extends AbstractTestCase {
     beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
       run(() => {
         array = class extends ArrayProxy {
           @computed('content.[]')
@@ -41,62 +43,86 @@ moduleFor(
       run(() => array.destroy());
     }
 
-    ['@test compact - returns arrangedContent without nulls and undefined'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test compact - returns arrangedContent without nulls and undefined`](
+      assert
+    ) {
       run(() => array.set('content', emberA([1, 3, null, 2, undefined])));
 
       assert.deepEqual(array.compact(), [3, 2, 1]);
     }
 
-    ['@test indexOf - returns index of object in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test indexOf - returns index of object in arrangedContent`](
+      assert
+    ) {
       assert.equal(array.indexOf(4), 1, 'returns arranged index');
     }
 
-    ['@test lastIndexOf - returns last index of object in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test lastIndexOf - returns last index of object in arrangedContent`](
+      assert
+    ) {
       array.get('content').pushObject(4);
       assert.equal(array.lastIndexOf(4), 2, 'returns last arranged index');
     }
 
-    ['@test objectAt - returns object at index in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectAt - returns object at index in arrangedContent`](
+      assert
+    ) {
       assert.equal(objectAt(array, 1), 4, 'returns object at index');
     }
 
     // Not sure if we need a specific test for it, since it's internal
-    ['@test objectAtContent - returns object at index in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectAtContent - returns object at index in arrangedContent`](
+      assert
+    ) {
       assert.equal(array.objectAtContent(1), 4, 'returns object at index');
     }
 
-    ['@test objectsAt - returns objects at indices in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectsAt - returns objects at indices in arrangedContent`](
+      assert
+    ) {
       assert.deepEqual(array.objectsAt([0, 2, 4]), [5, 2, undefined], 'returns objects at indices');
     }
 
-    ['@test replace - mutating an arranged ArrayProxy is not allowed']() {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test replace - mutating an arranged ArrayProxy is not allowed`]() {
       expectAssertion(() => {
         array.replace(0, 0, [3]);
       }, /Mutating an arranged ArrayProxy is not allowed/);
     }
 
-    ['@test replaceContent - does a standard array replace on content'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test replaceContent - does a standard array replace on content`](
+      assert
+    ) {
       run(() => array.replaceContent(1, 2, [3]));
       assert.deepEqual(array.get('content'), [1, 3, 5]);
     }
 
-    ['@test slice - returns a slice of the arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test slice - returns a slice of the arrangedContent`](
+      assert
+    ) {
       assert.deepEqual(array.slice(1, 3), [4, 2], 'returns sliced arrangedContent');
     }
 
-    ['@test toArray - returns copy of arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test toArray - returns copy of arrangedContent`](
+      assert
+    ) {
       assert.deepEqual(array.toArray(), [5, 4, 2, 1]);
     }
 
-    ['@test without - returns arrangedContent without object'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test without - returns arrangedContent without object`](
+      assert
+    ) {
       assert.deepEqual(array.without(2), [5, 4, 1], 'returns arranged without object');
     }
 
-    ['@test lastObject - returns last arranged object'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test lastObject - returns last arranged object`](
+      assert
+    ) {
       assert.equal(array.get('lastObject'), 1, 'returns last arranged object');
     }
 
-    ['@test firstObject - returns first arranged object'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test firstObject - returns first arranged object`](
+      assert
+    ) {
       assert.equal(array.get('firstObject'), 5, 'returns first arranged object');
     }
   }
@@ -106,6 +132,7 @@ moduleFor(
   'ArrayProxy - arrangedContent matching content',
   class extends AbstractTestCase {
     beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
       run(function () {
         array = ArrayProxy.create({
           content: emberA([1, 2, 4, 5]),
@@ -119,21 +146,27 @@ moduleFor(
       });
     }
 
-    ['@test insertAt - inserts object at specified index'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test insertAt - inserts object at specified index`](
+      assert
+    ) {
       run(function () {
         array.insertAt(2, 3);
       });
       assert.deepEqual(array.get('content'), [1, 2, 3, 4, 5]);
     }
 
-    ['@test replace - does a standard array replace'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test replace - does a standard array replace`](
+      assert
+    ) {
       run(function () {
         array.replace(1, 2, [3]);
       });
       assert.deepEqual(array.get('content'), [1, 3, 5]);
     }
 
-    ['@test reverseObjects - reverses content'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test reverseObjects - reverses content`](
+      assert
+    ) {
       run(function () {
         array.reverseObjects();
       });
@@ -146,6 +179,7 @@ moduleFor(
   'ArrayProxy - arrangedContent with transforms',
   class extends AbstractTestCase {
     beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
       run(function () {
         array = class extends ArrayProxy {
           @computed('content.[]')
@@ -183,25 +217,35 @@ moduleFor(
       });
     }
 
-    ['@test indexOf - returns index of object in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test indexOf - returns index of object in arrangedContent`](
+      assert
+    ) {
       assert.equal(array.indexOf('4'), 1, 'returns arranged index');
     }
 
-    ['@test lastIndexOf - returns last index of object in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test lastIndexOf - returns last index of object in arrangedContent`](
+      assert
+    ) {
       array.get('content').pushObject(4);
       assert.equal(array.lastIndexOf('4'), 2, 'returns last arranged index');
     }
 
-    ['@test objectAt - returns object at index in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectAt - returns object at index in arrangedContent`](
+      assert
+    ) {
       assert.equal(objectAt(array, 1), '4', 'returns object at index');
     }
 
     // Not sure if we need a specific test for it, since it's internal
-    ['@test objectAtContent - returns object at index in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectAtContent - returns object at index in arrangedContent`](
+      assert
+    ) {
       assert.equal(array.objectAtContent(1), '4', 'returns object at index');
     }
 
-    ['@test objectsAt - returns objects at indices in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectsAt - returns objects at indices in arrangedContent`](
+      assert
+    ) {
       assert.deepEqual(
         array.objectsAt([0, 2, 4]),
         ['5', '2', undefined],
@@ -209,23 +253,33 @@ moduleFor(
       );
     }
 
-    ['@test slice - returns a slice of the arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test slice - returns a slice of the arrangedContent`](
+      assert
+    ) {
       assert.deepEqual(array.slice(1, 3), ['4', '2'], 'returns sliced arrangedContent');
     }
 
-    ['@test toArray - returns copy of arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test toArray - returns copy of arrangedContent`](
+      assert
+    ) {
       assert.deepEqual(array.toArray(), ['5', '4', '2', '1']);
     }
 
-    ['@test without - returns arrangedContent without object'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test without - returns arrangedContent without object`](
+      assert
+    ) {
       assert.deepEqual(array.without('2'), ['5', '4', '1'], 'returns arranged without object');
     }
 
-    ['@test lastObject - returns last arranged object'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test lastObject - returns last arranged object`](
+      assert
+    ) {
       assert.equal(array.get('lastObject'), '1', 'returns last arranged object');
     }
 
-    ['@test firstObject - returns first arranged object'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test firstObject - returns first arranged object`](
+      assert
+    ) {
       assert.equal(array.get('firstObject'), '5', 'returns first arranged object');
     }
   }
@@ -235,6 +289,7 @@ moduleFor(
   'ArrayProxy - with transforms',
   class extends AbstractTestCase {
     beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
       run(function () {
         array = class extends ArrayProxy {
           objectAtContent(idx) {
@@ -253,23 +308,31 @@ moduleFor(
       });
     }
 
-    ['@test popObject - removes last object in arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test popObject - removes last object in arrangedContent`](
+      assert
+    ) {
       let popped = array.popObject();
       assert.equal(popped, '5', 'returns last object');
       assert.deepEqual(array.toArray(), ['1', '2', '4'], 'removes from content');
     }
 
-    ['@test removeObject - removes object from content'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test removeObject - removes object from content`](
+      assert
+    ) {
       array.removeObject('2');
       assert.deepEqual(array.toArray(), ['1', '4', '5']);
     }
 
-    ['@test removeObjects - removes objects from content'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test removeObjects - removes objects from content`](
+      assert
+    ) {
       array.removeObjects(['2', '4', '6']);
       assert.deepEqual(array.toArray(), ['1', '5']);
     }
 
-    ['@test shiftObject - removes from start of arrangedContent'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test shiftObject - removes from start of arrangedContent`](
+      assert
+    ) {
       let shifted = array.shiftObject();
       assert.equal(shifted, '1', 'returns first object');
       assert.deepEqual(array.toArray(), ['2', '4', '5'], 'removes object from content');

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/content_change_test.js
@@ -3,12 +3,19 @@ import { changeProperties } from '@ember/-internals/metal';
 import { set } from '@ember/object';
 import ArrayProxy from '@ember/array/proxy';
 import { A as emberA } from '@ember/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'ArrayProxy - content change',
   class extends AbstractTestCase {
-    ["@test The ArrayProxy doesn't explode when assigned a destroyed object"](assert) {
+    beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+    }
+
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test The ArrayProxy doesn't explode when assigned a destroyed object`](
+      assert
+    ) {
       let proxy1 = ArrayProxy.create();
       let proxy2 = ArrayProxy.create();
 
@@ -19,7 +26,9 @@ moduleFor(
       assert.ok(true, 'No exception was raised');
     }
 
-    ['@test should update if content changes while change events are deferred'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test should update if content changes while change events are deferred`](
+      assert
+    ) {
       let proxy = ArrayProxy.create();
 
       assert.deepEqual(proxy.toArray(), []);
@@ -30,7 +39,9 @@ moduleFor(
       });
     }
 
-    ['@test objectAt recomputes the object cache correctly'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test objectAt recomputes the object cache correctly`](
+      assert
+    ) {
       let indexes = [];
 
       let proxy = class extends ArrayProxy {
@@ -60,7 +71,9 @@ moduleFor(
       assert.deepEqual(indexes, [2, 3, 4]);
     }
 
-    ['@test negative indexes are handled correctly'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test negative indexes are handled correctly`](
+      assert
+    ) {
       let indexes = [];
 
       let proxy = class extends ArrayProxy {

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/length_test.js
@@ -2,14 +2,28 @@ import ArrayProxy from '@ember/array/proxy';
 import EmberObject, { observer } from '@ember/object';
 import { oneWay as reads, not } from '@ember/object/computed';
 import { A as a } from '@ember/array';
-import { moduleFor, AbstractTestCase, runTask, runLoopSettled } from 'internal-test-helpers';
+import {
+  moduleFor,
+  AbstractTestCase,
+  runTask,
+  runLoopSettled,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
 import { set, get } from '@ember/object';
 import { createCache, getValue } from '@glimmer/validator';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'Ember.ArrayProxy - content change (length)',
   class extends AbstractTestCase {
-    ['@test should update length for null content'](assert) {
+    beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+    }
+
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test should update length for null content`](
+      assert
+    ) {
       let proxy = ArrayProxy.create({
         content: a([1, 2, 3]),
       });
@@ -21,7 +35,7 @@ moduleFor(
       assert.equal(proxy.get('length'), 0, 'length updates');
     }
 
-    ['@test should update length for null content when there is a computed property watching length'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test should update length for null content when there is a computed property watching length`](
       assert
     ) {
       let proxy = class extends ArrayProxy {
@@ -42,7 +56,9 @@ moduleFor(
       assert.equal(proxy.get('length'), 0, 'length updates');
     }
 
-    ['@test getting length does not recompute the object cache'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test getting length does not recompute the object cache`](
+      assert
+    ) {
       let indexes = [];
 
       let proxy = class extends ArrayProxy {
@@ -68,7 +84,9 @@ moduleFor(
       assert.deepEqual(indexes, []);
     }
 
-    '@test accessing length after content set to null'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test accessing length after content set to null`](
+      assert
+    ) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
       assert.equal(obj.length, 2, 'precond');
@@ -79,7 +97,9 @@ moduleFor(
       assert.deepEqual(obj.content, null, 'content was updated');
     }
 
-    '@test accessing length after content set to null in willDestroy'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test accessing length after content set to null in willDestroy`](
+      assert
+    ) {
       let obj = class extends ArrayProxy {
         willDestroy() {
           this.set('content', null);
@@ -97,7 +117,9 @@ moduleFor(
       assert.deepEqual(obj.content, null, 'content was updated');
     }
 
-    '@test setting length to 0'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test setting length to 0`](
+      assert
+    ) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
       assert.equal(obj.length, 2, 'precond');
@@ -108,7 +130,9 @@ moduleFor(
       assert.deepEqual(obj.content, [], 'content length was truncated');
     }
 
-    '@test setting length to smaller value'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test setting length to smaller value`](
+      assert
+    ) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
       assert.equal(obj.length, 2, 'precond');
@@ -119,7 +143,9 @@ moduleFor(
       assert.deepEqual(obj.content, ['foo'], 'content length was truncated');
     }
 
-    '@test setting length to larger value'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test setting length to larger value`](
+      assert
+    ) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
       assert.equal(obj.length, 2, 'precond');
@@ -130,7 +156,9 @@ moduleFor(
       assert.deepEqual(obj.content, ['foo', 'bar', undefined], 'content length was updated');
     }
 
-    '@test setting length after content set to null'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test setting length after content set to null`](
+      assert
+    ) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
       assert.equal(obj.length, 2, 'precond');
@@ -142,7 +170,9 @@ moduleFor(
       assert.equal(obj.length, 0, 'length is still updated');
     }
 
-    '@test setting length to greater than zero'(assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test setting length to greater than zero`](
+      assert
+    ) {
       let obj = ArrayProxy.create({ content: ['foo', 'bar'] });
 
       assert.equal(obj.length, 2, 'precond');
@@ -153,7 +183,9 @@ moduleFor(
       assert.deepEqual(obj.content, ['foo'], 'content length was truncated');
     }
 
-    async ['@test array proxy + aliasedProperty complex test'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test array proxy + aliasedProperty complex test`](
+      assert
+    ) {
       let aCalled, bCalled, cCalled, dCalled, eCalled;
 
       aCalled = bCalled = cCalled = dCalled = eCalled = 0;
@@ -207,7 +239,9 @@ moduleFor(
       obj.destroy();
     }
 
-    async ['@test array proxy length is reactive when accessed normally'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test array proxy length is reactive when accessed normally`](
+      assert
+    ) {
       let proxy = ArrayProxy.create({
         content: a([1, 2, 3]),
       });
@@ -229,7 +263,9 @@ moduleFor(
       assert.equal(getValue(lengthCache), 0, 'length is correct');
     }
 
-    async ['@test array proxy length is reactive when accessed using get'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test array proxy length is reactive when accessed using get`](
+      assert
+    ) {
       let proxy = ArrayProxy.create({
         content: a([1, 2, 3]),
       });

--- a/packages/@ember/-internals/runtime/tests/system/array_proxy/watching_and_listening_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/array_proxy/watching_and_listening_test.js
@@ -1,7 +1,8 @@
 import { peekMeta } from '@ember/-internals/meta';
 import ArrayProxy from '@ember/array/proxy';
 import { A } from '@ember/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 function sortedListenersFor(obj, eventName) {
   let listeners = peekMeta(obj).matchingListeners(eventName) || [];
@@ -16,7 +17,13 @@ function sortedListenersFor(obj, eventName) {
 moduleFor(
   'ArrayProxy - watching and listening',
   class extends AbstractTestCase {
-    [`@test setting 'content' adds listeners correctly`](assert) {
+    beforeEach() {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+    }
+
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test setting 'content' adds listeners correctly`](
+      assert
+    ) {
       let content = A();
       let proxy = ArrayProxy.create();
 
@@ -33,7 +40,9 @@ moduleFor(
       ]);
     }
 
-    [`@test changing 'content' adds and removes listeners correctly`](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test changing 'content' adds and removes listeners correctly`](
+      assert
+    ) {
       let content1 = A();
       let content2 = A();
       let proxy = ArrayProxy.create({ content: content1 });

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -15,10 +15,15 @@ moduleFor(
   'ObjectProxy',
   class extends AbstractTestCase {
     beforeEach() {
-      expectDeprecation(
-        /`ObjectProxy` is deprecated/,
-        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
-      );
+      // `deprecate` is stripped from production builds, so there is nothing to
+      // expect there -- and a couple of tests below assert an exact count of
+      // zero assertions when running against a production build.
+      if (DEBUG) {
+        expectDeprecation(
+          /`ObjectProxy` is deprecated/,
+          DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+        );
+      }
     }
 
     [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test should not proxy properties passed to create`](

--- a/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
+++ b/packages/@ember/-internals/runtime/tests/system/object_proxy_test.js
@@ -2,12 +2,28 @@ import { DEBUG } from '@glimmer/env';
 import { addObserver, removeObserver } from '@ember/-internals/metal';
 import { computed, get, set, observer } from '@ember/object';
 import ObjectProxy from '@ember/object/proxy';
-import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
+import {
+  moduleFor,
+  AbstractTestCase,
+  runLoopSettled,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'ObjectProxy',
   class extends AbstractTestCase {
-    ['@test should not proxy properties passed to create'](assert) {
+    beforeEach() {
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+    }
+
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test should not proxy properties passed to create`](
+      assert
+    ) {
       let Proxy = class extends ObjectProxy {
         get cp() {
           return this._cp;
@@ -25,7 +41,9 @@ moduleFor(
       assert.equal(proxy._cp, 'Bar', 'should use CP setter');
     }
 
-    ['@test should proxy properties to content'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test should proxy properties to content`](
+      assert
+    ) {
       let content = {
         firstName: 'Tom',
         lastName: 'Dale',
@@ -77,7 +95,9 @@ moduleFor(
       assert.equal(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
     }
 
-    ['@test getting proxied properties with Ember.get should work'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test getting proxied properties with Ember.get should work`](
+      assert
+    ) {
       let proxy = ObjectProxy.create({
         content: {
           foo: 'FOO',
@@ -87,7 +107,9 @@ moduleFor(
       assert.equal(get(proxy, 'foo'), 'FOO');
     }
 
-    [`@test JSON.stringify doens't assert`](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test JSON.stringify doens't assert`](
+      assert
+    ) {
       let proxy = ObjectProxy.create({
         content: {
           foo: 'FOO',
@@ -97,7 +119,9 @@ moduleFor(
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: { foo: 'FOO' } }));
     }
 
-    ['@test calling a function on the proxy avoids the assertion'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test calling a function on the proxy avoids the assertion`](
+      assert
+    ) {
       if (DEBUG) {
         let proxy = class extends ObjectProxy {
           init() {
@@ -123,7 +147,9 @@ moduleFor(
       }
     }
 
-    [`@test setting a property on the proxy avoids the assertion`](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test setting a property on the proxy avoids the assertion`](
+      assert
+    ) {
       let proxy = ObjectProxy.create({
         toJSON: undefined,
         content: {
@@ -136,7 +162,9 @@ moduleFor(
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
     }
 
-    [`@test setting a property on the proxy's prototype avoids the assertion`](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test setting a property on the proxy's prototype avoids the assertion`](
+      assert
+    ) {
       let proxy = ObjectProxy.extend({
         toJSON: null,
       }).create({
@@ -150,7 +178,9 @@ moduleFor(
       assert.equal(JSON.stringify(proxy), JSON.stringify({ content: 'hello' }));
     }
 
-    ['@test getting proxied properties with [] should be an error'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test getting proxied properties with [] should be an error`](
+      assert
+    ) {
       if (DEBUG) {
         let proxy = ObjectProxy.create({
           content: {
@@ -164,7 +194,9 @@ moduleFor(
       }
     }
 
-    async ['@test should work with watched properties'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test should work with watched properties`](
+      assert
+    ) {
       let content1 = { firstName: 'Tom', lastName: 'Dale' };
       let content2 = { firstName: 'Yehuda', lastName: 'Katz' };
       let count = 0;
@@ -243,7 +275,9 @@ moduleFor(
       proxy.destroy();
     }
 
-    async ['@test set and get should work with paths'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test set and get should work with paths`](
+      assert
+    ) {
       let content = { foo: { bar: 'baz' } };
       let proxy = ObjectProxy.create({ content });
       let count = 0;
@@ -266,7 +300,9 @@ moduleFor(
       proxy.destroy();
     }
 
-    async ['@test should transition between watched and unwatched strategies'](assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test should transition between watched and unwatched strategies`](
+      assert
+    ) {
       let content = { foo: 'foo' };
       let proxy = ObjectProxy.create({ content: content });
       let count = 0;
@@ -316,7 +352,7 @@ moduleFor(
       assert.equal(get(proxy, 'foo'), 'foo');
     }
 
-    ['@test setting `undefined` to a proxied content property should override its existing value'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test setting \`undefined\` to a proxied content property should override its existing value`](
       assert
     ) {
       let proxyObject = ObjectProxy.create({
@@ -332,19 +368,21 @@ moduleFor(
       );
     }
 
-    ['@test should not throw or deprecate when adding an observer to an ObjectProxy based class'](
+    [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test should not throw or deprecate when adding an observer to an ObjectProxy based class`](
       assert
     ) {
-      assert.expect(0);
-
       let obj = ObjectProxy.extend({
         observe: observer('foo', function () {}),
       }).create();
 
+      assert.ok(obj, 'the proxy was created without throwing');
+
       obj.destroy();
     }
 
-    async '@test custom proxies should be able to notify property changes manually'(assert) {
+    async [`${testUnless(DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved)} @test custom proxies should be able to notify property changes manually`](
+      assert
+    ) {
       let proxy = class extends ObjectProxy {
         locals = { foo: 123 };
 

--- a/packages/@ember/array/proxy.ts
+++ b/packages/@ember/array/proxy.ts
@@ -18,6 +18,7 @@ import EmberObject from '@ember/object';
 import EmberArray, { type NativeArray } from '@ember/array';
 import MutableArray from '@ember/array/mutable';
 import { assert } from '@ember/debug';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import { setCustomTagFor } from '@glimmer/manager/lib/util/args-proxy';
 import {
   combine,
@@ -113,6 +114,7 @@ function customTagForArrayProxy(proxy: object, key: string) {
   @extends EmberObject
   @uses MutableArray
   @public
+  @deprecated Use a tracked array or a native `Proxy` instead.
 */
 interface ArrayProxy<T> extends MutableArray<T> {
   /**
@@ -200,6 +202,11 @@ class ArrayProxy<T> extends EmberObject implements PropertyDidChange {
 
   init(props: object | undefined) {
     super.init(props);
+
+    deprecateUntil(
+      '`ArrayProxy` is deprecated. Use a tracked array (for example `TrackedArray` from `tracked-built-ins`) or a native `Proxy` instead.',
+      DEPRECATIONS.DEPRECATE_ARRAY_PROXY
+    );
 
     setCustomTagFor(this, customTagForArrayProxy);
   }

--- a/packages/@ember/enumerable/tests/enumerable_test.js
+++ b/packages/@ember/enumerable/tests/enumerable_test.js
@@ -1,7 +1,8 @@
 import Enumerable from '@ember/enumerable';
 import ArrayProxy from '@ember/array/proxy';
 import { A } from '@ember/array';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'Enumerable',
@@ -10,7 +11,11 @@ moduleFor(
       assert.ok(Enumerable.detect(A()));
     }
 
-    ['@test should be mixed into ArrayProxy'](assert) {
+    [`${testUnless(DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isRemoved)} @test should be mixed into ArrayProxy`](
+      assert
+    ) {
+      expectDeprecation(/`ArrayProxy` is deprecated/, DEPRECATIONS.DEPRECATE_ARRAY_PROXY.isEnabled);
+
       assert.ok(Enumerable.detect(ArrayProxy.create()));
     }
   }

--- a/packages/@ember/object/promise-proxy-mixin.ts
+++ b/packages/@ember/object/promise-proxy-mixin.ts
@@ -3,6 +3,7 @@ import setProperties from '@ember/-internals/metal/lib/set_properties';
 import computed from '@ember/-internals/metal/lib/computed';
 import Mixin from '@ember/object/mixin';
 import { INTERNAL_MIXIN_CREATE } from '@ember/-internals/utils/lib/internal-mixin-create';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 import type { AnyFn, MethodNamesOf } from '@ember/-internals/utility-types';
 import type RSVP from 'rsvp';
 import type CoreObject from '@ember/object/core';
@@ -108,6 +109,7 @@ function tap<T>(proxy: PromiseProxyMixin<T>, promise: RSVP.Promise<T>) {
 
   @class PromiseProxyMixin
   @public
+  @deprecated Use native `async`/`await` and promises directly instead.
 */
 interface PromiseProxyMixin<T> {
   /**
@@ -213,6 +215,15 @@ interface PromiseProxyMixin<T> {
   finally: this['promise']['finally'];
 }
 const PromiseProxyMixin = Mixin[INTERNAL_MIXIN_CREATE]({
+  init() {
+    this._super(...arguments);
+
+    deprecateUntil(
+      '`PromiseProxyMixin` is deprecated. Use native `async`/`await` and promises directly, tracking the loading state on your own class instead.',
+      DEPRECATIONS.DEPRECATE_PROMISE_PROXY_MIXIN
+    );
+  },
+
   reason: null,
 
   isPending: computed('isSettled', function () {

--- a/packages/@ember/object/proxy.ts
+++ b/packages/@ember/object/proxy.ts
@@ -4,6 +4,7 @@
 
 import { FrameworkObject } from '@ember/object/-internals';
 import _ProxyMixin from '@ember/-internals/runtime/lib/mixins/-proxy';
+import { DEPRECATIONS, deprecateUntil } from '@ember/-internals/deprecations';
 
 /**
   `ObjectProxy` forwards all properties not defined by the proxy itself
@@ -81,6 +82,7 @@ import _ProxyMixin from '@ember/-internals/runtime/lib/mixins/-proxy';
   @extends EmberObject
   @uses Ember.ProxyMixin
   @public
+  @deprecated Use tracked properties or a native `Proxy` instead.
 */
 interface ObjectProxy<Content = unknown> extends _ProxyMixin<Content> {
   // Proxies forward to their content. This behavior *actually* comes from the
@@ -120,7 +122,16 @@ interface ObjectProxy<Content = unknown> extends _ProxyMixin<Content> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-class ObjectProxy<Content = unknown> extends FrameworkObject {}
+class ObjectProxy<Content = unknown> extends FrameworkObject {
+  init(properties: object | undefined) {
+    super.init(properties);
+
+    deprecateUntil(
+      '`ObjectProxy` is deprecated. Use tracked properties or a native `Proxy` instead.',
+      DEPRECATIONS.DEPRECATE_OBJECT_PROXY
+    );
+  }
+}
 ObjectProxy.PrototypeMixin.reopen(_ProxyMixin);
 
 export default ObjectProxy;

--- a/packages/@ember/object/tests/computed/reduce_computed_macros_test.js
+++ b/packages/@ember/object/tests/computed/reduce_computed_macros_test.js
@@ -26,7 +26,14 @@ import {
   intersect,
   collect,
 } from '@ember/object/computed';
-import { moduleFor, AbstractTestCase, runLoopSettled } from 'internal-test-helpers';
+import {
+  moduleFor,
+  AbstractTestCase,
+  runLoopSettled,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 let obj;
 moduleFor(
@@ -1168,9 +1175,13 @@ class SortWithSortPropertiesTestCase extends AbstractTestCase {
     );
   }
 
-  ['@test guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys'](
+  [`${testUnless(
+    DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+  )} @test guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys`](
     assert
   ) {
+    expectDeprecation(/`ObjectProxy` is deprecated/, DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled);
+
     let tyrion = {
       fname: 'Tyrion',
       lname: 'Lannister',
@@ -1773,9 +1784,16 @@ moduleFor(
       );
     }
 
-    ['@test guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys'](
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+    )} @test guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys`](
       assert
     ) {
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+
       let tyrion = {
         fname: 'Tyrion',
         lname: 'Lannister',

--- a/packages/@ember/routing/tests/system/route_test.js
+++ b/packages/@ember/routing/tests/system/route_test.js
@@ -1,9 +1,17 @@
 import { setOwner } from '@ember/-internals/owner';
-import { runDestroy, buildOwner, moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import {
+  runDestroy,
+  buildOwner,
+  moduleFor,
+  AbstractTestCase,
+  expectDeprecation,
+  testUnless,
+} from 'internal-test-helpers';
 import Service, { service } from '@ember/service';
 import EmberRoute from '@ember/routing/route';
 import ObjectProxy from '@ember/object/proxy';
 import { getDebugFunction, setDebugFunction } from '@ember/debug';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 let route, routeOne, routeTwo, lookupHash;
 
@@ -202,7 +210,14 @@ moduleFor(
       assert.deepEqual(route.serialize(model, ['post_id']), { post_id: 3 }, 'serialized correctly');
     }
 
-    ['@test returns model.id if model is a Proxy'](assert) {
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+    )} @test returns model.id if model is a Proxy`](assert) {
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+
       let model = ObjectProxy.create({ content: { id: 3 } });
 
       assert.deepEqual(route.serialize(model, ['id']), { id: 3 }, 'serialized Proxy correctly');

--- a/packages/@ember/utils/tests/is_empty_test.js
+++ b/packages/@ember/utils/tests/is_empty_test.js
@@ -1,6 +1,7 @@
 import { isEmpty } from '..';
-import { moduleFor, AbstractTestCase } from 'internal-test-helpers';
+import { moduleFor, AbstractTestCase, expectDeprecation, testUnless } from 'internal-test-helpers';
 import ObjectProxy from '@ember/object/proxy';
+import { DEPRECATIONS } from '@ember/-internals/deprecations';
 
 moduleFor(
   'isEmpty',
@@ -9,7 +10,6 @@ moduleFor(
       let string = 'string';
       let fn = function () {};
       let object = { length: 0 };
-      let proxy = ObjectProxy.create({ content: { size: 0 } });
 
       assert.equal(true, isEmpty(null), 'for null');
       assert.equal(true, isEmpty(undefined), 'for undefined');
@@ -24,6 +24,18 @@ moduleFor(
       assert.equal(true, isEmpty([]), 'for an empty Array');
       assert.equal(false, isEmpty({}), 'for an empty Object');
       assert.equal(true, isEmpty(object), "for an Object that has zero 'length'");
+    }
+
+    [`${testUnless(
+      DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isRemoved
+    )} @test isEmpty with an ObjectProxy`](assert) {
+      expectDeprecation(
+        /`ObjectProxy` is deprecated/,
+        DEPRECATIONS.DEPRECATE_OBJECT_PROXY.isEnabled
+      );
+
+      let proxy = ObjectProxy.create({ content: { size: 0 } });
+
       assert.equal(true, isEmpty(proxy), "for a proxy that has zero 'size'");
     }
   }

--- a/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/deprecation.ts
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, getDebugFunction, setDebugFunction } from '@ember/debug';
 import DebugAssert from './debug';
 import type { DebugEnv, Message } from './utils';
 import { callWithStub } from './utils';
@@ -32,11 +32,11 @@ export let expectDeprecation: DeprecationAssert['expectDeprecation'] = () => {
   );
 };
 
-export let ignoreDeprecation: DeprecationAssert['ignoreDeprecation'] = () => {
-  throw new Error(
-    'DeprecationAssert: To use `ignoreDeprecation` in a test you must call `setupDeprecationHelpers` first'
-  );
-};
+// Unlike the other helpers, this one does not touch the deprecation tracker, so
+// it also works outside of a test -- e.g. when a test module builds fixtures at
+// import time.
+export let ignoreDeprecation: DeprecationAssert['ignoreDeprecation'] = (func) =>
+  callWithStub({ getDebugFunction, setDebugFunction } as DebugEnv, 'deprecate', func);
 
 export let expectDeprecationAsync: DeprecationAssert['expectDeprecationAsync'] = () => {
   throw new Error(
@@ -221,8 +221,8 @@ class DeprecationAssert extends DebugAssert {
     }
   }
 
-  private ignoreDeprecation(func: () => void): void {
-    callWithStub(this.env, 'deprecate', func);
+  private ignoreDeprecation<T>(func: () => T): T {
+    return callWithStub(this.env, 'deprecate', func);
   }
 }
 

--- a/packages/internal-test-helpers/lib/ember-dev/utils.ts
+++ b/packages/internal-test-helpers/lib/ember-dev/utils.ts
@@ -10,16 +10,16 @@ export interface DebugEnv {
 
 function noop() {}
 
-export function callWithStub(
+export function callWithStub<T>(
   env: DebugEnv,
   name: string,
-  func: () => void,
+  func: () => T,
   debugStub: DebugFunction = noop
-) {
+): T {
   let originalFunc = env.getDebugFunction(name);
   try {
     env.setDebugFunction(name, debugStub);
-    func();
+    return func();
   } finally {
     env.setDebugFunction(name, originalFunc);
   }


### PR DESCRIPTION
Replaces #21579, rebased onto current main.

Advancement:
- https://github.com/emberjs/rfcs/pull/1135

RFC:
- https://github.com/emberjs/rfcs/pull/1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GSgBwzsjV3iTreDTN3fHZ