### PR TITLE
[BUGFIX lts] Destroy dynamic modifiers that were set after the initial render

### DIFF
--- a/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
+++ b/packages/@ember/-internals/glimmer/tests/integration/custom-modifier-manager-test.js
@@ -105,6 +105,35 @@ class ModifierManagerTest extends RenderingTestCase {
     runTask(() => set(this.context, 'truthy', true));
   }
 
+  '@test destroys a dynamic modifier that was set after the initial render'(assert) {
+    let ModifierClass = setModifierManager(
+      (owner) => {
+        return new this.CustomModifierManager(owner);
+      },
+      class extends EmberObject {
+        didInsertElement() {
+          assert.step('didInsertElement');
+        }
+        didUpdate() {}
+        willDestroyElement() {
+          assert.step('willDestroyElement');
+        }
+      }
+    );
+
+    this.render('{{#if this.show}}<div {{this.dyn}}></div>{{/if}}', {
+      show: true,
+      dyn: undefined,
+    });
+    assert.verifySteps([]);
+
+    runTask(() => set(this.context, 'dyn', ModifierClass));
+    assert.verifySteps(['didInsertElement']);
+
+    runTask(() => set(this.context, 'show', false));
+    assert.verifySteps(['willDestroyElement']);
+  }
+
   '@test associates manager even through an inheritance structure'(assert) {
     assert.expect(5);
     let ModifierClass = setModifierManager(

--- a/packages/@glimmer-workspace/integration-tests/test/modifiers/dynamic-modifiers-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/modifiers/dynamic-modifiers-test.ts
@@ -7,6 +7,7 @@ import {
   RenderTest,
   syntaxErrorFor,
   test,
+  trackedObj,
 } from '@glimmer-workspace/integration-tests';
 
 class DynamicModifiersResolutionModeTest extends RenderTest {
@@ -198,6 +199,55 @@ class DynamicModifiersResolutionModeTest extends RenderTest {
     this.renderComponent(Bar);
     this.assertHTML('<div>Hello, world!</div>');
     this.assertStableRerender();
+  }
+
+  @test
+  'Destroys a dynamic modifier that was set after the initial render when its block is removed'(
+    assert: Assert
+  ) {
+    const foo = defineSimpleModifier(() => {
+      assert.step('install');
+
+      return () => assert.step('destroy');
+    });
+
+    const Bar = defineComponent({}, '{{#if @show}}<div {{@foo}}></div>{{/if}}');
+    const args = trackedObj({ show: true, foo: undefined });
+
+    this.renderComponent(Bar, args);
+    assert.verifySteps([]);
+
+    args['foo'] = foo;
+    this.rerender();
+    assert.verifySteps(['install']);
+
+    args['show'] = false;
+    this.rerender();
+    assert.verifySteps(['destroy']);
+  }
+
+  @test
+  'Destroys a dynamic modifier that was set after the initial render when the render result is destroyed'(
+    assert: Assert
+  ) {
+    const foo = defineSimpleModifier(() => {
+      assert.step('install');
+
+      return () => assert.step('destroy');
+    });
+
+    const Bar = defineComponent({}, '<div {{@foo}}></div>');
+    const args = trackedObj({ foo: undefined });
+
+    this.renderComponent(Bar, args);
+    assert.verifySteps([]);
+
+    args['foo'] = foo;
+    this.rerender();
+    assert.verifySteps(['install']);
+
+    this.destroy();
+    assert.verifySteps(['destroy']);
   }
 }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts
@@ -296,7 +296,12 @@ APPEND_OPCODES.add(VM_DYNAMIC_MODIFIER_OP, (vm) => {
   }
 
   if (!isConstRef(ref) || tag) {
-    return vm.updateWith(new UpdateDynamicModifierOpcode(tag, instance, instanceRef));
+    let updateOpcode = new UpdateDynamicModifierOpcode(tag, instance, instanceRef);
+
+    // The block must own this opcode, or instances created on update are never destroyed.
+    vm.associateDestroyable(updateOpcode);
+
+    return vm.updateWith(updateOpcode);
   }
 });
 


### PR DESCRIPTION
Dynamic modifiers that become defined after the first render never run their destructor. This leaks whatever the modifier set up, for example the `@floating-ui/dom` observers behind universal-ember/ember-primitives#805.

Mechanism, in `packages/@glimmer/runtime/lib/compiled/opcodes/dom.ts`:

1. `{{this.mod}}` renders with `this.mod` as `undefined`. No instance is created, and an `UpdateDynamicModifierOpcode` is pushed with `vm.updateWith`.
2. `this.mod` becomes a modifier. `UpdateDynamicModifierOpcode.evaluate` creates the instance and calls `associateDestroyableChild(this, destroyable)`.
3. The opcode itself was never registered as a destroyable child of its block. `vm.updateWith` only pushes to the updating list, and only block opcodes go through `didEnter`, which calls `associateDestroyable`.
4. When the block is destroyed, nothing reaches the opcode, so the destructor never runs.

The same leak happens whenever the dynamic modifier value changes to a different modifier. The replacement instance is attached to the orphaned opcode.

This dates from `cb11136` (February 2021), so every Ember release since 3.25 is affected.

Earlier reports of the same bug:

- Fixes #21037 (the reproduction there, a modifier enabled after the first render and then `clearRender()`, is the second new test in this pull request)
- ember-modifier/ember-modifier#613
- glimmerjs/glimmer-vm-issues#9

This pull request is in two commits, so CI can show the failure first:

1. Failing tests in the Glimmer integration suite and in the Ember rendering suite.
2. The fix: register the updating opcode with the block before pushing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fvnp457DHuZC4fBa2KCiqB
