### PR TITLE
[SPIKE] Compile the updating pass to a static plan per template

### DIFF
--- a/packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts
@@ -1,0 +1,152 @@
+import type { UpdatePlan } from '@glimmer/interfaces';
+import {
+  PLAN_BLOCK,
+  PLAN_CALL,
+  PLAN_GUARD,
+  PLAN_GUARD_END,
+  PLAN_LEAF,
+  PLAN_LIST,
+  PLAN_MULTI,
+} from '@glimmer/constants';
+import { expect, unwrapHandle } from '@glimmer/debug-util';
+import { jitSuite, JitRenderDelegate, RenderTest, test } from '@glimmer-workspace/integration-tests';
+
+interface Instance {
+  plan: UpdatePlan;
+  slots: unknown[];
+}
+
+const NAMES = {
+  [PLAN_LEAF]: 'leaf',
+  [PLAN_MULTI]: 'multi',
+  [PLAN_GUARD]: 'guard',
+  [PLAN_GUARD_END]: 'guard-end',
+  [PLAN_BLOCK]: 'block',
+  [PLAN_LIST]: 'list',
+  [PLAN_CALL]: 'call',
+};
+
+/**
+ * A compile-time plan: `block` and `list` show their nested plan, `call`
+ * cannot (the callee is only known at runtime).
+ */
+function describePlan(plan: UpdatePlan): string {
+  let parts = plan.kinds.map((kind, i) => {
+    let child = plan.children[i];
+    return child ? `${NAMES[kind]}${describePlan(child)}` : NAMES[kind];
+  });
+
+  return `[${parts.join(' ')}]`;
+}
+
+/**
+ * A rendered instance: a slot that recorded nothing prints as `-`, a
+ * `call` prints the callee instance, a `list` prints one instance per item.
+ */
+function describeInstance({ plan, slots }: Instance): string {
+  let parts = plan.kinds.map((kind, i) => {
+    let value = slots[i];
+
+    if (value === undefined) return '-';
+
+    switch (kind) {
+      case PLAN_BLOCK:
+      case PLAN_CALL:
+        return `${NAMES[kind]}${describeInstance(value as Instance)}`;
+      case PLAN_LIST: {
+        let items = (value as { children: Instance[] }).children;
+        return `list{${items.map(describeInstance).join(' ')}}`;
+      }
+      case PLAN_MULTI:
+        return `multi(${(value as unknown[]).length})`;
+      default:
+        return NAMES[kind];
+    }
+  });
+
+  return `[${parts.join(' ')}]`;
+}
+
+class UpdatePlanTest extends RenderTest {
+  static suiteName = 'update plan';
+
+  private planFor(template: string): string {
+    let delegate = this.delegate as JitRenderDelegate;
+    let handle = unwrapHandle(delegate.compileTemplate(template));
+
+    return describePlan(delegate.context.program.heap.planFor(handle));
+  }
+
+  private get instance(): string {
+    let result = expect(this.renderResult, 'render first') as unknown as { root: Instance };
+
+    return describeInstance(result.root);
+  }
+
+  @test
+  'a static template has an empty plan'() {
+    this.assert.strictEqual(this.planFor('<div>hello</div>'), '[]');
+  }
+
+  @test
+  'dynamic attributes and text are leaves and calls'() {
+    // `{{this.name}}` calls the stdlib append routine; its switch over the
+    // content type lives in the callee's plan.
+    this.assert.strictEqual(
+      this.planFor('<div class={{this.cls}} title={{this.t}}>{{this.name}}</div>'),
+      '[leaf leaf call]'
+    );
+  }
+
+  @test
+  'an if block nests its assertion and body'() {
+    this.assert.strictEqual(
+      this.planFor('{{#if this.a}}<p>x</p>{{else}}<p>y</p>{{/if}}'),
+      '[block[leaf call call]]'
+    );
+  }
+
+  @test
+  'an each block nests a per-item plan'() {
+    this.assert.strictEqual(
+      this.planFor('{{#each this.items as |item|}}<li>{{item}}</li>{{else}}none{{/each}}'),
+      '[block[leaf list[call] call]]'
+    );
+  }
+
+  @test
+  'a component invocation is a guarded call'() {
+    this.registerComponent('TemplateOnly', 'Foo', '<p>{{@name}}</p>');
+
+    // A template-only component has no instance to create, so there is no
+    // update-hook leaf between the guard and the debug render tree slot.
+    this.assert.strictEqual(
+      this.planFor('<Foo @name={{this.name}} />'),
+      '[guard multi call multi guard-end]'
+    );
+  }
+
+  @test
+  'a rendered instance fills only the slots that recorded something'() {
+    this.render('<div class={{this.cls}}>{{this.name}}</div>{{#if this.a}}{{this.b}}{{/if}}', {
+      cls: 'x',
+      name: 'hello',
+      a: true,
+      b: 'world',
+    });
+
+    // The stdlib append routine has one slot per content-type clause. A string
+    // fills the content-type assertion and the text leaf; the other clauses
+    // stay empty.
+    let append = 'call[block[leaf - - - - - - - - - - - leaf]]';
+
+    // The body of the `if` is an inline block, which is a call of its own.
+    this.assert.strictEqual(this.instance, `[leaf ${append} block[leaf call[${append}]]]`);
+
+    this.rerender({ a: false });
+
+    this.assert.strictEqual(this.instance, `[leaf ${append} block[leaf]]`);
+  }
+}
+
+jitSuite(UpdatePlanTest);

--- a/packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts
@@ -127,6 +127,31 @@ class UpdatePlanTest extends RenderTest {
   }
 
   @test
+  'a counter has a modifier slot, an attribute flush slot, and a text call'() {
+    this.registerModifier(
+      'on',
+      class {
+        didInsertElement() {}
+        didUpdate() {}
+      }
+    );
+
+    this.assert.strictEqual(
+      this.planFor('<button {{on "click" this.increment}}>Count: {{this.count}}</button>'),
+      '[multi multi call]'
+    );
+
+    this.render('<button {{on "click" this.increment}}>Count: {{this.count}}</button>', {
+      count: 0,
+      increment() {},
+    });
+
+    let append = 'call[block[leaf - - - - - - - - - - - leaf]]';
+
+    this.assert.strictEqual(this.instance, `[multi(1) - ${append}]`);
+  }
+
+  @test
   'a rendered instance fills only the slots that recorded something'() {
     this.render('<div class={{this.cls}}>{{this.name}}</div>{{#if this.a}}{{this.b}}{{/if}}', {
       cls: 'x',

--- a/packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts
+++ b/packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts
@@ -145,7 +145,8 @@ class UpdatePlanTest extends RenderTest {
 
     this.rerender({ a: false });
 
-    this.assert.strictEqual(this.instance, `[leaf ${append} block[leaf]]`);
+    // The re-rendered block keeps its assertion; the body call is untaken.
+    this.assert.strictEqual(this.instance, `[leaf ${append} block[leaf -]]`);
   }
 }
 

--- a/packages/@glimmer/constants/index.ts
+++ b/packages/@glimmer/constants/index.ts
@@ -5,3 +5,4 @@ export * from './lib/dom';
 export * from './lib/immediate';
 export * from './lib/syscall-ops';
 export * from './lib/vm-ops';
+export * from './lib/update-plan';

--- a/packages/@glimmer/constants/lib/update-plan.ts
+++ b/packages/@glimmer/constants/lib/update-plan.ts
@@ -1,0 +1,9 @@
+import type { UpdatePlanKind } from '@glimmer/interfaces';
+
+export const PLAN_LEAF = 1 satisfies UpdatePlanKind;
+export const PLAN_MULTI = 2 satisfies UpdatePlanKind;
+export const PLAN_GUARD = 3 satisfies UpdatePlanKind;
+export const PLAN_GUARD_END = 4 satisfies UpdatePlanKind;
+export const PLAN_BLOCK = 5 satisfies UpdatePlanKind;
+export const PLAN_LIST = 6 satisfies UpdatePlanKind;
+export const PLAN_CALL = 7 satisfies UpdatePlanKind;

--- a/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
+++ b/packages/@glimmer/interfaces/lib/compile/encoder.d.ts
@@ -11,10 +11,15 @@ import type * as WireFormat from './wire-format/api.js';
 export type HighLevelLabel = 1000;
 export type HighLevelStartLabels = 1001;
 export type HighLevelStopLabels = 1002;
+export type HighLevelEndItem = 1012;
 export type HighLevelStart = HighLevelLabel;
-export type HighLevelEnd = HighLevelStopLabels;
+export type HighLevelEnd = HighLevelEndItem;
 
-export type HighLevelBuilderOpcode = HighLevelLabel | HighLevelStartLabels | HighLevelStopLabels;
+export type HighLevelBuilderOpcode =
+  | HighLevelLabel
+  | HighLevelStartLabels
+  | HighLevelStopLabels
+  | HighLevelEndItem;
 
 export type HighLevelResolveModifier = 1003;
 export type HighLevelResolveComponent = 1004;
@@ -52,7 +57,14 @@ export type StopLabelsOp = [op: HighLevelStopLabels];
 
 export type LabelOp = [op: HighLevelLabel, op1: string];
 
-export type HighLevelBuilderOp = StartLabelsOp | StopLabelsOp | LabelOp;
+/**
+ * Marks the end of the per-item region of an `{{#each}}` body in the update
+ * plan. The `Exit` that closes an item is shared with the enclosing block, so
+ * the compiler needs an explicit marker.
+ */
+export type EndItemOp = [op: HighLevelEndItem];
+
+export type HighLevelBuilderOp = StartLabelsOp | StopLabelsOp | LabelOp | EndItemOp;
 
 export type ResolveModifierOp = [
   op: HighLevelResolveModifier,
@@ -145,6 +157,11 @@ export interface Encoder {
    * @param size
    */
   commit(size: number): HandleResult;
+
+  /**
+   * Close the per-item region of an `{{#each}}` body in the update plan.
+   */
+  endItem(): void;
 
   /**
    * Push a syscall into the program with up to three optional

--- a/packages/@glimmer/interfaces/lib/program.d.ts
+++ b/packages/@glimmer/interfaces/lib/program.d.ts
@@ -25,7 +25,41 @@ export interface SerializedHeap {
   handle: number;
 }
 
+/**
+ * The kind of value that lives in one slot of an update plan.
+ *
+ * - `LEAF`: at most one updating opcode (a hole when the reference was constant)
+ * - `MULTI`: an array of updating opcodes, for instructions whose emission
+ *   count depends on runtime data (component attribute flushes, debug tree nodes)
+ * - `GUARD`/`GUARD_END`: a component cache group; `links` pairs them
+ * - `BLOCK`: a re-renderable block; `children` holds the block's own plan
+ * - `LIST`: an `{{#each}}` list; `children` holds the plan for one item
+ * - `CALL`: an invocation of another compiled unit; the callee's plan comes
+ *   from its handle at runtime
+ */
+export type UpdatePlanKind = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/**
+ * The static shape of the updating pass for one compiled unit (or one block
+ * inside it). The compiler emits one plan per handle; a render instance holds
+ * a slot array of the same length, filled in by the append pass.
+ */
+export interface UpdatePlan {
+  readonly kinds: UpdatePlanKind[];
+  readonly children: (UpdatePlan | null)[];
+  readonly links: number[];
+  readonly size: number;
+}
+
 export interface ProgramHeap {
+  /**
+   * The update-plan slot index for the instruction at `address`, or -1.
+   */
+  slotAt(address: number): number;
+  setSlotAt(address: number, slot: number): void;
+  planFor(handle: number): UpdatePlan;
+  setPlan(handle: number, plan: UpdatePlan): void;
+
   pushRaw(value: number): void;
   pushOp(name: VmOp, op1?: number, op2?: number, op3?: number): void;
   pushMachine(name: VmMachineOp, op1?: number, op2?: number, op3?: number): void;

--- a/packages/@glimmer/interfaces/lib/runtime/local-debug.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/local-debug.d.ts
@@ -6,7 +6,8 @@ import type { Cursor } from '../dom/bounds.js';
 import type { EvaluationContext } from '../program.js';
 import type { BlockMetadata } from '../template.js';
 import type { DynamicScope, Scope, ScopeSlot } from './scope.js';
-import type { UpdatingBlockOpcode, UpdatingOpcode } from './vm.js';
+import type { Bounds } from '../dom/bounds.js';
+import type { UpdatePlan } from '../program.js';
 
 export type MachineRegisters = [$pc: number, $ra: number, $fp: number, $sp: number];
 
@@ -68,8 +69,8 @@ export interface DebugVmSnapshot {
 export interface DebugStacks {
   scope: Scope[];
   dynamicScope: DynamicScope[];
-  updating: UpdatingOpcode[][];
-  cache: UpdatingOpcode[];
-  list: UpdatingBlockOpcode[];
+  updating: { plan: UpdatePlan; slots: unknown[] }[];
+  cache: object[];
+  list: Bounds[];
   destroyable: object[];
 }

--- a/packages/@glimmer/interfaces/lib/runtime/render.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/render.d.ts
@@ -8,7 +8,7 @@ export interface ExceptionHandler {
   handleException(): void;
 }
 
-export interface RenderResult extends Bounds, ExceptionHandler {
+export interface RenderResult extends Bounds {
   readonly env: Environment;
   readonly drop: object;
 

--- a/packages/@glimmer/interfaces/lib/runtime/vm.d.ts
+++ b/packages/@glimmer/interfaces/lib/runtime/vm.d.ts
@@ -1,16 +1,16 @@
-import type { Bounds } from '../dom/bounds.js';
 import type { GlimmerTreeChanges } from '../dom/changes.js';
 import type { Environment } from './environment.js';
-import type { ExceptionHandler } from './render.js';
 
 export interface UpdatingVM {
   env: Environment;
   dom: GlimmerTreeChanges;
   alwaysRevalidate: boolean;
 
-  execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler): void;
-  goto(index: number): void;
-  try(ops: UpdatingOpcode[], handler: ExceptionHandler | null): void;
+  /**
+   * Set by an assertion opcode when its value changed. The plan walker
+   * unwinds to the nearest block and re-renders it.
+   */
+  thrown: boolean;
   throw(): void;
 }
 
@@ -18,4 +18,3 @@ export interface UpdatingOpcode {
   evaluate(vm: UpdatingVM): void;
 }
 
-export interface UpdatingBlockOpcode extends UpdatingOpcode, Bounds {}

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/encoder.ts
@@ -15,10 +15,51 @@ import type {
   ProgramHeap,
   SingleBuilderOperand,
   STDLib,
+  UpdatePlan,
+  UpdatePlanKind,
 } from '@glimmer/interfaces';
 import { encodeHandle } from '@glimmer/constants/lib/immediate';
-import { isMachineOp, VM_RETURN_OP } from '@glimmer/constants/lib/vm-ops';
-import { VM_PRIMITIVE_OP } from '@glimmer/constants/lib/syscall-ops';
+import {
+  isMachineOp,
+  VM_INVOKE_STATIC_OP,
+  VM_INVOKE_VIRTUAL_OP,
+  VM_RETURN_OP,
+} from '@glimmer/constants/lib/vm-ops';
+import {
+  VM_APPEND_TEXT_OP,
+  VM_ASSERT_SAME_OP,
+  VM_BEGIN_COMPONENT_TRANSACTION_OP,
+  VM_COMMIT_COMPONENT_TRANSACTION_OP,
+  VM_CONTENT_TYPE_OP,
+  VM_CREATE_COMPONENT_OP,
+  VM_DID_RENDER_LAYOUT_OP,
+  VM_DYNAMIC_ATTR_OP,
+  VM_DYNAMIC_CONTENT_TYPE_OP,
+  VM_DYNAMIC_MODIFIER_OP,
+  VM_ENTER_LIST_OP,
+  VM_ENTER_OP,
+  VM_EXIT_LIST_OP,
+  VM_EXIT_OP,
+  VM_FLUSH_ELEMENT_OP,
+  VM_GET_COMPONENT_SELF_OP,
+  VM_INVOKE_COMPONENT_LAYOUT_OP,
+  VM_INVOKE_YIELD_OP,
+  VM_ITERATE_OP,
+  VM_JUMP_UNLESS_OP,
+  VM_MODIFIER_OP,
+  VM_PRIMITIVE_OP,
+  VM_PUSH_REMOTE_ELEMENT_OP,
+  VM_PUT_COMPONENT_OPERATIONS_OP,
+} from '@glimmer/constants/lib/syscall-ops';
+import {
+  PLAN_BLOCK,
+  PLAN_CALL,
+  PLAN_GUARD,
+  PLAN_GUARD_END,
+  PLAN_LEAF,
+  PLAN_LIST,
+  PLAN_MULTI,
+} from '@glimmer/constants/lib/update-plan';
 import { expect } from '@glimmer/debug-util/lib/platform-utils';
 import { isPresentArray } from '@glimmer/debug-util/lib/present';
 import assert from '@glimmer/debug-util/lib/assert';
@@ -85,6 +126,8 @@ export function encodeOp(
         return encoder.startLabels();
       case HighLevelBuilderOpcodes.StopLabels:
         return encoder.stopLabels();
+      case HighLevelBuilderOpcodes.EndItem:
+        return encoder.endItem();
       case HighLevelResolutionOpcodes.Component:
         return resolveComponent(resolver, constants, meta, op);
       case HighLevelResolutionOpcodes.Modifier:
@@ -127,11 +170,142 @@ export function encodeOp(
   }
 }
 
+class UpdatePlanImpl implements UpdatePlan {
+  readonly kinds: UpdatePlanKind[] = [];
+  readonly children: (UpdatePlan | null)[] = [];
+  readonly links: number[] = [];
+  size = 0;
+
+  add(kind: UpdatePlanKind, child: UpdatePlan | null = null, link = -1): number {
+    this.kinds.push(kind);
+    this.children.push(child);
+    this.links.push(link);
+    return this.size++;
+  }
+}
+
+/**
+ * Derives the update plan of a compilation unit from the instructions the
+ * encoder emits. Every instruction whose handler can record an updating opcode
+ * gets a slot; block, list, and call instructions open nested plans that the
+ * append VM mirrors with its updating stack.
+ */
+class PlanBuilder {
+  readonly root = new UpdatePlanImpl();
+  private readonly regions = new Stack<UpdatePlanImpl>();
+  private readonly items = new Stack<UpdatePlanImpl>();
+  private readonly guards: number[] = [];
+  private componentOperations = false;
+
+  constructor() {
+    this.regions.push(this.root);
+  }
+
+  private get current(): UpdatePlanImpl {
+    return expect(this.regions.current, 'bug: update plan region stack is empty');
+  }
+
+  visit(heap: ProgramHeap, type: number, address: number): void {
+    switch (type) {
+      case VM_JUMP_UNLESS_OP:
+      case VM_ASSERT_SAME_OP:
+      case VM_CONTENT_TYPE_OP:
+      case VM_DYNAMIC_CONTENT_TYPE_OP:
+      case VM_APPEND_TEXT_OP:
+      case VM_DYNAMIC_ATTR_OP:
+      case VM_CREATE_COMPONENT_OP:
+        heap.setSlotAt(address, this.current.add(PLAN_LEAF));
+        return;
+
+      case VM_PUSH_REMOTE_ELEMENT_OP:
+      case VM_MODIFIER_OP:
+      case VM_DYNAMIC_MODIFIER_OP:
+      case VM_GET_COMPONENT_SELF_OP:
+      case VM_DID_RENDER_LAYOUT_OP:
+        heap.setSlotAt(address, this.current.add(PLAN_MULTI));
+        return;
+
+      case VM_PUT_COMPONENT_OPERATIONS_OP:
+        this.componentOperations = true;
+        return;
+
+      case VM_FLUSH_ELEMENT_OP:
+        if (this.componentOperations) {
+          this.componentOperations = false;
+          heap.setSlotAt(address, this.current.add(PLAN_MULTI));
+        }
+        return;
+
+      case VM_INVOKE_STATIC_OP:
+      case VM_INVOKE_VIRTUAL_OP:
+      case VM_INVOKE_YIELD_OP:
+      case VM_INVOKE_COMPONENT_LAYOUT_OP:
+        heap.setSlotAt(address, this.current.add(PLAN_CALL));
+        return;
+
+      case VM_BEGIN_COMPONENT_TRANSACTION_OP: {
+        let index = this.current.add(PLAN_GUARD);
+        heap.setSlotAt(address, index);
+        this.guards.push(index);
+        return;
+      }
+
+      case VM_COMMIT_COMPONENT_TRANSACTION_OP: {
+        let begin = expect(this.guards.pop(), 'bug: commit without begin component transaction');
+        let plan = this.current;
+        let end = plan.add(PLAN_GUARD_END, null, begin);
+        plan.links[begin] = end;
+        heap.setSlotAt(address, end);
+        return;
+      }
+
+      case VM_ENTER_OP: {
+        let child = new UpdatePlanImpl();
+        heap.setSlotAt(address, this.current.add(PLAN_BLOCK, child));
+        this.regions.push(child);
+        return;
+      }
+
+      case VM_EXIT_OP:
+        this.regions.pop();
+        return;
+
+      case VM_ENTER_LIST_OP: {
+        let item = new UpdatePlanImpl();
+        let plan = this.current;
+        heap.setSlotAt(address, plan.add(PLAN_LEAF));
+        plan.add(PLAN_LIST, item);
+        this.items.push(item);
+        return;
+      }
+
+      case VM_ITERATE_OP:
+        this.regions.push(expect(this.items.current, 'bug: iterate outside of a list'));
+        return;
+
+      case VM_EXIT_LIST_OP:
+        this.items.pop();
+        return;
+    }
+  }
+
+  endItem(): void {
+    this.regions.pop();
+  }
+
+  finish(): UpdatePlan {
+    assert(this.regions.current === this.root, 'bug: unbalanced update plan regions');
+    assert(this.guards.length === 0, 'bug: unbalanced component transactions');
+    return this.root;
+  }
+}
+
 export class EncoderImpl implements Encoder {
   private labelsStack = new Stack<Labels>();
   private encoder: InstructionEncoder = new InstructionEncoderImpl([]);
   private errors: EncoderError[] = [];
   private handle: number;
+  private plan = new PlanBuilder();
 
   constructor(
     private heap: ProgramHeap,
@@ -139,6 +313,10 @@ export class EncoderImpl implements Encoder {
     private stdlib?: STDLib
   ) {
     this.handle = heap.malloc();
+  }
+
+  endItem(): void {
+    this.plan.endItem();
   }
 
   error(error: EncoderError): void {
@@ -151,6 +329,7 @@ export class EncoderImpl implements Encoder {
 
     this.heap.pushMachine(VM_RETURN_OP);
     this.heap.finishMalloc(handle, size);
+    this.heap.setPlan(handle, this.plan.finish());
 
     if (isPresentArray(this.errors)) {
       return { errors: this.errors, handle };
@@ -173,6 +352,7 @@ export class EncoderImpl implements Encoder {
     let machine = isMachineOp(type) ? MACHINE_MASK : 0;
     let first = type | machine | (args.length << ARG_SHIFT);
 
+    this.plan.visit(heap, type, heap.offset);
     heap.pushRaw(first);
 
     for (let i = 0; i < args.length; i++) {

--- a/packages/@glimmer/opcode-compiler/lib/opcode-builder/opcodes.ts
+++ b/packages/@glimmer/opcode-compiler/lib/opcode-builder/opcodes.ts
@@ -1,5 +1,6 @@
 import type {
   HighLevelEnd,
+  HighLevelEndItem,
   HighLevelLabel,
   HighLevelResolveComponent,
   HighLevelResolveComponentOrHelper,
@@ -27,6 +28,7 @@ export const HighLevelBuilderOpcodes = {
   Label: 1000 satisfies HighLevelLabel,
   StartLabels: 1001 satisfies HighLevelStartLabels,
   StopLabels: 1002 satisfies HighLevelStopLabels,
+  EndItem: 1012 satisfies HighLevelEndItem,
   Start: 1000 satisfies HighLevelStart,
-  End: 1002 satisfies HighLevelEnd,
+  End: 1012 satisfies HighLevelEnd,
 } as const;

--- a/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
+++ b/packages/@glimmer/opcode-compiler/lib/syntax/statements.ts
@@ -344,6 +344,7 @@ STATEMENTS.add(SexpOpcodes.Each, (op, [, value, key, block, inverse]) =>
       op(HighLevelBuilderOpcodes.Label, 'BODY');
       InvokeStaticBlockWithStack(op, block, 2);
       op(VM_POP_OP, 2);
+      op(HighLevelBuilderOpcodes.EndItem);
       op(VM_JUMP_OP, labelOperand('FINALLY'));
       op(HighLevelBuilderOpcodes.Label, 'BREAK');
       op(VM_POP_FRAME_OP);

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -24,6 +24,12 @@ export type StdlibPlaceholder = [number, StdLibOperand];
 const PAGE_SIZE = 0x100000;
 
 /**
+ * The slot table grows on demand in small pages, so an app pays for the
+ * instructions it compiled rather than for the heap's reserved size.
+ */
+const SLOT_PAGE_SIZE = 0x4000;
+
+/**
  * The Program Heap is responsible for dynamically allocating
  * memory in which we read/write the VM's instructions
  * from/to. When we malloc we pass out a VMHandle, which
@@ -47,25 +53,37 @@ export class ProgramHeapImpl implements ProgramHeap {
   offset = 0;
 
   private heap: Int32Array;
-  private slots: Int32Array;
+  private slots: Int16Array;
   private plans: UpdatePlan[];
   private handleTable: number[];
   private handleState: TableSlotState[];
 
   constructor() {
     this.heap = new Int32Array(PAGE_SIZE);
-    this.slots = new Int32Array(PAGE_SIZE).fill(-1);
+    this.slots = new Int16Array(0);
     this.plans = [];
     this.handleTable = [];
     this.handleState = [];
   }
 
   slotAt(address: number): number {
-    return unwrap(this.slots[address]);
+    let slot = this.slots[address];
+
+    return slot === undefined ? -1 : slot;
   }
 
   setSlotAt(address: number, slot: number): void {
-    this.slots[address] = slot;
+    let { slots } = this;
+
+    if (address >= slots.length) {
+      let grown = new Int16Array(
+        Math.ceil((address + 1) / SLOT_PAGE_SIZE) * SLOT_PAGE_SIZE
+      ).fill(-1);
+      grown.set(slots, 0);
+      this.slots = slots = grown;
+    }
+
+    slots[address] = slot;
   }
 
   planFor(handle: number): UpdatePlan {
@@ -99,10 +117,6 @@ export class ProgramHeapImpl implements ProgramHeap {
       let newHeap = new Int32Array(heap.length + PAGE_SIZE);
       newHeap.set(heap, 0);
       this.heap = newHeap;
-
-      let newSlots = new Int32Array(heap.length + PAGE_SIZE).fill(-1);
-      newSlots.set(this.slots, 0);
-      this.slots = newSlots;
     }
   }
 

--- a/packages/@glimmer/program/lib/program.ts
+++ b/packages/@glimmer/program/lib/program.ts
@@ -1,4 +1,10 @@
-import type { Program, ProgramConstants, ProgramHeap, StdLibOperand } from '@glimmer/interfaces';
+import type {
+  Program,
+  ProgramConstants,
+  ProgramHeap,
+  StdLibOperand,
+  UpdatePlan,
+} from '@glimmer/interfaces';
 import { unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { MACHINE_MASK } from '@glimmer/vm/lib/flags';
@@ -41,13 +47,33 @@ export class ProgramHeapImpl implements ProgramHeap {
   offset = 0;
 
   private heap: Int32Array;
+  private slots: Int32Array;
+  private plans: UpdatePlan[];
   private handleTable: number[];
   private handleState: TableSlotState[];
 
   constructor() {
     this.heap = new Int32Array(PAGE_SIZE);
+    this.slots = new Int32Array(PAGE_SIZE).fill(-1);
+    this.plans = [];
     this.handleTable = [];
     this.handleState = [];
+  }
+
+  slotAt(address: number): number {
+    return unwrap(this.slots[address]);
+  }
+
+  setSlotAt(address: number, slot: number): void {
+    this.slots[address] = slot;
+  }
+
+  planFor(handle: number): UpdatePlan {
+    return unwrap(this.plans[handle]);
+  }
+
+  setPlan(handle: number, plan: UpdatePlan): void {
+    this.plans[handle] = plan;
   }
   entries(): number {
     return this.offset;
@@ -73,6 +99,10 @@ export class ProgramHeapImpl implements ProgramHeap {
       let newHeap = new Int32Array(heap.length + PAGE_SIZE);
       newHeap.set(heap, 0);
       this.heap = newHeap;
+
+      let newSlots = new Int32Array(heap.length + PAGE_SIZE).fill(-1);
+      newSlots.set(this.slots, 0);
+      this.slots = newSlots;
     }
   }
 

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/vm.ts
@@ -53,8 +53,8 @@ import {
   UNDEFINED_REFERENCE,
   valueForRef,
 } from '@glimmer/reference/lib/reference';
-import { beginTrackFrame, consumeTag, endTrackFrame } from '@glimmer/validator/lib/tracking';
-import { CONSTANT_TAG, INITIAL, validateTag, valueForTag } from '@glimmer/validator/lib/validators';
+import { consumeTag } from '@glimmer/validator/lib/tracking';
+import { CONSTANT_TAG, INITIAL, valueForTag } from '@glimmer/validator/lib/validators';
 
 import type { UpdatingVM } from '../../vm';
 import type { VM } from '../../vm/append';
@@ -283,45 +283,19 @@ export class AssertFilter<T, U> implements UpdatingOpcode {
   }
 }
 
-export class JumpIfNotModifiedOpcode implements UpdatingOpcode {
-  private tag: Tag = CONSTANT_TAG;
-  private lastRevision: Revision = INITIAL;
-  private target?: number;
+/**
+ * The state of one component cache group. The plan walker validates the tag
+ * and skips the group's slots when nothing tracked inside it changed.
+ */
+export class Guard {
+  public tag: Tag = CONSTANT_TAG;
+  public lastRevision: Revision = INITIAL;
 
-  finalize(tag: Tag, target: number) {
-    this.target = target;
-    this.didModify(tag);
-  }
-
-  evaluate(vm: UpdatingVM) {
-    let { tag, target, lastRevision } = this;
-
-    if (!vm.alwaysRevalidate && validateTag(tag, lastRevision)) {
-      consumeTag(tag);
-      vm.goto(expect(target, 'VM BUG: Target must be set before attempting to jump'));
-    }
-  }
+  constructor(public debugLabel?: string) {}
 
   didModify(tag: Tag) {
     this.tag = tag;
     this.lastRevision = valueForTag(this.tag);
     consumeTag(tag);
-  }
-}
-
-export class BeginTrackFrameOpcode implements UpdatingOpcode {
-  constructor(private debugLabel?: string) {}
-
-  evaluate() {
-    beginTrackFrame(this.debugLabel);
-  }
-}
-
-export class EndTrackFrameOpcode implements UpdatingOpcode {
-  constructor(private target: JumpIfNotModifiedOpcode) {}
-
-  evaluate() {
-    let tag = endTrackFrame();
-    this.target.didModify(tag);
   }
 }

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -18,12 +18,14 @@ import type {
   Scope,
   SyscallRegisters,
   TreeBuilder,
-  UpdatingOpcode,
+  UpdatePlan,
 } from '@glimmer/interfaces';
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
 import type { Reference } from '@glimmer/reference/lib/reference';
 import type { MachineRegister, Register, SyscallRegister } from '@glimmer/vm/lib/registers';
-import { dev, expect } from '@glimmer/debug-util/lib/platform-utils';
+import { PLAN_MULTI } from '@glimmer/constants/lib/update-plan';
+import assert from '@glimmer/debug-util/lib/assert';
+import { dev, expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import { unwrapHandle } from '@glimmer/debug-util/lib/template';
 import { associateDestroyableChild } from '@glimmer/destroyable';
 import { DESTROYABLE_META_KEY } from '@glimmer/util/lib/destroyable-key';
@@ -35,25 +37,27 @@ import { reverse } from '@glimmer/util/lib/array-utils';
 import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { LOCAL_LOGGER } from '@glimmer/util';
 import { beginTrackFrame, endTrackFrame, resetTracking } from '@glimmer/validator/lib/tracking';
-import { $pc, isLowLevelRegister } from '@glimmer/vm/lib/registers';
+import { $pc, $ra, isLowLevelRegister } from '@glimmer/vm/lib/registers';
 
 import type { ScopeOptions } from '../scope';
 import type { AppendingBlockList } from './element-builder';
 import type { EvaluationStack } from './stack';
-import type { BlockOpcode } from './update';
+import type { BlockOpcode, UpdateInstance } from './update';
 
-import {
-  BeginTrackFrameOpcode,
-  EndTrackFrameOpcode,
-  JumpIfNotModifiedOpcode,
-} from '../compiled/opcodes/vm';
+import { Guard } from '../compiled/opcodes/vm';
 import { externs } from '../opcodes';
 import { ScopeImpl } from '../scope';
 import { VMArgumentsImpl } from './arguments';
 import { LowLevelVM } from './low-level';
 import RenderResultImpl from './render-result';
 import EvaluationStackImpl from './stack';
-import { ListBlockOpcode, ListItemOpcode, TryOpcode } from './update';
+import {
+  createInstance,
+  EMPTY_PLAN,
+  ListBlockOpcode,
+  ListItemOpcode,
+  TryOpcode,
+} from './update';
 
 /*
  * The VM's own root destroyable, on the fast path like the block opcodes.
@@ -70,8 +74,13 @@ class Stacks {
 
   readonly scope = new Stack<Scope>();
   readonly dynamicScope = new Stack<DynamicScope>();
-  readonly updating = new Stack<UpdatingOpcode[]>();
-  readonly cache = new Stack<JumpIfNotModifiedOpcode>();
+  readonly updating = new Stack<UpdateInstance>();
+  readonly cache = new Stack<Guard>();
+  /**
+   * The return address of every call that pushed an update instance, so that
+   * `Return` pops the instance only when it leaves that call.
+   */
+  readonly calls: number[] = [];
   readonly list = new Stack<ListBlockOpcode>();
   readonly destroyable = new Stack<object>();
 
@@ -217,6 +226,15 @@ export class VM {
         dev(this.trace).willCall(handle);
       }
 
+      let plan = this.program.heap.planFor(handle);
+
+      if (plan.size !== 0) {
+        let callee = createInstance(plan);
+        this.record(callee);
+        this.#stacks.updating.push(callee);
+        this.#stacks.calls.push(this.lowlevel.fetchRegister($pc));
+      }
+
       this.lowlevel.call(handle);
     }
   }
@@ -225,6 +243,13 @@ export class VM {
   return() {
     if (LOCAL_DEBUG) {
       dev(this.trace).return();
+    }
+
+    let { calls } = this.#stacks;
+
+    if (calls.length !== 0 && calls[calls.length - 1] === this.lowlevel.fetchRegister($ra)) {
+      calls.pop();
+      this.#stacks.updating.pop();
     }
 
     this.lowlevel.return();
@@ -236,7 +261,8 @@ export class VM {
   constructor(
     { scope, dynamicScope, stack, pc }: ClosureState,
     context: EvaluationContext,
-    tree: TreeBuilder
+    tree: TreeBuilder,
+    root: UpdateInstance
   ) {
     if (DEBUG) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
@@ -281,7 +307,7 @@ export class VM {
       });
     }
 
-    this.pushUpdating();
+    this.#stacks.updating.push(root);
   }
 
   static initial(context: EvaluationContext, options: InitialVmState) {
@@ -296,7 +322,9 @@ export class VM {
       options.dynamicScope
     );
 
-    return new VM(state, context, options.tree);
+    let root = createInstance(context.program.heap.planFor(options.handle));
+
+    return new VM(state, context, options.tree, root);
   }
 
   compile(block: CompilableTemplate): number {
@@ -349,11 +377,9 @@ export class VM {
    * [!] push Tracking Stack
    */
   beginCacheGroup(name?: string) {
-    let opcodes = this.updating();
-    let guard = new JumpIfNotModifiedOpcode();
+    let guard = new Guard(name);
 
-    opcodes.push(guard);
-    opcodes.push(new BeginTrackFrameOpcode(name));
+    this.record(guard);
     this.#stacks.cache.push(guard);
 
     beginTrackFrame(name);
@@ -374,13 +400,10 @@ export class VM {
    * [-] consume `tag`
    */
   commitCacheGroup() {
-    let opcodes = this.updating();
     let guard = expect(this.#stacks.cache.pop(), 'VM BUG: Expected a cache group');
 
-    let tag = endTrackFrame();
-    opcodes.push(new EndTrackFrameOpcode(guard));
-
-    guard.finalize(tag, opcodes.length);
+    guard.didModify(endTrackFrame());
+    this.record(guard);
   }
 
   /**
@@ -400,12 +423,10 @@ export class VM {
    * [!] push Updating Stack <- `try.children`
    */
   enter(args: number) {
-    let updating: UpdatingOpcode[] = [];
-
     let state = this.capture(args);
     let block = this.tree().pushResettableBlock();
 
-    let tryOpcode = new TryOpcode(state, this.context, block, updating);
+    let tryOpcode = new TryOpcode(state, this.context, block, this.childPlan(0));
 
     this.didEnter(tryOpcode);
   }
@@ -446,15 +467,38 @@ export class VM {
 
     let state = this.capture(2);
     let block = this.tree().pushResettableBlock();
+    let list = this.#stacks.updating.current as ListBlockOpcode;
 
-    let opcode = new ListItemOpcode(state, this.context, block, key, memoRef, valueRef);
-    this.didEnter(opcode);
+    let opcode = new ListItemOpcode(
+      state,
+      this.context,
+      block,
+      list.itemPlan,
+      key,
+      memoRef,
+      valueRef
+    );
+
+    this.associateDestroyable(opcode);
+    this.#stacks.destroyable.push(opcode);
+    this.#stacks.updating.push(opcode);
 
     return opcode;
   }
 
   registerItem(opcode: ListItemOpcode) {
-    this.listBlock().initializeChild(opcode);
+    let list = this.listBlock();
+
+    list.children.push(opcode);
+    list.initializeChild(opcode);
+  }
+
+  /**
+   * Make `instance` the target of subsequent records. Used when a block
+   * re-renders itself from its closure.
+   */
+  pushInstance(instance: UpdateInstance): void {
+    this.#stacks.updating.push(instance);
   }
 
   /**
@@ -483,11 +527,18 @@ export class VM {
     let state = this.capture(0, addr);
     let list = this.tree().pushBlockList(updating) as AppendingBlockList;
 
-    let opcode = new ListBlockOpcode(state, this.context, list, updating, iterableRef);
+    let opcode = new ListBlockOpcode(
+      state,
+      this.context,
+      list,
+      updating,
+      this.childPlan(1),
+      iterableRef
+    );
 
     this.#stacks.list.push(opcode);
 
-    this.didEnter(opcode);
+    this.didEnter(opcode, 1);
   }
 
   /**
@@ -506,11 +557,22 @@ export class VM {
    * [!] push Updating Stack <- `opcode.children`
    *
    */
-  private didEnter(opcode: BlockOpcode) {
+  private didEnter(opcode: BlockOpcode, slotOffset = 0) {
     this.associateDestroyable(opcode);
     this.#stacks.destroyable.push(opcode);
-    this.updateWith(opcode);
-    this.pushUpdating(opcode.children);
+    this.record(opcode, slotOffset);
+    this.#stacks.updating.push(opcode);
+  }
+
+  /**
+   * The nested plan the current instruction opens: a block's own plan, or the
+   * per-item plan of a list.
+   */
+  private childPlan(slotOffset: number): UpdatePlan {
+    let instance = this.instance();
+    let slot = this.program.heap.slotAt(this.lowlevel.opAddr) + slotOffset;
+
+    return unwrap(instance.plan.children[slot]);
   }
 
   /**
@@ -528,7 +590,7 @@ export class VM {
   exit() {
     this.#stacks.destroyable.pop();
     this.#tree.popBlock();
-    this.popUpdating();
+    this.#stacks.updating.pop();
   }
 
   /**
@@ -638,36 +700,36 @@ export class VM {
   }
 
   /**
-   * ## State changes
-   *
-   * - [!] push Updating Stack
+   * Record an updating opcode into the slot the current instruction owns in the
+   * current instance. `slotOffset` selects a later slot for instructions that
+   * own more than one.
    *
    * @utility
    */
-  pushUpdating(list: UpdatingOpcode[] = []): void {
-    this.#stacks.updating.push(list);
+  record(opcode: unknown, slotOffset = 0): void {
+    let instance = this.instance();
+    let slot = this.program.heap.slotAt(this.lowlevel.opAddr) + slotOffset;
+
+    assert(slot >= slotOffset, 'BUG: the current instruction has no update-plan slot');
+
+    let { plan, slots } = instance;
+
+    if (plan.kinds[slot] === PLAN_MULTI) {
+      let list = slots[slot] as unknown[] | undefined;
+
+      if (list === undefined) {
+        slots[slot] = [opcode];
+      } else {
+        list.push(opcode);
+      }
+    } else {
+      assert(slots[slot] === undefined, 'BUG: update-plan slot recorded twice');
+      slots[slot] = opcode;
+    }
   }
 
-  /**
-   * ## State changes
-   *
-   * [!] pop Updating Stack
-   *
-   * @utility
-   */
-  popUpdating(): UpdatingOpcode[] {
-    return expect(this.#stacks.updating.pop(), "can't pop an empty stack");
-  }
-
-  /**
-   * ## State changes
-   *
-   * [!] push Updating List
-   *
-   * @utility
-   */
-  updateWith(opcode: UpdatingOpcode) {
-    this.updating().push(opcode);
+  updateWith(opcode: unknown) {
+    this.record(opcode);
   }
 
   private listBlock(): ListBlockOpcode {
@@ -686,11 +748,8 @@ export class VM {
     associateDestroyableChild(parent, child);
   }
 
-  private updating(): UpdatingOpcode[] {
-    return expect(
-      this.#stacks.updating.current,
-      'expected updating opcode on the updating opcode stack'
-    );
+  private instance(): UpdateInstance {
+    return expect(this.#stacks.updating.current, 'expected an update instance on the stack');
   }
 
   /**
@@ -798,7 +857,7 @@ export class VM {
         done: true,
         value: new RenderResultImpl(
           env,
-          this.popUpdating(),
+          expect(this.#stacks.updating.pop(), 'expected the root update instance'),
           this.#tree.popBlock(),
           this.#stacks.drop
         ),
@@ -878,8 +937,8 @@ export class Closure {
     this.context = context;
   }
 
-  evaluate(tree: TreeBuilder): VM {
-    return new VM(this.state, this.context, tree);
+  evaluate(tree: TreeBuilder, root: UpdateInstance = createInstance(EMPTY_PLAN)): VM {
+    return new VM(this.state, this.context, tree, root);
   }
 }
 

--- a/packages/@glimmer/runtime/lib/vm/low-level.ts
+++ b/packages/@glimmer/runtime/lib/vm/low-level.ts
@@ -58,6 +58,8 @@ export interface Externs {
 
 export class LowLevelVM {
   public currentOpSize = 0;
+  /** The address of the instruction being evaluated. */
+  public opAddr = 0;
   readonly registers: LowLevelRegisters;
   readonly context: EvaluationContext;
 
@@ -151,6 +153,7 @@ export class LowLevelVM {
     // program counter to the next instruction prior to executing.
     let opcode = context.program.opcode(pc);
     let operationSize = (this.currentOpSize = opcode.size);
+    this.opAddr = pc;
     this.registers[$pc] += operationSize;
 
     return opcode;
@@ -184,7 +187,7 @@ export class LowLevelVM {
       case VM_POP_FRAME_OP:
         return void this.popFrame();
       case VM_INVOKE_STATIC_OP:
-        return void this.call(opcode.op1);
+        return void vm.call(opcode.op1);
       case VM_INVOKE_VIRTUAL_OP:
         return void vm.call(this.stack.pop());
       case VM_JUMP_OP:

--- a/packages/@glimmer/runtime/lib/vm/render-result.ts
+++ b/packages/@glimmer/runtime/lib/vm/render-result.ts
@@ -4,13 +4,13 @@ import type {
   RenderResult,
   SimpleElement,
   SimpleNode,
-  UpdatingOpcode,
 } from '@glimmer/interfaces';
-import { unreachable } from '@glimmer/debug-util/lib/platform-utils';
 import { associateDestroyableChild, registerDestructor } from '@glimmer/destroyable';
 import { DESTROYABLE_META_KEY } from '@glimmer/util/lib/destroyable-key';
 
 import { clear } from '../bounds';
+import type { UpdateInstance } from './update';
+
 import { UpdatingVM } from './update';
 
 export default class RenderResultImpl implements RenderResult {
@@ -18,7 +18,7 @@ export default class RenderResultImpl implements RenderResult {
 
   constructor(
     public env: Environment,
-    private updating: UpdatingOpcode[],
+    private root: UpdateInstance,
     private bounds: AppendingBlock,
     readonly drop: object
   ) {
@@ -27,9 +27,9 @@ export default class RenderResultImpl implements RenderResult {
   }
 
   rerender({ alwaysRevalidate = false } = { alwaysRevalidate: false }) {
-    let { env, updating } = this;
+    let { env, root } = this;
     let vm = new UpdatingVM(env, { alwaysRevalidate });
-    vm.execute(updating, this);
+    vm.execute(root);
   }
 
   parentElement(): SimpleElement {
@@ -42,9 +42,5 @@ export default class RenderResultImpl implements RenderResult {
 
   lastNode(): SimpleNode {
     return this.bounds.lastNode();
-  }
-
-  handleException() {
-    unreachable(`this should never happen`);
   }
 }

--- a/packages/@glimmer/runtime/lib/vm/update.ts
+++ b/packages/@glimmer/runtime/lib/vm/update.ts
@@ -2,42 +2,70 @@ import { DEBUG } from '@glimmer/env';
 import type {
   AppendingBlock,
   Bounds,
-  DynamicScope,
   Environment,
   EvaluationContext,
-  ExceptionHandler,
   GlimmerTreeChanges,
-  Nullable,
   ResettableBlock,
-  Scope,
   SimpleComment,
+  UpdatePlan,
   UpdatingOpcode,
   UpdatingVM as IUpdatingVM,
 } from '@glimmer/interfaces';
 import type { OpaqueIterationItem, OpaqueIterator } from '@glimmer/reference/lib/iterable';
 import type { Reference } from '@glimmer/reference/lib/reference';
+import {
+  PLAN_BLOCK,
+  PLAN_CALL,
+  PLAN_GUARD,
+  PLAN_GUARD_END,
+  PLAN_LEAF,
+  PLAN_LIST,
+  PLAN_MULTI,
+} from '@glimmer/constants/lib/update-plan';
 import { expect, unwrap } from '@glimmer/debug-util/lib/platform-utils';
 import { associateDestroyableChild, destroy, destroyChildren } from '@glimmer/destroyable';
 import { DESTROYABLE_META_KEY } from '@glimmer/util/lib/destroyable-key';
 import { LOCAL_DEBUG } from '@glimmer/local-debug-flags';
 import { updateRef, valueForRef } from '@glimmer/reference/lib/reference';
 import { logStep } from '@glimmer/util/lib/debug-steps';
-import { StackImpl as Stack } from '@glimmer/util/lib/collections';
 import { debug } from '@glimmer/validator/lib/debug';
-import { resetTracking } from '@glimmer/validator/lib/tracking';
+import {
+  beginTrackFrame,
+  consumeTag,
+  endTrackFrame,
+  resetTracking,
+} from '@glimmer/validator/lib/tracking';
+import { validateTag } from '@glimmer/validator/lib/validators';
 
 import type { Closure } from './append';
 import type { AppendingBlockList } from './element-builder';
+import type { Guard } from '../compiled/opcodes/vm';
 
 import { clear, move as moveBounds } from '../bounds';
 import { NewTreeBuilder } from './element-builder';
+
+/**
+ * One render of a compilation unit or block: the static plan plus the values
+ * the append pass recorded into its slots. A slot is `undefined` when the
+ * instruction ran but recorded nothing (a constant reference, an untaken
+ * branch, a debug-only opcode in production).
+ */
+export interface UpdateInstance {
+  readonly plan: UpdatePlan;
+  slots: unknown[];
+}
+
+export const EMPTY_PLAN: UpdatePlan = { kinds: [], children: [], links: [], size: 0 };
+
+export function createInstance(plan: UpdatePlan): UpdateInstance {
+  return { plan, slots: plan.size === 0 ? [] : new Array<unknown>(plan.size) };
+}
 
 export class UpdatingVM implements IUpdatingVM {
   public env: Environment;
   public dom: GlimmerTreeChanges;
   public alwaysRevalidate: boolean;
-
-  private frameStack: Stack<UpdatingVMFrame> = new Stack<UpdatingVMFrame>();
+  public thrown = false;
 
   constructor(env: Environment, { alwaysRevalidate = false }) {
     this.env = env;
@@ -45,13 +73,13 @@ export class UpdatingVM implements IUpdatingVM {
     this.alwaysRevalidate = alwaysRevalidate;
   }
 
-  execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler) {
+  execute(root: UpdateInstance) {
     if (DEBUG) {
       let hasErrored = true;
       try {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- @fixme
         debug.runInTrackingTransaction!(
-          () => this._execute(opcodes, handler),
+          () => walk(this, root.plan, root.slots),
           '- While rendering:'
         );
 
@@ -65,56 +93,94 @@ export class UpdatingVM implements IUpdatingVM {
         }
       }
     } else {
-      this._execute(opcodes, handler);
+      walk(this, root.plan, root.slots);
     }
-  }
-
-  private _execute(opcodes: UpdatingOpcode[], handler: ExceptionHandler) {
-    let { frameStack } = this;
-
-    this.try(opcodes, handler);
-
-    while (!frameStack.isEmpty()) {
-      let opcode = this.frame.nextStatement();
-
-      if (opcode === undefined) {
-        frameStack.pop();
-        continue;
-      }
-
-      opcode.evaluate(this);
-    }
-  }
-
-  private get frame() {
-    return expect(this.frameStack.current, 'bug: expected a frame');
-  }
-
-  goto(index: number) {
-    this.frame.goto(index);
-  }
-
-  try(ops: UpdatingOpcode[], handler: Nullable<ExceptionHandler>) {
-    this.frameStack.push(new UpdatingVMFrame(ops, handler));
   }
 
   throw() {
-    this.frame.handleException();
-    this.frameStack.pop();
+    this.thrown = true;
   }
 }
 
-export interface VMState {
-  readonly pc: number;
-  readonly scope: Scope;
-  readonly dynamicScope: DynamicScope;
-  readonly stack: unknown[];
+/**
+ * Run the updating pass for one instance. Returns early with `vm.thrown` set
+ * when an assertion failed; the nearest enclosing block re-renders itself.
+ */
+export function walk(vm: UpdatingVM, plan: UpdatePlan, slots: unknown[]): void {
+  let { kinds, links } = plan;
+  let openFrames = 0;
+
+  for (let i = 0; i < kinds.length; i++) {
+    let value = slots[i];
+
+    if (value === undefined) continue;
+
+    switch (kinds[i]) {
+      case PLAN_LEAF:
+        (value as UpdatingOpcode).evaluate(vm);
+        break;
+
+      case PLAN_MULTI: {
+        let opcodes = value as UpdatingOpcode[];
+        for (let j = 0; j < opcodes.length && !vm.thrown; j++) {
+          unwrap(opcodes[j]).evaluate(vm);
+        }
+        break;
+      }
+
+      case PLAN_GUARD: {
+        let guard = value as Guard;
+
+        if (!vm.alwaysRevalidate && validateTag(guard.tag, guard.lastRevision)) {
+          consumeTag(guard.tag);
+          i = unwrap(links[i]);
+        } else {
+          beginTrackFrame(guard.debugLabel);
+          openFrames++;
+        }
+        break;
+      }
+
+      case PLAN_GUARD_END:
+        openFrames--;
+        (value as Guard).didModify(endTrackFrame());
+        break;
+
+      case PLAN_BLOCK: {
+        let block = value as TryOpcode;
+        walk(vm, block.plan, block.slots);
+
+        if (vm.thrown) {
+          vm.thrown = false;
+          block.handleException();
+        }
+        break;
+      }
+
+      case PLAN_LIST:
+        (value as ListBlockOpcode).update(vm);
+        break;
+
+      case PLAN_CALL: {
+        let callee = value as UpdateInstance;
+        walk(vm, callee.plan, callee.slots);
+        break;
+      }
+    }
+
+    if (vm.thrown) {
+      // Close the tracking frames this walk opened. The guards keep their
+      // previous tag and revalidate on the next update.
+      while (openFrames-- > 0) endTrackFrame();
+      return;
+    }
+  }
 }
 
-export abstract class BlockOpcode implements UpdatingOpcode, Bounds {
+export abstract class BlockOpcode implements UpdateInstance, Bounds {
   [DESTROYABLE_META_KEY]: object | undefined;
 
-  public children: UpdatingOpcode[];
+  public slots: unknown[];
 
   protected readonly bounds: AppendingBlock;
 
@@ -122,10 +188,10 @@ export abstract class BlockOpcode implements UpdatingOpcode, Bounds {
     protected state: Closure,
     protected context: EvaluationContext,
     bounds: AppendingBlock,
-    children: UpdatingOpcode[]
+    public readonly plan: UpdatePlan
   ) {
-    this.children = children;
     this.bounds = bounds;
+    this.slots = plan.size === 0 ? [] : new Array<unknown>(plan.size);
   }
 
   parentElement() {
@@ -139,20 +205,12 @@ export abstract class BlockOpcode implements UpdatingOpcode, Bounds {
   lastNode() {
     return this.bounds.lastNode();
   }
-
-  evaluate(vm: UpdatingVM) {
-    vm.try(this.children, null);
-  }
 }
 
-export class TryOpcode extends BlockOpcode implements ExceptionHandler {
+export class TryOpcode extends BlockOpcode {
   public type = 'try';
 
   declare protected bounds: ResettableBlock; // Shadows property on base class
-
-  override evaluate(vm: UpdatingVM) {
-    vm.try(this.children, this);
-  }
 
   handleException() {
     let {
@@ -164,14 +222,11 @@ export class TryOpcode extends BlockOpcode implements ExceptionHandler {
     destroyChildren(this);
 
     let tree = NewTreeBuilder.resume(env, bounds);
+    this.slots = this.plan.size === 0 ? [] : new Array<unknown>(this.plan.size);
     let vm = state.evaluate(tree);
 
-    let children = (this.children = []);
-
-    let result = vm.execute((vm) => {
-      vm.updateWith(this);
-      vm.pushUpdating(children);
-    });
+    // The block's own `Exit` pops it again, the same way the initial render did.
+    let result = vm.execute((vm) => vm.pushInstance(this));
 
     associateDestroyableChild(this, result.drop);
   }
@@ -185,11 +240,12 @@ export class ListItemOpcode extends TryOpcode {
     state: Closure,
     context: EvaluationContext,
     bounds: ResettableBlock,
+    plan: UpdatePlan,
     public key: unknown,
     public memo: Reference,
     public value: Reference
   ) {
-    super(state, context, bounds, []);
+    super(state, context, bounds, plan);
   }
 
   shouldRemove(): boolean {
@@ -203,7 +259,7 @@ export class ListItemOpcode extends TryOpcode {
 
 export class ListBlockOpcode extends BlockOpcode {
   public type = 'list-block';
-  declare public children: ListItemOpcode[];
+  public children: ListItemOpcode[];
 
   private opcodeMap = new Map<unknown, ListItemOpcode>();
   private marker: SimpleComment | null = null;
@@ -216,9 +272,11 @@ export class ListBlockOpcode extends BlockOpcode {
     context: EvaluationContext,
     bounds: AppendingBlockList,
     children: ListItemOpcode[],
+    public readonly itemPlan: UpdatePlan,
     private iterableRef: Reference<OpaqueIterator>
   ) {
-    super(state, context, bounds, children);
+    super(state, context, bounds, EMPTY_PLAN);
+    this.children = children;
     this.lastIterator = valueForRef(iterableRef);
   }
 
@@ -227,7 +285,7 @@ export class ListBlockOpcode extends BlockOpcode {
     this.opcodeMap.set(opcode.key, opcode);
   }
 
-  override evaluate(vm: UpdatingVM) {
+  update(vm: UpdatingVM) {
     let iterator = valueForRef(this.iterableRef);
 
     if (this.lastIterator !== iterator) {
@@ -248,8 +306,17 @@ export class ListBlockOpcode extends BlockOpcode {
       this.lastIterator = iterator;
     }
 
-    // Run now-updated updating opcodes
-    super.evaluate(vm);
+    let { children } = this;
+
+    for (let i = 0; i < children.length; i++) {
+      let item = unwrap(children[i]);
+      walk(vm, item.plan, item.slots);
+
+      if (vm.thrown) {
+        vm.thrown = false;
+        item.handleException();
+      }
+    }
   }
 
   private sync(iterator: OpaqueIterator) {
@@ -364,7 +431,7 @@ export class ListBlockOpcode extends BlockOpcode {
       nextSibling,
     });
 
-    let vm = state.evaluate(elementStack);
+    let vm = state.evaluate(elementStack, this);
 
     vm.execute((vm) => {
       let opcode = vm.enterItem(item);
@@ -423,28 +490,5 @@ export class ListBlockOpcode extends BlockOpcode {
     destroy(opcode);
     clear(opcode);
     this.opcodeMap.delete(opcode.key);
-  }
-}
-
-class UpdatingVMFrame {
-  private current = 0;
-
-  constructor(
-    private ops: UpdatingOpcode[],
-    private exceptionHandler: Nullable<ExceptionHandler>
-  ) {}
-
-  goto(index: number) {
-    this.current = index;
-  }
-
-  nextStatement(): UpdatingOpcode | undefined {
-    return this.ops[this.current++];
-  }
-
-  handleException() {
-    if (this.exceptionHandler) {
-      this.exceptionHandler.handleException();
-    }
   }
 }


### PR DESCRIPTION
## A counter, before and after

```hbs
<button {{on "click" this.increment}}>Count: {{this.count}}</button>
```

The wire format is unchanged by this PR:

```json
[[[11,"button"],[4,[38,1],["click",[30,0,["increment"]]],null],[12],[1,"Count: "],[1,[30,0,["count"]]],[13]],[],["button","on"]]
```

### Before

The append pass builds the structure of the updating pass at render time, once per instance, as a list of objects. `UpdatingVM` walks it with a frame stack and one virtual `evaluate` call per entry.

```js
[
  UpdateModifierOpcode { lastUpdated: 1, tag, modifier },          // {{on}}
  TryOpcode {                                                     // {{this.count}}: the stdlib append switch
    state: Closure { pc, scope, dynamicScope, stack },
    bounds: ResettableBlockImpl,
    children: [
      AssertFilter { last: 2, ref },                              // 2 = ContentType.String
      DynamicTextContent { node, reference, lastValue: "0" },
    ],
  },
]
```

### After

Everything below is dumped from a browser run of the integration tests at 6b0903d855, with `JSON.stringify` on the real objects (object-valued fields shown as `<ClassName>`, `undefined` slots as `null`).

The compiler turns the wire format into these 19 instructions. Three of them can record an updating opcode, and each of those gets a slot index in a side table keyed by instruction address:

```
addr  instruction                     slot
 0    PutComponentOperations
 1    OpenElement "button"
 3    PushFrame
 4    Primitive
 6    PrimitiveReference
 7    GetVariable 0
 9    GetProperty "increment"
11    PushArgs
15    Modifier on                     0
17    PopFrame
18    FlushElement                    1
19    Text "Count: "
21    PushFrame
22    GetVariable 0
24    GetProperty "count"
26    InvokeStatic cautious-append    2
28    PopFrame
29    CloseElement
30    Return
```

The plan stored for the counter's handle. Kinds: 1 leaf, 2 multi, 3 guard, 4 guard-end, 5 block, 6 list, 7 call.

```json
{ "kinds": [2, 2, 7], "children": [null, null, null], "links": [-1, -1, -1], "size": 3 }
```

The plan stored for the stdlib `cautious-append` routine, which the counter calls at address 26. Its `Enter` opens a block, and the block has one slot per content-type clause; `links` pairs the guard at 6 with its end at 11:

```json
{
  "kinds": [5],
  "children": [
    {
      "kinds": [1, 1, 1, 1, 7, 1, 3, 1, 2, 7, 2, 4, 1],
      "children": [null, null, null, null, null, null, null, null, null, null, null, null, null],
      "links": [-1, -1, -1, -1, -1, -1, 11, -1, -1, -1, -1, 6, -1],
      "size": 13
    }
  ],
  "links": [-1],
  "size": 1
}
```

The root instance after the first render. An instance is `{ plan, slots }`; the append pass wrote each recorded opcode into the slot of the instruction that ran:

```json
{
  "plan": { "kinds": [2, 2, 7], "children": [null, null, null], "links": [-1, -1, -1], "size": 3 },
  "slots": [
    [
      { "$class": "UpdateModifierOpcode", "lastUpdated": 1, "tag": "<MonomorphicTagImpl>", "modifier": "<Object>" }
    ],
    null,
    {
      "plan": { "kinds": [5], "children": ["<the 13-slot block plan above>"], "links": [-1], "size": 1 },
      "slots": [
        {
          "$class": "TryOpcode",
          "type": "try",
          "state": "<Closure>",
          "bounds": "<ResettableBlockImpl>",
          "plan": "<the 13-slot block plan above>",
          "slots": [
            { "$class": "AssertFilter", "last": 2, "ref": "<ReferenceImpl>" },
            null, null, null, null, null, null, null, null, null, null, null,
            { "$class": "DynamicTextContent", "node": "<Text>", "reference": "<ReferenceImpl>", "lastValue": "0" }
          ]
        }
      ]
    }
  ]
}
```

Slot 1 is empty because `FlushElement` only records component attributes and there are none. In the block, the 11 empty slots are the clauses for node, fragment, safe string, helper, and component content, which a string never takes. The updating pass is one loop over `kinds` with a switch; the frame stack, `goto`, `try`, and `throw` are gone.

Spike. Not for merge as is.

## What this does

The opcode compiler derives the structure of the updating pass while it emits bytecode. Every instruction whose handler can record an updating opcode gets a slot in an update plan. `Enter`, `EnterList`, and the four call instructions open nested plans. The program heap keeps a side table from instruction address to slot index, and one plan per handle.

A render instance is the plan plus a slot array of the same length. The append pass writes each recorded opcode into the slot its instruction owns. The updating pass is one loop over the plan with a switch on the slot kind.

Removed from the runtime: the `UpdatingVM` frame stack, `goto`, `try`, `throw`, and the `JumpIfNotModified`, `BeginTrackFrame`, and `EndTrackFrame` opcode classes.

A slot stays empty when its instruction recorded nothing: a constant reference, an untaken branch, or a debug-only opcode in production. Instructions whose emission count depends on runtime data (component attribute flushes, modifiers, debug render tree nodes) own one array slot.

The test file `packages/@glimmer-workspace/integration-tests/test/update-plan-test.ts` prints the plan of a few templates and the slots of a rendered instance. A rendered `<div class={{this.cls}}>{{this.name}}</div>{{#if this.a}}{{this.b}}{{/if}}` reads as:

```
[leaf call[block[leaf - - - - - - - - - - - leaf]] block[leaf call[call[block[leaf - - - - - - - - - - - leaf]]]]]
```

## Open points

- The plan builder ships with the JIT compiler, so the bundle grows by 2.5 kB raw and 0.7 kB gzip. Under an AOT compile it moves to build time.
- Untaken branches are holes. The stdlib append routine has 13 slots and a plain text append fills 2. Per-clause sub-plans selected by the taken branch would remove those checks.
- The `{{#each}}` body needs a new compiler marker (`EndItem`), because the `Exit` at `FINALLY` closes both an item and the outer block.

## rere-benchmark

Base `bdb2580255` vs `8c2814f96e`, mirrored rounds (base, plan, plan, base), cpu throttle 8. The third commit only changes memory use.

| benchmark | unit | main p50 (round 1 / round 2) | plan p50 (round 1 / round 2) | change (median of rounds) |
| --- | --- | ---: | ---: | ---: |
| DB Monitor w/ chat simulation | FPS | 30.3 / 24.0 | 28.7 / 26.9 | +2.4% |
| Incrementing Render Effect | ms | 2282.0 / 2278.6 | 2163.8 / 2173.3 | -4.9% |
| 1 item, 1k updates (async) | ms | 59.7 / 59.3 | 55.5 / 54.9 | -7.3% (better) |
| 1 item, 1k updates | ms | 9.4 / 9.4 | 9.1 / 9.1 | -3.2% |
| 1 item, 100k updates (async) | ms | 1024.3 / 1016.7 | 967.2 / 992.6 | -4.0% |
| 1 item, 100k updates | ms | 37.8 / 39.4 | 41.4 / 37.7 | +2.3% |
| 1k items, 1 update each (sequentially, async) | ms | 950.5 / 949.1 | 823.3 / 843.7 | -12.2% (better) |
| 1k items, 1 update each (sequentially) | ms | 55.6 / 55.8 | 56.9 / 57.1 | +2.3% |
| 1k items 1 update on 5% (random, async) | ms | 128.7 / 130.7 | 107.0 / 116.3 | -13.9% (better) |
| 1k items 1 update on 5% (random) | ms | 30.0 / 31.0 | 24.3 / 27.3 | -15.5% (better) |
| 1k items 1 update on 25% (random, async) | ms | 325.0 / 312.4 | 291.7 / 301.1 | -7.0% (better) |
| 1k items 1 update on 25% (random) | ms | 39.0 / 35.0 | 33.3 / 35.5 | -7.1% |
| 1 value, 1k consumers, 10k updates (bursts of 100) | ms | 2184.8 / 2019.9 | 1920.9 / 2114.2 | -4.0% |
| 1 value, 1k consumers, 10k updates (bursts of 1000) | ms | 278.3 / 272.7 | 286.7 / 228.3 | -6.5% |
| 1 value, 1k consumers, 10k updates (single burst) | ms | 61.2 / 62.3 | 60.3 / 62.1 | -0.9% |

## js-framework-benchmark

Base `bdb2580255` vs `7e9a9efd93`. The first run with `8c2814f96e` showed ready memory up 4 MB from an eagerly sized slot table; the third commit fixes that, and this table is the rerun. The first-paint row is a single sample and moves 20% between runs of identical code.

| benchmark | type | base (median) | plan2 (median) | change |
| --- | --- | ---: | ---: | ---: |
| 01_run1k | cpu | 81.1 ms (±3.0) | 82.1 ms (±3.3) | +1.2% |
| 02_replace1k | cpu | 98.1 ms (±4.1) | 96.1 ms (±2.8) | -2.0% |
| 03_update10th1k_x16 | cpu | 37.8 ms (±2.7) | 36.8 ms (±5.0) | -2.6% |
| 04_select1k | cpu | 14.8 ms (±1.3) | 12.6 ms (±2.5) | -14.9% |
| 05_swap1k | cpu | 51.5 ms (±2.6) | 46.9 ms (±2.5) | -8.9% |
| 06_remove-one-1k | cpu | 31.8 ms (±1.8) | 31.2 ms (±1.6) | -1.9% |
| 07_create10k | cpu | 762.7 ms (±10.3) | 772.0 ms (±17.3) | +1.2% |
| 08_create1k-after1k_x2 | cpu | 100.1 ms (±2.8) | 98.7 ms (±3.2) | -1.4% |
| 09_clear1k_x8 | cpu | 40.6 ms (±2.7) | 41.2 ms (±2.7) | +1.5% |
| 21_ready-memory | memory | 5.38 MB (±n/a) | 5.43 MB (±n/a) | +0.9% |
| 22_run-memory | memory | 11.90 MB (±n/a) | 12.08 MB (±n/a) | +1.5% |
| 25_run-clear-memory | memory | 6.00 MB (±n/a) | 6.12 MB (±n/a) | +1.9% |
| 41_size-uncompressed | size | 139.30 kB (±n/a) | 141.80 kB (±n/a) | +1.8% |
| 42_size-compressed | size | 39.10 kB (±n/a) | 39.80 kB (±n/a) | +1.8% |
| 43_first-paint | size | 234.70 ms (±n/a) | 265.50 ms (±n/a) | +13.1% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCsx9qptiMuhjjeovJzPf


